### PR TITLE
feat(lab): add iad route-reflector worker node to gvpc containerlab

### DIFF
--- a/cmd/galactic-agent/main.go
+++ b/cmd/galactic-agent/main.go
@@ -33,6 +33,8 @@ func newRootCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.MetricsAddr, "metrics-addr", ":8082", "Address to serve Prometheus metrics on")
 	cmd.Flags().StringVar(&opts.HealthAddr, "health-addr", ":8083", "Address to serve health/readiness probes on")
 	cmd.Flags().StringVar(&opts.NodeName, "node-name", "", "Override node name (default: NODE_NAME env var)")
+	cmd.Flags().StringVar(&opts.Plane, "plane", "overlay",
+		"BGP plane label published on the BGPProvider (e.g. overlay, overlay-rr)")
 	cmd.Flags().BoolVar(&opts.GoBGPEnabled, "gobgp-enabled", false,
 		"Enable embedded GoBGP and publish BGPProvider")
 	cmd.Flags().IntVar(&opts.GoBGPAPIPort, "gobgp-api-port", 50051,

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -59,15 +59,32 @@ tasks:
     desc: Build images and deploy the full lab end-to-end
     deps: [build, host-setup]
     cmds:
+      - task: "deploy:clusters"
       - task: "deploy:topology"
+      - task: "deploy:rename-rr"
       - task: "deploy:images"
       - task: "deploy:underlay"
       - task: "deploy:overlay"
 
+  "deploy:clusters":
+    desc: Create Kind clusters (sequential to avoid kubeadm contention during parallel clab deploy)
+    cmds:
+      - kind create cluster --name dfw --config node_files/dfw/config.yaml --image kindest/node:galactic
+      - kind create cluster --name sjc --config node_files/sjc/config.yaml --image kindest/node:galactic
+      - kind create cluster --name iad --config node_files/iad/config.yaml --image kindest/node:galactic
+      - kind export kubeconfig --name dfw --kubeconfig dfw.kubeconfig
+      - kind export kubeconfig --name sjc --kubeconfig sjc.kubeconfig
+      - kind export kubeconfig --name iad --kubeconfig iad.kubeconfig
+
   "deploy:topology":
-    desc: Deploy the ContainerLab topology (transit routers + Kind clusters)
+    desc: Deploy the ContainerLab topology (transit routers + ext-container wiring)
     cmds:
       - sudo containerlab deploy -t {{.TOPO}}
+
+  "deploy:rename-rr":
+    desc: Rename iad-worker2 to iad-worker-rr (kind does not support custom worker node names)
+    cmds:
+      - docker rename iad-worker2 iad-worker-rr
 
   "load-image":
     internal: true
@@ -83,17 +100,23 @@ tasks:
       - task: load-image
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: iad-worker}
       - task: load-image
+        vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: iad-worker-rr}
+      - task: load-image
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: sjc-worker}
       - task: load-image
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: dfw-worker}
       - task: load-image
         vars: {IMAGE: galactic-agent:latest, NODE: iad-worker}
       - task: load-image
+        vars: {IMAGE: galactic-agent:latest, NODE: iad-worker-rr}
+      - task: load-image
         vars: {IMAGE: galactic-agent:latest, NODE: sjc-worker}
       - task: load-image
         vars: {IMAGE: galactic-agent:latest, NODE: dfw-worker}
       - task: load-image
         vars: {IMAGE: "{{.COSMOS_IMAGE}}", NODE: iad-worker}
+      - task: load-image
+        vars: {IMAGE: "{{.COSMOS_IMAGE}}", NODE: iad-worker-rr}
       - task: load-image
         vars: {IMAGE: "{{.COSMOS_IMAGE}}", NODE: sjc-worker}
       - task: load-image
@@ -103,6 +126,9 @@ tasks:
     desc: Destroy the lab
     cmds:
       - sudo containerlab destroy -t {{.TOPO}} --cleanup
+      - kind delete cluster --name dfw || true
+      - kind delete cluster --name sjc || true
+      - kind delete cluster --name iad || true
 
   reload:
     desc: Full rebuild and redeploy

--- a/deploy/containerlab/gvpc.clab.yaml
+++ b/deploy/containerlab/gvpc.clab.yaml
@@ -16,25 +16,8 @@ topology:
   kinds:
     linux:
       image: frrouting/frr:latest
-    k8s-kind:
-      image: kindest/node:galactic
 
   nodes:
-    dfw:
-      kind: k8s-kind
-      startup-config: node_files/dfw/config.yaml
-      labels:
-        graph-group: kind-cluster
-        graph-level: 1
-        graph-icon: server
-        reload: disabled
-      mgmt-ipv4: 172.20.20.101
-      extras:
-        k8s_kind:
-          deploy:
-            wait: 0s
-            kubeconfig: dfw.kubeconfig
-
     dfw-control-plane:
       kind: ext-container
       labels:
@@ -74,21 +57,6 @@ topology:
         - ip link set lo-galactic up
         - ip -6 addr add 2001:db8:ff01:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
         - /galactic/scripts/install.sh
-
-    sjc:
-      kind: k8s-kind
-      startup-config: node_files/sjc/config.yaml
-      labels:
-        graph-group: kind-cluster
-        graph-level: 1
-        graph-icon: server
-        reload: disabled
-      mgmt-ipv4: 172.20.20.121
-      extras:
-        k8s_kind:
-          deploy:
-            wait: 0s
-            kubeconfig: sjc.kubeconfig
 
     sjc-control-plane:
       kind: ext-container
@@ -130,21 +98,6 @@ topology:
         - ip -6 addr add 2001:db8:ff02:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
         - /galactic/scripts/install.sh
 
-    iad:
-      kind: k8s-kind
-      startup-config: node_files/iad/config.yaml
-      labels:
-        graph-group: kind-cluster
-        graph-level: 1
-        graph-icon: server
-        reload: disabled
-      mgmt-ipv4: 172.20.20.111
-      extras:
-        k8s_kind:
-          deploy:
-            wait: 0s
-            kubeconfig: iad.kubeconfig
-
     iad-control-plane:
       kind: ext-container
       labels:
@@ -183,6 +136,25 @@ topology:
         - ip link add lo-galactic type dummy
         - ip link set lo-galactic up
         - ip -6 addr add 2001:db8:ff03:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
+        - /galactic/scripts/install.sh
+
+    iad-worker2:
+      kind: ext-container
+      labels:
+        cluster: iad
+        graph-group: kind-worker
+        graph-level: 1
+        graph-icon: server
+        platform: kind
+        reload: disabled
+        worker-index: "2"
+      mgmt-ipv4: 172.20.20.114
+      sysctls:
+        fs.inotify.max_user_instances: "256"
+        net.ipv4.conf.all.arp_announce: "2"
+        net.ipv4.ip_forward: "1"
+        net.ipv6.conf.all.forwarding: "1"
+      exec:
         - /galactic/scripts/install.sh
 
     tr1:
@@ -238,6 +210,7 @@ topology:
     - endpoints: ["dfw-worker:eth1", "tr1:eth1"]
     - endpoints: ["sjc-worker:eth1", "tr2:eth1"]
     - endpoints: ["iad-worker:eth1", "tr3:eth5"]
+    - endpoints: ["iad-worker2:eth1", "tr3:eth4"]
 
     # TR full mesh (iBGP within AS 65100)
     - endpoints: ["tr1:eth2", "tr2:eth2"]

--- a/deploy/containerlab/node_files/iad/config.yaml
+++ b/deploy/containerlab/node_files/iad/config.yaml
@@ -5,5 +5,18 @@ nodes:
   - role: worker
     labels:
       topology.kubernetes.io/region: iad
+      galactic.io/role: pop
+  - role: worker
+    labels:
+      topology.kubernetes.io/region: iad
+      galactic.io/role: route-reflector
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          taints:
+            - key: galactic.io/role
+              value: route-reflector
+              effect: NoSchedule
 networking:
   disableDefaultCNI: true

--- a/deploy/containerlab/node_files/tr3/frr.conf
+++ b/deploy/containerlab/node_files/tr3/frr.conf
@@ -18,8 +18,11 @@ interface eth3
  description tr4-facing
  ipv6 address 2001:db8:0:34::3/64
 !
+interface eth4
+ description iad-rr-worker-facing
+!
 interface eth5
- description infra-worker-facing
+ description iad-worker-facing
 !
 router bgp 65100
  bgp router-id 10.255.255.102
@@ -29,6 +32,7 @@ router bgp 65100
  neighbor eth1 interface remote-as 65100
  neighbor eth2 interface remote-as 65100
  neighbor eth3 interface remote-as 65100
+ neighbor eth4 interface remote-as 65000
  neighbor eth5 interface remote-as 65000
  !
  address-family ipv6 unicast
@@ -38,6 +42,7 @@ router bgp 65100
   neighbor eth2 next-hop-self
   neighbor eth3 activate
   neighbor eth3 next-hop-self
+  neighbor eth4 activate
   neighbor eth5 activate
   network fc00:0:6::1/128
  exit-address-family

--- a/deploy/containerlab/resources/bgp/dfw/bgpinstance.yaml
+++ b/deploy/containerlab/resources/bgp/dfw/bgpinstance.yaml
@@ -7,6 +7,7 @@ spec:
     matchLabels:
       galactic.io/plane: overlay
   asNumber: 65000
+  listenPort: 1790
   routerIDSource: Manual
   routerID: "10.255.255.2"
   addressFamilies:

--- a/deploy/containerlab/resources/bgp/dfw/bgppeer.yaml
+++ b/deploy/containerlab/resources/bgp/dfw/bgppeer.yaml
@@ -1,13 +1,13 @@
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: overlay-to-dfw
+  name: overlay-to-rr
 spec:
   instanceRef: overlay
   providerSelector:
     matchLabels:
       galactic.io/plane: overlay
-  address: "fc00:0:4::1"
+  address: "fc00:0:8::1"
   asNumber: 65000
   remotePort: 1179
   addressFamilies:

--- a/deploy/containerlab/resources/bgp/iad/bgpinstance-rr.yaml
+++ b/deploy/containerlab/resources/bgp/iad/bgpinstance-rr.yaml
@@ -1,15 +1,17 @@
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPInstance
 metadata:
-  name: overlay
+  name: overlay-rr
 spec:
   providerSelector:
     matchLabels:
-      galactic.io/plane: overlay
+      galactic.io/plane: overlay-rr
   asNumber: 65000
-  listenPort: 1790
   routerIDSource: Manual
-  routerID: "10.255.255.1"
+  routerID: "10.255.255.4"
   addressFamilies:
     - afi: L2VPN
       safi: EVPN
+  listenPort: 1179
+  routeReflector:
+    clusterID: "10.255.255.4"

--- a/deploy/containerlab/resources/bgp/iad/bgppeer-rr.yaml
+++ b/deploy/containerlab/resources/bgp/iad/bgppeer-rr.yaml
@@ -1,0 +1,50 @@
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeer
+metadata:
+  name: overlay-rr-to-dfw
+spec:
+  instanceRef: overlay-rr
+  providerSelector:
+    matchLabels:
+      galactic.io/plane: overlay-rr
+  address: "fc00:0:2::1"
+  asNumber: 65000
+  passive: true
+  routeReflectorClient: true
+  addressFamilies:
+    - afi: L2VPN
+      safi: EVPN
+---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeer
+metadata:
+  name: overlay-rr-to-sjc
+spec:
+  instanceRef: overlay-rr
+  providerSelector:
+    matchLabels:
+      galactic.io/plane: overlay-rr
+  address: "fc00:0:3::1"
+  asNumber: 65000
+  passive: true
+  routeReflectorClient: true
+  addressFamilies:
+    - afi: L2VPN
+      safi: EVPN
+---
+apiVersion: bgp.miloapis.com/v1alpha1
+kind: BGPPeer
+metadata:
+  name: overlay-rr-to-iad
+spec:
+  instanceRef: overlay-rr
+  providerSelector:
+    matchLabels:
+      galactic.io/plane: overlay-rr
+  address: "fc00:0:4::1"
+  asNumber: 65000
+  passive: true
+  routeReflectorClient: true
+  addressFamilies:
+    - afi: L2VPN
+      safi: EVPN

--- a/deploy/containerlab/resources/bgp/iad/bgppeer.yaml
+++ b/deploy/containerlab/resources/bgp/iad/bgppeer.yaml
@@ -1,33 +1,15 @@
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: overlay-to-iad
+  name: overlay-to-rr
 spec:
   instanceRef: overlay
   providerSelector:
     matchLabels:
       galactic.io/plane: overlay
-  address: "fc00:0:2::1"
+  address: "fc00:0:8::1"
   asNumber: 65000
-  passive: true
-  routeReflectorClient: true
-  addressFamilies:
-    - afi: L2VPN
-      safi: EVPN
----
-apiVersion: bgp.miloapis.com/v1alpha1
-kind: BGPPeer
-metadata:
-  name: overlay-to-sjc
-spec:
-  instanceRef: overlay
-  providerSelector:
-    matchLabels:
-      galactic.io/plane: overlay
-  address: "fc00:0:3::1"
-  asNumber: 65000
-  passive: true
-  routeReflectorClient: true
+  remotePort: 1179
   addressFamilies:
     - afi: L2VPN
       safi: EVPN

--- a/deploy/containerlab/resources/bgp/sjc/bgpinstance.yaml
+++ b/deploy/containerlab/resources/bgp/sjc/bgpinstance.yaml
@@ -7,6 +7,7 @@ spec:
     matchLabels:
       galactic.io/plane: overlay
   asNumber: 65000
+  listenPort: 1790
   routerIDSource: Manual
   routerID: "10.255.255.3"
   addressFamilies:

--- a/deploy/containerlab/resources/bgp/sjc/bgppeer.yaml
+++ b/deploy/containerlab/resources/bgp/sjc/bgppeer.yaml
@@ -1,13 +1,13 @@
 apiVersion: bgp.miloapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: overlay-to-dfw
+  name: overlay-to-rr
 spec:
   instanceRef: overlay
   providerSelector:
     matchLabels:
       galactic.io/plane: overlay
-  address: "fc00:0:4::1"
+  address: "fc00:0:8::1"
   asNumber: 65000
   remotePort: 1179
   addressFamilies:

--- a/deploy/containerlab/resources/overlay/base/daemonset.yaml
+++ b/deploy/containerlab/resources/overlay/base/daemonset.yaml
@@ -32,6 +32,7 @@ spec:
             - --metrics-addr=:8082
             - --health-addr=:8083
             - --grpc-health-port=8084
+            - --plane=overlay
           env:
             - name: NODE_NAME
               valueFrom:

--- a/deploy/containerlab/resources/overlay/iad/daemonset/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/iad/daemonset/daemonset-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: overlay
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.io/role
+                    operator: In
+                    values:
+                      - pop

--- a/deploy/containerlab/resources/overlay/iad/daemonset/kustomization.yaml
+++ b/deploy/containerlab/resources/overlay/iad/daemonset/kustomization.yaml
@@ -3,3 +3,8 @@ namespace: galactic-system
 resources:
   - ../../base
   - namespace.yaml
+patches:
+  - path: daemonset-patch.yaml
+    target:
+      kind: DaemonSet
+      name: overlay

--- a/deploy/containerlab/resources/overlay/iad/kustomization.yaml
+++ b/deploy/containerlab/resources/overlay/iad/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - daemonset
+  - rr
   - nad.yaml

--- a/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: overlay
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: overlay-rr
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: overlay-rr
+    spec:
+      tolerations:
+        - key: galactic.io/role
+          value: route-reflector
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: galactic.io/role
+                    operator: In
+                    values:
+                      - route-reflector
+      containers:
+        - name: galactic-agent
+          args:
+            - --gobgp-enabled=true
+            - --gobgp-api-port=50052
+            - --gobgp-log-level=debug
+            - --metrics-addr=:9085
+            - --health-addr=:9086
+            - --grpc-health-port=9087
+            - --plane=overlay-rr
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9086
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9086

--- a/deploy/containerlab/resources/overlay/iad/rr/kustomization.yaml
+++ b/deploy/containerlab/resources/overlay/iad/rr/kustomization.yaml
@@ -1,11 +1,9 @@
-namePrefix: iad-
+namePrefix: iad-rr-
 namespace: galactic-system
 resources:
-  - ../base
-  - namespace.yaml
-  - configmap.yaml
+  - ../../base
 patches:
   - path: daemonset-patch.yaml
     target:
       kind: DaemonSet
-      name: underlay
+      name: overlay

--- a/deploy/containerlab/resources/overlay/iad/rr/namespace.yaml
+++ b/deploy/containerlab/resources/overlay/iad/rr/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: galactic-system

--- a/deploy/containerlab/resources/underlay/iad-rr/configmap.yaml
+++ b/deploy/containerlab/resources/underlay/iad-rr/configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: underlay-config
+  namespace: galactic-system
+data:
+  daemons: |
+    zebra=yes
+    bgpd=yes
+    ospfd=no
+    ospf6d=no
+    ripd=no
+    ripngd=no
+    isisd=no
+    pimd=no
+    ldpd=no
+    nhrpd=no
+    eigrpd=no
+    babeld=no
+    sharpd=no
+    pbrd=no
+    bfdd=no
+    fabricd=no
+    vrrpd=no
+    pathd=no
+
+    vtysh_enable=yes
+    zebra_options="  -A 127.0.0.1 -s 90000000"
+    bgpd_options="  -A 127.0.0.1"
+  frr.conf: |
+    frr version 9.1
+    frr defaults traditional
+    hostname iad-rr-underlay
+    log syslog informational
+
+    interface lo
+     ! /48 provides a reachable address for GoBGP peers to connect to on port 1179.
+     ipv6 address fc00:0:8::1/48
+    !
+    interface eth1
+     description tr3-facing
+    !
+
+    router bgp 65000
+     bgp router-id 10.255.255.4
+     no bgp default ipv4-unicast
+     no bgp ebgp-requires-policy
+     bgp log-neighbor-changes
+     neighbor eth1 interface remote-as 65100
+     !
+     address-family ipv6 unicast
+      neighbor eth1 activate
+      neighbor eth1 allowas-in 1
+      network fc00:0:8::/48
+     exit-address-family
+    !
+
+    ipv6 forwarding
+  vtysh.conf: |
+    service integrated-vtysh-config

--- a/deploy/containerlab/resources/underlay/iad-rr/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/underlay/iad-rr/daemonset-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: underlay
+spec:
+  template:
+    spec:
+      tolerations:
+        - key: galactic.io/role
+          value: route-reflector
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.io/role
+                    operator: In
+                    values:
+                      - route-reflector

--- a/deploy/containerlab/resources/underlay/iad-rr/kustomization.yaml
+++ b/deploy/containerlab/resources/underlay/iad-rr/kustomization.yaml
@@ -1,4 +1,4 @@
-namePrefix: iad-
+namePrefix: iad-rr-
 namespace: galactic-system
 resources:
   - ../base

--- a/deploy/containerlab/resources/underlay/iad-rr/namespace.yaml
+++ b/deploy/containerlab/resources/underlay/iad-rr/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: galactic-system

--- a/deploy/containerlab/resources/underlay/iad/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/underlay/iad/daemonset-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: underlay
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.io/role
+                    operator: In
+                    values:
+                      - pop

--- a/deploy/containerlab/scripts/install-overlay.sh
+++ b/deploy/containerlab/scripts/install-overlay.sh
@@ -37,4 +37,10 @@ deploy_cosmos dfw-control-plane
 deploy_cosmos sjc-control-plane
 deploy_cosmos iad-control-plane
 
+# iad hosts the overlay-rr BGPInstance (route reflector), which requires infra role.
+echo "Patching cosmos clusterRole to infra on iad-control-plane..."
+docker exec iad-control-plane kubectl patch configmap cosmos-config \
+  -n cosmos-system --type=merge -p '{"data":{"clusterRole":"infra"}}'
+docker exec iad-control-plane kubectl rollout restart daemonset bgp -n bgp-system
+
 echo "Done."

--- a/deploy/containerlab/scripts/install-underlay.sh
+++ b/deploy/containerlab/scripts/install-underlay.sh
@@ -13,7 +13,8 @@ apply() {
 }
 
 apply iad-control-plane   iad
+apply iad-control-plane   iad-rr
 apply sjc-control-plane   sjc
-apply dfw-control-plane dfw
+apply dfw-control-plane   dfw
 
 echo "Done."

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -44,6 +44,7 @@ type Options struct {
 	MetricsAddr    string
 	HealthAddr     string
 	NodeName       string
+	Plane          string
 	GoBGPEnabled   bool
 	GoBGPAPIPort   int
 	GoBGPLogLevel  string
@@ -129,7 +130,7 @@ func Run(ctx context.Context, opts Options) error {
 			return fmt.Errorf("create bootstrap client: %w", err)
 		}
 		if opts.NodeName != "" {
-			if err := bootstrap.EnsureGoBGPProvider(ctx, directClient, opts.NodeName, gobgpSrv.Addr()); err != nil {
+			if err := bootstrap.EnsureGoBGPProvider(ctx, directClient, opts.NodeName, opts.Plane, gobgpSrv.Addr()); err != nil {
 				return fmt.Errorf("bootstrap gobgp provider: %w", err)
 			}
 		}
@@ -139,7 +140,7 @@ func Run(ctx context.Context, opts Options) error {
 			deleteCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if opts.NodeName != "" {
-				if err := bootstrap.DeleteGoBGPProvider(deleteCtx, directClient, opts.NodeName); err != nil {
+				if err := bootstrap.DeleteGoBGPProvider(deleteCtx, directClient, opts.NodeName, opts.Plane); err != nil {
 					slog.Error("failed to delete BGPProvider on shutdown", "err", err)
 				}
 			}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -18,14 +18,15 @@ const (
 	labelPlane     = "galactic.io/plane"
 	labelDaemon    = "galactic.io/daemon"
 
-	managedByValue = "galactic-agent"
+	managedByValue  = "galactic-agent"
+	defaultPlane    = "overlay"
 )
 
 // providerName returns the BGPProvider resource name for this node and plane.
 // The default "overlay" plane uses the short form for compatibility with existing
 // deployments; additional planes append a suffix.
 func providerName(nodeName, plane string) string {
-	if plane == "" || plane == "overlay" {
+	if plane == "" || plane == defaultPlane {
 		return fmt.Sprintf("galactic-gobgp-%s", nodeName)
 	}
 	return fmt.Sprintf("galactic-gobgp-%s-%s", nodeName, plane)
@@ -35,7 +36,7 @@ func providerName(nodeName, plane string) string {
 // Idempotent — safe to call on every startup.
 func EnsureGoBGPProvider(ctx context.Context, c client.Client, nodeName, plane, endpoint string) error {
 	if plane == "" {
-		plane = "overlay"
+		plane = defaultPlane
 	}
 
 	obj := &providersv1alpha1.BGPProvider{}

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -18,8 +18,8 @@ const (
 	labelPlane     = "galactic.io/plane"
 	labelDaemon    = "galactic.io/daemon"
 
-	managedByValue  = "galactic-agent"
-	defaultPlane    = "overlay"
+	managedByValue = "galactic-agent"
+	defaultPlane   = "overlay"
 )
 
 // providerName returns the BGPProvider resource name for this node and plane.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -21,16 +21,25 @@ const (
 	managedByValue = "galactic-agent"
 )
 
-// providerName returns the BGPProvider resource name for this node.
-func providerName(nodeName string) string {
-	return fmt.Sprintf("galactic-gobgp-%s", nodeName)
+// providerName returns the BGPProvider resource name for this node and plane.
+// The default "overlay" plane uses the short form for compatibility with existing
+// deployments; additional planes append a suffix.
+func providerName(nodeName, plane string) string {
+	if plane == "" || plane == "overlay" {
+		return fmt.Sprintf("galactic-gobgp-%s", nodeName)
+	}
+	return fmt.Sprintf("galactic-gobgp-%s-%s", nodeName, plane)
 }
 
 // EnsureGoBGPProvider creates or updates the BGPProvider resource for this node.
 // Idempotent — safe to call on every startup.
-func EnsureGoBGPProvider(ctx context.Context, c client.Client, nodeName, endpoint string) error {
+func EnsureGoBGPProvider(ctx context.Context, c client.Client, nodeName, plane, endpoint string) error {
+	if plane == "" {
+		plane = "overlay"
+	}
+
 	obj := &providersv1alpha1.BGPProvider{}
-	obj.Name = providerName(nodeName)
+	obj.Name = providerName(nodeName, plane)
 
 	_, err := controllerutil.CreateOrUpdate(ctx, c, obj, func() error {
 		if obj.Labels == nil {
@@ -38,7 +47,7 @@ func EnsureGoBGPProvider(ctx context.Context, c client.Client, nodeName, endpoin
 		}
 		obj.Labels[labelNode] = nodeName
 		obj.Labels[labelManagedBy] = managedByValue
-		obj.Labels[labelPlane] = "overlay"
+		obj.Labels[labelPlane] = plane
 		obj.Labels[labelDaemon] = "gobgp"
 		obj.Spec = providersv1alpha1.BGPProviderSpec{
 			Type: "GoBGP",
@@ -54,12 +63,12 @@ func EnsureGoBGPProvider(ctx context.Context, c client.Client, nodeName, endpoin
 	return nil
 }
 
-// DeleteGoBGPProvider removes the BGPProvider resource for this node.
+// DeleteGoBGPProvider removes the BGPProvider resource for this node and plane.
 // Idempotent — safe to call even if the resource does not exist.
-func DeleteGoBGPProvider(ctx context.Context, c client.Client, nodeName string) error {
+func DeleteGoBGPProvider(ctx context.Context, c client.Client, nodeName, plane string) error {
 	obj := &providersv1alpha1.BGPProvider{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: providerName(nodeName),
+			Name: providerName(nodeName, plane),
 		},
 	}
 	if err := c.Delete(ctx, obj); client.IgnoreNotFound(err) != nil {

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -6,16 +6,19 @@ import (
 
 func TestProviderName(t *testing.T) {
 	cases := []struct {
-		node string
-		want string
+		node  string
+		plane string
+		want  string
 	}{
-		{"worker-1", "galactic-gobgp-worker-1"},
-		{"node-abc", "galactic-gobgp-node-abc"},
+		{"worker-1", "overlay", "galactic-gobgp-worker-1"},
+		{"worker-1", "", "galactic-gobgp-worker-1"},
+		{"node-abc", "overlay", "galactic-gobgp-node-abc"},
+		{"iad-rr-worker", "overlay-rr", "galactic-gobgp-iad-rr-worker-overlay-rr"},
 	}
 	for _, tc := range cases {
-		got := providerName(tc.node)
+		got := providerName(tc.node, tc.plane)
 		if got != tc.want {
-			t.Errorf("providerName(%q) = %q, want %q", tc.node, got, tc.want)
+			t.Errorf("providerName(%q, %q) = %q, want %q", tc.node, tc.plane, got, tc.want)
 		}
 	}
 }

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -10,9 +10,9 @@ func TestProviderName(t *testing.T) {
 		plane string
 		want  string
 	}{
-		{"worker-1", "overlay", "galactic-gobgp-worker-1"},
+		{"worker-1", defaultPlane, "galactic-gobgp-worker-1"},
 		{"worker-1", "", "galactic-gobgp-worker-1"},
-		{"node-abc", "overlay", "galactic-gobgp-node-abc"},
+		{"node-abc", defaultPlane, "galactic-gobgp-node-abc"},
 		{"iad-rr-worker", "overlay-rr", "galactic-gobgp-iad-rr-worker-overlay-rr"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Adds a dedicated `iad-worker-rr` node to the iad Kind cluster running galactic-agent in RR mode (overlay-rr plane) and FRR eBGP-connected to tr3; all POP overlay agents peer with the RR at `fc00:0:8::1:1179`
- Splits Kind cluster creation into a sequential `deploy:clusters` task separate from `clab deploy` to avoid kubeadm init failures under parallel resource contention
- Adds `--plane` flag to galactic-agent so the RR registers a distinct BGPProvider (`galactic-gobgp-<node>-overlay-rr`) without conflicting with the regular overlay provider; sets `listenPort: 1790` on all POP BGPInstances to avoid collision with FRR underlay holding port 179

## Key design decisions

- `k8s-kind` nodes removed from `gvpc.clab.yaml`; containerlab now only manages transit routers and ext-container wiring
- `iad-worker2` is renamed to `iad-worker-rr` via a `deploy:rename-rr` task because kind v0.32 does not support custom node names in v1alpha4
- RR overlay agent uses ports 9085/9086/9087 to avoid conflict with cosmos (which uses 8086/8087) on the same hostNetwork node
- `fc00:0:8::/48` was chosen for the RR's SRv6 prefix because `fc00:0:5::1` (the original assignment) conflicted with tr2's loopback address, causing all traffic to route to tr2 instead of iad-worker-rr

## Test plan

- [ ] `task destroy && task deploy` completes cleanly from scratch
- [ ] All three iBGP sessions establish: dfw-worker, sjc-worker, iad-worker → iad-worker-rr:1179
- [ ] `iad-rr-overlay` and `iad-rr-underlay` DaemonSets reach Ready on iad-worker-rr
- [ ] `task test` passes (bootstrap_test covers new plane-aware providerName logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)