### PR TITLE
Publish multi-arch (amd64 + arm64) container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,9 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_TREE_STATE=clean
+            BUILD_DATE=${{ github.event.repository.updated_at }}
 
       - name: Generate install manifest
         run: |

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,11 @@
 # Build the unified galactic binary
-FROM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +25,13 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o galactic cmd/galactic/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X go.datum.net/galactic/internal/cmd/version.Version=${VERSION} \
+      -X go.datum.net/galactic/internal/cmd/version.GitCommit=${GIT_COMMIT} \
+      -X go.datum.net/galactic/internal/cmd/version.GitTreeState=${GIT_TREE_STATE} \
+      -X go.datum.net/galactic/internal/cmd/version.BuildDate=${BUILD_DATE}" \
+    -o galactic cmd/galactic/main.go
 
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -25,11 +25,12 @@ import (
 
 var (
 	// Version information - set via ldflags during build
-	Version   = "dev"
-	GitCommit = "unknown"
-	BuildDate = "unknown"
-	GoVersion = runtime.Version()
-	Platform  = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	Version      = "dev"
+	GitCommit    = "unknown"
+	GitTreeState = "unknown"
+	BuildDate    = "unknown"
+	GoVersion    = runtime.Version()
+	Platform     = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 )
 
 func NewCommand() *cobra.Command {
@@ -40,6 +41,7 @@ func NewCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Galactic Version: %s\n", Version)
 			fmt.Printf("Git Commit: %s\n", GitCommit)
+			fmt.Printf("Git Tree State: %s\n", GitTreeState)
 			fmt.Printf("Build Date: %s\n", BuildDate)
 			fmt.Printf("Go Version: %s\n", GoVersion)
 			fmt.Printf("Platform: %s\n", Platform)


### PR DESCRIPTION
## Summary

Galactic container images now build natively for both amd64 and arm64, so Apple Silicon and arm64 Linux hosts can pull a matching image instead of being stuck on amd64-only (or falling back to slow emulation).

The release workflow already requested both platforms, but the Dockerfile builder stage was not pinned to the build platform, which caused the arm64 leg to run Go under QEMU emulation. Pinning the builder to \$BUILDPLATFORM lets Go cross-compile natively for each target. Version metadata (version, git commit, git tree state, build date) is also now stamped into the binary via ldflags.

Cold local multi-arch build time dropped from 15+ minutes (QEMU) to roughly 1 minute 11 seconds.

## Test plan

- [ ] Release workflow succeeds on a tag push
- [ ] Published image manifest lists both linux/amd64 and linux/arm64
- [ ] galactic version prints the injected version, commit, tree state, and build date
- [ ] Image runs on an arm64 host without emulation