### PR TITLE
chore: add CODEOWNERS to the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @datum-cloud/engineering


### PR DESCRIPTION
This small change adds the `CODEOWNERS` to the repository and assigned `datum-cloud/engineer` as the only owner.  Adding this file to the repo will instructure Github to assign an incoming PR to the group.