### PR TITLE
chore: clean up `pyproject.toml` and `Dockefile`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: router
-        run: pip install -e .[test]
+        run: pip install -e .[test,lint]
 
       - name: Lint
         working-directory: router

--- a/router/.dockerignore
+++ b/router/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+*.db
+*.sqlite
+*.sqlite3
+dist/
+build/

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,12 +1,33 @@
-FROM python:3
+FROM python:3.13-slim AS builder
 
-RUN mkdir /workspace
+WORKDIR /build
+
+COPY README.md pyproject.toml ./
+COPY galactic_router ./galactic_router
+
+RUN python -m pip install --no-cache-dir --upgrade pip build && \
+    python -m build --wheel
+
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /workspace
 
-COPY galactic_router galactic_router
-COPY alembic alembic
-COPY pyproject.toml .
+RUN addgroup --system galactic && \
+    adduser --system --ingroup galactic --home /workspace galactic && \
+    mkdir -p /workspace/data && \
+    chown -R galactic:galactic /workspace
 
-RUN pip install -e .
+COPY --from=builder /build/dist/*.whl /tmp/
+COPY alembic ./alembic
+COPY README.md pyproject.toml ./
+
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir /tmp/*.whl && \
+    rm -f /tmp/*.whl
+
+USER galactic
 
 ENTRYPOINT ["galactic-router"]

--- a/router/Dockerfile.test
+++ b/router/Dockerfile.test
@@ -1,14 +1,18 @@
-FROM python:3
+FROM python:3.13-slim
 
-RUN mkdir /workspace
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
 WORKDIR /workspace
 
-COPY galactic_router galactic_router
-COPY alembic alembic
-COPY features features
-COPY .flake8 .flake8
-COPY pyproject.toml .
+COPY README.md pyproject.toml ./
+COPY .flake8 ./.flake8
+COPY alembic ./alembic
+COPY features ./features
+COPY galactic_router ./galactic_router
 
-RUN pip install -e .[test]
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir -e .[test,lint]
+
 RUN flake8 -v .
 RUN behave

--- a/router/pyproject.toml
+++ b/router/pyproject.toml
@@ -2,29 +2,37 @@
 name = "galactic-router"
 version = "0.0.1"
 description = "Routing engine for Galactic"
-
+readme = "README.md"
+license = { text = "AGPL-3.0-or-later" }
 requires-python = ">=3.13"
 dependencies = [
+    "aiomqtt>=2.4.0",
     "aiorun>=2025.1.1",
-    "click>=8.2.1",
+    "alembic>=1.16.5",
     "bubus>=1.5.5",
+    "click>=8.2.1",
     "protobuf>=6.32.0",
+    "psycopg[binary]>=3.2.10",
     "pydantic>=2.11.7",
     "sqlmodel>=0.0.24",
-    "alembic>=1.16.5",
-    "psycopg[binary]>=3.2.10",
-    "mysqlclient>=2.2.7",
-    "aiomqtt>=2.4.0",
 ]
 
 [project.optional-dependencies]
+mysql = [
+    "mysqlclient>=2.2.7",
+]
 test = [
     "behave>=1.3.1",
     "deepdiff>=8.6.0",
-    "flake8>=7.3.0",
-    "wemake-python-styleguide>=1.4.0",
     "time-machine>=2.19.0",
 ]
+lint = [
+    "flake8>=7.3.0",
+    "wemake-python-styleguide>=1.4.0",
+]
+
+[project.urls]
+Documentation = "http://datum.net/docs/galactic-vpc/#galactic-router"
 
 [project.scripts]
 galactic-router = "galactic_router:run"


### PR DESCRIPTION
The `pyproject.toml` file had some old references and missing pinned
depdendencies.   This patch bring the `pyproject.toml` file up to
minimum standard for a Python app.

Additionally the `Dockerfile` and `Dockerfile.test` container build files had some very loosely defined requirments.  The updates in this patch change out the base image which is substaintially smaller in size, reorder the steps to be more optimial for handling changes and now run the application as user `galactic`.

For the "production" container, the build was split into two parts, the first one builds the application and the second one uses the built application in container that is closer to production ready.