### PR TITLE
chore: pin renovate to using Go 1.24.x.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended"
+    ],
+    "contraints": {
+        "go": "1.24"
+    }
 }


### PR DESCRIPTION
Tthe `renovate[bot]` is attempting to upgrade the application to use Go
1.26.x.   This patch puts a contraint on the bot to force it to remain
on the Go 1.24.x train.