### PR TITLE
chore: Disable automated Go version upgrades in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,24 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "description": "Disable Go version upgrades in go.mod (go directive and toolchain directive)",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "enabled": false
+    },
+    {
+      "description": "Disable golang Docker image version upgrades",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["golang"],
+      "enabled": false
+    },
+    {
+      "description": "Disable go-version upgrades in GitHub Actions (actions/setup-go)",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["actions/go-versions"],
+      "enabled": false
+    },
+    {
       "description": "Group all Go dependencies",
       "matchManagers": ["gomod"],
       "groupName": "Go dependencies",


### PR DESCRIPTION
## Summary

- Adds three package rules to `renovate.json` to prevent Renovate from opening PRs to bump the Go toolchain version
- Covers the `go`/`toolchain` directives in `go.mod`, the `golang` base image in Dockerfiles, and `go-version` in GitHub Actions `setup-go` steps

## Test plan

- [ ] Confirm no Renovate PRs appear for Go version bumps after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)