### PR TITLE
fix: galactic kind node lab fixes

### DIFF
--- a/lab/kindest-node-galactic/install.sh
+++ b/lab/kindest-node-galactic/install.sh
@@ -34,8 +34,8 @@ if hostname |grep -q control-plane; then # control-plane
   kubectl -n galactic-mqtt rollout status deployment galactic-mqtt
 
   # Galactic Operator
-  curl -L "https://raw.githubusercontent.com/datum-cloud/galactic/refs/heads/main/dist/install.yaml" |sed -e "s/galactic:latest/galactic:${GALACTIC_VERSION}/g" |kubectl apply -f -
-  kubectl -n galactic-system rollout status deployment galactic-controller-manager
+  curl -L "https://raw.githubusercontent.com/datum-cloud/galactic-operator/refs/heads/main/dist/install.yaml" |sed -e "s/galactic:latest/galactic:${GALACTIC_VERSION}/g" |kubectl apply -f -
+  kubectl -n galactic-operator-system rollout status deployment galactic-operator-controller-manager
 
   # Galactic Router
   cat /galactic/router.k8s.yml |sed -e "s/galactic-router:latest/galactic-router:${GALACTIC_VERSION}/g" |kubectl apply -f -
@@ -72,5 +72,5 @@ else # worker
   curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}.tgz" |tar xvfz - -C /opt/cni/bin
 
   # Galactic CNI (now bundled in the unified galactic binary)
-  curl -Lo /opt/cni/bin/galactic "https://github.com/datum-cloud/galactic/releases/download/${GALACTIC_VERSION}/galactic_linux_${ARCH}" && chmod +x /opt/cni/bin/galactic
+  curl -Lo /opt/cni/bin/galactic "https://github.com/datum-cloud/galactic-cni/releases/download/${GALACTIC_VERSION}/galactic_${ARCH}" && chmod +x /opt/cni/bin/galactic
 fi


### PR DESCRIPTION
There were two issues with the `install.sh` file that prevents the labs in the Galactic project from working.  Both issues were introduced when the repos were consolidated.

The first fix updates the installation of the Galactic Operator.  This change reverts the curl command to pulling the binary from the old repository `galactic-operator`.

The second fix address an issue pulling the CI from the `galactic-cni` repository.

Once applied, the example labs `basic` and `geo` are working again.

This is a temporary fix to get the devel labs working again.  A more permenant patch needs to be applie to finish the repo consolidation.