### PR TITLE
refactor: align BGPPeer status with cosmos API v3 consolidated conditions

### DIFF
--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -258,16 +258,10 @@ func (r *BGPRouterReconciler) updatePeerStatuses(ctx context.Context, router *bg
 			continue
 		}
 		peerCopy := peer.DeepCopy()
-		setPeerSessionState(peerCopy, ps.SessionState)
+		setPeerReadyCondition(peerCopy, ps.SessionState, "Idle")
 		if ps.LastEstablishedTime != nil {
 			peerCopy.Status.LastEstablishedTime = ps.LastEstablishedTime
 		}
-		setPeerCondition(peerCopy, metav1.Condition{
-			Type:    ConditionReady,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Configured",
-			Message: "Peer is configured",
-		})
 		if updateErr := r.Status().Update(ctx, peerCopy); updateErr != nil {
 			logger.Error(updateErr, "update BGPPeer status", "peer", peer.Name)
 		}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -16,40 +16,12 @@ const (
 	ConditionReady         = "Ready"
 	ConditionConfigApplied = "ConfigApplied"
 
-	// BGPPeer FSM conditions (set by setPeerSessionState).
-	ConditionSessionIdle     = "SessionIdle"
-	ConditionSessionConnect  = "SessionConnect"
-	ConditionSessionActive   = "SessionActive"
-	ConditionSessionOpenSent = "SessionOpenSent"
-	ConditionSessionOpenCfm  = "SessionOpenConfirm"
-	ConditionSessionEstab    = "SessionEstablished"
-
 	// BGPAdvertisement conditions.
 	ConditionAdvertised = "Advertised"
 
 	// BGPPolicy conditions.
 	ConditionPolicyApplied = "PolicyApplied"
 )
-
-// fsmConditions is the ordered set of FSM session condition type names.
-var fsmConditions = []string{
-	ConditionSessionIdle,
-	ConditionSessionConnect,
-	ConditionSessionActive,
-	ConditionSessionOpenSent,
-	ConditionSessionOpenCfm,
-	ConditionSessionEstab,
-}
-
-// fsmStateToCondition maps a BGPPeerState to its corresponding condition name.
-var fsmStateToCondition = map[bgpv1alpha1.BGPPeerState]string{
-	bgpv1alpha1.BGPPeerStateIdle:        ConditionSessionIdle,
-	bgpv1alpha1.BGPPeerStateConnect:     ConditionSessionConnect,
-	bgpv1alpha1.BGPPeerStateActive:      ConditionSessionActive,
-	bgpv1alpha1.BGPPeerStateOpenSent:    ConditionSessionOpenSent,
-	bgpv1alpha1.BGPPeerStateOpenConfirm: ConditionSessionOpenCfm,
-	bgpv1alpha1.BGPPeerStateEstablished: ConditionSessionEstab,
-}
 
 // setRouterPhase sets the BGPRouter phase in status.
 func setRouterPhase(router *bgpv1alpha1.BGPRouter, phase bgpv1alpha1.BGPRouterPhase) {
@@ -63,33 +35,52 @@ func setRouterCondition(router *bgpv1alpha1.BGPRouter, condition metav1.Conditio
 	meta.SetStatusCondition(&router.Status.Conditions, condition)
 }
 
-// setPeerSessionState updates the BGPPeer session state and sets exactly one
-// FSM condition to True, all others to False.
-func setPeerSessionState(peer *bgpv1alpha1.BGPPeer, state bgpv1alpha1.BGPPeerState) {
+// setPeerReadyCondition updates the Ready condition based on the current BGP
+// FSM state, following the same semantics as the reference implementation in
+// the cosmos API (BGPPeerStatus.updatePeerConditions). Ready is True only when
+// sessionState == Established; False otherwise with Reason set to the FSM
+// state (for Idle, the idleReason argument is used).
+func setPeerReadyCondition(peer *bgpv1alpha1.BGPPeer, state bgpv1alpha1.BGPPeerState, idleReason string) {
 	peer.Status.SessionState = state
 	peer.Status.ObservedGeneration = peer.Generation
 
-	activeCondition := fsmStateToCondition[state]
-	for _, condType := range fsmConditions {
-		status := metav1.ConditionFalse
-		reason := "NotInState"
-		if condType == activeCondition {
-			status = metav1.ConditionTrue
-			reason = string(state)
-		}
-		meta.SetStatusCondition(&peer.Status.Conditions, metav1.Condition{
-			Type:               condType,
-			Status:             status,
-			ObservedGeneration: peer.Generation,
-			Reason:             reason,
-		})
+	cond := metav1.Condition{
+		Type:               bgpv1alpha1.ConditionTypeReady,
+		ObservedGeneration: peer.Generation,
 	}
-}
 
-// setPeerCondition sets or updates a condition on BGPPeer.
-func setPeerCondition(peer *bgpv1alpha1.BGPPeer, condition metav1.Condition) {
-	condition.ObservedGeneration = peer.Generation
-	meta.SetStatusCondition(&peer.Status.Conditions, condition)
+	switch state {
+	case bgpv1alpha1.BGPPeerStateEstablished:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "Established"
+		cond.Message = "BGP session is Established; address families negotiated."
+	case bgpv1alpha1.BGPPeerStateOpenConfirm:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "OpenConfirm"
+		cond.Message = "BGP session in OpenConfirm state, awaiting KEEPALIVE."
+	case bgpv1alpha1.BGPPeerStateOpenSent:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "OpenSent"
+		cond.Message = "BGP OPEN message sent, awaiting peer OPEN."
+	case bgpv1alpha1.BGPPeerStateActive:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "Active"
+		cond.Message = "BGP session Active, attempting to establish TCP connection."
+	case bgpv1alpha1.BGPPeerStateConnect:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "Connect"
+		cond.Message = "BGP session in Connect state, waiting for TCP connection."
+	case bgpv1alpha1.BGPPeerStateIdle:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = idleReason
+		cond.Message = "BGP session is Idle."
+	default:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "Unknown"
+		cond.Message = "BGP session is in unknown state " + string(state) + "."
+	}
+
+	meta.SetStatusCondition(&peer.Status.Conditions, cond)
 }
 
 // setAdvertisementCondition sets or updates a condition on BGPAdvertisement.


### PR DESCRIPTION
## Summary

Align BGPPeer status with the consolidated condition model from cosmos API v3.

### Changes
- Replace setPeerSessionState + setPeerCondition with setPeerReadyCondition
  that sets a single Ready condition using bgpv1alpha1.ConditionTypeReady
- Remove unused FSM condition constants (SessionIdle..SessionEstablished)
- Remove dead code: fsmConditions slice, fsmStateToCondition map
- Update go.mod for cosmos dependency bump

## Dependencies
- Depends on: #125 (galactic-router core)