### PR TITLE
fix(ci): run e2e tests on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,12 +71,11 @@ jobs:
       - name: Build binary
         run: task build
 
-  # Tier 2: Integration tests (main branch and releases)
+  # Tier 2: Integration tests (every PR, main branch, and releases)
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [lint, test-unit, build]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -16,6 +16,8 @@ case "$COMMAND" in
     trap 'kind delete cluster --name "$CLUSTER_NAME"' EXIT
 
     echo "--- Loading kernel modules required by galactic"
+    sudo apt-get update -qq
+    sudo apt-get install -y --no-install-recommends linux-modules-extra-azure
     sudo modprobe vrf
 
     echo "--- Installing kind"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -15,6 +15,9 @@ case "$COMMAND" in
 
     trap 'kind delete cluster --name "$CLUSTER_NAME"' EXIT
 
+    echo "--- Loading kernel modules required by galactic"
+    sudo modprobe vrf
+
     echo "--- Installing kind"
     go install sigs.k8s.io/kind@latest
 


### PR DESCRIPTION
## Summary

- Remove the `if:` condition that restricted the `test-e2e` job to `main` branch and tags only
- E2E tests now run on every PR after lint, unit tests, and build pass

## Test plan

- [ ] Open a PR and confirm the `E2E Tests` job appears and runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)