### PR TITLE
feat: overhaul galactic-cni CLI with cobra/viper and local IPAM

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,11 +102,11 @@ See [docs/agent-startup.md](docs/agent-startup.md) for the router startup sequen
 
 ### `cmd/galactic-cni/main.go` — CNI plugin
 
-Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads config from stdin (CNI spec). Requires `NODE_NAME` env var at runtime. See [docs/cni-sequence.md](docs/cni-sequence.md) for the full ADD/DEL sequence.
+Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads config from stdin (CNI spec). Requires `GALACTIC_CNI_NODE_NAME` env var at runtime. See [docs/cni-sequence.md](docs/cni-sequence.md) for the full ADD/DEL sequence.
 
 ### `cmd/galactic-router/main.go` — Router daemon
 
-1. Read `NODE_NAME`, `ROUTER_ROLE`, optionally `BGP_LISTEN_PORT` and `BGP_LOCAL_ADDRESS`
+1. Read `GALACTIC_ROUTER_NODE_NAME`, `GALACTIC_ROUTER_ROUTER_ROLE`, optionally `GALACTIC_ROUTER_BGP_LISTEN_PORT` and `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS`
 2. Select `RuntimeFactory`: `tenant` → GoBGP, `fabric` → FRR stub
 3. Build controller-runtime manager (Prometheus on `:8080`, no HTTP health)
 4. Start gRPC health server on `:5000`
@@ -120,12 +120,12 @@ Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads con
 
 ### galactic-router environment variables
 
-| Variable           | Required | Default | Description                                                             |
-|--------------------|----------|---------|-------------------------------------------------------------------------|
-| `NODE_NAME`        | Yes      | —       | Kubernetes node name; filters which BGPRouter CRDs this instance owns   |
-| `ROUTER_ROLE`      | Yes      | —       | `tenant` (GoBGP) or `fabric` (FRR stub, not yet implemented)            |
-| `BGP_LISTEN_PORT`  | No       | `179`   | BGP TCP listen port; `-1` disables inbound connections (outbound-only)  |
-| `BGP_LOCAL_ADDRESS`| No       | —       | Source address for outgoing BGP TCP connections (numbered underlay use) |
+| Variable                        | Required | Default | Description                                                             |
+|---------------------------------|----------|---------|-------------------------------------------------------------------------|
+| `GALACTIC_ROUTER_NODE_NAME`     | Yes      | —       | Kubernetes node name; filters which BGPRouter CRDs this instance owns   |
+| `GALACTIC_ROUTER_ROUTER_ROLE`   | Yes      | —       | `tenant` (GoBGP) or `fabric` (FRR stub, not yet implemented)            |
+| `GALACTIC_ROUTER_BGP_LISTEN_PORT` | No     | `179`   | BGP TCP listen port; `-1` disables inbound connections (outbound-only)  |
+| `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` | No   | —       | Source address for outgoing BGP TCP connections (numbered underlay use) |
 
 ### galactic-cni CNI config fields (`PluginConf`)
 
@@ -141,9 +141,9 @@ Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads con
 
 ### galactic-cni environment variables
 
-| Variable    | Required | Description                                                |
-|-------------|----------|------------------------------------------------------------|
-| `NODE_NAME` | Yes      | Kubernetes node name; used to look up the owning BGPRouter |
+| Variable                  | Required | Description                                                |
+|---------------------------|----------|------------------------------------------------------------|
+| `GALACTIC_CNI_NODE_NAME`  | Yes      | Kubernetes node name; used to look up the owning BGPRouter |
 
 ---
 
@@ -193,7 +193,7 @@ Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads con
 - **GoBGP embedded, lazy-started.** GoBGP runs in-process and starts only when the first `BGPRouter` is reconciled (`listenPort=-1`, outbound-only). ASN or RouterID changes trigger a full `Reconfigure` (fresh `BgpServer` — `StopBgp` is not called because it permanently terminates the v4 Serve loop).
 - **CRD-driven config, no sidecar gRPC.** `galactic-router` watches cosmos BGP CRDs directly via controller-runtime. The CNI writes a `BGPAdvertisement` CRD; the router reconciler picks it up. No in-node gRPC calls.
 - **Hash-based no-op suppression.** SHA-256 over the sorted `DesiredRouter` prevents redundant GoBGP Apply calls on every CRD event.
-- **RuntimeFactory pattern.** `ROUTER_ROLE=tenant` selects GoBGP; `ROUTER_ROLE=fabric` selects FRR (Phase 2 stub). The binary is selected at startup; no controller changes are needed for Phase 2.
+- **RuntimeFactory pattern.** `GALACTIC_ROUTER_ROUTER_ROLE=tenant` selects GoBGP; `GALACTIC_ROUTER_ROUTER_ROLE=fabric` selects FRR (Phase 2 stub). The binary is selected at startup; no controller changes are needed for Phase 2.
 - **gRPC health on :5000.** Liveness and readiness probes use the gRPC health protocol (`google.golang.org/grpc/health`) on port 5000. No HTTP health endpoint.
 
 ---

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -10,7 +10,7 @@ This document defines the coding standards, naming rules, error handling pattern
 
 - Module: `go.datum.net/galactic`
 - `cmd/galactic-cni/main.go` — CNI plugin entry point; calls `cni.RunPlugin()` directly
-- `cmd/galactic-router/main.go` — router entry point; reads `NODE_NAME` and `ROUTER_ROLE` env vars, starts controller-runtime manager
+- `cmd/galactic-router/main.go` — router entry point; reads `GALACTIC_ROUTER_NODE_NAME` and `GALACTIC_ROUTER_ROUTER_ROLE` env vars, starts controller-runtime manager
 - `internal/plumbing/` — low-level kernel and network primitives shared between router and CNI (`intf`, `srv6`, `sysctl`, `vrf`)
 - `internal/controller/` — controller-runtime reconcilers (BGPRouter, BGPPeer, BGPAdvertisement, BGPPolicy, Secret, Node); also contains field index registration (`indexer.go`) and CRD status helpers (`status.go`)
 - `internal/reconcile/` — CRD → DesiredRouter translation

--- a/cmd/galactic-cni/main.go
+++ b/cmd/galactic-cni/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containernetworking/cni/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -79,6 +80,12 @@ func newRootCommand() *cobra.Command {
 			if ok, _ := cmd.Flags().GetBool("version"); ok {
 				fmt.Printf("galactic-cni version %s\n", metadata.Version)
 				return nil
+			}
+			// Handle CNI_COMMAND=VERSION before config validation -- the CNI
+			// runtime invokes the plugin with this env var to query supported
+			// spec versions; --node-name is not required for this call.
+			if os.Getenv("CNI_COMMAND") == "VERSION" {
+				return version.All.Encode(os.Stdout)
 			}
 			if err := validateConfig(v); err != nil {
 				return err

--- a/cmd/galactic-cni/main.go
+++ b/cmd/galactic-cni/main.go
@@ -4,8 +4,104 @@
 
 package main
 
-import "go.datum.net/galactic/internal/cni"
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"go.datum.net/galactic/internal/cni"
+	"go.datum.net/galactic/internal/metadata"
+)
+
+const (
+	appName = "galactic-cni"
+
+	appDesc = `Galactic CNI Plugin
+
+ Find more information at: https://www.datum.net/docs`
+)
+
+// newViper returns a configured viper instance with defaults, env var
+// bindings, and automatic fallback for keys not explicitly bound.
+func newViper() *viper.Viper {
+	v := viper.New()
+	v.SetDefault("galactic_cni.node_name", "")
+	v.SetDefault("galactic_cni.enable_local_ipam", false)
+	v.AutomaticEnv()
+	//nolint:errcheck // keys are controlled, BindEnv cannot fail here
+	v.BindEnv("galactic_cni.node_name", "GALACTIC_CNI_NODE_NAME", "NODE_NAME")
+	//nolint:errcheck // keys are controlled, BindEnv cannot fail here
+	v.BindEnv("galactic_cni.enable_local_ipam", "GALACTIC_CNI_ENABLE_LOCAL_IPAM")
+	return v
+}
+
+// bindFlags registers each viper-configured flag on the command so that
+// `viper.BindPFlags` can resolve flag values at runtime.
+func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	cmd.Flags().StringP("node-name", "n", v.GetString("galactic_cni.node_name"),
+		"Kubernetes node name (required)")
+	cmd.Flags().Bool("enable-local-ipam", v.GetBool("galactic_cni.enable_local_ipam"),
+		"Enable built-in IPv6 pool IPAM when no explicit ipam block is configured")
+	//nolint:errcheck // keys are controlled, BindPFlag cannot fail here
+	v.BindPFlag("galactic_cni.node_name", cmd.Flags().Lookup("node-name"))
+	//nolint:errcheck // keys are controlled, BindPFlag cannot fail here
+	v.BindPFlag("galactic_cni.enable_local_ipam", cmd.Flags().Lookup("enable-local-ipam"))
+	//nolint:errcheck // keys are controlled, BindPFlags cannot fail here
+	v.BindPFlags(cmd.Flags())
+}
+
+// validateConfig checks that the configuration values are valid.
+func validateConfig(v *viper.Viper) error {
+	if v.GetString("galactic_cni.node_name") == "" {
+		return fmt.Errorf("--node-name is required (or set GALACTIC_CNI_NODE_NAME)")
+	}
+	return nil
+}
+
+// newRootCommand builds the root cobra command with all flags and the
+// CNI plugin startup logic.
+func newRootCommand() *cobra.Command {
+	v := newViper()
+
+	cmd := &cobra.Command{
+		Use:   appName,
+		Short: strings.Split(appDesc, "\n")[0],
+		Long:  appDesc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
+				fmt.Println(metadata.BuildInfo(appName))
+				return nil
+			}
+			if ok, _ := cmd.Flags().GetBool("version"); ok {
+				fmt.Printf("galactic-cni version %s\n", metadata.Version)
+				return nil
+			}
+			if err := validateConfig(v); err != nil {
+				return err
+			}
+			// Propagate the node name from viper into the env so the
+			// existing cni.cmdAdd path continues to read os.Getenv.
+			nodeName := v.GetString("galactic_cni.node_name")
+			_ = os.Setenv("NODE_NAME", nodeName)
+			// Pass the local IPAM flag to the CNI package.
+			cni.SetEnableLocalIPAM(v.GetBool("galactic_cni.enable_local_ipam"))
+			cni.RunPlugin()
+			return nil
+		},
+	}
+
+	bindFlags(cmd, v)
+	cmd.Flags().Bool("build-info", false, "Print build information and exit")
+	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
+	return cmd
+}
 
 func main() {
-	cni.RunPlugin()
+	if err := newRootCommand().Execute(); err != nil {
+		log.Fatalf("error: %v", err)
+	}
 }

--- a/cmd/galactic-cni/main_test.go
+++ b/cmd/galactic-cni/main_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"go.datum.net/galactic/internal/metadata"
+)
+
+// testCmdName is the placeholder command name used in tests.
+const testCmdName = "test"
+
+// cmdWithViper creates a cobra command with a fresh viper instance and
+// binds all flags. This is used to test flag defaults and cobra integration.
+func cmdWithViper(t *testing.T) *viper.Viper {
+	t.Helper()
+	v := newViper()
+	cmd := &cobra.Command{Use: testCmdName}
+	bindFlags(cmd, v)
+	return v
+}
+
+func TestNodeNameDefault(t *testing.T) {
+	v := cmdWithViper(t)
+	if v.GetString("galactic_cni.node_name") != "" {
+		t.Errorf("node_name default = %q, want empty", v.GetString("galactic_cni.node_name"))
+	}
+}
+
+func TestNodeNameFromEnv(t *testing.T) {
+	t.Setenv("GALACTIC_CNI_NODE_NAME", "test-node")
+	v := cmdWithViper(t)
+	if v.GetString("galactic_cni.node_name") != "test-node" {
+		t.Errorf("node_name from env = %q, want %q", v.GetString("galactic_cni.node_name"), "test-node")
+	}
+}
+
+func TestValidateConfigRequiresNodeName(t *testing.T) {
+	v := cmdWithViper(t)
+	if err := validateConfig(v); err == nil {
+		t.Error("validateConfig with empty node-name returned nil")
+	}
+}
+
+func TestValidateConfigPassesWithNodeName(t *testing.T) {
+	t.Setenv("GALACTIC_CNI_NODE_NAME", "test-node")
+	v := cmdWithViper(t)
+	if err := validateConfig(v); err != nil {
+		t.Errorf("validateConfig with node-name: %v", err)
+	}
+}
+
+func TestBuildInfoFlag(t *testing.T) {
+	if metadata.Version == "" {
+		t.Error("metadata.Version should not be empty")
+	}
+}
+
+func TestVersionFlag(t *testing.T) {
+	if metadata.Version == "" {
+		t.Error("metadata.Version should not be empty")
+	}
+}
+
+func TestDefaultsUnsetEnv(t *testing.T) {
+	_ = os.Unsetenv("GALACTIC_CNI_NODE_NAME")
+	v := cmdWithViper(t)
+	if v.GetString("galactic_cni.node_name") != "" {
+		t.Errorf("node_name default = %q, want empty", v.GetString("galactic_cni.node_name"))
+	}
+}
+
+func TestEnableLocalIPAMDefault(t *testing.T) {
+	v := cmdWithViper(t)
+	if v.GetBool("galactic_cni.enable_local_ipam") != false {
+		t.Errorf("enable_local_ipam default = %t, want false", v.GetBool("galactic_cni.enable_local_ipam"))
+	}
+}
+
+func TestEnableLocalIPAMFromEnv(t *testing.T) {
+	t.Setenv("GALACTIC_CNI_ENABLE_LOCAL_IPAM", "true")
+	v := cmdWithViper(t)
+	if !v.GetBool("galactic_cni.enable_local_ipam") {
+		t.Error("enable_local_ipam from env = false, want true")
+	}
+}
+
+func TestEnableLocalIPAMFromFlag(t *testing.T) {
+	v := newViper()
+	cmd := &cobra.Command{Use: testCmdName}
+	bindFlags(cmd, v)
+
+	// Set the flag directly on the cobra command.
+	if err := cmd.Flags().Set("enable-local-ipam", "true"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	// BindPFlag was called in bindFlags, so viper should read
+	// the flag value at resolution time.
+	if !v.GetBool("galactic_cni.enable_local_ipam") {
+		t.Error("enable_local_ipam after setting flag = false, want true")
+	}
+}
+
+func TestNodeNameFromFlag(t *testing.T) {
+	v := newViper()
+	cmd := &cobra.Command{Use: testCmdName}
+	bindFlags(cmd, v)
+
+	if err := cmd.Flags().Set("node-name", "test-node"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+
+	if v.GetString("galactic_cni.node_name") != "test-node" {
+		t.Errorf("node_name after setting flag = %q, want %q",
+			v.GetString("galactic_cni.node_name"), "test-node")
+	}
+}

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -53,25 +53,25 @@ func newViper() *viper.Viper {
 
 	v.AutomaticEnv()
 
-	// Explicit bindings — env var names do not follow a uniform
-	// GALACTIC_ROUTER_* prefix pattern, so AutomaticEnv alone would not
-	// resolve them correctly.
+	// Explicit bindings — AutomaticEnv uses the snake_case key derived from
+	// the viper key path (e.g. galactic_router.node_name ->
+	// GALACTIC_ROUTER_NODE_NAME), but some keys need explicit mapping.
 	//nolint:errcheck // keys are controlled, BindEnv cannot fail here
-	v.BindEnv("galactic_router.node_name", "NODE_NAME")
+	v.BindEnv("galactic_router.node_name", "GALACTIC_ROUTER_NODE_NAME")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.router_role", "ROUTER_ROLE")
+	v.BindEnv("galactic_router.router_role", "GALACTIC_ROUTER_ROUTER_ROLE")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.bgp_listen_port", "BGP_LISTEN_PORT")
+	v.BindEnv("galactic_router.bgp_listen_port", "GALACTIC_ROUTER_BGP_LISTEN_PORT")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.bgp_local_address", "BGP_LOCAL_ADDRESS")
+	v.BindEnv("galactic_router.bgp_local_address", "GALACTIC_ROUTER_BGP_LOCAL_ADDRESS")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.gobgp_grpc_server_enabled", "GALACTIC_GOBGP_GRPC_SERVER_ENABLED")
+	v.BindEnv("galactic_router.gobgp_grpc_server_enabled", "GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.gobgp_grpc_port", "GALACTIC_GOBGP_GRPC_PORT")
+	v.BindEnv("galactic_router.gobgp_grpc_port", "GALACTIC_ROUTER_GOBGP_GRPC_PORT")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.metrics_port", "METRICS_PORT")
+	v.BindEnv("galactic_router.metrics_port", "GALACTIC_ROUTER_METRICS_PORT")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.grpc_health_port", "GRPC_HEALTH_PORT")
+	v.BindEnv("galactic_router.grpc_health_port", "GALACTIC_ROUTER_GRPC_HEALTH_PORT")
 
 	return v
 }
@@ -126,19 +126,19 @@ func validateConfig(v *viper.Viper) error {
 		return fmt.Errorf("--router-role is required")
 	}
 	if routerRole != roleTenant && routerRole != roleFabric {
-		return fmt.Errorf("ROUTER_ROLE must be 'tenant' or 'fabric', got %q", routerRole)
+		return fmt.Errorf("GALACTIC_ROUTER_ROUTER_ROLE must be 'tenant' or 'fabric', got %q", routerRole)
 	}
 	if bgpListenPort < -1 || bgpListenPort > 65535 {
-		return fmt.Errorf("BGP_LISTEN_PORT must be -1 or a valid port number, got %d", bgpListenPort)
+		return fmt.Errorf("GALACTIC_ROUTER_BGP_LISTEN_PORT must be -1 or a valid port number, got %d", bgpListenPort)
 	}
 	if grpcPort < 1 || grpcPort > 65535 {
-		return fmt.Errorf("GALACTIC_GOBGP_GRPC_PORT must be a valid port number (1-65535), got %d", grpcPort)
+		return fmt.Errorf("GALACTIC_ROUTER_GOBGP_GRPC_PORT must be a valid port number (1-65535), got %d", grpcPort)
 	}
 	if metricsPort < 1 || metricsPort > 65535 {
-		return fmt.Errorf("METRICS_PORT must be a valid port number (1-65535), got %d", metricsPort)
+		return fmt.Errorf("GALACTIC_ROUTER_METRICS_PORT must be a valid port number (1-65535), got %d", metricsPort)
 	}
 	if grpcHealthPort < 1 || grpcHealthPort > 65535 {
-		return fmt.Errorf("GRPC_HEALTH_PORT must be a valid port number (1-65535), got %d", grpcHealthPort)
+		return fmt.Errorf("GALACTIC_ROUTER_GRPC_HEALTH_PORT must be a valid port number (1-65535), got %d", grpcHealthPort)
 	}
 	return nil
 }

--- a/cmd/galactic-router/root_test.go
+++ b/cmd/galactic-router/root_test.go
@@ -55,9 +55,9 @@ func TestRequiredFlags(t *testing.T) {
 }
 
 func TestEnvVarDefaults(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "false")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "false")
 
 	v := cmdWithViper(t)
 	if err := validateConfig(v); err != nil {
@@ -66,19 +66,19 @@ func TestEnvVarDefaults(t *testing.T) {
 }
 
 func TestGRPCPortEnvVar(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "true")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "9999")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "true")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "9999")
 
 	v := cmdWithViper(t)
 	if err := validateConfig(v); err != nil {
-		t.Errorf("validateConfig with GALACTIC_GOBGP_GRPC_PORT=9999: %v", err)
+		t.Errorf("validateConfig with GALACTIC_ROUTER_GOBGP_GRPC_PORT=9999: %v", err)
 	}
 }
 
 func TestFlagOverridesEnv(t *testing.T) {
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "9999")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "9999")
 
 	v := cmdWithViper(t)
 	// Simulate a flag override by setting the viper key directly (v.Set
@@ -90,10 +90,10 @@ func TestFlagOverridesEnv(t *testing.T) {
 }
 
 func TestEnvVarOnly(t *testing.T) {
-	t.Setenv("NODE_NAME", "env-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "true")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "7777")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "env-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "true")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "7777")
 
 	v := cmdWithViper(t)
 	if v.GetString("galactic_router.node_name") != "env-node" {
@@ -105,8 +105,8 @@ func TestEnvVarOnly(t *testing.T) {
 }
 
 func TestInvalidRouterRole(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "invalid")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "invalid")
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
@@ -116,10 +116,10 @@ func TestInvalidRouterRole(t *testing.T) {
 }
 
 func TestGRPCPortOverflow(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "true")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "70000")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "true")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "70000")
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
@@ -129,10 +129,10 @@ func TestGRPCPortOverflow(t *testing.T) {
 }
 
 func TestGRPCPortZero(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "true")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "0")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "true")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "0")
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
@@ -142,25 +142,25 @@ func TestGRPCPortZero(t *testing.T) {
 }
 
 func TestBGPListenPortMinusOne(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("BGP_LISTEN_PORT", "-1")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "-1")
 
 	v := cmdWithViper(t)
 	if err := validateConfig(v); err != nil {
-		t.Errorf("validateConfig with BGP_LISTEN_PORT=-1: %v", err)
+		t.Errorf("validateConfig with GALACTIC_ROUTER_BGP_LISTEN_PORT=-1: %v", err)
 	}
 }
 
 func TestBGPListenPortOverflow(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("BGP_LISTEN_PORT", "70000")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "70000")
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
 	if err == nil {
-		t.Error("validateConfig with BGP_LISTEN_PORT=70000 returned nil error")
+		t.Error("validateConfig with GALACTIC_ROUTER_BGP_LISTEN_PORT=70000 returned nil error")
 	}
 }
 
@@ -173,8 +173,8 @@ func TestNodeNameRequired(t *testing.T) {
 }
 
 func TestRouterRoleRequired(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	// ROUTER_ROLE unset
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	// GALACTIC_ROUTER_ROUTER_ROLE unset
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
@@ -186,9 +186,9 @@ func TestRouterRoleRequired(t *testing.T) {
 func TestValidRoles(t *testing.T) {
 	for _, role := range []string{"tenant", "fabric"} {
 		t.Run(role, func(t *testing.T) {
-			t.Setenv("NODE_NAME", "test-node")
-			t.Setenv("ROUTER_ROLE", role)
-			t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "false")
+			t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+			t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", role)
+			t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "false")
 
 			v := cmdWithViper(t)
 			// Verify the role is read correctly.
@@ -204,9 +204,9 @@ func TestValidRoles(t *testing.T) {
 }
 
 func TestMetricsPortOverride(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("METRICS_PORT", "9090")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_METRICS_PORT", "9090")
 
 	v := cmdWithViper(t)
 	if v.GetInt("galactic_router.metrics_port") != 9090 {
@@ -215,9 +215,9 @@ func TestMetricsPortOverride(t *testing.T) {
 }
 
 func TestGRPCHealthPortOverride(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GRPC_HEALTH_PORT", "9091")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT", "9091")
 
 	v := cmdWithViper(t)
 	if v.GetInt("galactic_router.grpc_health_port") != 9091 {
@@ -226,10 +226,10 @@ func TestGRPCHealthPortOverride(t *testing.T) {
 }
 
 func TestGRPCServerEnabled(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "true")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "50051")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "true")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "50051")
 
 	v := cmdWithViper(t)
 	if !v.GetBool("galactic_router.gobgp_grpc_server_enabled") {
@@ -241,10 +241,10 @@ func TestGRPCServerEnabled(t *testing.T) {
 }
 
 func TestGRPCServerDisabled(t *testing.T) {
-	t.Setenv("NODE_NAME", "test-node")
-	t.Setenv("ROUTER_ROLE", "tenant")
-	t.Setenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED", "false")
-	t.Setenv("GALACTIC_GOBGP_GRPC_PORT", "9999")
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED", "false")
+	t.Setenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT", "9999")
 
 	v := cmdWithViper(t)
 	if v.GetBool("galactic_router.gobgp_grpc_server_enabled") {
@@ -260,14 +260,14 @@ func TestVersionFlag(t *testing.T) {
 
 func TestDefaults(t *testing.T) {
 	// Clear all relevant env vars.
-	_ = os.Unsetenv("NODE_NAME")
-	_ = os.Unsetenv("ROUTER_ROLE")
-	_ = os.Unsetenv("BGP_LISTEN_PORT")
-	_ = os.Unsetenv("BGP_LOCAL_ADDRESS")
-	_ = os.Unsetenv("GALACTIC_GOBGP_GRPC_SERVER_ENABLED")
-	_ = os.Unsetenv("GALACTIC_GOBGP_GRPC_PORT")
-	_ = os.Unsetenv("METRICS_PORT")
-	_ = os.Unsetenv("GRPC_HEALTH_PORT")
+	_ = os.Unsetenv("GALACTIC_ROUTER_NODE_NAME")
+	_ = os.Unsetenv("GALACTIC_ROUTER_ROUTER_ROLE")
+	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LISTEN_PORT")
+	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LOCAL_ADDRESS")
+	_ = os.Unsetenv("GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED")
+	_ = os.Unsetenv("GALACTIC_ROUTER_GOBGP_GRPC_PORT")
+	_ = os.Unsetenv("GALACTIC_ROUTER_METRICS_PORT")
+	_ = os.Unsetenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT")
 
 	v := cmdWithViper(t)
 

--- a/config/daemonset/tenant/daemonset.yaml
+++ b/config/daemonset/tenant/daemonset.yaml
@@ -25,11 +25,11 @@ spec:
           command:
             - /galactic-router
           env:
-            - name: NODE_NAME
+            - name: GALACTIC_ROUTER_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_ROLE
               value: tenant
           ports:
             - name: metrics

--- a/deploy/containerlab/containers/galactic-router/Dockerfile
+++ b/deploy/containerlab/containers/galactic-router/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
       -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
       -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE}" \
-    -o galactic-router cmd/galactic-router/main.go
+    -o galactic-router ./cmd/galactic-router/
 
 # Use distroless as minimal base image to package the router binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
+++ b/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
@@ -59,14 +59,16 @@ else # worker
 
   # Galactic CNI plugin and agent
   # Install the binary under a .bin suffix and front it with a wrapper that
-  # exports NODE_NAME from the container hostname. CNI binaries are exec'd
-  # directly by the kubelet and do not inherit NODE_NAME from the pod downward
-  # API; in Kind the container hostname equals the Kubernetes node name.
+  # exports NODE_NAME and GALACTIC_CNI_NODE_NAME from the container hostname.
+  # CNI binaries are exec'd directly by the kubelet and do not inherit
+  # NODE_NAME from the pod downward API; in Kind the container hostname
+  # equals the Kubernetes node name.
   install -m 0755 /galactic/bin/galactic-cni /opt/cni/bin/galactic-cni.bin
   install -m 0755 /galactic/bin/galactic-cni /usr/local/bin/galactic-cni
   cat > /opt/cni/bin/galactic-cni <<'EOF'
 #!/bin/sh
 export NODE_NAME=$(hostname)
+export GALACTIC_CNI_NODE_NAME=$(hostname)
 exec /opt/cni/bin/galactic-cni.bin "$@"
 EOF
   chmod 0755 /opt/cni/bin/galactic-cni

--- a/deploy/containerlab/resources/overlay/base/daemonset.yaml
+++ b/deploy/containerlab/resources/overlay/base/daemonset.yaml
@@ -32,13 +32,13 @@ spec:
           command:
             - /galactic-router
           env:
-            - name: NODE_NAME
+            - name: GALACTIC_ROUTER_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_ROLE
               value: tenant
-            - name: BGP_LISTEN_PORT
+            - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "-1"
           securityContext:
             capabilities:

--- a/deploy/containerlab/resources/overlay/dfw/daemonset/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/dfw/daemonset/daemonset-patch.yaml
@@ -8,5 +8,5 @@ spec:
       containers:
         - name: galactic-router
           env:
-            - name: BGP_LOCAL_ADDRESS
+            - name: GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
               value: "fc00:0:2::1"

--- a/deploy/containerlab/resources/overlay/iad/daemonset/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/iad/daemonset/daemonset-patch.yaml
@@ -19,5 +19,5 @@ spec:
       containers:
         - name: galactic-router
           env:
-            - name: BGP_LOCAL_ADDRESS
+            - name: GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
               value: "fc00:0:4::1"

--- a/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
@@ -30,11 +30,11 @@ spec:
       containers:
         - name: galactic-router
           env:
-            - name: BGP_LOCAL_ADDRESS
+            - name: GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
               value: "fc00:0:8::1"
-            - name: ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_ROLE
               value: tenant
-            - name: BGP_LISTEN_PORT
+            - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "1790"
           livenessProbe:
             grpc:

--- a/deploy/containerlab/resources/overlay/sjc/daemonset/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/sjc/daemonset/daemonset-patch.yaml
@@ -8,5 +8,5 @@ spec:
       containers:
         - name: galactic-router
           env:
-            - name: BGP_LOCAL_ADDRESS
+            - name: GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
               value: "fc00:0:3::1"

--- a/deploy/containerlab/scripts/install-testvpc.sh
+++ b/deploy/containerlab/scripts/install-testvpc.sh
@@ -63,11 +63,13 @@ EOF
     docker exec "${worker}" mkdir -p /etc/galactic
     echo "${kubeconfig}" | docker exec -i "${worker}" tee /etc/galactic/kubeconfig > /dev/null
 
-    # Update the wrapper to export KUBECONFIG so the CNI binary can reach the
-    # API server. Rewrite the wrapper in-place.
+    # Update the wrapper to export KUBECONFIG and NODE_NAME so the CNI binary
+    # can reach the API server and resolve the node name. Rewrite the wrapper
+    # in-place.
     docker exec "${worker}" sh -c 'cat > /opt/cni/bin/galactic-cni <<'"'"'EOF'"'"'
 #!/bin/sh
 export NODE_NAME=$(hostname)
+export GALACTIC_CNI_NODE_NAME=$(hostname)
 export KUBECONFIG=/etc/galactic/kubeconfig
 exec /opt/cni/bin/galactic-cni.bin "$@"
 EOF

--- a/deploy/galactic-router/daemonset.yaml
+++ b/deploy/galactic-router/daemonset.yaml
@@ -24,11 +24,11 @@ spec:
           command:
             - /galactic-router
           env:
-            - name: NODE_NAME
+            - name: GALACTIC_ROUTER_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_ROLE
               value: tenant
           ports:
             - name: metrics

--- a/docs/agent-startup.md
+++ b/docs/agent-startup.md
@@ -6,7 +6,7 @@ sequenceDiagram
     participant GoBGP
     participant Kubernetes
 
-    Router->>Router: validate NODE_NAME and ROUTER_ROLE env vars
+    Router->>Router: validate GALACTIC_ROUTER_NODE_NAME and GALACTIC_ROUTER_ROUTER_ROLE env vars
     Router->>Router: start gRPC health server (:5000, SERVING immediately)
     Router->>Kubernetes: register field indexes (BGPPeer, BGPAdvertisement, BGPPolicy, Secret)
     Router->>Kubernetes: start controller-runtime manager (metrics :8080, watch BGPRouter/BGPPeer/BGPAdvertisement/BGPPolicy/Secret/Node)

--- a/docs/cni-sequence.md
+++ b/docs/cni-sequence.md
@@ -16,7 +16,7 @@ sequenceDiagram
         note over Multus,Router: cmdAdd — Container Attach
         Multus->>CNI: ADD (VPC, VPCAttachment, SRv6Locator, namespace, IPAM, terminations)
         CNI->>CNI: parseConf()
-        CNI->>CNI: validate NODE_NAME env var
+        CNI->>CNI: validate GALACTIC_CNI_NODE_NAME env var
         CNI->>VRF: Add(VPC, VPCAttachment)
         CNI->>Veth: Add(VPC, VPCAttachment, MTU)
         loop for each termination

--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -1,0 +1,184 @@
+# CNI Configuration
+
+`galactic-cni` is configured through the CNI JSON configuration passed by Multus
+(or any CNI manager). Additionally, the binary requires a node name at runtime
+via an environment variable or CLI flag.
+
+## Runtime Configuration
+
+The `galactic-cni` binary requires the node name to scope BGP advertisement
+CRD creation. It also supports an optional built-in IPAM mode for deployments
+that do not configure an explicit `ipam` block in the CNI config.
+
+| Option | Environment Variable | CLI Flag | Default |
+|---|---|---|---|
+| Node name | `GALACTIC_CNI_NODE_NAME` | `--node-name` | _(required)_ |
+| Enable local IPAM | `GALACTIC_CNI_ENABLE_LOCAL_IPAM` | `--enable-local-ipam` | `false` |
+
+### `--node-name` / `GALACTIC_CNI_NODE_NAME`
+
+The Kubernetes node name where the container is running. Used to create the
+`BGPAdvertisement` CRD on the correct `BGPRouter`.
+
+**Type:** string
+**Required:** yes
+
+### `--enable-local-ipam` / `GALACTIC_CNI_ENABLE_LOCAL_IPAM`
+
+When enabled, the plugin performs IP allocation using a built-in IPv6 pool
+allocator even when no explicit `ipam` block is present in the CNI config.
+This is useful for simple deployments that do not need an external IPAM
+plugin.
+
+When local IPAM is active but the config does not specify pool parameters,
+the following defaults are used:
+
+| Parameter | Default |
+|---|---|
+| Pool CIDR | `fd00:10:ff01::/48` |
+| Subnet length | `/80` |
+| Gateway | First usable address in the pool (`::1`) |
+
+If an explicit `ipam` block is present in the CNI config, it takes precedence
+and this flag has no effect on the allocation behavior.
+
+**Type:** bool
+**Default:** `false`
+
+## CNI Configuration JSON
+
+The CNI configuration is a JSON object passed at pod creation time. It extends
+the standard CNI `PluginConf` with Galactic-specific fields.
+
+### Top-Level Fields
+
+| Field | JSON Key | Required | Type | Description |
+|---|---|---|---|---|
+| `vpc` | `"vpc"` | **Yes** | `string` | Base62-encoded VPC identifier (48-bit value). Used to derive VRF names, interface names, and BGP route targets. |
+| `vpcattachment` | `"vpcattachment"` | **Yes** | `string` | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming. |
+| `srv6_locator` | `"srv6_locator"` | **Yes** | `string` | IPv6 prefix (e.g. `2001:db8:ff01::/48`). VPC and VPCAttachment identifiers are encoded into the low 64 bits to produce SRv6 endpoints for BGP advertisements. |
+| `mtu` | `"mtu"` | No | `int` | MTU for the host-side veth pair. Passed to `veth.Add()`. |
+| `terminations` | `"terminations"` | No | `[]Termination` | Array of static routes to add on the host side (see Termination sub-fields below). |
+| `namespace` | `"namespace"` | No | `string` | Kubernetes namespace used to look up the `BGPRouter` CRD. Defaults to `"default"` if omitted. |
+| `ipam` | `"ipam"` | No* | `IPAM` | IP address management configuration (see IPAM sub-fields below). *Required unless `--enable-local-ipam` is set. |
+
+Standard CNI fields (`cniVersion`, `name`, `dns`, `runtimeConfig`) are also
+supported via the embedded `types.PluginConf`.
+
+### IPAM Fields
+
+| Field | JSON Key | Required | Type | Description |
+|---|---|---|---|---|
+| `type` | `"type"` | **Yes** | `string` | `"pool"` (default) or `"static"`. Determines IP allocation strategy. |
+| `pool` | `"pool"` | Conditionally required | `string` | IPv6 CIDR pool (e.g. `"fd00:10:ff01::/48"`) from which subnets are allocated. Required when `type` is `"pool"`. |
+| `gateway` | `"gateway"` | No | `string` | IPv6 gateway address. If omitted, uses the first usable address in the pool (host bits = 1). Must be within the pool CIDR. |
+| `subnet_len` | `"subnet_len"` | No | `int` | Prefix length per allocation. Default is `80` (giving 2^48 addresses per pod subnet). Pool prefix must be <= this value. |
+| `static_ip` | `"static_ip"` | Conditionally required | `string` | A single IPv6 address to assign when `type` is `"static"`. |
+
+#### IPAM `type=pool`
+
+Allocates a `/subnet_len` subnet (default `/80`) from the pool CIDR. Thread-safe
+in-memory allocation. Allocations are ephemeral (lost on process restart);
+deallocation during `cmdDel` looks up the subnet from a `BGPAdvertisement` CRD
+annotation on the host.
+
+#### IPAM `type=static`
+
+Validates and assigns a single IPv6 address with a `/64` mask. No deallocation
+needed.
+
+> **Note:** The plugin uses IPv6 only — both the pool allocator and static
+> allocator explicitly reject IPv4 addresses.
+
+### Termination Fields
+
+Each entry in the `terminations` array has the following fields:
+
+| Field | JSON Key | Required | Type | Description |
+|---|---|---|---|---|
+| `network` | `"network"` | **Yes** | `string` | CIDR prefix for a static route (e.g. `"fd00::/48"`). |
+| `via` | `"via"` | No | `string` | Next-hop gateway IP. If omitted, a link-local route is installed via the host-side device. |
+
+Used in `cmdAdd` to install routes into the VRF table for each termination
+entry. Deleted in `cmdDel` in reverse order.
+
+## Example Configurations
+
+### Minimal configuration (overlay)
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "galactic",
+  "type": "galactic-cni",
+  "vpc": "1",
+  "vpcattachment": "1",
+  "srv6_locator": "2001:db8:ff01::/48"
+}
+```
+
+Omits `namespace` (defaults to `"default"`), `ipam`, and `terminations`.
+Without the `--enable-local-ipam` flag, no IP address is assigned to the
+guest interface. With `--enable-local-ipam`, a subnet is allocated from the
+built-in pool.
+
+### Full pool-based configuration (testvpc)
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "testvpc",
+  "type": "galactic-cni",
+  "vpc": "10",
+  "vpcattachment": "10",
+  "namespace": "galactic-system",
+  "srv6_locator": "2001:db8:ff02::/48",
+  "ipam": {
+    "type": "pool",
+    "pool": "fd00:10:ff02::/48",
+    "gateway": "fd00:10:ff02::1",
+    "subnet_len": 80
+  }
+}
+```
+
+### Static IP configuration
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "galactic",
+  "type": "galactic-cni",
+  "vpc": "1",
+  "vpcattachment": "1",
+  "srv6_locator": "2001:db8:ff01::/48",
+  "ipam": {
+    "type": "static",
+    "static_ip": "fd00:1::1"
+  }
+}
+```
+
+### Configuration with terminations
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "galactic",
+  "type": "galactic-cni",
+  "vpc": "1",
+  "vpcattachment": "1",
+  "srv6_locator": "2001:db8:ff01::/48",
+  "terminations": [
+    { "network": "fd00::/48", "via": "fe80::1" },
+    { "network": "fd01::/48" }
+  ],
+  "ipam": {
+    "type": "pool",
+    "pool": "fd00:1:ff01::/48"
+  }
+}
+```
+
+The first termination installs a specific next-hop route; the second installs
+a link-local route via the host-side device.

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -1,32 +1,32 @@
-# CLI Configuration
+# Router Configuration
 
 `galactic-router` supports configuration via environment variables, CLI flags,
 or a combination of both. CLI flags take precedence over environment variables.
 
 ## Quick Reference
 
-| Option            | Environment Variable                 | CLI Flag                      | Default      |
-|-------------------|--------------------------------------|-------------------------------|--------------|
-| Node name         | `NODE_NAME`                          | `--node-name`                 | _(required)_ |
-| Router role       | `ROUTER_ROLE`                        | `--router-role`               | _(required)_ |
-| BGP listen port   | `BGP_LISTEN_PORT`                    | `--bgp-listen-port`           | `179`        |
-| BGP local address | `BGP_LOCAL_ADDRESS`                  | `--bgp-local-address`         | `""`         |
-| GoBGP gRPC server | `GALACTIC_GOBGP_GRPC_SERVER_ENABLED` | `--gobgp-grpc-server-enabled` | `false`      |
-| GoBGP gRPC port   | `GALACTIC_GOBGP_GRPC_PORT`           | `--gobgp-grpc-port`           | `50051`      |
-| Metrics port      | `METRICS_PORT`                       | `--metrics-port`              | `8080`       |
-| gRPC health port  | `GRPC_HEALTH_PORT`                   | `--grpc-health-port`          | `5000`       |
+| Option | Environment Variable | CLI Flag | Default |
+|---|---|---|---|
+| Node name | `GALACTIC_ROUTER_NODE_NAME` | `--node-name` | _(required)_ |
+| Router role | `GALACTIC_ROUTER_ROUTER_ROLE` | `--router-role` | _(required)_ |
+| BGP listen port | `GALACTIC_ROUTER_BGP_LISTEN_PORT` | `--bgp-listen-port` | `179` |
+| BGP local address | `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` | `--bgp-local-address` | `""` |
+| GoBGP gRPC server | `GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED` | `--gobgp-grpc-server-enabled` | `false` |
+| GoBGP gRPC port | `GALACTIC_ROUTER_GOBGP_GRPC_PORT` | `--gobgp-grpc-port` | `50051` |
+| Metrics port | `GALACTIC_ROUTER_METRICS_PORT` | `--metrics-port` | `8080` |
+| gRPC health port | `GALACTIC_ROUTER_GRPC_HEALTH_PORT` | `--grpc-health-port` | `5000` |
 
 ## Required Options
 
 The following options are **required**. If unset, `galactic-router` exits with
 an error:
 
-- `--node-name` (`NODE_NAME`) — Kubernetes node name where the router runs.
-- `--router-role` (`ROUTER_ROLE`) — Router role: `tenant` or `fabric`.
+- `--node-name` (`GALACTIC_ROUTER_NODE_NAME`) — Kubernetes node name where the router runs.
+- `--router-role` (`GALACTIC_ROUTER_ROUTER_ROLE`) — Router role: `tenant` or `fabric`.
 
 ## Option Details
 
-### `--node-name` / `NODE_NAME`
+### `--node-name` / `GALACTIC_ROUTER_NODE_NAME`
 
 The Kubernetes node name where `galactic-router` is deployed. This value is
 used to scope BGP configuration to the correct node.
@@ -34,7 +34,7 @@ used to scope BGP configuration to the correct node.
 **Type:** string
 **Required:** yes
 
-### `--router-role` / `ROUTER_ROLE`
+### `--router-role` / `GALACTIC_ROUTER_ROUTER_ROLE`
 
 The routing role of this instance. Determines which BGP backend is used:
 
@@ -45,7 +45,7 @@ The routing role of this instance. Determines which BGP backend is used:
 **Required:** yes
 **Valid values:** `tenant`, `fabric`
 
-### `--bgp-listen-port` / `BGP_LISTEN_PORT`
+### `--bgp-listen-port` / `GALACTIC_ROUTER_BGP_LISTEN_PORT`
 
 TCP port that GoBGP binds for inbound BGP peer connections. Set to `-1` to
 run in outbound-only mode (no inbound BGP listener).
@@ -54,7 +54,7 @@ run in outbound-only mode (no inbound BGP listener).
 **Default:** `179`
 **Valid values:** `-1`, `1`–`65535`
 
-### `--bgp-local-address` / `BGP_LOCAL_ADDRESS`
+### `--bgp-local-address` / `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS`
 
 Source IP address used for outgoing BGP TCP connections. When empty, the kernel
 selects the default source address.
@@ -62,7 +62,7 @@ selects the default source address.
 **Type:** string
 **Default:** `""` (empty)
 
-### `--gobgp-grpc-server-enabled` / `GALACTIC_GOBGP_GRPC_SERVER_ENABLED`
+### `--gobgp-grpc-server-enabled` / `GALACTIC_ROUTER_GOBGP_GRPC_SERVER_ENABLED`
 
 Enable the embedded GoBGP gRPC API server. When enabled, the gRPC server
 listens on the port specified by `--gobgp-grpc-port`.
@@ -70,7 +70,7 @@ listens on the port specified by `--gobgp-grpc-port`.
 **Type:** boolean
 **Default:** `false`
 
-### `--gobgp-grpc-port` / `GALACTIC_GOBGP_GRPC_PORT`
+### `--gobgp-grpc-port` / `GALACTIC_ROUTER_GOBGP_GRPC_PORT`
 
 TCP port for the GoBGP gRPC API server. Only used when
 `--gobgp-grpc-server-enabled` is `true`.
@@ -79,7 +79,7 @@ TCP port for the GoBGP gRPC API server. Only used when
 **Default:** `50051`
 **Valid values:** `1`–`65535`
 
-### `--metrics-port` / `METRICS_PORT`
+### `--metrics-port` / `GALACTIC_ROUTER_METRICS_PORT`
 
 TCP port for the controller-runtime metrics HTTP server. Exposes Prometheus
 metrics for monitoring.
@@ -88,7 +88,7 @@ metrics for monitoring.
 **Default:** `8080`
 **Valid values:** `1`–`65535`
 
-### `--grpc-health-port` / `GRPC_HEALTH_PORT`
+### `--grpc-health-port` / `GALACTIC_ROUTER_GRPC_HEALTH_PORT`
 
 TCP port for the gRPC health check server. Used by Kubernetes liveness and
 readiness probes.
@@ -102,7 +102,7 @@ readiness probes.
 Values are resolved in the following order (highest to lowest priority):
 
 1. **CLI flag** — e.g. `--metrics-port 9090`
-2. **Environment variable** — e.g. `METRICS_PORT=9090`
+2. **Environment variable** — e.g. `GALACTIC_ROUTER_METRICS_PORT=9090`
 3. **Default** — compiled-in default value
 
 ## Examples
@@ -111,11 +111,11 @@ Values are resolved in the following order (highest to lowest priority):
 
 ```yaml
 env:
-  - name: NODE_NAME
+  - name: GALACTIC_ROUTER_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: status.nodeName
-  - name: ROUTER_ROLE
+  - name: GALACTIC_ROUTER_ROUTER_ROLE
     value: tenant
 ```
 
@@ -127,13 +127,13 @@ All other options use their defaults.
 command:
   - /galactic-router
 args:
-  - --node-name=$(NODE_NAME)
+  - --node-name=$(GALACTIC_ROUTER_NODE_NAME)
   - --router-role=tenant
   - --metrics-port=9090
   - --gobgp-grpc-server-enabled=true
   - --gobgp-grpc-port=50051
 env:
-  - name: NODE_NAME
+  - name: GALACTIC_ROUTER_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: status.nodeName
@@ -145,18 +145,18 @@ Environment variables provide defaults; CLI flags override specific values:
 
 ```yaml
 env:
-  - name: NODE_NAME
+  - name: GALACTIC_ROUTER_NODE_NAME
     valueFrom:
       fieldRef:
         fieldPath: status.nodeName
-  - name: ROUTER_ROLE
+  - name: GALACTIC_ROUTER_ROUTER_ROLE
     value: tenant
-  - name: METRICS_PORT
+  - name: GALACTIC_ROUTER_METRICS_PORT
     value: "9090"
 command:
   - /galactic-router
 args:
-  - --node-name=$(NODE_NAME)
+  - --node-name=$(GALACTIC_ROUTER_NODE_NAME)
   - --router-role=tenant
-  - --metrics-port=9100   # overrides METRICS_PORT env var
+  - --metrics-port=9100   # overrides GALACTIC_ROUTER_METRICS_PORT env var
 ```

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -40,6 +40,19 @@ import (
 
 const cniTimeout = 10 * time.Second
 
+// ipamTypePool is the ipam type for the built-in local IPAM pool allocator.
+const ipamTypePool = "pool"
+
+const (
+	// localIPAMDefaultPool is the IPv6 CIDR pool used when local IPAM is
+	// enabled but no explicit ipam block is present in the CNI config.
+	localIPAMDefaultPool = "fd00:10:ff01::/48"
+
+	// localIPAMDefaultSubnetLen is the default prefix length for local IPAM
+	// allocations (default /80, giving 2^48 addresses per pod subnet).
+	localIPAMDefaultSubnetLen = 80
+)
+
 const (
 	// annotationAllocatedSubnet is the BGPAdvertisement annotation key prefix
 	// holding the allocated pod subnet CIDR for a container ID. The full key
@@ -67,6 +80,15 @@ func subnetAnnotationKey(containerID string) string {
 }
 
 var cniScheme = runtime.NewScheme()
+
+// enableLocalIPAM controls whether the plugin performs IP allocation when
+// no explicit ipam block is present in the CNI config. Defaults to false.
+var enableLocalIPAM bool
+
+// SetEnableLocalIPAM sets the local IPAM flag from the CLI.
+func SetEnableLocalIPAM(v bool) {
+	enableLocalIPAM = v
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(cniScheme))
@@ -220,7 +242,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	// After hostDevice("ADD"), the guest interface is named args.IfName inside
 	// the container (host-device renames it), not the original guestName.
 	var ipamResult *ipamResult
-	if pluginConf.IPAM.Type != "" {
+	if pluginConf.IPAM.Type != "" || enableLocalIPAM {
 		result, err := configureIPAM(args, pluginConf, args.IfName)
 		if err != nil {
 			return fmt.Errorf("configure IPAM: %w", err)
@@ -318,7 +340,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	// Deallocate IPAM subnet before any other cleanup.
-	if pluginConf.IPAM.Type != "" {
+	if pluginConf.IPAM.Type != "" || enableLocalIPAM {
 		deallocateIPAM(args, pluginConf)
 	}
 
@@ -413,13 +435,22 @@ func buildResult(pluginConf *PluginConf, ipRes *ipamResult) *type100.Result {
 }
 
 // configureIPAM allocates a subnet and configures the guest interface inside the
-// container network namespace.
+// container network namespace. When enableLocalIPAM is true and no explicit
+// ipam block is configured, falls back to a built-in pool allocator using
+// default pool CIDR and subnet length.
 func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string) (*ipamResult, error) {
 	var pool *ipam.PoolAllocator
 	var subnet *net.IPNet
 	var err error
 
-	switch pluginConf.IPAM.Type {
+	// When local IPAM is enabled but no explicit ipam type is configured,
+	// use the built-in pool allocator with defaults.
+	poolType := pluginConf.IPAM.Type
+	if poolType == "" && enableLocalIPAM {
+		poolType = ipamTypePool
+	}
+
+	switch poolType {
 	case "static":
 		alloc := ipam.NewStaticAllocator()
 		allocIP, err := alloc.Allocate(args.ContainerID, pluginConf.IPAM.StaticIP)
@@ -430,8 +461,17 @@ func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string)
 			IP:   allocIP,
 			Mask: net.CIDRMask(64, 128),
 		}
-	case "pool", "":
-		pool, err = ipam.NewPoolAllocator(pluginConf.IPAM.Pool, pluginConf.IPAM.Gateway, pluginConf.IPAM.SubnetLen)
+	case ipamTypePool:
+		poolCIDR := pluginConf.IPAM.Pool
+		gateway := pluginConf.IPAM.Gateway
+		subnetLen := pluginConf.IPAM.SubnetLen
+		if poolCIDR == "" && enableLocalIPAM {
+			poolCIDR = localIPAMDefaultPool
+		}
+		if subnetLen == 0 && enableLocalIPAM {
+			subnetLen = localIPAMDefaultSubnetLen
+		}
+		pool, err = ipam.NewPoolAllocator(poolCIDR, gateway, subnetLen)
 		if err != nil {
 			return nil, fmt.Errorf("create pool allocator: %w", err)
 		}
@@ -515,7 +555,8 @@ func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gatew
 
 // deallocateIPAM releases the IPAM allocation for the given container.
 // Reads the allocated subnet from the BGPAdvertisement CRD annotation, then
-// deallocates it from the in-memory pool.
+// deallocates it from the in-memory pool. When enableLocalIPAM is true and
+// no explicit ipam block is configured, uses the default pool CIDR.
 func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) {
 	// Look up the allocated subnet from the BGPAdvertisement annotation.
 	subnetCIDR := getAllocatedSubnetFromCRD(args.ContainerID, pluginConf)
@@ -525,9 +566,18 @@ func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) {
 		return
 	}
 
-	switch pluginConf.IPAM.Type {
-	case "pool", "":
-		pa, err := ipam.NewPoolAllocator(pluginConf.IPAM.Pool, pluginConf.IPAM.Gateway, pluginConf.IPAM.SubnetLen)
+	ipamType := pluginConf.IPAM.Type
+	if ipamType == "" && enableLocalIPAM {
+		ipamType = ipamTypePool
+	}
+
+	switch ipamType {
+	case ipamTypePool:
+		poolCIDR := pluginConf.IPAM.Pool
+		if poolCIDR == "" && enableLocalIPAM {
+			poolCIDR = localIPAMDefaultPool
+		}
+		pa, err := ipam.NewPoolAllocator(poolCIDR, pluginConf.IPAM.Gateway, pluginConf.IPAM.SubnetLen)
 		if err != nil {
 			// Pool creation failed — allocation was never completed, nothing to clean up.
 			return

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -186,6 +186,31 @@ func TestRouteTarget(t *testing.T) {
 	}
 }
 
+// ---- SetEnableLocalIPAM --------------------------------------------------
+
+func TestSetEnableLocalIPAM(t *testing.T) {
+	// Save and restore original state.
+	original := enableLocalIPAM
+	defer func() { enableLocalIPAM = original }()
+
+	// Default should be false.
+	if enableLocalIPAM {
+		t.Error("enableLocalIPAM default = true, want false")
+	}
+
+	// Setting to true should work.
+	SetEnableLocalIPAM(true)
+	if !enableLocalIPAM {
+		t.Error("enableLocalIPAM after SetEnableLocalIPAM(true) = false, want true")
+	}
+
+	// Setting back to false should work.
+	SetEnableLocalIPAM(false)
+	if enableLocalIPAM {
+		t.Error("enableLocalIPAM after SetEnableLocalIPAM(false) = true, want false")
+	}
+}
+
 // ---- lookupBGPRouter -----------------------------------------------------
 
 func TestLookupBGPRouter(t *testing.T) {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,7 +6,7 @@ COMMAND="${1:-}"
 case "$COMMAND" in
   unittest)
     echo "--- Running Go unit tests"
-    go test -v -race -coverprofile=coverage.out ./internal/...
+    go test -v -race -coverprofile=coverage.out ./cmd/... ./internal/...
     ;;
 
   e2etest)


### PR DESCRIPTION
## Summary

Updates the `galactic-cni` binary with command line options and env variable configuration options for better supportability and consistency.

## Changes

- Introduce cobra/viper CLI for galactic-cni (--node-name, --enable-local-ipam)
- Add comprehensive unit tests for CNI CLI flag defaults, env vars, and validation
- Support built-in IPv6 pool IPAM when no explicit ipam block is configured
- Add enable-local-ipam command line option (default is not enabled)
- Rename galactic-router env vars to GALACTIC_ROUTER_* prefix for consistency
- Update all deploy manifests (production, containerlab overlays) with new env var names
- Add KIND/Kind install wrappers to export GALACTIC_CNI_NODE_NAME alongside NODE_NAME
- Split configuration docs into docs/cni/ and docs/router/ subdirectories
- Extend CI test run to cover cmd/ packages