### PR TITLE
chore: clean up tasks from repo consolidation

### DIFF
--- a/lab/kindest-node-galactic/Dockerfile
+++ b/lab/kindest-node-galactic/Dockerfile
@@ -1,7 +1,9 @@
 FROM kindest/node:v1.34.0
-RUN mkdir /galactic
-COPY install.sh /galactic/
-COPY mqtt.k8s.yml /galactic/
-COPY router.k8s.yml /galactic/
-COPY agent.k8s.yml /galactic/
-RUN chmod +x /galactic/install.sh
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        tcpdump \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 install.sh /galactic/
+COPY mqtt.k8s.yml router.k8s.yml agent.k8s.yml operator.k8s.yaml /galactic/

--- a/lab/kindest-node-galactic/install.sh
+++ b/lab/kindest-node-galactic/install.sh
@@ -34,8 +34,8 @@ if hostname |grep -q control-plane; then # control-plane
   kubectl -n galactic-mqtt rollout status deployment galactic-mqtt
 
   # Galactic Operator
-  curl -L "https://raw.githubusercontent.com/datum-cloud/galactic-operator/refs/heads/main/dist/install.yaml" |sed -e "s/galactic:latest/galactic:${GALACTIC_VERSION}/g" |kubectl apply -f -
-  kubectl -n galactic-operator-system rollout status deployment galactic-operator-controller-manager
+  kubectl apply -f /galactic/operator.k8s.yml
+  kubectl -n galactic-system rollout status deployment galactic-controller-manager
 
   # Galactic Router
   cat /galactic/router.k8s.yml |sed -e "s/galactic-router:latest/galactic-router:${GALACTIC_VERSION}/g" |kubectl apply -f -

--- a/lab/kindest-node-galactic/operator.k8s.yaml
+++ b/lab/kindest-node-galactic/operator.k8s.yaml
@@ -1,0 +1,813 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+    control-plane: controller-manager
+  name: galactic-operator-system
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  names:
+    kind: NetworkAttachmentDefinition
+    plural: network-attachment-definitions
+    shortNames:
+    - net-attach-def
+    singular: network-attachment-definition
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'NetworkAttachmentDefinition is a CRD schema specified by the
+          Network Plumbing Working Group to express the intent for attaching pods
+          to one or more logical or physical networks. More information available
+          at: https://github.com/k8snetworkplumbingwg/multi-net-spec'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this represen
+              tation of an object. Servers should convert recognized schemas to the
+              latest internal value, and may reject unrecognized values. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkAttachmentDefinition spec defines the desired state
+              of a network attachment
+            properties:
+              config:
+                description: NetworkAttachmentDefinition config is a JSON-formatted
+                  CNI configuration
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: vpcattachments.galactic.datumapis.com
+spec:
+  group: galactic.datumapis.com
+  names:
+    kind: VPCAttachment
+    listKind: VPCAttachmentList
+    plural: vpcattachments
+    singular: vpcattachment
+  scope: Namespaced
+  versions:
+  - name: v1alpha
+    schema:
+      openAPIV3Schema:
+        description: VPCAttachment is the Schema for the vpcattachments API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of VPCAttachment
+            properties:
+              interface:
+                description: Interface defines the network interface configuration.
+                properties:
+                  addresses:
+                    description: A list of IPv4 or IPv6 addresses associated with
+                      the interface.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  name:
+                    default: galactic0
+                    description: Name of the interface (e.g., eth0).
+                    type: string
+                required:
+                - addresses
+                - name
+                type: object
+              routes:
+                description: Routes defines additional routing entries for the VPCAttachment.
+                items:
+                  description: VPCAttachmentRoute defines a routing entry for the
+                    VPCAttachment.
+                  properties:
+                    destination:
+                      description: IPv4 or IPv6 destination network in CIDR notation.
+                      type: string
+                    via:
+                      description: Via is the next hop address.
+                      type: string
+                  required:
+                  - destination
+                  type: object
+                type: array
+              vpc:
+                description: VPC this attachment belongs to.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - interface
+            - vpc
+            type: object
+          status:
+            description: status defines the observed state of VPCAttachment
+            properties:
+              identifier:
+                description: A unique identifier assigned to this VPCAttachment
+                type: string
+              ready:
+                default: false
+                description: Indicates whether the VPCAttachment is ready for use
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: vpcs.galactic.datumapis.com
+spec:
+  group: galactic.datumapis.com
+  names:
+    kind: VPC
+    listKind: VPCList
+    plural: vpcs
+    singular: vpc
+  scope: Namespaced
+  versions:
+  - name: v1alpha
+    schema:
+      openAPIV3Schema:
+        description: VPC is the Schema for the vpcs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of a VPC
+            properties:
+              networks:
+                description: A list of networks in IPv4 or IPv6 CIDR notation associated
+                  with the VPC
+                items:
+                  type: string
+                minItems: 1
+                type: array
+            required:
+            - networks
+            type: object
+          status:
+            description: status defines the observed state of a VPC
+            properties:
+              identifier:
+                description: A unique identifier assigned to this VPC
+                type: string
+              ready:
+                default: false
+                description: Indicates whether the VPC is ready for use
+                type: boolean
+            required:
+            - ready
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-controller-manager
+  namespace: galactic-operator-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-leader-election-role
+  namespace: galactic-operator-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-operator-manager-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments
+  - vpcs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments/finalizers
+  - vpcs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments/status
+  - vpcs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-operator-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpc-admin-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs
+  verbs:
+  - '*'
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpc-editor-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpc-viewer-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpcattachment-admin-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments
+  verbs:
+  - '*'
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpcattachment-editor-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-vpcattachment-viewer-role
+rules:
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - galactic.datumapis.com
+  resources:
+  - vpcattachments/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-leader-election-rolebinding
+  namespace: galactic-operator-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: galactic-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: galactic-operator-controller-manager
+  namespace: galactic-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galactic-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: galactic-operator-controller-manager
+  namespace: galactic-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: galactic-operator-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galactic-operator-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: galactic-operator-controller-manager
+  namespace: galactic-operator-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+    control-plane: controller-manager
+  name: galactic-operator-controller-manager-metrics-service
+  namespace: galactic-operator-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: galactic-operator
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-webhook-service
+  namespace: galactic-operator-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: galactic-operator
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+    control-plane: controller-manager
+  name: galactic-operator-controller-manager
+  namespace: galactic-operator-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: galactic-operator
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: galactic-operator
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+        command:
+        - /manager
+        image: ghcr.io/datum-cloud/galactic-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: webhook-certs
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: galactic-operator-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-metrics-certs
+  namespace: galactic-operator-system
+spec:
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: galactic-operator-selfsigned-issuer
+  secretName: metrics-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-serving-cert
+  namespace: galactic-operator-system
+spec:
+  dnsNames:
+  - galactic-operator-webhook-service.galactic-operator-system.svc
+  - galactic-operator-webhook-service.galactic-operator-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: galactic-operator-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: galactic-operator
+  name: galactic-operator-selfsigned-issuer
+  namespace: galactic-operator-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: galactic-operator-system/galactic-operator-serving-cert
+  name: galactic-operator-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: galactic-operator-webhook-service
+      namespace: galactic-operator-system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  matchConditions:
+  - expression: object != null && has(object.metadata) && has(object.metadata.annotations)
+      && "k8s.v1alpha.galactic.datumapis.com/vpc-attachment" in object.metadata.annotations
+    name: vpc-attachment-annotation-exists
+  name: mpod-v1.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: galactic-operator-system/galactic-operator-serving-cert
+  name: galactic-operator-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: galactic-operator-webhook-service
+      namespace: galactic-operator-system
+      path: /validate--v1-pod
+  failurePolicy: Fail
+  matchConditions:
+  - expression: object != null && has(object.metadata) && has(object.metadata.annotations)
+      && "k8s.v1alpha.galactic.datumapis.com/vpc-attachment" in object.metadata.annotations
+    name: vpc-attachment-annotation-exists
+  name: vpod-v1.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None


### PR DESCRIPTION
When the Galactic repos were merged into a single monorepo, there were some outstanding touch points that were still cross repository.  This patch cleans those up to use only the monorepo `galactic`.

The `operator.k8s.yml` file was being pulled from the archived `galactic-operator` repo.  The manifest has been copied from the `galactic-operator` repo to this repository and referened locally in the `Dockerfile` when building the Kind node.

The `install.sh` script has been updated to use the local `operator.k8s.yml` manifest file instead of pulling it from the `galactic-operator` repo.

The `Dockerfile` that is used to build the Kind node has been updated to include `tcpdump` for troubleshooting.