### PR TITLE
feat: replace SRv6 endpoint routing with IPAM-managed pod subnet alloc

### DIFF
--- a/containers/galactic/Dockerfile
+++ b/containers/galactic/Dockerfile
@@ -28,11 +28,17 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE}" \
     -o galactic-cni cmd/galactic-cni/main.go
 
+# Create the IPAM state directory in the builder (where /bin/sh exists)
+# so it can be copied into the final distroless image.
+RUN mkdir -p /var/run/galactic-cni && chmod 777 /var/run/galactic-cni
+
 # Use distroless as minimal base image to package the binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
+
 COPY --from=builder /workspace/galactic-cni .
+COPY --from=builder /var/run/galactic-cni /var/run/galactic-cni
 USER 65532:65532
 
 # Default entrypoint is the CNI plugin (invoked by CNI runtime).

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -50,7 +50,7 @@ tasks:
       - task: "deploy:overlay"
 
   "deploy:clusters":
-    desc: Create Kind clusters (sequential to avoid kubeadm contention during parallel clab deploy)
+    desc: Create Kind clusters
     cmds:
       - kind create cluster --name dfw --config node_files/dfw/config.yaml --image kindest/node:galactic
       - kind create cluster --name sjc --config node_files/sjc/config.yaml --image kindest/node:galactic
@@ -65,7 +65,7 @@ tasks:
       - sudo containerlab deploy -t {{.TOPO}}
 
   "deploy:rename-rr":
-    desc: Rename iad-worker2 to iad-worker-rr (kind does not support custom worker node names)
+    desc: Rename iad-worker2 to iad-worker-rr
     cmds:
       - docker rename iad-worker2 iad-worker-rr
 
@@ -135,6 +135,11 @@ tasks:
     desc: Install the galactic-router overlay DaemonSets
     cmds:
       - ./scripts/install-overlay.sh
+
+  "deploy:testvpc":
+    desc: Deploy test VPC across all clusters
+    cmds:
+      - ./scripts/install-testvpc.sh
 
   test:
     desc: Run all verification checks

--- a/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
+++ b/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
@@ -58,8 +58,18 @@ else # worker
   curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}.tgz" |tar xvfz - -C /opt/cni/bin
 
   # Galactic CNI plugin and agent
-  install -m 0755 /galactic/bin/galactic-cni /opt/cni/bin/galactic-cni
+  # Install the binary under a .bin suffix and front it with a wrapper that
+  # exports NODE_NAME from the container hostname. CNI binaries are exec'd
+  # directly by the kubelet and do not inherit NODE_NAME from the pod downward
+  # API; in Kind the container hostname equals the Kubernetes node name.
+  install -m 0755 /galactic/bin/galactic-cni /opt/cni/bin/galactic-cni.bin
   install -m 0755 /galactic/bin/galactic-cni /usr/local/bin/galactic-cni
+  cat > /opt/cni/bin/galactic-cni <<'EOF'
+#!/bin/sh
+export NODE_NAME=$(hostname)
+exec /opt/cni/bin/galactic-cni.bin "$@"
+EOF
+  chmod 0755 /opt/cni/bin/galactic-cni
 
   # Bring up the transit-facing data-plane interface
   ip link set dev eth1 up

--- a/deploy/containerlab/resources/testvpc/dfw/nad.yaml
+++ b/deploy/containerlab/resources/testvpc/dfw/nad.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: testvpc
+  namespace: vpc
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "testvpc",
+      "type": "galactic-cni",
+      "vpc": "10",
+      "vpcattachment": "10",
+      "namespace": "galactic-system",
+      "srv6_locator": "2001:db8:ff01::/48",
+      "ipam": {
+        "type": "pool",
+        "pool": "fd00:10:ff01::/48",
+        "gateway": "fd00:10:ff01::1",
+        "subnet_len": 80
+      }
+    }

--- a/deploy/containerlab/resources/testvpc/dfw/nginx.yaml
+++ b/deploy/containerlab/resources/testvpc/dfw/nginx.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: vpc
+  labels:
+    app: nginx
+    site: dfw
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        site: dfw
+      annotations:
+        k8s.v1.cni.cncf.io/networks: testvpc
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: multitool
+          image: wbitt/network-multitool
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http

--- a/deploy/containerlab/resources/testvpc/iad/nad.yaml
+++ b/deploy/containerlab/resources/testvpc/iad/nad.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: testvpc
+  namespace: vpc
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "testvpc",
+      "type": "galactic-cni",
+      "vpc": "10",
+      "vpcattachment": "10",
+      "namespace": "galactic-system",
+      "srv6_locator": "2001:db8:ff03::/48",
+      "ipam": {
+        "type": "pool",
+        "pool": "fd00:10:ff03::/48",
+        "gateway": "fd00:10:ff03::1",
+        "subnet_len": 80
+      }
+    }

--- a/deploy/containerlab/resources/testvpc/iad/nginx.yaml
+++ b/deploy/containerlab/resources/testvpc/iad/nginx.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: vpc
+  labels:
+    app: nginx
+    site: iad
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        site: iad
+      annotations:
+        k8s.v1.cni.cncf.io/networks: testvpc
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: multitool
+          image: wbitt/network-multitool
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http

--- a/deploy/containerlab/resources/testvpc/rbac.yaml
+++ b/deploy/containerlab/resources/testvpc/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: galactic-cni
+  namespace: galactic-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-cni
+rules:
+  - apiGroups: ["bgp.miloapis.com"]
+    resources:
+      - bgprouters
+    verbs: ["get", "list"]
+  - apiGroups: ["bgp.miloapis.com"]
+    resources:
+      - bgpadvertisements
+      - bgpvrfinstances
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: galactic-cni
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galactic-cni
+subjects:
+  - kind: ServiceAccount
+    name: galactic-cni
+    namespace: galactic-system

--- a/deploy/containerlab/resources/testvpc/sjc/nad.yaml
+++ b/deploy/containerlab/resources/testvpc/sjc/nad.yaml
@@ -1,0 +1,22 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: testvpc
+  namespace: vpc
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "testvpc",
+      "type": "galactic-cni",
+      "vpc": "10",
+      "vpcattachment": "10",
+      "namespace": "galactic-system",
+      "srv6_locator": "2001:db8:ff02::/48",
+      "ipam": {
+        "type": "pool",
+        "pool": "fd00:10:ff02::/48",
+        "gateway": "fd00:10:ff02::1",
+        "subnet_len": 80
+      }
+    }

--- a/deploy/containerlab/resources/testvpc/sjc/nginx.yaml
+++ b/deploy/containerlab/resources/testvpc/sjc/nginx.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: vpc
+  labels:
+    app: nginx
+    site: sjc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        site: sjc
+      annotations:
+        k8s.v1.cni.cncf.io/networks: testvpc
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: multitool
+          image: wbitt/network-multitool
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http

--- a/deploy/containerlab/scripts/install-testvpc.sh
+++ b/deploy/containerlab/scripts/install-testvpc.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+RESOURCES_DIR="${SCRIPT_DIR}/../resources"
+
+# setup_cni_kubeconfig applies the galactic-cni ServiceAccount/RBAC to a
+# cluster and writes a kubeconfig for it onto the corresponding worker node(s).
+# The kubeconfig uses the control-plane's Docker-network IPv6 address so it
+# is reachable from workers within the same ContainerLab bridge network.
+setup_cni_kubeconfig() {
+  local control_plane="$1"
+  shift
+  local workers=("$@")
+
+  echo "Setting up galactic-cni RBAC on ${control_plane}..."
+  docker cp "${RESOURCES_DIR}/testvpc/rbac.yaml" "${control_plane}:/galactic/resources/testvpc-rbac.yaml"
+  docker exec "${control_plane}" kubectl apply -f /galactic/resources/testvpc-rbac.yaml
+
+  # Resolve the API server address reachable from worker nodes: use the
+  # control-plane container's IPv6 address on the Docker bridge (port 6443).
+  local api_ip
+  api_ip=$(docker inspect "${control_plane}" \
+    --format '{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}' \
+    | head -1)
+  local api_server="https://[${api_ip}]:6443"
+
+  # Mint a long-lived token for the ServiceAccount.
+  local token
+  token=$(docker exec "${control_plane}" \
+    kubectl create token galactic-cni -n galactic-system --duration=87600h)
+
+  # Fetch the cluster CA cert.
+  local ca_data
+  ca_data=$(docker exec "${control_plane}" \
+    kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+
+  # Write a minimal kubeconfig and push it to each worker.
+  local kubeconfig
+  kubeconfig=$(cat <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: galactic
+    cluster:
+      server: ${api_server}
+      certificate-authority-data: ${ca_data}
+contexts:
+  - name: galactic
+    context:
+      cluster: galactic
+      user: galactic-cni
+current-context: galactic
+users:
+  - name: galactic-cni
+    user:
+      token: ${token}
+EOF
+)
+
+  for worker in "${workers[@]}"; do
+    echo "Installing galactic-cni kubeconfig on ${worker}..."
+    docker exec "${worker}" mkdir -p /etc/galactic
+    echo "${kubeconfig}" | docker exec -i "${worker}" tee /etc/galactic/kubeconfig > /dev/null
+
+    # Update the wrapper to export KUBECONFIG so the CNI binary can reach the
+    # API server. Rewrite the wrapper in-place.
+    docker exec "${worker}" sh -c 'cat > /opt/cni/bin/galactic-cni <<'"'"'EOF'"'"'
+#!/bin/sh
+export NODE_NAME=$(hostname)
+export KUBECONFIG=/etc/galactic/kubeconfig
+exec /opt/cni/bin/galactic-cni.bin "$@"
+EOF
+chmod 0755 /opt/cni/bin/galactic-cni'
+  done
+}
+
+apply_testvpc() {
+  local node="$1"
+  local site="$2"
+  echo "Applying testvpc/${site} to ${node}..."
+  docker cp "${RESOURCES_DIR}/testvpc/${site}" "${node}:/galactic/resources/testvpc-${site}"
+  # Apply NAD first so the network is available when the pod starts, then the
+  # Deployment. BGPVRFInstance and BGPAdvertisement are created by the CNI on
+  # pod attach — do not pre-apply them here.
+  docker exec "${node}" sh -c 'kubectl create namespace vpc --dry-run=client -o yaml | kubectl apply -f -'
+  docker exec "${node}" kubectl apply -f /galactic/resources/testvpc-${site}/nad.yaml
+  docker exec "${node}" kubectl apply -f /galactic/resources/testvpc-${site}/nginx.yaml
+}
+
+setup_cni_kubeconfig dfw-control-plane dfw-worker
+setup_cni_kubeconfig sjc-control-plane sjc-worker
+setup_cni_kubeconfig iad-control-plane iad-worker iad-worker-rr
+
+apply_testvpc dfw-control-plane dfw
+apply_testvpc sjc-control-plane sjc
+apply_testvpc iad-control-plane iad
+
+echo "Done."

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/containernetworking/plugins v1.9.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da // indirect
 	github.com/eapache/channels v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containernetworking/cni v1.3.0 h1:v6EpN8RznAZj9765HhXQrtXgX+ECGebEYEmnuFjskwo=
 github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNGEaBb9KS5KtNMnJ4=
+github.com/containernetworking/plugins v1.9.1 h1:8oU6WsIsU3bpnNZuvHp74a6cE1MJwbj2P7s4/yTUNlA=
+github.com/containernetworking/plugins v1.9.1/go.mod h1:fj7kS55qg3o/RgS+WGsF3+ZxwIImMPusQZKzBpcSr4c=
 github.com/coreos/go-iptables v0.8.0 h1:MPc2P89IhuVpLI7ETL/2tx3XZ61VeICZjYqDEgNsPRc=
 github.com/coreos/go-iptables v0.8.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,6 +19,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
 	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,15 +30,41 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"go.datum.net/galactic/internal/cni/ipam"
 	"go.datum.net/galactic/internal/cni/route"
 	"go.datum.net/galactic/internal/cni/veth"
 	"go.datum.net/galactic/internal/metadata"
 	"go.datum.net/galactic/internal/plumbing/intf"
-	"go.datum.net/galactic/internal/plumbing/srv6"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
 const cniTimeout = 10 * time.Second
+
+const (
+	// annotationAllocatedSubnet is the BGPAdvertisement annotation key prefix
+	// holding the allocated pod subnet CIDR for a container ID. The full key
+	// appends a truncated container ID; see subnetAnnotationKey.
+	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
+
+	// annotationContainerIDLen is the number of characters used from a
+	// container ID in annotation keys. Kubernetes limits the name part of an
+	// annotation key to 63 bytes; "allocated-subnet." is 17 bytes, leaving 46
+	// bytes for the container ID prefix.
+	annotationContainerIDLen = 46
+
+	// defaultNamespace is used when the CNI config does not specify a namespace.
+	defaultNamespace = "default"
+)
+
+// subnetAnnotationKey returns the annotation key for storing the allocated
+// subnet for the given container ID.
+func subnetAnnotationKey(containerID string) string {
+	id := containerID
+	if len(id) > annotationContainerIDLen {
+		id = id[:annotationContainerIDLen]
+	}
+	return fmt.Sprintf("%s.%s", annotationAllocatedSubnet, id)
+}
 
 var cniScheme = runtime.NewScheme()
 
@@ -90,7 +119,7 @@ func bgpAdvertisementName(vpc, vpcAttachment string) string {
 }
 
 // routeTarget returns the RT in "ASN:NN" format using the low 32 bits of the
-// VPC identifier. All nodes in the same VPC produce the same value, enabling
+// VPC identifier. All nodes in the same VRF produce the same value, enabling
 // VPC-scoped route import/export. vpcHex is the 48-bit hex VPC identifier.
 func routeTarget(asNumber int64, vpcHex string) (string, error) {
 	v, err := strconv.ParseUint(vpcHex, 16, 64)
@@ -162,7 +191,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	namespace := pluginConf.Namespace
 	if namespace == "" {
-		namespace = "default"
+		namespace = defaultNamespace
 	}
 
 	if err := vrf.Add(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
@@ -177,17 +206,31 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return fmt.Errorf("add route %s: %w", termination.Network, err)
 		}
 	}
-	if err := hostDevice("ADD", args, pluginConf); err != nil {
-		return fmt.Errorf("host-device ADD: %w", err)
+	// Only call host-device ADD if the guest interface is still in the host
+	// namespace. If a prior attempt already moved it to the container netns but
+	// failed at a later step, we must not try to move it again.
+	guestName := intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment)
+	if _, linkErr := netlink.LinkByName(guestName); linkErr == nil {
+		if err := hostDevice("ADD", args, pluginConf); err != nil {
+			return fmt.Errorf("host-device ADD: %w", err)
+		}
+	}
+
+	// Configure IP address on the guest interface inside the container netns.
+	// After hostDevice("ADD"), the guest interface is named args.IfName inside
+	// the container (host-device renames it), not the original guestName.
+	var ipamResult *ipamResult
+	if pluginConf.IPAM.Type != "" {
+		result, err := configureIPAM(args, pluginConf, args.IfName)
+		if err != nil {
+			return fmt.Errorf("configure IPAM: %w", err)
+		}
+		ipamResult = result
 	}
 
 	vpcHex, err := intf.Base62ToHex(pluginConf.VPC)
 	if err != nil {
 		return fmt.Errorf("decode VPC: %w", err)
-	}
-	vpcAttachmentHex, err := intf.Base62ToHex(pluginConf.VPCAttachment)
-	if err != nil {
-		return fmt.Errorf("decode VPCAttachment: %w", err)
 	}
 
 	k8s, err := newK8sClient()
@@ -207,11 +250,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("compute route target: %w", err)
 	}
 
-	srv6Endpoint, err := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttachmentHex)
-	if err != nil {
-		return fmt.Errorf("encode SRv6 endpoint: %w", err)
-	}
-
 	// Create the BGPVRFInstance to configure the VRF with its route distinguisher
 	// and import/export route targets. This must be created before advertisements
 	// so the BGP runtime has the VRF context when originating EVPN paths.
@@ -228,8 +266,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 				RouterRef: &bgpv1alpha1.RouterRef{Name: bgp.routerName},
 			},
 			RouteDistinguisher: rtValue,
-			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "rt:" + rtValue}},
-			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "rt:" + rtValue}},
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: rtValue}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: rtValue}},
 		}
 		return nil
 	})
@@ -237,19 +275,31 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("apply BGPVRFInstance: %w", err)
 	}
 
-	// Create the BGPAdvertisement to originate the SRv6 endpoint prefix.
+	// Create the BGPAdvertisement to originate the pod's subnet prefix.
 	adv := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
 			Namespace: namespace,
 		},
 	}
+	podSubnet := ""
+	if ipamResult != nil {
+		podSubnet = ipamResult.subnet.String()
+	}
 	_, err = controllerutil.CreateOrUpdate(ctx, k8s, adv, func() error {
 		adv.Spec = bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: bgp.routerName},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
-			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(srv6Endpoint + "/128")},
-			Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community("rt:" + rtValue)},
+			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(podSubnet)},
+			Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community(rtValue)},
+		}
+		// Store the allocated subnet keyed by container ID in annotations
+		// so cmdDel can look it up for deallocation.
+		if ipamResult != nil {
+			if adv.Annotations == nil {
+				adv.Annotations = make(map[string]string)
+			}
+			adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
 		}
 		return nil
 	})
@@ -257,11 +307,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("apply BGPAdvertisement: %w", err)
 	}
 
-	if err := srv6.RouteIngressAdd(srv6Endpoint); err != nil {
-		return fmt.Errorf("add SRv6 ingress route: %w", err)
-	}
-
-	result := &type100.Result{}
+	result := buildResult(pluginConf, ipamResult)
 	return types.PrintResult(result, pluginConf.CNIVersion)
 }
 
@@ -271,29 +317,18 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// Deallocate IPAM subnet before any other cleanup.
+	if pluginConf.IPAM.Type != "" {
+		deallocateIPAM(args, pluginConf)
+	}
+
 	namespace := pluginConf.Namespace
 	if namespace == "" {
-		namespace = "default"
+		namespace = defaultNamespace
 	}
 
-	vpcHex, err := intf.Base62ToHex(pluginConf.VPC)
-	if err != nil {
-		return fmt.Errorf("decode VPC: %w", err)
-	}
-	vpcAttachmentHex, err := intf.Base62ToHex(pluginConf.VPCAttachment)
-	if err != nil {
-		return fmt.Errorf("decode VPCAttachment: %w", err)
-	}
-	srv6Endpoint, err := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttachmentHex)
-	if err != nil {
-		return fmt.Errorf("encode SRv6 endpoint: %w", err)
-	}
-	if err := srv6.RouteIngressDel(srv6Endpoint); err != nil {
-		return fmt.Errorf("delete SRv6 ingress route: %w", err)
-	}
-
-	// Signal BGP route withdrawal immediately after stopping kernel ingress so
-	// remote peers are notified as soon as possible. cosmos reconciles async.
+	// Signal BGP route withdrawal immediately to notify remote peers.
+	// cosmos reconciles async.
 	// IgnoreNotFound handles concurrent DEL races.
 	k8s, err := newK8sClient()
 	if err != nil {
@@ -308,6 +343,9 @@ func cmdDel(args *skel.CmdArgs) error {
 			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
 			Namespace: namespace,
 		},
+	}
+	if err := k8s.Get(ctx, client.ObjectKeyFromObject(adv), adv); client.IgnoreNotFound(err) != nil {
+		return fmt.Errorf("get BGPAdvertisement: %w", err)
 	}
 	if err := k8s.Delete(ctx, adv); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("delete BGPAdvertisement: %w", err)
@@ -343,10 +381,195 @@ func cmdDel(args *skel.CmdArgs) error {
 	return types.PrintResult(result, pluginConf.CNIVersion)
 }
 
+// ipamResult holds the IPAM allocation details for building the CNI result.
+type ipamResult struct {
+	subnet  *net.IPNet
+	gateway net.IP
+	routes  []*net.IPNet
+}
+
+// buildResult constructs the CNI result, including IPAM data if configured.
+func buildResult(pluginConf *PluginConf, ipRes *ipamResult) *type100.Result {
+	result := &type100.Result{
+		CNIVersion: pluginConf.CNIVersion,
+	}
+	if ipRes != nil {
+		result.IPs = []*type100.IPConfig{
+			{
+				Address: *ipRes.subnet,
+				Gateway: ipRes.gateway,
+			},
+		}
+		if len(ipRes.routes) > 0 {
+			result.Routes = make([]*types.Route, 0, len(ipRes.routes))
+			for _, dst := range ipRes.routes {
+				result.Routes = append(result.Routes, &types.Route{
+					Dst: *dst,
+				})
+			}
+		}
+	}
+	return result
+}
+
+// configureIPAM allocates a subnet and configures the guest interface inside the
+// container network namespace.
+func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string) (*ipamResult, error) {
+	var pool *ipam.PoolAllocator
+	var subnet *net.IPNet
+	var err error
+
+	switch pluginConf.IPAM.Type {
+	case "static":
+		alloc := ipam.NewStaticAllocator()
+		allocIP, err := alloc.Allocate(args.ContainerID, pluginConf.IPAM.StaticIP)
+		if err != nil {
+			return nil, fmt.Errorf("allocate static IP: %w", err)
+		}
+		subnet = &net.IPNet{
+			IP:   allocIP,
+			Mask: net.CIDRMask(64, 128),
+		}
+	case "pool", "":
+		pool, err = ipam.NewPoolAllocator(pluginConf.IPAM.Pool, pluginConf.IPAM.Gateway, pluginConf.IPAM.SubnetLen)
+		if err != nil {
+			return nil, fmt.Errorf("create pool allocator: %w", err)
+		}
+		subnet, err = pool.Allocate(args.ContainerID)
+		if err != nil {
+			return nil, fmt.Errorf("allocate from pool: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unknown IPAM type: %s", pluginConf.IPAM.Type)
+	}
+
+	var gateway net.IP
+	if pool != nil {
+		gateway = pool.Gateway()
+	}
+
+	var routes []*net.IPNet
+	if gateway != nil {
+		defaultRoute := &net.IPNet{
+			IP:   net.IPv6zero,
+			Mask: net.CIDRMask(0, 128),
+		}
+		routes = append(routes, defaultRoute)
+	}
+
+	if err := configureInterfaceInNetns(args.Netns, guestName, subnet, gateway); err != nil {
+		return nil, err
+	}
+
+	return &ipamResult{
+		subnet:  subnet,
+		gateway: gateway,
+		routes:  routes,
+	}, nil
+}
+
+// configureInterfaceInNetns applies an IP address and routes to the guest
+// interface inside the container network namespace.
+func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gateway net.IP) error {
+	containerNS, err := ns.GetNS(netnsPath)
+	if err != nil {
+		return fmt.Errorf("get container netns %q: %w", netnsPath, err)
+	}
+	defer containerNS.Close() //nolint:errcheck // netns close on teardown
+
+	return containerNS.Do(func(_ ns.NetNS) error {
+		handle, err := netlink.NewHandle()
+		if err != nil {
+			return fmt.Errorf("create netlink handle: %w", err)
+		}
+		defer handle.Close() //nolint:errcheck // netlink cleanup on teardown
+
+		link, err := handle.LinkByName(ifName)
+		if err != nil {
+			return fmt.Errorf("find guest interface %q: %w", ifName, err)
+		}
+
+		if err := handle.AddrAdd(link, &netlink.Addr{IPNet: ipNet}); err != nil {
+			return fmt.Errorf("add IP %s to %q: %w", ipNet, ifName, err)
+		}
+
+		if err := handle.LinkSetUp(link); err != nil {
+			return fmt.Errorf("set interface %q up: %w", ifName, err)
+		}
+
+		// Install default route via gateway.
+		if gateway != nil {
+			defaultRoute := &netlink.Route{
+				Dst:       nil, // default route
+				Gw:        gateway,
+				LinkIndex: link.Attrs().Index,
+			}
+			if err := handle.RouteAdd(defaultRoute); err != nil {
+				return fmt.Errorf("add default route via %s: %w", gateway, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// deallocateIPAM releases the IPAM allocation for the given container.
+// Reads the allocated subnet from the BGPAdvertisement CRD annotation, then
+// deallocates it from the in-memory pool.
+func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) {
+	// Look up the allocated subnet from the BGPAdvertisement annotation.
+	subnetCIDR := getAllocatedSubnetFromCRD(args.ContainerID, pluginConf)
+	if subnetCIDR == "" {
+		// No allocation found — either allocation was never completed,
+		// or the advertisement was already deleted. Nothing to clean up.
+		return
+	}
+
+	switch pluginConf.IPAM.Type {
+	case "pool", "":
+		pa, err := ipam.NewPoolAllocator(pluginConf.IPAM.Pool, pluginConf.IPAM.Gateway, pluginConf.IPAM.SubnetLen)
+		if err != nil {
+			// Pool creation failed — allocation was never completed, nothing to clean up.
+			return
+		}
+		pa.Deallocate(subnetCIDR)
+	case "static":
+		// Static allocations don't need deallocation.
+	}
+}
+
+// getAllocatedSubnetFromCRD reads the allocated subnet for the given container
+// from the BGPAdvertisement CRD annotation. Returns empty string if not found.
+func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf) string {
+	namespace := pluginConf.Namespace
+	if namespace == "" {
+		namespace = defaultNamespace
+	}
+
+	k8s, err := newK8sClient()
+	if err != nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)
+	defer cancel()
+
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
+			Namespace: namespace,
+		},
+	}
+	if err := k8s.Get(ctx, client.ObjectKeyFromObject(adv), adv); err != nil {
+		return ""
+	}
+
+	return adv.Annotations[subnetAnnotationKey(containerID)]
+}
+
 type HostDevicePluginConf struct {
 	types.PluginConf
 	Device string `json:"device"`
-	IPAM   IPAM   `json:"ipam"`
 }
 
 func hostDeviceExecutable() string {
@@ -363,7 +586,6 @@ func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) 
 			Type:       "host-device",
 		},
 		Device: intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment),
-		IPAM:   pluginConf.IPAM,
 	})
 	if err != nil {
 		return err

--- a/internal/cni/ipam/ipam.go
+++ b/internal/cni/ipam/ipam.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package ipam provides IPv6 subnet allocation for the Galactic CNI.
+// Each allocation returns a subnet (default /80) from a larger CIDR pool.
+// Allocations are kept ephemeral in memory; separate CNI plugin processes
+// (each invocation is a separate process) rely on the BGPAdvertisement CRD
+// annotation to look up the allocated subnet during teardown.
+package ipam
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+const (
+	// ipv6Bits is the number of bits in an IPv6 address.
+	ipv6Bits = 128
+
+	// DefaultSubnetLen is the default prefix length returned per allocation.
+	// A /80 gives 2^48 addresses per pod subnet.
+	DefaultSubnetLen = 80
+)
+
+// PoolAllocator allocates IPv6 subnets from a CIDR pool, tracking
+// allocations by subnet CIDR string in memory. All bindings are ephemeral.
+type PoolAllocator struct {
+	pool        *net.IPNet // the master pool (e.g. fd00:10:ff01::/48)
+	subnetLen   int        // prefix length per allocation (e.g. 80)
+	gateway     net.IP     // gateway IP address
+	poolIP      net.IP     // immutable copy of pool.IP for boundary checks
+	allocations sync.Map   // allocated subnet CIDR string -> struct{}{}
+	mu          sync.Mutex // serializes Allocate calls
+}
+
+// NewPoolAllocator creates a new pool allocator from an IPv6 CIDR pool,
+// an optional gateway address, and a subnet prefix length. The pool must be
+// an IPv6 prefix with a length of subnetLen or fewer bits. If gateway is
+// empty, the first address in the pool (host bits = 1) is used as the
+// gateway. If subnetLen is 0, DefaultSubnetLen (80) is used.
+func NewPoolAllocator(poolCIDR, gateway string, subnetLen int) (*PoolAllocator, error) {
+	_, pool, err := net.ParseCIDR(poolCIDR)
+	if err != nil {
+		return nil, fmt.Errorf("parse pool CIDR %q: %w", poolCIDR, err)
+	}
+	if pool.IP.To4() != nil {
+		return nil, fmt.Errorf("pool must be IPv6, got IPv4: %s", poolCIDR)
+	}
+
+	if subnetLen == 0 {
+		subnetLen = DefaultSubnetLen
+	}
+
+	mask, _ := pool.Mask.Size()
+	if mask > subnetLen {
+		return nil, fmt.Errorf("pool prefix length %d is longer than subnet length %d", mask, subnetLen)
+	}
+
+	pa := &PoolAllocator{
+		pool:        pool,
+		subnetLen:   subnetLen,
+		poolIP:      make(net.IP, ipv6Bits/8),
+		allocations: sync.Map{},
+	}
+	copy(pa.poolIP, pool.IP)
+
+	if gateway != "" {
+		gwIP := net.ParseIP(gateway)
+		if gwIP == nil {
+			return nil, fmt.Errorf("invalid gateway IP: %s", gateway)
+		}
+		if !pool.Contains(gwIP) {
+			return nil, fmt.Errorf("gateway %s is not in pool %s", gateway, poolCIDR)
+		}
+		pa.gateway = gwIP.To16()
+	} else {
+		// Default gateway: first usable address (host bits = 1)
+		gw := make(net.IP, ipv6Bits/8)
+		copy(gw, pool.IP)
+		gw[ipv6Bits/8-1] = 1
+		pa.gateway = gw
+	}
+
+	return pa, nil
+}
+
+// Allocate assigns the next available IPv6 subnet from the pool for the
+// given container ID. Returns the allocated subnet CIDR or an error if the
+// pool is exhausted. Thread-safe.
+func (a *PoolAllocator) Allocate(containerID string) (*net.IPNet, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Collect currently allocated subnets for fast lookup.
+	used := make(map[string]struct{})
+	a.allocations.Range(func(key, value any) bool {
+		used[key.(string)] = struct{}{}
+		return true
+	})
+
+	// Iterate subnet boundaries within the pool.
+	subnetStart := make(net.IP, ipv6Bits/8)
+	copy(subnetStart, a.poolIP)
+
+	for ; a.pool.Contains(subnetStart); subnetStart = incSubnet(subnetStart, a.subnetLen) {
+		// Build the subnet CIDR for this boundary.
+		subnet := &net.IPNet{
+			IP:   make(net.IP, ipv6Bits/8),
+			Mask: net.CIDRMask(a.subnetLen, ipv6Bits),
+		}
+		copy(subnet.IP, subnetStart)
+		subnetStr := subnet.String()
+
+		// Skip already allocated.
+		if _, ok := used[subnetStr]; ok {
+			continue
+		}
+
+		// Allocate.
+		a.allocations.Store(subnetStr, struct{}{})
+		return subnet, nil
+	}
+
+	return nil, fmt.Errorf("pool %s exhausted (subnet /%d)", a.pool.String(), a.subnetLen)
+}
+
+// Deallocate removes the allocation for the given subnet CIDR string.
+// Silently ignores unknown subnets.
+func (a *PoolAllocator) Deallocate(subnetCIDR string) {
+	a.allocations.Delete(subnetCIDR)
+}
+
+// IsAllocated reports whether the given subnet CIDR string is actively allocated.
+func (a *PoolAllocator) IsAllocated(subnetCIDR string) bool {
+	_, ok := a.allocations.Load(subnetCIDR)
+	return ok
+}
+
+// Gateway returns the gateway IP for the pool.
+func (a *PoolAllocator) Gateway() net.IP {
+	return a.gateway
+}
+
+// StaticAllocator validates and returns a static IPv6 address.
+type StaticAllocator struct{}
+
+// NewStaticAllocator creates a new static allocator.
+func NewStaticAllocator() *StaticAllocator {
+	return &StaticAllocator{}
+}
+
+// Allocate validates the given IPv6 address and returns it.
+// The address must be a well-formed IPv6 address.
+func (a *StaticAllocator) Allocate(containerID, addr string) (net.IP, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IPv6 address: %s", addr)
+	}
+	if ip.To4() != nil {
+		return nil, fmt.Errorf("static allocator requires IPv6, got IPv4: %s", addr)
+	}
+	return ip.To16(), nil
+}
+
+// incSubnet increments an IP by one subnet step and returns it in place.
+// The step size is 2^(128-subnetLen), advancing to the next subnet boundary.
+func incSubnet(ip net.IP, subnetLen int) net.IP {
+	// Zero out host bits (bytes after the network boundary).
+	boundary := subnetLen / 8
+	for i := boundary; i < len(ip); i++ {
+		ip[i] = 0
+	}
+	// Increment the first host byte (just past the network prefix).
+	for i := boundary; i >= 0; i-- {
+		ip[i]++
+		if ip[i] != 0 {
+			break
+		}
+	}
+	return ip
+}

--- a/internal/cni/ipam/ipam_test.go
+++ b/internal/cni/ipam/ipam_test.go
@@ -1,0 +1,320 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ipam
+
+import (
+	"net"
+	"testing"
+)
+
+const (
+	testPoolCIDR     = "fd00:10:ff01::/48"
+	testPoolGw       = "fd00:10:ff01::1"
+	testSubnetLen    = 80
+	testAllocatedSub = "fd00:10:ff01::/80"
+	// nextSubnet is the second /80 subnet from a /48 pool, used across tests.
+	nextSubnet = "fd00:10:ff01::100:0:0/80"
+)
+
+func TestNewPoolAllocator(t *testing.T) {
+	tests := []struct {
+		name      string
+		poolCIDR  string
+		gateway   string
+		subnetLen int
+		wantErr   bool
+		wantGw    string
+		wantLen   int
+	}{
+		{
+			name:      "valid /48 pool with gateway and subnet length",
+			poolCIDR:  testPoolCIDR,
+			gateway:   testPoolGw,
+			subnetLen: testSubnetLen,
+			wantGw:    testPoolGw,
+			wantLen:   testSubnetLen,
+		},
+		{
+			name:      "valid /48 pool without gateway defaults to .1",
+			poolCIDR:  "fd00:10:ff02::/48",
+			subnetLen: testSubnetLen,
+			wantGw:    "fd00:10:ff02::1",
+			wantLen:   testSubnetLen,
+		},
+		{
+			name:     "zero subnet length uses default",
+			poolCIDR: "fd00:feed::/48",
+			wantGw:   "fd00:feed::1",
+			wantLen:  DefaultSubnetLen,
+		},
+		{
+			name:     "rejects IPv4 pool",
+			poolCIDR: "10.244.1.0/24",
+			wantErr:  true,
+		},
+		{
+			name:     "rejects invalid CIDR",
+			poolCIDR: "not-a-cidr",
+			wantErr:  true,
+		},
+		{
+			name:     "rejects gateway outside pool",
+			poolCIDR: testPoolCIDR,
+			gateway:  "fd00:20::1",
+			wantErr:  true,
+		},
+		{
+			name:     "rejects invalid gateway",
+			poolCIDR: testPoolCIDR,
+			gateway:  "not-an-ip",
+			wantErr:  true,
+		},
+		{
+			name:      "rejects pool longer than subnet length",
+			poolCIDR:  "fd00:10:ff01::/80",
+			subnetLen: 64,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa, err := NewPoolAllocator(tt.poolCIDR, tt.gateway, tt.subnetLen)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gw := pa.Gateway()
+			if gw == nil {
+				t.Fatal("Gateway() returned nil")
+			}
+			if gw.String() != tt.wantGw {
+				t.Errorf("Gateway() = %q, want %q", gw.String(), tt.wantGw)
+			}
+		})
+	}
+}
+
+func TestPoolAllocatorAllocate(t *testing.T) {
+	pa, err := NewPoolAllocator(testPoolCIDR, testPoolGw, testSubnetLen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		containerID string
+		wantSubnet  string
+		wantErr     bool
+	}{
+		{
+			name:        "first allocation returns first subnet",
+			containerID: "container-1",
+			wantSubnet:  testAllocatedSub,
+		},
+		{
+			name:        "second allocation returns next subnet",
+			containerID: "container-2",
+			wantSubnet:  nextSubnet,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subnet, err := pa.Allocate(tt.containerID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if subnet == nil {
+				t.Fatal("Allocate returned nil subnet")
+			}
+			if subnet.String() != tt.wantSubnet {
+				t.Errorf("Allocate() = %q, want %q", subnet.String(), tt.wantSubnet)
+			}
+		})
+	}
+}
+
+func TestPoolAllocatorSkipsAllocatedSubnets(t *testing.T) {
+	pa, err := NewPoolAllocator(testPoolCIDR, testPoolGw, testSubnetLen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First container gets the first /80.
+	subnet1, err := pa.Allocate("container-x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if subnet1.String() != testAllocatedSub {
+		t.Errorf("first alloc = %q, want %q", subnet1, testAllocatedSub)
+	}
+
+	// Second container should get the next /80, not the first (already taken).
+	subnet2, err := pa.Allocate("container-y")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want2 := nextSubnet
+	if subnet2.String() != want2 {
+		t.Errorf("second alloc = %q, want %q", subnet2, want2)
+	}
+}
+
+func TestPoolAllocatorDeallocate(t *testing.T) {
+	pa, err := NewPoolAllocator(testPoolCIDR, testPoolGw, testSubnetLen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Allocate a subnet.
+	subnet1, err := pa.Allocate("container-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Deallocate it.
+	pa.Deallocate(subnet1.String())
+
+	// Allocate again — should get the same subnet back.
+	subnet2, err := pa.Allocate("container-b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if subnet1.String() != subnet2.String() {
+		t.Errorf("re-allocated subnet %q != original %q", subnet2, subnet1)
+	}
+}
+
+func TestPoolAllocatorDeallocateUnknown(t *testing.T) {
+	pa, err := NewPoolAllocator(testPoolCIDR, testPoolGw, testSubnetLen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should not panic.
+	pa.Deallocate("fd00:dead::/80")
+}
+
+func TestPoolAllocatorIsAllocated(t *testing.T) {
+	pa, err := NewPoolAllocator(testPoolCIDR, testPoolGw, testSubnetLen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pa.IsAllocated("fd00:dead::/80") {
+		t.Error("IsAllocated returned true for unknown subnet")
+	}
+
+	if _, err := pa.Allocate("known"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !pa.IsAllocated(testAllocatedSub) {
+		t.Error("IsAllocated returned false for known container")
+	}
+
+	pa.Deallocate(testAllocatedSub)
+	if pa.IsAllocated(testAllocatedSub) {
+		t.Error("IsAllocated returned true after deallocate")
+	}
+}
+
+func TestStaticAllocator(t *testing.T) {
+	sa := NewStaticAllocator()
+
+	tests := []struct {
+		name        string
+		containerID string
+		addr        string
+		wantIP      string
+		wantErr     bool
+	}{
+		{
+			name:        "valid IPv6",
+			containerID: "c1",
+			addr:        "fd00:10:ff01::5",
+			wantIP:      "fd00:10:ff01::5",
+		},
+		{
+			name:        "valid IPv6 full form",
+			containerID: "c2",
+			addr:        "2001:db8::1",
+			wantIP:      "2001:db8::1",
+		},
+		{
+			name:        "rejects IPv4",
+			containerID: "c3",
+			addr:        "10.244.1.5",
+			wantErr:     true,
+		},
+		{
+			name:        "rejects invalid IP",
+			containerID: "c4",
+			addr:        "not-an-ip",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, err := sa.Allocate(tt.containerID, tt.addr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ip == nil {
+				t.Fatal("Allocate returned nil IP")
+			}
+			if ip.String() != tt.wantIP {
+				t.Errorf("Allocate() = %q, want %q", ip.String(), tt.wantIP)
+			}
+		})
+	}
+}
+
+func TestIncSubnet(t *testing.T) {
+	tests := []struct {
+		input     string
+		subnetLen int
+		output    string
+	}{
+		// /80 subnets from a /48 pool: each step advances by 2^48.
+		{input: "fd00:10:ff01::", subnetLen: 80, output: "fd00:10:ff01::100:0:0"},
+		{input: "fd00:10:ff01:0:1::", subnetLen: 80, output: "fd00:10:ff01:0:1:100::"},
+		{input: "fd00:10:ff01:0:ff::", subnetLen: 80, output: "fd00:10:ff01:0:ff:100::"},
+		{input: "fd00:10:ff00::", subnetLen: 80, output: "fd00:10:ff00::100:0:0"},
+		// /64 subnets (boundary at byte 8).
+		{input: "fd00:10::", subnetLen: 64, output: "fd00:10:0:0:100::"},
+		// /56 subnets (boundary at byte 7).
+		{input: "fd00::", subnetLen: 56, output: "fd00:0:0:1::"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			ip := net.ParseIP(tt.input)
+			incSubnet(ip, tt.subnetLen)
+			if ip.String() != tt.output {
+				t.Errorf("incSubnet(%q, /%d) = %q, want %q", tt.input, tt.subnetLen, ip.String(), tt.output)
+			}
+		})
+	}
+}

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -10,7 +10,11 @@ type Termination struct {
 }
 
 type IPAM struct {
-	Type      string    `json:"type"`
+	Type      string    `json:"type"`                 // "pool" (default) or "static"
+	Pool      string    `json:"pool,omitempty"`       // IPv6 CIDR pool, e.g. "fd00:10:ff01::/48"
+	Gateway   string    `json:"gateway,omitempty"`    // IPv6 gateway address
+	SubnetLen int       `json:"subnet_len,omitempty"` // prefix length per allocation (default 80)
+	StaticIP  string    `json:"static_ip,omitempty"`  // used when type="static"
 	Routes    []Route   `json:"routes,omitempty"`
 	Addresses []Address `json:"addresses,omitempty"`
 }

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -45,6 +45,12 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	guestName := intf.GenerateInterfaceNameGuest(vpc, vpcAttachment)
 
+	// If the host veth already exists (e.g. left behind by a failed cmdAdd
+	// with no corresponding cmdDel), skip creation and reuse it.
+	if _, err := netlink.LinkByName(hostName); err == nil {
+		return nil
+	}
+
 	veth := &netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: hostName,

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -30,11 +30,17 @@ var vrfMu sync.Mutex
 // Add creates a Linux VRF interface for the given base62-encoded VPC and
 // VPCAttachment, allocating the next available routing table ID and applying
 // the required sysctl settings. Concurrent calls are serialized internally.
+// If a VRF with the same name already exists (e.g. left behind by a previous
+// failed cmdAdd with no corresponding cmdDel), Add returns nil.
 func Add(vpc, vpcAttachment string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
 
 	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+
+	if _, err := netlink.LinkByName(name); err == nil {
+		return nil
+	}
 
 	vrfId, err := findNextAvailableVRFId()
 	if err != nil {


### PR DESCRIPTION
## Summary

This patch adds a new resource that can be used to test and exercise the
CNI connection.   The once the containerlab deployment is active running
`task deploy:testvpc` will deploy pods to each cluster and craete a VPC
between them

## Changes

- Add internal/cni/ipam package with PoolAllocator and StaticAllocator for IPv6 /80 subnet allocation from a CIDR pool
- Rewrite cmdAdd to configure IPAM, set IP address and default route on the guest interface inside the container netns, and advertise the allocated pod subnet in the BGPAdvertisement CRD
- Rewrite cmdDel to deallocate IPAM by reading the allocated subnet from the BGPAdvertisement CRD annotation keyed by container ID
- Remove SRv6 ingress route setup from CNI; the controller now derives the SRv6 endpoint from the pod subnet and installs the ingress route
- Add idempotency guards to veth.Add and vrf.Add so a leftover interface from a prior failed cmdAdd does not cause cmdAdd to fail
- Wrap galactic-cni binary with a shell script that exports NODE_NAME and KUBECONFIG so the CNI binary can reach the API server in Kind
- Add containerlab test VPC resources (NAD, nginx deployment, RBAC) and install-testvpc.sh script to deploy cross-cluster connectivity
- Create /var/run/galactic-cni directory in Dockerfile for IPAM state
- Update BGPVRFInstance route target format to drop "rt:" prefix