### PR TITLE
chore(renovate): allow Go patch-level updates while blocking major/minor

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,14 +10,16 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "Block all Go toolchain version upgrades (go.mod go/toolchain directives and setup-go go-version inputs)",
+      "description": "Block Go toolchain major/minor upgrades; allow patch-only updates",
       "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {
-      "description": "Block golang Docker base image upgrades to keep Go major/minor pinned",
+      "description": "Block golang Docker base image major/minor upgrades; allow patch-only updates",
       "matchManagers": ["dockerfile"],
       "matchDepNames": ["golang"],
+      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Summary

- Refines the Go toolchain renovate rule to block only `major` and `minor` version upgrades, while allowing patch-only updates to flow through
- Applies the same refinement to the Docker `golang` base image rule

## Test plan

- [ ] Verify renovate picks up patch-level Go updates (e.g., `1.24.x → 1.24.y`) after merging
- [ ] Confirm major/minor upgrades (e.g., `1.24 → 1.25`) remain blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)