### PR TITLE
chore: upgrade GoBGP from v3.37.0 to v4.5.0

### DIFF
--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -6,7 +6,7 @@ vars:
   TOPO:
     sh: echo *.clab.yaml
   COSMOS_IMAGE: ghcr.io/milo-os/cosmos:latest
-  GOBGP_VERSION: "3.37.0"
+  GOBGP_VERSION: "4.5.0"
   GOBGP_IMAGE: gobgp:{{.GOBGP_VERSION}}
   FRR_VERSION: "10.6.1"
   FRR_IMAGE: frr:{{.FRR_VERSION}}

--- a/deploy/containerlab/containers/gobgp/Dockerfile
+++ b/deploy/containerlab/containers/gobgp/Dockerfile
@@ -9,5 +9,5 @@ RUN apk add --no-cache wget ca-certificates && \
 FROM alpine:3.20
 COPY --from=fetch /usr/local/bin/gobgpd /usr/local/bin/gobgpd
 COPY --from=fetch /usr/local/bin/gobgp /usr/local/bin/gobgp
-EXPOSE 50051 179
+EXPOSE 50051
 ENTRYPOINT ["gobgpd"]

--- a/deploy/containerlab/resources/overlay/base/daemonset.yaml
+++ b/deploy/containerlab/resources/overlay/base/daemonset.yaml
@@ -22,14 +22,7 @@ spec:
                     operator: DoesNotExist
       containers:
         - name: gobgp
-          image: gobgp:3.37.0
+          image: gobgp:4.5.0
           imagePullPolicy: Never
-          command:
-            - gobgpd
-            - --api-hosts
-            - :50051
-          securityContext:
-            capabilities:
-              add:
-                - NET_ADMIN
-                - NET_RAW
+          command: ["gobgpd"]
+          args: ["--api-hosts", ":50051", "--log-level", "debug"]


### PR DESCRIPTION
## Summary

- Bumps GoBGP version from `3.37.0` to `4.5.0` in `Taskfile.yaml` and the overlay `daemonset.yaml`
- Removes `NET_ADMIN`/`NET_RAW` capabilities from the GoBGP container (no longer needed in v4)
- Adds `--log-level debug` arg and removes the now-redundant `EXPOSE 179` from the Dockerfile

## Test plan

- [ ] Rebuild the GoBGP container image with `task build-gobgp` (or equivalent)
- [ ] Deploy the containerlab topology and verify GoBGP starts cleanly with v4
- [ ] Confirm BGP sessions establish and routes are exchanged as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)