### PR TITLE
feat: support GALACTIC_GOBGP_GRPC_SERVER and GALACTIC_GOBGP_GRPC_PORT env vars

### DIFF
--- a/cmd/galactic-router/main.go
+++ b/cmd/galactic-router/main.go
@@ -9,10 +9,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
@@ -47,6 +49,9 @@ const (
 	resourceBGPVRFInstances   = "bgpvrfinstances"
 	resourceSecrets           = "secrets"
 	resourceNodes             = "nodes"
+
+	defaultGrpcPort   = 50051
+	grpcServerEnabled = "true"
 )
 
 func main() {
@@ -70,10 +75,14 @@ func main() {
 
 	bgpLocalAddr := os.Getenv("BGP_LOCAL_ADDRESS")
 
+	// GALACTIC_ENABLE_GOBGP_GRPC_SERVER controls whether the embedded GoBGP
+	// gRPC API server is enabled. Defaults to false.
+	grpcListenAddress := parseGrpcListenAddress()
+
 	var factory galacticruntime.RuntimeFactory
 	switch routerRole {
 	case "tenant":
-		factory = gobgp.NewRuntimeFactory(bgpListenPort, bgpLocalAddr)
+		factory = gobgp.NewRuntimeFactory(bgpListenPort, bgpLocalAddr, grpcListenAddress)
 	case "fabric":
 		factory = frr.NewRuntimeFactory()
 	default:
@@ -254,4 +263,30 @@ func checkWatchPermissions(mgr ctrl.Manager) {
 		logger.Error(nil, "missing watch RBAC for "+r.resource,
 			"verb", "watch", "detail", "informer cache will not sync; add resource to ServiceAccount ClusterRole and restart")
 	}
+}
+
+// parseGrpcPort reads GALACTIC_GOBGP_GRPC_SERVER_PORT and returns the port
+// to use for the GoBGP gRPC API. Returns defaultGrpcPort when the env var is
+// unset or invalid.
+func parseGrpcPort() int {
+	v := os.Getenv("GALACTIC_GOBGP_GRPC_PORT")
+	if v == "" {
+		return defaultGrpcPort
+	}
+	port, err := strconv.Atoi(v)
+	if err != nil || port < 1 || port > 65535 {
+		return defaultGrpcPort
+	}
+	return port
+}
+
+// parseGrpcListenAddress reads GALACTIC_ENABLE_GOBGP_GRPC_SERVER and returns
+// the gRPC listen address to use. Returns ":<port>" when the env var is
+// "true" (case-insensitive), otherwise returns an empty string to disable
+// the GoBGP gRPC API server.
+func parseGrpcListenAddress() string {
+	if strings.ToLower(os.Getenv("GALACTIC_ENABLE_GOBGP_GRPC_SERVER")) == grpcServerEnabled {
+		return fmt.Sprintf(":%d", parseGrpcPort())
+	}
+	return ""
 }

--- a/cmd/galactic-router/main_test.go
+++ b/cmd/galactic-router/main_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"testing"
+)
+
+func TestParseGrpcPort(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{
+			name: "Unset",
+			env:  "",
+			want: defaultGrpcPort,
+		},
+		{
+			name: "Default",
+			env:  "50051",
+			want: 50051,
+		},
+		{
+			name: "CustomPort",
+			env:  "9999",
+			want: 9999,
+		},
+		{
+			name: "Zero",
+			env:  "0",
+			want: defaultGrpcPort, // invalid, falls back to default
+		},
+		{
+			name: "Negative",
+			env:  "-1",
+			want: defaultGrpcPort, // invalid, falls back to default
+		},
+		{
+			name: "TooLarge",
+			env:  "70000",
+			want: defaultGrpcPort, // invalid, falls back to default
+		},
+		{
+			name: "NonNumeric",
+			env:  "abc",
+			want: defaultGrpcPort, // invalid, falls back to default
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GALACTIC_GOBGP_GRPC_PORT", tt.env)
+			got := parseGrpcPort()
+			if got != tt.want {
+				t.Errorf("parseGrpcPort() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGrpcListenAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		enableEnv   string
+		portEnv     string
+		want        string
+		wantHasPort bool
+	}{
+		{
+			name:        "Disabled",
+			enableEnv:   "false",
+			portEnv:     "9999",
+			want:        "",
+			wantHasPort: false,
+		},
+		{
+			name:        "EnabledDefaultPort",
+			enableEnv:   grpcServerEnabled,
+			portEnv:     "",
+			want:        ":50051",
+			wantHasPort: true,
+		},
+		{
+			name:        "EnabledCustomPort",
+			enableEnv:   grpcServerEnabled,
+			portEnv:     "9999",
+			want:        ":9999",
+			wantHasPort: true,
+		},
+		{
+			name:        "EnabledInvalidPort",
+			enableEnv:   grpcServerEnabled,
+			portEnv:     "abc",
+			want:        ":50051",
+			wantHasPort: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GALACTIC_ENABLE_GOBGP_GRPC_SERVER", tt.enableEnv)
+			t.Setenv("GALACTIC_GOBGP_GRPC_PORT", tt.portEnv)
+			got := parseGrpcListenAddress()
+			if got != tt.want {
+				t.Errorf("parseGrpcListenAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGrpcListenAddressIsolation(t *testing.T) {
+	// Verify that one test's env var doesn't leak to another.
+	t.Setenv("GALACTIC_ENABLE_GOBGP_GRPC_SERVER", "false")
+	got := parseGrpcListenAddress()
+	if got != "" {
+		t.Errorf("parseGrpcListenAddress() = %q after setting false, want empty", got)
+	}
+}

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -49,11 +49,11 @@ type GoBGPRuntime struct {
 // Pass -1 to disable inbound connections (outbound-only mode).
 // localAddress, if non-empty, is bound as the source address for outgoing BGP
 // TCP connections (sets Transport.LocalAddress on every peer).
-func NewRuntimeFactory(listenPort int32, localAddress string) runtime.RuntimeFactory {
+func NewRuntimeFactory(listenPort int32, localAddress string, grpcListenAddress string) runtime.RuntimeFactory {
 	return func(key types.NamespacedName) (runtime.RouterRuntime, error) {
 		return &GoBGPRuntime{
 			key:             key,
-			server:          newServer(Config{}),
+			server:          newServer(Config{GRPCListenAddress: grpcListenAddress}),
 			listenPort:      listenPort,
 			localAddress:    localAddress,
 			establishedAt:   make(map[string]time.Time),

--- a/internal/runtime/gobgp/server.go
+++ b/internal/runtime/gobgp/server.go
@@ -23,6 +23,9 @@ type Config struct {
 	// LogLevel controls GoBGP's internal log verbosity.
 	// Valid values: debug, info, warn, error, panic. Defaults to panic.
 	LogLevel string
+	// GRPCListenAddress is the TCP address the GoBGP gRPC API listens on.
+	// An empty string (default) disables the gRPC server entirely.
+	GRPCListenAddress string
 }
 
 // Server wraps an embedded GoBGP BgpServer.
@@ -74,11 +77,22 @@ func (s *Server) Reconfigure() (*gobgpserver.BgpServer, error) {
 }
 
 func (s *Server) newBgpServer() *gobgpserver.BgpServer {
+	opts := s.buildServerOptions()
+	return gobgpserver.NewBgpServer(opts...)
+}
+
+// buildServerOptions assembles the ServerOption slice for NewBgpServer.
+// Exported for testing.
+func (s *Server) buildServerOptions() []gobgpserver.ServerOption {
 	level := parseLogLevel(s.cfg.LogLevel)
 	levelVar := &slog.LevelVar{}
 	levelVar.Set(level)
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: levelVar}))
-	return gobgpserver.NewBgpServer(gobgpserver.LoggerOption(logger, levelVar))
+	opts := []gobgpserver.ServerOption{gobgpserver.LoggerOption(logger, levelVar)}
+	if s.cfg.GRPCListenAddress != "" {
+		opts = append(opts, gobgpserver.GrpcListenAddress(s.cfg.GRPCListenAddress))
+	}
+	return opts
 }
 
 // WaitReady blocks until the GoBGP server is initialized or ctx is cancelled.

--- a/internal/runtime/gobgp/server_test.go
+++ b/internal/runtime/gobgp/server_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gobgp
+
+import (
+	"testing"
+)
+
+func TestBuildServerOptionsCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		grpcListenAddr string
+		wantCount      int
+	}{
+		{
+			name:           "Disabled",
+			grpcListenAddr: "",
+			wantCount:      1, // only LoggerOption
+		},
+		{
+			name:           "Enabled",
+			grpcListenAddr: ":50051",
+			wantCount:      2, // LoggerOption + GrpcListenAddress
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newServer(Config{GRPCListenAddress: tt.grpcListenAddr})
+			opts := s.buildServerOptions()
+			if len(opts) != tt.wantCount {
+				t.Errorf("buildServerOptions() has %d options, want %d", len(opts), tt.wantCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This patch adds two new env vars to Galatic intended assist with troubleshooting.   By default, the GoBGP gRPC server is disabled when `galactic-router` starts up.  This enables the gRPC server.   When enabled, operators and developers can use the `gobgp` cli to introspect the GoBGP state.

## Changes

- Add GALACTIC_ENABLE_GOBGP_GRPC_SERVER env var to toggle the GoBGP gRPC API server on/off
- Add GALACTIC_GOBGP_GRPC_PORT env var to configure the gRPC listen port (default 50051)
- Wire grpcListenAddress through NewRuntimeFactory into the GoBGP server Config
- Extract buildServerOptions from newBgpServer for testability
- Add unit tests for parseGrpcPort, parseGrpcListenAddress, and buildServerOptions