### PR TITLE
chore: constrain Renovate to Go 1.24 to block transitive toolchain bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,9 @@
     "labels": ["security"],
     "schedule": ["at any time"]
   },
+  "constraints": {
+    "go": "1.24"
+  },
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
## Summary

- Adds `constraints.go = "1.24"` to `renovate.json`
- The existing rule disabling direct `go` directive updates didn't cover the case where a dep update (e.g. `grpc v1.81.1`) requires Go 1.25 in its own `go.mod`, causing `go mod tidy` to bump our `go` directive as a side effect
- With `constraints.go` set, Renovate skips any module update whose new version requires Go > 1.24 — no indirect bumps possible
- Closes #77 (the offending dep update PR that snuck in a `go 1.24 → 1.25` bump)

## Test plan

- [ ] Verify Renovate next run does not reopen a Go deps PR that bumps `go 1.25`
- [ ] Merge this before closing #77 so Renovate knows not to requeue it

🤖 Generated with [Claude Code](https://claude.com/claude-code)