### PR TITLE
chore: rename binary to galactic-cni and wire up e2e tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -68,9 +68,9 @@ tasks:
     desc: Build galactic binary
     deps: [fmt, vet]
     cmds:
-      - go build -o bin/galactic cmd/galactic/main.go
-      - file bin/galactic
-      - ./bin/galactic version
+      - go build -o bin/galactic-cni cmd/galactic/main.go
+      - file bin/galactic-cni
+      - ./bin/galactic-cni version
 
   docker-build:
     desc: Build docker image with the unified binary

--- a/containers/galactic/Dockerfile
+++ b/containers/galactic/Dockerfile
@@ -31,13 +31,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/cmd/version.GitCommit=${GIT_COMMIT} \
       -X go.datum.net/galactic/internal/cmd/version.GitTreeState=${GIT_TREE_STATE} \
       -X go.datum.net/galactic/internal/cmd/version.BuildDate=${BUILD_DATE}" \
-    -o galactic cmd/galactic/main.go
+    -o galactic-cni cmd/galactic/main.go
 
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/galactic .
+COPY --from=builder /workspace/galactic-cni .
 USER 65532:65532
 
-ENTRYPOINT ["/galactic"]
+ENTRYPOINT ["/galactic-cni"]

--- a/deploy/containerlab/containers/kindest-node-galactic/Dockerfile
+++ b/deploy/containerlab/containers/kindest-node-galactic/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.26 AS builder
 WORKDIR /src
 COPY . .
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/galactic cmd/galactic/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/galactic-cni cmd/galactic/main.go
 
 FROM kindest/node:${KINDEST_VER}
 
@@ -18,7 +18,7 @@ RUN apt-get update \
 
 WORKDIR /galactic
 
-COPY --from=builder /src/bin/galactic ./bin/galactic
+COPY --from=builder /src/bin/galactic-cni ./bin/galactic-cni
 COPY deploy/containerlab/resources/ ./resources/
 COPY --chmod=0755 deploy/containerlab/containers/kindest-node-galactic/scripts/ ./scripts/
 

--- a/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
+++ b/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
@@ -58,8 +58,8 @@ else # worker
   curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}.tgz" |tar xvfz - -C /opt/cni/bin
 
   # Galactic CNI plugin and agent
-  install -m 0755 /galactic/bin/galactic /opt/cni/bin/galactic
-  install -m 0755 /galactic/bin/galactic /usr/local/bin/galactic
+  install -m 0755 /galactic/bin/galactic-cni /opt/cni/bin/galactic-cni
+  install -m 0755 /galactic/bin/galactic-cni /usr/local/bin/galactic-cni
 
   # Bring up the transit-facing data-plane interface
   ip link set dev eth1 up

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -53,6 +53,9 @@ case "$COMMAND" in
 
     echo "--- Loading image into cluster"
     kind load docker-image "$IMG" --name "$CLUSTER_NAME"
+
+    echo "--- Running e2e tests"
+    IMG="$IMG" go test -v -timeout 10m ./tests/e2e/...
     ;;
 
   *)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,219 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package e2e contains end-to-end tests for the galactic binary running inside
+// a Kind cluster. The tests assume:
+//   - A Kind cluster named "galactic-e2e" (or $CLUSTER_NAME) is already running.
+//   - The image "galactic:e2e" (or $IMG) has already been loaded into the cluster.
+//   - kubectl is on PATH and its context points at that cluster.
+//
+// These preconditions are set up by the e2etest target in scripts/ci.sh.
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultImg      = "galactic:e2e"
+	podReadyTimeout = 60 * time.Second
+	podPollInterval = 2 * time.Second
+)
+
+func image() string {
+	if v := os.Getenv("IMG"); v != "" {
+		return v
+	}
+	return defaultImg
+}
+
+// TestMain verifies that kubectl is available and the cluster is reachable
+// before running any test. Any missing prerequisite skips the suite rather
+// than failing, so a plain `go test ./tests/e2e/...` without a cluster is a
+// no-op rather than a hard error.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		fmt.Fprintln(os.Stderr, "SKIP: kubectl not found in PATH")
+		os.Exit(0)
+	}
+	if out, err := kubectl("cluster-info"); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: cluster not reachable: %v\n%s\n", err, out)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+// TestGalacticBinaryVersion runs the galactic binary with the "version"
+// subcommand inside a pod and verifies the output contains the expected fields.
+func TestGalacticBinaryVersion(t *testing.T) {
+	name := "e2e-version-check"
+	t.Cleanup(func() { deletePod(t, name) })
+	deletePod(t, name) // remove any leftover from a prior run
+
+	_, err := kubectl(
+		"run", name,
+		"--image="+image(),
+		"--image-pull-policy=Never",
+		"--restart=Never",
+		"--command", "--",
+		"/galactic-cni", "version",
+	)
+	if err != nil {
+		t.Fatalf("kubectl run failed: %v", err)
+	}
+
+	if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
+		t.Fatalf("pod did not succeed: %v", err)
+	}
+
+	logs, err := kubectl("logs", name)
+	if err != nil {
+		t.Fatalf("kubectl logs failed: %v", err)
+	}
+
+	for _, field := range []string{"Galactic Version:", "Git Commit:", "Go Version:", "Platform:"} {
+		if !strings.Contains(logs, field) {
+			t.Errorf("expected %q in version output, got:\n%s", field, logs)
+		}
+	}
+}
+
+// TestCNIPluginVersionReport invokes the binary with CNI_COMMAND=VERSION, which
+// causes it to report the CNI spec versions it supports. The response must be
+// valid JSON containing a "cniVersion" key.
+func TestCNIPluginVersionReport(t *testing.T) {
+	name := "e2e-cni-version"
+	t.Cleanup(func() { deletePod(t, name) })
+	deletePod(t, name)
+
+	_, err := kubectl(
+		"run", name,
+		"--image="+image(),
+		"--image-pull-policy=Never",
+		"--restart=Never",
+		"--env=CNI_COMMAND=VERSION",
+		"--command", "--",
+		"/galactic-cni",
+	)
+	if err != nil {
+		t.Fatalf("kubectl run failed: %v", err)
+	}
+
+	if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
+		t.Fatalf("pod did not succeed: %v", err)
+	}
+
+	logs, err := kubectl("logs", name)
+	if err != nil {
+		t.Fatalf("kubectl logs failed: %v", err)
+	}
+
+	// The CNI version report is JSON; find the first '{'.
+	jsonStart := strings.Index(logs, "{")
+	if jsonStart == -1 {
+		t.Fatalf("no JSON found in CNI VERSION output:\n%s", logs)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(logs[jsonStart:]), &report); err != nil {
+		t.Fatalf("CNI VERSION output is not valid JSON: %v\noutput:\n%s", err, logs)
+	}
+	if _, ok := report["cniVersion"]; !ok {
+		t.Errorf("CNI VERSION response missing \"cniVersion\" key; got: %v", report)
+	}
+	if _, ok := report["supportedVersions"]; !ok {
+		t.Errorf("CNI VERSION response missing \"supportedVersions\" key; got: %v", report)
+	}
+}
+
+// TestKernelCapabilities verifies that the Kind node exposes the Linux kernel
+// features galactic depends on: VRF devices and SRv6 (SEG6) local routing.
+// These checks run as a privileged pod so they can interrogate the host kernel.
+func TestKernelCapabilities(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string // shell expression to run inside the privileged pod
+	}{
+		{
+			name:    "vrf_module",
+			command: "ip link add vrf-e2e-test type vrf table 9999 && ip link del vrf-e2e-test",
+		},
+		{
+			name:    "ipv6_enabled",
+			command: "test -f /proc/sys/net/ipv6/conf/all/disable_ipv6",
+		},
+		{
+			// seg6_local may be a loadable module or compiled into the kernel.
+			// When built-in, lsmod and /sys/module won't show it, but the
+			// seg6_enabled sysctl is present on any kernel with SEG6 support.
+			name:    "seg6_local_module",
+			command: "modprobe seg6_local 2>/dev/null || lsmod | grep -q seg6 || test -d /sys/module/seg6_local || test -f /proc/sys/net/ipv6/conf/all/seg6_enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := "e2e-kernel-" + strings.ReplaceAll(tt.name, "_", "-")
+			t.Cleanup(func() { deletePod(t, name) })
+			deletePod(t, name)
+
+			_, err := kubectl(
+				"run", name,
+				"--image=busybox:stable",
+				"--image-pull-policy=IfNotPresent",
+				"--restart=Never",
+				"--privileged",
+				"--command", "--",
+				"sh", "-c", tt.command,
+			)
+			if err != nil {
+				t.Fatalf("kubectl run failed: %v", err)
+			}
+
+			if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
+				// Fetch logs to aid debugging before failing.
+				if logs, logErr := kubectl("logs", name); logErr == nil && logs != "" {
+					t.Logf("pod logs:\n%s", logs)
+				}
+				t.Fatalf("kernel capability check %q failed: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+// kubectl runs kubectl with the given arguments and returns combined output.
+func kubectl(args ...string) (string, error) {
+	out, err := exec.Command("kubectl", args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// waitForPodPhase polls until the named pod reaches wantPhase or the timeout
+// expires. It returns an error describing the last observed phase on timeout.
+func waitForPodPhase(t *testing.T, name, wantPhase string, timeout time.Duration) error {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := kubectl("get", "pod", name, "-o", "jsonpath={.status.phase}")
+		if err == nil && out == wantPhase {
+			return nil
+		}
+		if out == "Failed" {
+			return fmt.Errorf("pod %s entered Failed phase", name)
+		}
+		time.Sleep(podPollInterval)
+	}
+	out, _ := kubectl("get", "pod", name, "-o", "jsonpath={.status.phase}")
+	return fmt.Errorf("timed out after %v waiting for phase %q; last phase: %q", timeout, wantPhase, out)
+}
+
+// deletePod removes a pod by name, ignoring not-found errors.
+func deletePod(t *testing.T, name string) {
+	t.Helper()
+	kubectl("delete", "pod", name, "--ignore-not-found", "--wait=false") //nolint:errcheck
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -152,8 +152,9 @@ func TestKernelCapabilities(t *testing.T) {
 			// seg6_local may be a loadable module or compiled into the kernel.
 			// When built-in, lsmod and /sys/module won't show it, but the
 			// seg6_enabled sysctl is present on any kernel with SEG6 support.
-			name:    "seg6_local_module",
-			command: "modprobe seg6_local 2>/dev/null || lsmod | grep -q seg6 || test -d /sys/module/seg6_local || test -f /proc/sys/net/ipv6/conf/all/seg6_enabled",
+			name: "seg6_local_module",
+			command: "modprobe seg6_local 2>/dev/null || lsmod | grep -q seg6 ||" +
+				" test -d /sys/module/seg6_local || test -f /proc/sys/net/ipv6/conf/all/seg6_enabled",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Renames the built binary from `galactic` to `galactic-cni` across all Dockerfiles, Taskfile, and the containerlab install script to better reflect its role as a CNI plugin
- Wires up e2e tests in `ci.sh` so they actually run in CI (the `go test` invocation was previously missing)
- Fixes the `TestKernelCapabilities/seg6_local_module` e2e test to detect SEG6 when it is compiled directly into the kernel (via the `seg6_enabled` sysctl) rather than only as a loadable module

## Test plan

- [x] `task test` passes all unit and e2e tests locally
- [x] `TestKernelCapabilities/seg6_local_module` now passes on kernels with `CONFIG_IPV6_SEG6_LWTUNNEL=y` (built-in, not a module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)