### PR TITLE
chore: move CI job logic into scripts/ci.sh and Taskfile tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+      - uses: arduino/setup-task@v2
         with:
-          version: v2.12.2
-          args: --timeout=5m
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run lint
+        run: task lint
 
   test-unit:
     name: Unit Tests
@@ -37,10 +39,13 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run unit tests
-        run: |
-          go test -v -race -coverprofile=coverage.out \
-            ./pkg/common/util/...
+        run: task ci:unittest
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6
@@ -66,29 +71,6 @@ jobs:
       - name: Build binary
         run: task build
 
-      - name: Verify binary
-        run: |
-          file bin/galactic
-          ./bin/galactic version
-
-  docker-build:
-    name: Docker Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Build image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: containers/galactic/Dockerfile
-          push: false
-          tags: ghcr.io/datum-cloud/galactic:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # Tier 2: Integration tests (main branch and releases)
   test-e2e:
     name: E2E Tests
@@ -107,21 +89,5 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Kind
-        run: |
-          go install sigs.k8s.io/kind@latest
-          kind version
-
-      - name: Create Kind cluster
-        run: |
-          kind create cluster --name galactic-e2e --wait 5m
-          kubectl cluster-info
-
-      - name: Build and load image
-        run: |
-          task docker-build IMG=galactic:e2e
-          kind load docker-image galactic:e2e --name galactic-e2e
-
-      - name: Cleanup
-        if: always()
-        run: kind delete cluster --name galactic-e2e
+      - name: Run E2E tests
+        run: task ci:e2etest

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -11,7 +11,7 @@ vars:
       [ -n "$gobin" ] && echo "$gobin" || echo "$(go env GOPATH)/bin"
   GOLANGCI_LINT: '{{.LOCALBIN}}/golangci-lint'
   GO_LICENSES: '{{.LOCALBIN}}/go-licenses'
-  GOLANGCI_LINT_VERSION: v2.1.6
+  GOLANGCI_LINT_VERSION: v2.12.2
   GO_LICENSES_VERSION: v1.6.0
 
 tasks:
@@ -37,10 +37,10 @@ tasks:
       - GOOS=linux go vet ./...
 
   test:
-    desc: Run tests
-    deps: [fmt, vet]
+    desc: Run unit and e2e tests
     cmds:
-      - GOOS=linux go test $(go list ./... | grep -v /e2e) -coverprofile cover.out
+      - task: ci:unittest
+      - task: ci:e2etest
 
   lint:
     desc: Run golangci-lint linter
@@ -69,6 +69,8 @@ tasks:
     deps: [fmt, vet]
     cmds:
       - go build -o bin/galactic cmd/galactic/main.go
+      - file bin/galactic
+      - ./bin/galactic version
 
   run-agent:
     desc: Run agent from your host
@@ -80,6 +82,20 @@ tasks:
     desc: Build docker image with the unified binary
     cmds:
       - '{{.CONTAINER_TOOL}} build -t {{.IMG}} -f containers/galactic/Dockerfile .'
+
+  ##
+  ## CI
+  ##
+
+  ci:unittest:
+    desc: Run unit tests with race detection and coverage output (mirrors CI)
+    cmds:
+      - bash scripts/ci.sh unittest
+
+  ci:e2etest:
+    desc: Run full e2e lifecycle — install Kind, create cluster, build+load image, cleanup
+    cmds:
+      - bash scripts/ci.sh e2etest
 
   ##
   ## Cleanup

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND="${1:-}"
+
+case "$COMMAND" in
+  unittest)
+    go test -v -race -coverprofile=coverage.out ./pkg/common/util/...
+    ;;
+
+  e2etest)
+    CLUSTER_NAME="${CLUSTER_NAME:-galactic-e2e}"
+    IMG="${IMG:-galactic:e2e}"
+
+    trap 'kind delete cluster --name "$CLUSTER_NAME"' EXIT
+
+    go install sigs.k8s.io/kind@latest
+    kind create cluster --name "$CLUSTER_NAME" --wait 5m
+    kubectl cluster-info
+    docker build -t "$IMG" -f containers/galactic/Dockerfile .
+    kind load docker-image "$IMG" --name "$CLUSTER_NAME"
+    ;;
+
+  *)
+    echo "Usage: $0 {unittest|e2etest}"
+    exit 1
+    ;;
+esac

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Local testing script for Galactic
 # Runs tests in Docker to ensure Linux compatibility
 
-set -e
+set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 IMAGE="golang:1.24"
@@ -11,39 +11,16 @@ echo "=== Galactic Local Test Runner ==="
 echo "Repository: $REPO_ROOT"
 echo ""
 
-# Parse arguments
 TEST_TYPE="${1:-unit}"
 
 case "$TEST_TYPE" in
   unit)
-    echo "Running unit tests (no K8s required)..."
+    echo "Running unit tests..."
     docker run --rm \
       -v "$REPO_ROOT":/workspace \
       -w /workspace \
       "$IMAGE" \
-      go test -v \
-        ./internal/operator/identifier/... \
-        ./internal/operator/cniconfig/... \
-        ./pkg/common/util/...
-    ;;
-
-  operator)
-    echo "Running operator tests with envtest..."
-    docker run --rm \
-      -v "$REPO_ROOT":/workspace \
-      -w /workspace \
-      "$IMAGE" \
-      sh -c '
-        # Install setup-envtest
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-
-        # Setup envtest binaries
-        KUBEBUILDER_ASSETS=$(setup-envtest use 1.31.0 --bin-dir /workspace/bin/k8s -p path)
-        export KUBEBUILDER_ASSETS
-
-        # Run tests
-        go test -v ./internal/operator/...
-      '
+      go test -v -race ./pkg/common/util/...
     ;;
 
   build)
@@ -52,24 +29,16 @@ case "$TEST_TYPE" in
       -v "$REPO_ROOT":/workspace \
       -w /workspace \
       "$IMAGE" \
-      go build -o bin/galactic ./cmd/galactic/...
+      go build -o bin/galactic ./cmd/galactic/main.go
     echo "Binary built: bin/galactic"
     file "$REPO_ROOT/bin/galactic"
     ;;
 
-  all)
-    echo "Running all tests..."
-    "$0" unit
-    "$0" operator
-    ;;
-
   *)
-    echo "Usage: $0 {unit|operator|build|all}"
+    echo "Usage: $0 {unit|build}"
     echo ""
-    echo "  unit     - Run unit tests (fast, no K8s)"
-    echo "  operator - Run operator tests with envtest"
-    echo "  build    - Build the galactic binary"
-    echo "  all      - Run all tests"
+    echo "  unit   - Run unit tests with race detector"
+    echo "  build  - Build the galactic binary in Docker"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- Adds `scripts/ci.sh` with two sub-commands (`unittest`, `e2etest`) so CI logic is runnable locally via the same path as GitHub Actions
- Wires each sub-command to a `ci:unittest` / `ci:e2etest` Taskfile task; updates `task test` to invoke both in sequence
- Replaces `golangci-lint-action` and all inline shell in `ci.yml` with `task` calls; removes the no-dependency `docker-build` job and the now-redundant verify step (absorbed into `task build`)
- `e2etest` uses `trap`-based Kind cluster cleanup, eliminating the `if: always()` cleanup step
- Bumps `golangci-lint` from `v2.1.6` to `v2.12.2` to match what CI was already using
- Fixes stale `scripts/test-local.sh` references to removed `internal/operator` packages

## Test Plan

- [ ] `task lint` — passes with golangci-lint v2.12.2
- [ ] `task ci:unittest` — unit tests pass with race detector and coverage output
- [ ] `task build` — binary built, `file` and `version` verification included
- [ ] `bash scripts/ci.sh bad-arg` — exits 1 with usage line
- [ ] CI workflow jobs (lint, test-unit, build, test-e2e) run green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)