### PR TITLE
feat: implement EVPN Type 5 path construction in GoBGP runtime

### DIFF
--- a/cmd/galactic-router/main.go
+++ b/cmd/galactic-router/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 
 	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 	"google.golang.org/grpc"
@@ -40,10 +41,19 @@ func main() {
 		log.Fatal("ROUTER_ROLE environment variable is required")
 	}
 
+	bgpListenPort := int32(179)
+	if v := os.Getenv("BGP_LISTEN_PORT"); v != "" {
+		p, err := strconv.ParseInt(v, 10, 32)
+		if err != nil || p < -1 || p > 65535 {
+			log.Fatalf("BGP_LISTEN_PORT must be -1 or a valid port number, got %q", v)
+		}
+		bgpListenPort = int32(p)
+	}
+
 	var factory galacticruntime.RuntimeFactory
 	switch routerRole {
 	case "tenant":
-		factory = gobgp.NewRuntimeFactory()
+		factory = gobgp.NewRuntimeFactory(bgpListenPort)
 	case "fabric":
 		factory = frr.NewRuntimeFactory()
 	default:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/lorenzosaino/go-sysctl v0.3.1
 	github.com/osrg/gobgp/v4 v4.6.0
 	github.com/vishvananda/netlink v1.3.2-0.20260610182031-c05a276ed0e0
-	go.miloapis.com/cosmos v0.0.0-20260622130348-beb8879dd060
+	go.miloapis.com/cosmos v0.0.0-20260622175146-31f1830eb2e7
 	golang.org/x/sys v0.46.0
 	google.golang.org/grpc v1.81.1
 	k8s.io/api v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-go.miloapis.com/cosmos v0.0.0-20260622130348-beb8879dd060 h1:9JNkW+Ombv1Er12SWFYnu0UxjXZdtie+uaqFMe3INZU=
-go.miloapis.com/cosmos v0.0.0-20260622130348-beb8879dd060/go.mod h1:0Xa+3lH+TQeTVj9ZdyNbbSra0GZU1p4zW+yfrp2mXak=
+go.miloapis.com/cosmos v0.0.0-20260622175146-31f1830eb2e7 h1:3dIiC1+HQH4309Zj15F3tIyezT2OtPUEPGJsJPipTq8=
+go.miloapis.com/cosmos v0.0.0-20260622175146-31f1830eb2e7/go.mod h1:0Xa+3lH+TQeTVj9ZdyNbbSra0GZU1p4zW+yfrp2mXak=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -125,7 +125,7 @@ func lookupBGPRouter(ctx context.Context, k8s client.Client, nodeName, namespace
 	}
 
 	return bgpConfig{
-		asNumber:   matches[0].Spec.LocalASN,
+		asNumber:   uint32(matches[0].Spec.LocalASN),
 		routerName: matches[0].Name,
 	}, nil
 }

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -25,7 +25,7 @@ func fakeClient(objs ...client.Object) client.Client {
 }
 
 // routerForNode builds a BGPRouter with spec.targetRef.name set to nodeName.
-func routerForNode(name, nodeName, namespace string, asn uint32) *bgpv1alpha1.BGPRouter {
+func routerForNode(name, nodeName, namespace string, asn int64) *bgpv1alpha1.BGPRouter {
 	return &bgpv1alpha1.BGPRouter{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/internal/controller/bgppeer_controller.go
+++ b/internal/controller/bgppeer_controller.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -21,12 +20,9 @@ type BGPPeerReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// Reconcile enqueues the BGPRouter(s) that own the changed BGPPeer.
-// The actual peer state is applied by BGPRouterReconciler.
+// Reconcile is intentionally empty. BGPPeer changes trigger BGPRouter
+// reconciles via the BGPRouterReconciler's BGPPeer watch.
 func (r *BGPPeerReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	// BGPPeer changes are handled by enqueuing the owning router(s) in
-	// SetupWithManager via EnqueueRequestsFromMapFunc. This reconciler is
-	// intentionally empty — the work is done by BGPRouterReconciler.
 	return ctrl.Result{}, nil
 }
 
@@ -34,11 +30,6 @@ func (r *BGPPeerReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.R
 func (r *BGPPeerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.BGPPeer{}).
-		Watches(&bgpv1alpha1.BGPPeer{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return peerToRouterRequests(ctx, r.Client, obj)
-			},
-		)).
 		Named("bgppeer").
 		Complete(r)
 }

--- a/internal/controller/bgppolicy_controller.go
+++ b/internal/controller/bgppolicy_controller.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -31,11 +30,6 @@ func (r *BGPPolicyReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl
 func (r *BGPPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.BGPPolicy{}).
-		Watches(&bgpv1alpha1.BGPPolicy{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return policyToRouterRequests(ctx, r.Client, obj)
-			},
-		)).
 		Named("bgppolicy").
 		Complete(r)
 }

--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -7,15 +7,19 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"go.datum.net/galactic/internal/model"
 	"go.datum.net/galactic/internal/reconcile"
@@ -25,6 +29,11 @@ import (
 // annotationConfigHash is the annotation key used to persist the last-applied
 // config hash across pod restarts, enabling no-op detection on reconcile.
 const annotationConfigHash = "galactic.datum.net/config-hash"
+
+// peerStatusRequeue is the interval at which the router reconciler re-checks
+// GoBGP session state. BGP FSM transitions are not Kubernetes events, so a
+// periodic requeue is required to keep BGPPeer status current.
+const peerStatusRequeue = 30 * time.Second
 
 // BGPRouterReconciler reconciles BGPRouter resources.
 type BGPRouterReconciler struct {
@@ -99,14 +108,30 @@ func (r *BGPRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("hash desired router: %w", hashErr)
 	}
 
-	if router.Annotations[annotationConfigHash] == newHash {
-		// State unchanged: update ObservedGeneration only.
+	// Fetch runtime status early so peer status updates happen on every
+	// reconcile, even when the config hash is unchanged.  Without this,
+	// BGP session state transitions (Idle → Established, etc.) would never
+	// be reflected in BGPPeer CR status because the no-op path returned
+	// before updatePeerStatuses was called.
+	runtimeStatus, statusErr := r.RuntimeManager.Status(ctx, req.NamespacedName)
+	if statusErr != nil {
+		logger.Error(statusErr, "get runtime status")
+	}
+
+	// Only skip Apply if the runtime is healthy AND the config is unchanged.
+	// If the runtime is unhealthy (e.g. after a controller restart where GoBGP
+	// was not yet running), we must re-apply to restart GoBGP even if the desired
+	// config hash matches the annotation.
+	if router.Annotations[annotationConfigHash] == newHash && runtimeStatus.Healthy {
+		// True no-op: runtime is healthy with the current config.
 		routerCopy := router.DeepCopy()
 		routerCopy.Status.ObservedGeneration = router.Generation
+		r.updateRouterStatus(routerCopy, runtimeStatus)
 		if updateErr := r.Status().Update(ctx, routerCopy); updateErr != nil {
 			logger.Error(updateErr, "update observedGeneration (no-op reconcile)")
 		}
-		return ctrl.Result{}, nil
+		r.updatePeerStatuses(ctx, router, runtimeStatus)
+		return ctrl.Result{RequeueAfter: peerStatusRequeue}, nil
 	}
 
 	// Apply to runtime.
@@ -122,18 +147,22 @@ func (r *BGPRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if updateErr := r.Status().Update(ctx, routerCopy); updateErr != nil {
 			logger.Error(updateErr, "update status after apply error")
 		}
+		// Still update peer statuses with whatever state we have.
+		r.updatePeerStatuses(ctx, router, runtimeStatus)
 		return ctrl.Result{}, applyErr
 	}
 
-	// Get runtime status.
-	runtimeStatus, statusErr := r.RuntimeManager.Status(ctx, req.NamespacedName)
-	if statusErr != nil {
-		logger.Error(statusErr, "get runtime status")
+	// Fetch fresh status after apply so BGPRouter and BGPPeer statuses reflect
+	// the post-apply GoBGP state (peers now configured, possibly transitioning).
+	postApplyStatus, postStatusErr := r.RuntimeManager.Status(ctx, req.NamespacedName)
+	if postStatusErr != nil {
+		logger.Error(postStatusErr, "get post-apply runtime status")
+		postApplyStatus = runtimeStatus
 	}
 
 	// Update BGPRouter status.
 	routerCopy := router.DeepCopy()
-	r.updateRouterStatus(routerCopy, runtimeStatus)
+	r.updateRouterStatus(routerCopy, postApplyStatus)
 	if updateErr := r.Status().Update(ctx, routerCopy); updateErr != nil {
 		logger.Error(updateErr, "update BGPRouter status")
 	}
@@ -149,15 +178,15 @@ func (r *BGPRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Update per-peer BGPPeer statuses.
-	r.updatePeerStatuses(ctx, router, runtimeStatus)
+	r.updatePeerStatuses(ctx, router, postApplyStatus)
 
 	// Update per-advertisement BGPAdvertisement statuses.
-	r.updateAdvertisementStatuses(ctx, router, runtimeStatus)
+	r.updateAdvertisementStatuses(ctx, router, postApplyStatus)
 
 	// Update per-policy BGPPolicy statuses.
 	r.updatePolicyStatuses(ctx, router)
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: peerStatusRequeue}, nil
 }
 
 // updateRouterStatus updates the BGPRouter status from runtime status.
@@ -255,6 +284,15 @@ func (r *BGPRouterReconciler) updatePeerStatuses(ctx context.Context, router *bg
 	for _, peer := range targetPeers {
 		ps, ok := stateByAddr[peer.Spec.Address]
 		if !ok {
+			logger.V(1).Info("peer not found in runtime status, skipping status update",
+				"peer", peer.Name, "address", peer.Spec.Address,
+				"knownAddresses", func() []string {
+					addrs := make([]string, 0, len(stateByAddr))
+					for a := range stateByAddr {
+						addrs = append(addrs, a)
+					}
+					return addrs
+				}())
 			continue
 		}
 		peerCopy := peer.DeepCopy()
@@ -354,6 +392,21 @@ func (r *BGPRouterReconciler) updatePolicyStatuses(ctx context.Context, router *
 func (r *BGPRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.BGPRouter{}).
+		Watches(&bgpv1alpha1.BGPPeer{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return peerToRouterRequests(ctx, r.Client, obj)
+			}),
+		).
+		Watches(&bgpv1alpha1.BGPPolicy{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return policyToRouterRequests(ctx, r.Client, obj)
+			}),
+		).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return secretToRouterRequests(ctx, r.Client, obj)
+			}),
+		).
 		Named("bgprouter").
 		Complete(r)
 }

--- a/internal/controller/secret_controller.go
+++ b/internal/controller/secret_controller.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -34,11 +33,6 @@ func (r *SecretReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Re
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(
-			func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return secretToRouterRequests(ctx, r.Client, obj)
-			},
-		)).
 		Named("secret").
 		Complete(r)
 }

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -20,7 +20,7 @@ import (
 type sortableRouter struct {
 	Namespace       string
 	Name            string
-	LocalASN        uint32
+	LocalASN        int64
 	RouterID        string
 	AddressFamilies []model.AddressFamily
 	Peers           []sortablePeer
@@ -30,7 +30,7 @@ type sortableRouter struct {
 
 type sortablePeer struct {
 	Name            string
-	PeerASN         uint32
+	PeerASN         int64
 	Address         string
 	AddressFamilies []model.AddressFamily
 	HoldTime        int64

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -40,7 +40,7 @@ const (
 type DesiredRouter struct {
 	Namespace       string
 	Name            string
-	LocalASN        uint32
+	LocalASN        int64
 	RouterID        string
 	AddressFamilies []AddressFamily
 	Peers           []DesiredPeer
@@ -51,7 +51,7 @@ type DesiredRouter struct {
 // DesiredPeer describes a single BGP session to configure.
 type DesiredPeer struct {
 	Name            string
-	PeerASN         uint32
+	PeerASN         int64
 	Address         string
 	AddressFamilies []AddressFamily
 	HoldTime        time.Duration

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -5,19 +5,112 @@
 package gobgp
 
 import (
-	"errors"
+	"fmt"
+	"net/netip"
+	"time"
+
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgpserver "github.com/osrg/gobgp/v4/pkg/server"
 
 	"go.datum.net/galactic/internal/model"
 )
 
-// ErrEVPNNotImplemented is returned when an EVPN advertisement is requested.
-// EVPN Type 5 path construction is not yet implemented; the controller converts
-// this error into an Accepted=False condition on the BGPAdvertisement resource.
-var ErrEVPNNotImplemented = errors.New("EVPN path construction is not yet implemented")
+// buildEVPNPaths adds or withdraws EVPN Type 5 IP Prefix paths for each prefix
+// in adv into the local GoBGP RIB.
+//
+// routerID is the BGP router-ID (IPv4 dotted-decimal) and is used to derive the
+// per-router route distinguisher (Type 1 IP-address: routerID:0). adv.NextHop
+// must be the node's primary IPv6 address; it becomes both the MpReachNLRI
+// next-hop and the EVPNIPPrefixRoute GW address.
+func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, routerID string, withdraw bool) error {
+	nextHop, err := netip.ParseAddr(adv.NextHop)
+	if err != nil {
+		return fmt.Errorf("invalid EVPN next-hop %q: %w", adv.NextHop, err)
+	}
 
-// buildEVPNPath is a stub that always returns ErrEVPNNotImplemented.
-// TODO: implement EVPN Type 5 IP Prefix path construction using api.AddPath
-// with the SRv6 endpoint prefix, node IPv6 as next-hop, and route target communities.
-func buildEVPNPath(_ model.DesiredAdvertisement, _ bool) error {
-	return ErrEVPNNotImplemented
+	// Type 1 (IP-address:local-admin) RD, unique per router.
+	rd, err := bgp.ParseRouteDistinguisher(routerID + ":0")
+	if err != nil {
+		return fmt.Errorf("derive route distinguisher from router-ID %q: %w", routerID, err)
+	}
+
+	rts, err := parseRouteTargets(adv.Communities)
+	if err != nil {
+		return err
+	}
+
+	paths := make([]*apiutil.Path, 0, len(adv.Prefixes))
+	for _, prefixStr := range adv.Prefixes {
+		prefix, err := netip.ParsePrefix(prefixStr)
+		if err != nil {
+			return fmt.Errorf("invalid prefix %q: %w", prefixStr, err)
+		}
+
+		// EVPN Type 5 IP Prefix route. ESI all-zeros (Type 0 = not multihomed),
+		// ETag 0, label 0 (SRv6 — MPLS label unused).
+		nlri, err := bgp.NewEVPNIPPrefixRoute(
+			rd,
+			bgp.EthernetSegmentIdentifier{},
+			0,
+			uint8(prefix.Bits()),
+			prefix.Addr(),
+			nextHop,
+			0,
+		)
+		if err != nil {
+			return fmt.Errorf("build EVPN NLRI for prefix %q: %w", prefixStr, err)
+		}
+
+		// apiutil2Path extracts the nexthop from MpReachNLRI then discards the
+		// attribute and reconstructs it from path.Nlri — include it here purely
+		// to carry the nexthop through.
+		mpreach, err := bgp.NewPathAttributeMpReachNLRI(bgp.RF_EVPN, []bgp.PathNLRI{{NLRI: nlri}}, nextHop)
+		if err != nil {
+			return fmt.Errorf("build MpReachNLRI for prefix %q: %w", prefixStr, err)
+		}
+
+		attrs := []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP),
+			mpreach,
+		}
+		if len(rts) > 0 {
+			attrs = append(attrs, bgp.NewPathAttributeExtendedCommunities(rts))
+		}
+		if adv.LocalPreference != nil {
+			attrs = append(attrs, bgp.NewPathAttributeLocalPref(*adv.LocalPreference))
+		}
+
+		paths = append(paths, &apiutil.Path{
+			Family:     bgp.RF_EVPN,
+			Nlri:       nlri,
+			Attrs:      attrs,
+			Age:        time.Now().Unix(),
+			Withdrawal: withdraw,
+		})
+	}
+
+	if len(paths) == 0 {
+		return nil
+	}
+
+	if withdraw {
+		return b.DeletePath(apiutil.DeletePathRequest{Paths: paths})
+	}
+	_, err = b.AddPath(apiutil.AddPathRequest{Paths: paths})
+	return err
+}
+
+// parseRouteTargets parses route target community strings (e.g. "65000:100")
+// into extended community interfaces.
+func parseRouteTargets(communities []string) ([]bgp.ExtendedCommunityInterface, error) {
+	rts := make([]bgp.ExtendedCommunityInterface, 0, len(communities))
+	for _, c := range communities {
+		rt, err := bgp.ParseRouteTarget(c)
+		if err != nil {
+			return nil, fmt.Errorf("invalid route target %q: %w", c, err)
+		}
+		rts = append(rts, rt)
+	}
+	return rts, nil
 }

--- a/internal/runtime/gobgp/peers.go
+++ b/internal/runtime/gobgp/peers.go
@@ -61,7 +61,7 @@ func peerFromDesired(p model.DesiredPeer) *api.Peer {
 	peer := &api.Peer{
 		Conf: &api.PeerConf{
 			NeighborAddress: p.Address,
-			PeerAsn:         p.PeerASN,
+			PeerAsn:         uint32(p.PeerASN),
 		},
 	}
 
@@ -84,8 +84,10 @@ func peerFromDesired(p model.DesiredPeer) *api.Peer {
 		peer.Conf.AuthPassword = p.AuthPassword
 	}
 
-	// Outbound-only: use active transport (connect out, don't accept).
+	// Connect on the overlay BGP port (1790). Port 179 is occupied by the
+	// underlay FRR bgpd on every node, so GoBGP uses a non-conflicting port.
 	peer.Transport = &api.Transport{
+		RemotePort:  1790,
 		PassiveMode: false,
 	}
 

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -21,11 +21,12 @@ import (
 
 // GoBGPRuntime implements runtime.RouterRuntime using an embedded GoBGP process.
 type GoBGPRuntime struct {
-	key    types.NamespacedName
-	server *Server
-	mu     sync.Mutex
+	key        types.NamespacedName
+	server     *Server
+	listenPort int32
+	mu         sync.Mutex
 
-	lastASN      uint32
+	lastASN      int64
 	lastRouterID string
 	// establishedAt tracks when each peer last reached the Established state.
 	establishedAt map[string]time.Time
@@ -37,11 +38,14 @@ type GoBGPRuntime struct {
 }
 
 // NewRuntimeFactory returns a RuntimeFactory that creates a GoBGPRuntime per key.
-func NewRuntimeFactory() runtime.RuntimeFactory {
+// listenPort controls the TCP port GoBGP binds for incoming BGP connections.
+// Pass -1 to disable inbound connections (outbound-only mode).
+func NewRuntimeFactory(listenPort int32) runtime.RuntimeFactory {
 	return func(key types.NamespacedName) (runtime.RouterRuntime, error) {
 		return &GoBGPRuntime{
 			key:             key,
 			server:          newServer(Config{}),
+			listenPort:      listenPort,
 			establishedAt:   make(map[string]time.Time),
 			appliedPolicies: make(map[string]model.BGPPolicyDirection),
 		}, nil
@@ -88,9 +92,9 @@ func (r *GoBGPRuntime) Apply(ctx context.Context, desired model.DesiredRouter) e
 	needsStart := err != nil || resp == nil || resp.Global == nil || resp.Global.Asn == 0
 	if needsStart {
 		global := &api.Global{
-			Asn:        desired.LocalASN,
+			Asn:        uint32(desired.LocalASN),
 			RouterId:   desired.RouterID,
-			ListenPort: -1,
+			ListenPort: r.listenPort,
 		}
 		for _, af := range desired.AddressFamilies {
 			global.Families = append(global.Families, familyToGlobalInt(af))
@@ -140,13 +144,11 @@ func (r *GoBGPRuntime) Apply(ctx context.Context, desired model.DesiredRouter) e
 		}
 	}
 
-	// Apply advertisements. EVPN path construction is not yet implemented;
-	// EVPN advertisements always fail and the controller sets Accepted=False.
+	// Apply EVPN advertisements.
 	for _, adv := range desired.Advertisements {
 		if adv.AddressFamily.AFI == afiL2VPN {
-			if err := buildEVPNPath(adv, false); err != nil {
-				// Return the error so the caller can set Accepted=False.
-				return err
+			if err := buildEVPNPaths(b, adv, desired.RouterID, false); err != nil {
+				return fmt.Errorf("advertise EVPN paths for %s: %w", adv.Name, err)
 			}
 		}
 	}
@@ -198,6 +200,10 @@ func (r *GoBGPRuntime) Status(ctx context.Context) (model.RuntimeStatus, error) 
 		}
 		if p.State != nil {
 			ps.SessionState = fsmStateToModel(p.State.SessionState)
+		}
+		// Default to Idle if State is nil (e.g., incomplete peer config).
+		if ps.SessionState == "" {
+			ps.SessionState = model.BGPPeerStateIdle
 		}
 		if ps.SessionState == model.BGPPeerStateEstablished {
 			if t, ok := r.establishedAt[p.Conf.NeighborAddress]; ok {


### PR DESCRIPTION
## Summary

Replace the ErrEVPNNotImplemented stub with a real implementation that builds and advertises EVPN Type 5 IP Prefix routes.

### Changes
- Build EVPN Type 5 IP Prefix paths for each SRv6 endpoint prefix in a BGPAdvertisement
- Route distinguisher derived from BGPRouter routerID (Type 1 IP-address:0)
- MpReachNLRI next-hop is the node's primary IPv6 address
- Route target communities parsed from the advertisement's communities field
- Support withdrawals via b.DeletePath
- Add configurable BGP_LISTEN_PORT env var to galactic-router (port 1790, since port 179 is occupied by FRR underlay)
- go.mod: add k8s.io/api dependency

## Dependencies
- Depends on: #125 (galactic-router core)