### PR TITLE
bugfix: implement SRv6 EVPN data plane for inter-node VPC routing

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -223,7 +223,7 @@ func runCmd(v *viper.Viper) error {
 	runtimeMgr := galacticruntime.NewRuntimeManager(factory)
 
 	// Create reconciler.
-	rec := reconcile.New(mgr.GetClient(), nodeName, routerRole)
+	rec := reconcile.New(mgr.GetClient(), nodeName, routerRole, bgpLocalAddr)
 
 	// Register BGPRouter controller.
 	if err := (&controller.BGPRouterReconciler{

--- a/deploy/containerlab/containers/galactic-router/Dockerfile
+++ b/deploy/containerlab/containers/galactic-router/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
       -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
       -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE}" \
-    -o galactic-router ./cmd/galactic-router/
+    -o galactic-router ./cmd/galactic-router
 
 # Use distroless as minimal base image to package the router binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/deploy/containerlab/resources/overlay/base/daemonset.yaml
+++ b/deploy/containerlab/resources/overlay/base/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
             - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "-1"
           securityContext:
+            runAsUser: 0
             capabilities:
               add:
                 - NET_ADMIN

--- a/deploy/galactic-router/daemonset.yaml
+++ b/deploy/galactic-router/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:
+            runAsUser: 0
             capabilities:
               add:
                 - NET_ADMIN

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -284,36 +284,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("read guest interface: %w", err)
 	}
 
-	// Add the gateway address to the host-side veth as a /128 host route, then
-	// explicitly install the pod subnet route into the VRF table.
-	//
-	// Using /128 (not the pod subnet mask) prevents the kernel from auto-creating
-	// a subnet-router anycast entry for the pod subnet prefix in the VRF local
-	// table. When the pod address equals the subnet network address (e.g. the pod
-	// holds fd00:10:ffXX::/80 and the gateway is fd00:10:ffXX::1/80), that
-	// anycast absorbs seg6local-decapped inner packets before they reach the pod.
-	//
-	// The explicit subnet route replaces the one the kernel would have created
-	// automatically from the /80 assignment, ensuring return-path routing after
-	// SRv6 decapsulation still works.
-	if ipamResult != nil && ipamResult.gateway != nil {
-		gwNet := &net.IPNet{IP: ipamResult.gateway, Mask: net.CIDRMask(128, 128)}
-		if addErr := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); addErr != nil {
-			if !errors.Is(addErr, syscall.EEXIST) {
-				return fmt.Errorf("add gateway address to host veth %q: %w", hostName, addErr)
-			}
-		}
-		tableID, tableErr := vrf.TableID(pluginConf.VPC, pluginConf.VPCAttachment)
-		if tableErr != nil {
-			return fmt.Errorf("get VRF table ID for pod subnet route: %w", tableErr)
-		}
-		if addErr := netlink.RouteReplace(&netlink.Route{
-			Dst:       ipamResult.subnet,
-			LinkIndex: hostLink.Attrs().Index,
-			Table:     int(tableID),
-		}); addErr != nil {
-			return fmt.Errorf("add pod subnet route to VRF table: %w", addErr)
-		}
+	if err := configureHostVethGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
+		return err
 	}
 
 	vpcHex, err := intf.Base62ToHex(pluginConf.VPC)
@@ -324,16 +296,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return fmt.Errorf("decode VPCAttachment: %w", err)
 	}
-	var srv6SIDStr string
-	if pluginConf.SRv6Locator != "" {
-		sid, err := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex)
-		if err != nil {
-			return fmt.Errorf("encode SRv6 endpoint: %w", err)
-		}
-		if err := srv6.RouteIngressAdd(sid); err != nil {
-			return fmt.Errorf("add SRv6 ingress route: %w", err)
-		}
-		srv6SIDStr = sid
+	srv6SIDStr, err := setupSRv6Ingress(pluginConf.SRv6Locator, vpcHex, vpcAttHex)
+	if err != nil {
+		return err
 	}
 
 	// Build and print the CNI result before Kubernetes operations so that the
@@ -345,6 +310,24 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("print CNI result: %w", err)
 	}
 
+	err = applyBGPObjects(nodeName, namespace, args.ContainerID, pluginConf, vpcHex, ipamResult, srv6SIDStr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// applyBGPObjects creates or updates the BGPVRFInstance and BGPAdvertisement
+// CRDs for the given VPC attachment. It is called after the CNI result is
+// printed so that K8s unavailability does not suppress the result.
+func applyBGPObjects(
+	nodeName, namespace, containerID string,
+	pluginConf *PluginConf,
+	vpcHex string,
+	ipamResult *ipamResult,
+	srv6SIDStr string,
+) error {
 	k8s, err := newK8sClient()
 	if err != nil {
 		return err
@@ -411,7 +394,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 			// Store the allocated subnet keyed by container ID so cmdDel can look it up.
 			if ipamResult != nil {
-				adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
+				adv.Annotations[subnetAnnotationKey(containerID)] = podSubnet
 			}
 			// Store the End.DT46 SID so galactic-router uses it as the EVPN GWIPAddress.
 			if srv6SIDStr != "" {
@@ -801,6 +784,59 @@ func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf) strin
 	}
 
 	return adv.Annotations[subnetAnnotationKey(containerID)]
+}
+
+// configureHostVethGateway assigns the gateway address as a /128 host address on
+// the host-side veth and installs an explicit pod-subnet route into the VRF table.
+//
+// Using /128 (not the pod subnet mask) prevents the kernel from auto-creating a
+// subnet-router anycast entry in the VRF local table. When the pod address equals
+// the subnet network address the anycast absorbs seg6local-decapped inner packets
+// before they reach the pod veth. The explicit subnet route replaces the one the
+// kernel would have created from the wider mask.
+func configureHostVethGateway(vpc, vpcAttachment string, res *ipamResult) error {
+	if res == nil || res.gateway == nil {
+		return nil
+	}
+	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	hostLink, err := netlink.LinkByName(hostName)
+	if err != nil {
+		return fmt.Errorf("get host veth %q: %w", hostName, err)
+	}
+	gwNet := &net.IPNet{IP: res.gateway, Mask: net.CIDRMask(128, 128)}
+	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); err != nil {
+		if !errors.Is(err, syscall.EEXIST) {
+			return fmt.Errorf("add gateway address to host veth %q: %w", hostName, err)
+		}
+	}
+	tableID, err := vrf.TableID(vpc, vpcAttachment)
+	if err != nil {
+		return fmt.Errorf("get VRF table ID for pod subnet route: %w", err)
+	}
+	if err := netlink.RouteReplace(&netlink.Route{
+		Dst:       res.subnet,
+		LinkIndex: hostLink.Attrs().Index,
+		Table:     int(tableID),
+	}); err != nil {
+		return fmt.Errorf("add pod subnet route to VRF table: %w", err)
+	}
+	return nil
+}
+
+// setupSRv6Ingress installs the End.DT46 SRv6 ingress decap route for the given
+// locator and returns the SID string. Returns empty string when locator is empty.
+func setupSRv6Ingress(locator, vpcHex, vpcAttHex string) (string, error) {
+	if locator == "" {
+		return "", nil
+	}
+	sid, err := intf.EncodeSRv6Endpoint(locator, vpcHex, vpcAttHex)
+	if err != nil {
+		return "", fmt.Errorf("encode SRv6 endpoint: %w", err)
+	}
+	if err := srv6.RouteIngressAdd(sid); err != nil {
+		return "", fmt.Errorf("add SRv6 ingress route: %w", err)
+	}
+	return sid, nil
 }
 
 type HostDevicePluginConf struct {

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -36,6 +37,7 @@ import (
 	"go.datum.net/galactic/internal/cni/veth"
 	"go.datum.net/galactic/internal/metadata"
 	"go.datum.net/galactic/internal/plumbing/intf"
+	"go.datum.net/galactic/internal/plumbing/srv6"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
@@ -59,6 +61,13 @@ const (
 	// holding the allocated pod subnet CIDR for a container ID. The full key
 	// appends a truncated container ID; see subnetAnnotationKey.
 	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
+
+	// annotationSRv6SID is the BGPAdvertisement annotation key holding the
+	// End.DT46 SRv6 SID for this VPC attachment. Galactic-router reads this
+	// annotation to set the EVPN GWIPAddress to the actual SRv6 SID rather
+	// than the BGP peering loopback, so remote nodes install correct seg6
+	// encap routes.
+	annotationSRv6SID = "galactic.datum.net/srv6-sid"
 
 	// annotationContainerIDLen is the number of characters used from a
 	// container ID in annotation keys. Kubernetes limits the name part of an
@@ -275,9 +284,56 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("read guest interface: %w", err)
 	}
 
+	// Add the gateway address to the host-side veth as a /128 host route, then
+	// explicitly install the pod subnet route into the VRF table.
+	//
+	// Using /128 (not the pod subnet mask) prevents the kernel from auto-creating
+	// a subnet-router anycast entry for the pod subnet prefix in the VRF local
+	// table. When the pod address equals the subnet network address (e.g. the pod
+	// holds fd00:10:ffXX::/80 and the gateway is fd00:10:ffXX::1/80), that
+	// anycast absorbs seg6local-decapped inner packets before they reach the pod.
+	//
+	// The explicit subnet route replaces the one the kernel would have created
+	// automatically from the /80 assignment, ensuring return-path routing after
+	// SRv6 decapsulation still works.
+	if ipamResult != nil && ipamResult.gateway != nil {
+		gwNet := &net.IPNet{IP: ipamResult.gateway, Mask: net.CIDRMask(128, 128)}
+		if addErr := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); addErr != nil {
+			if !errors.Is(addErr, syscall.EEXIST) {
+				return fmt.Errorf("add gateway address to host veth %q: %w", hostName, addErr)
+			}
+		}
+		tableID, tableErr := vrf.TableID(pluginConf.VPC, pluginConf.VPCAttachment)
+		if tableErr != nil {
+			return fmt.Errorf("get VRF table ID for pod subnet route: %w", tableErr)
+		}
+		if addErr := netlink.RouteReplace(&netlink.Route{
+			Dst:       ipamResult.subnet,
+			LinkIndex: hostLink.Attrs().Index,
+			Table:     int(tableID),
+		}); addErr != nil {
+			return fmt.Errorf("add pod subnet route to VRF table: %w", addErr)
+		}
+	}
+
 	vpcHex, err := intf.Base62ToHex(pluginConf.VPC)
 	if err != nil {
 		return fmt.Errorf("decode VPC: %w", err)
+	}
+	vpcAttHex, err := intf.Base62ToHex(pluginConf.VPCAttachment)
+	if err != nil {
+		return fmt.Errorf("decode VPCAttachment: %w", err)
+	}
+	var srv6SIDStr string
+	if pluginConf.SRv6Locator != "" {
+		sid, err := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex)
+		if err != nil {
+			return fmt.Errorf("encode SRv6 endpoint: %w", err)
+		}
+		if err := srv6.RouteIngressAdd(sid); err != nil {
+			return fmt.Errorf("add SRv6 ingress route: %w", err)
+		}
+		srv6SIDStr = sid
 	}
 
 	// Build and print the CNI result before Kubernetes operations so that the
@@ -349,13 +405,18 @@ func cmdAdd(args *skel.CmdArgs) error {
 			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(podSubnet)},
 			Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community(rtValue)},
 		}
-		// Store the allocated subnet keyed by container ID in annotations
-		// so cmdDel can look it up for deallocation.
-		if ipamResult != nil {
+		if ipamResult != nil || srv6SIDStr != "" {
 			if adv.Annotations == nil {
 				adv.Annotations = make(map[string]string)
 			}
-			adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
+			// Store the allocated subnet keyed by container ID so cmdDel can look it up.
+			if ipamResult != nil {
+				adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
+			}
+			// Store the End.DT46 SID so galactic-router uses it as the EVPN GWIPAddress.
+			if srv6SIDStr != "" {
+				adv.Annotations[annotationSRv6SID] = srv6SIDStr
+			}
 		}
 		return nil
 	})
@@ -426,6 +487,15 @@ func cmdDel(args *skel.CmdArgs) error {
 			termination.Network, termination.Via, dev,
 		); err != nil {
 			return fmt.Errorf("delete route %s: %w", termination.Network, err)
+		}
+	}
+	if pluginConf.SRv6Locator != "" {
+		if vpcHex, hexErr := intf.Base62ToHex(pluginConf.VPC); hexErr == nil {
+			if vpcAttHex, attErr := intf.Base62ToHex(pluginConf.VPCAttachment); attErr == nil {
+				if sid, sidErr := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex); sidErr == nil {
+					_ = srv6.RouteIngressDel(sid) // best-effort; veth deletion follows
+				}
+			}
 		}
 	}
 	if err := veth.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -75,9 +75,13 @@ type DesiredAdvertisement struct {
 	Prefixes        []string
 	Communities     []string
 	LocalPreference *uint32
-	// NextHop is the BGP next-hop for EVPN advertisements (node's primary IPv6 addr).
-	// Required when AddressFamily is l2vpn/evpn; rejection occurs in GoBGP backend if empty.
+	// NextHop is the BGP next-hop address placed in MpReachNLRI (node's transit-reachable
+	// IPv6 address). Required when AddressFamily is l2vpn/evpn.
 	NextHop string
+	// SRv6SID, when set, is placed in the EVPN Type 5 GWIPAddress field instead of NextHop.
+	// Must be the End.DT46 SID for this VPC attachment so that receiving nodes install
+	// a seg6 encap route targeting the correct SRv6 decap instruction.
+	SRv6SID string
 }
 
 // DesiredPolicy describes a routing policy in one direction.

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package srv6
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+)
+
+// RouteEgressAdd installs a SEG6 encap route for prefix into routing table
+// tableID, encapsulating to the given SRv6 SID (gateway). The outgoing
+// interface and L3 next-hop are resolved from the kernel's routing table for
+// gateway so the encapsulated outer packet can be L2-resolved on egress.
+func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
+	routes, err := netlink.RouteGet(gateway)
+	if err != nil || len(routes) == 0 {
+		return fmt.Errorf("no route to gateway %s: %w", gateway, err)
+	}
+	encap := &netlink.SEG6Encap{
+		Mode:     nl.SEG6_IPTUN_MODE_ENCAP,
+		Segments: []net.IP{gateway},
+	}
+	return netlink.RouteReplace(&netlink.Route{
+		Dst:       prefix,
+		Table:     int(tableID),
+		Encap:     encap,
+		LinkIndex: routes[0].LinkIndex,
+		Gw:        routes[0].Gw,
+	})
+}
+
+// RouteEgressDel removes the SEG6 encap route for prefix from routing table tableID.
+func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
+	return netlink.RouteDel(&netlink.Route{
+		Dst:   prefix,
+		Table: int(tableID),
+		Encap: &netlink.SEG6Encap{},
+	})
+}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -25,17 +25,22 @@ import (
 
 // Reconciler assembles DesiredRouter values from Cosmos CRDs.
 type Reconciler struct {
-	client     client.Client
-	nodeName   string
-	routerRole string
+	client       client.Client
+	nodeName     string
+	routerRole   string
+	localAddress string
 }
 
-// New returns a Reconciler for the given node and router role.
-func New(c client.Client, nodeName, routerRole string) *Reconciler {
+// New returns a Reconciler for the given node, router role, and local BGP address.
+// localAddress, when non-empty, is used as the EVPN next-hop instead of the
+// node's first IPv6 InternalIP — required when the node InternalIP is not
+// reachable via the SRv6 transit mesh (e.g. Kind/ContainerLab Docker bridge).
+func New(c client.Client, nodeName, routerRole, localAddress string) *Reconciler {
 	return &Reconciler{
-		client:     c,
-		nodeName:   nodeName,
-		routerRole: routerRole,
+		client:       c,
+		nodeName:     nodeName,
+		routerRole:   routerRole,
+		localAddress: localAddress,
 	}
 }
 
@@ -110,13 +115,22 @@ func (r *Reconciler) BuildDesiredRouter(
 		}
 	}
 
-	// Resolve NextHop from Node.
-	nextHop, err := r.resolveNodeIPv6(ctx, router.Spec.TargetRef.Name)
-	if err != nil {
-		return nil, fmt.Errorf("resolve node IPv6 address for %s: %w", router.Spec.TargetRef.Name, err)
+	// Resolve the EVPN next-hop. When localAddress is set (e.g. from
+	// BGP_LOCAL_ADDRESS), use it directly — it is the transit-reachable
+	// address. Fall back to the node's first IPv6 InternalIP only when
+	// localAddress is not configured.
+	var nextHop string
+	if r.localAddress != "" {
+		nextHop = r.localAddress
+	} else {
+		var err error
+		nextHop, err = r.resolveNodeIPv6(ctx, router.Spec.TargetRef.Name)
+		if err != nil {
+			return nil, fmt.Errorf("resolve node IPv6 address for %s: %w", router.Spec.TargetRef.Name, err)
+		}
 	}
 
-	// Require a node IPv6 address when any advertisement uses the EVPN address family.
+	// Require a next-hop when any advertisement uses the EVPN address family.
 	if nextHop == "" {
 		for _, adv := range advList.Items {
 			if adv.Spec.AddressFamily.AFI == bgpv1alpha1.AFIL2VPN {
@@ -158,6 +172,7 @@ func (r *Reconciler) BuildDesiredRouter(
 			Communities:     communities,
 			LocalPreference: int32PtrToUint32Ptr(adv.Spec.LocalPreference),
 			NextHop:         nextHop,
+			SRv6SID:         adv.Annotations["galactic.datum.net/srv6-sid"],
 		})
 	}
 

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -1,0 +1,185 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gobgp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	gobgpserver "github.com/osrg/gobgp/v4/pkg/server"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/model"
+	"go.datum.net/galactic/internal/plumbing/srv6"
+	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
+)
+
+// startRIBMonitor starts the EVPN best-path watcher goroutine once per
+// GoBGPRuntime lifetime. It installs and removes kernel SEG6 encap routes in
+// the VRF routing table as remote EVPN Type 5 paths are added or withdrawn.
+func (r *GoBGPRuntime) startRIBMonitor(b *gobgpserver.BgpServer, vrf *model.DesiredVRFInstance) {
+	if vrf == nil || r.srvCtx == nil {
+		slog.Info("startRIBMonitor: skipping — vrf or srvCtx is nil", "vrf", vrf, "srvCtx", r.srvCtx)
+		return
+	}
+	r.monitorOnce.Do(func() {
+		slog.Info("startRIBMonitor: launching watchEVPNRIB goroutine", "vrf", vrf.Name)
+		go r.watchEVPNRIB(r.srvCtx, b, vrf)
+	})
+}
+
+func (r *GoBGPRuntime) watchEVPNRIB(ctx context.Context, b *gobgpserver.BgpServer, vrfInst *model.DesiredVRFInstance) {
+	// VRF name is "{vpc}-{vpcAttachment}" in base62 — see bgpVRFInstanceName in cni.go.
+	parts := strings.SplitN(vrfInst.Name, "-", 2)
+	if len(parts) != 2 {
+		slog.Error("watchEVPNRIB: VRF name does not contain '-'", "name", vrfInst.Name)
+		return
+	}
+	vpc, vpcAtt := parts[0], parts[1]
+
+	tableID, err := vrfpkg.TableID(vpc, vpcAtt)
+	if err != nil {
+		slog.Error("watchEVPNRIB: failed to get VRF table ID", "vpc", vpc, "vpcAtt", vpcAtt, "err", err)
+		return
+	}
+	slog.Info("watchEVPNRIB: resolved VRF table", "vpc", vpc, "vpcAtt", vpcAtt, "tableID", tableID)
+
+	if err := probeRouteWrite(tableID); err != nil {
+		slog.Error("watchEVPNRIB: route write probe failed; SEG6 encap routes will not be installed",
+			"err", err, "hint", "set runAsUser: 0 and capabilities.add: [NET_ADMIN] in the container securityContext")
+		return
+	}
+
+	importRTs := vrfInst.ImportRouteTargets
+	localAddr := r.localAddress
+
+	slog.Info("watchEVPNRIB: registering WatchBestPath", "importRTs", importRTs, "localAddr", localAddr)
+
+	watchErr := b.WatchEvent(ctx, gobgpserver.WatchEventMessageCallbacks{
+		OnBestPath: func(paths []*apiutil.Path, _ time.Time) {
+			for _, path := range paths {
+				if path.Family != bgp.RF_EVPN {
+					continue
+				}
+				evpnNLRI, ok := path.Nlri.(*bgp.EVPNNLRI)
+				if !ok {
+					continue
+				}
+				ipPrefix, ok := evpnNLRI.RouteTypeData.(*bgp.EVPNIPPrefixRoute)
+				if !ok {
+					continue
+				}
+				// Skip locally-originated paths (our own EVPN advertisements).
+				// Compare the MpReachNLRI next-hop against localAddr rather than
+				// GWIPAddress — after the SRv6SID fix, GWIPAddress is the End.DT46
+				// SID (not the BGP peering loopback), so the old check would miss
+				// locally-originated paths and try to install a seg6 encap route
+				// for our own VPC subnet.
+				if evpnMpReachNexthop(path.Attrs) == localAddr {
+					continue
+				}
+				if !pathMatchesRTs(path.Attrs, importRTs) {
+					continue
+				}
+
+				prefix := addrToIPNet(ipPrefix.IPPrefix, int(ipPrefix.IPPrefixLength))
+				gw := addrToNetIP(ipPrefix.GWIPAddress)
+
+				if path.Withdrawal {
+					slog.Info("watchEVPNRIB: withdrawing route", "prefix", prefix, "table", tableID)
+					if delErr := srv6.RouteEgressDel(prefix, tableID); delErr != nil {
+						slog.Error("watchEVPNRIB: RouteEgressDel failed", "prefix", prefix, "table", tableID, "err", delErr)
+					}
+				} else {
+					slog.Info("watchEVPNRIB: installing route", "prefix", prefix, "gw", gw, "table", tableID)
+					if addErr := srv6.RouteEgressAdd(prefix, gw, tableID); addErr != nil {
+						slog.Error("watchEVPNRIB: RouteEgressAdd failed", "prefix", prefix, "gw", gw, "table", tableID, "err", addErr)
+					}
+				}
+			}
+		},
+	}, gobgpserver.WatchBestPath(true))
+	if watchErr != nil {
+		slog.Error("watchEVPNRIB: WatchEvent returned error", "err", watchErr)
+	}
+}
+
+// pathMatchesRTs returns true if any extended community in attrs matches any
+// of the given route target strings (e.g. "65000:62").
+func pathMatchesRTs(attrs []bgp.PathAttributeInterface, importRTs []string) bool {
+	for _, attr := range attrs {
+		ec, ok := attr.(*bgp.PathAttributeExtendedCommunities)
+		if !ok {
+			continue
+		}
+		for _, community := range ec.Value {
+			if slices.Contains(importRTs, community.String()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path
+// attrs, or empty string if none is found. Used to identify locally-originated
+// EVPN paths without relying on GWIPAddress (which is now the SRv6 SID).
+func evpnMpReachNexthop(attrs []bgp.PathAttributeInterface) string {
+	for _, attr := range attrs {
+		if mp, ok := attr.(*bgp.PathAttributeMpReachNLRI); ok {
+			return mp.Nexthop.String()
+		}
+	}
+	return ""
+}
+
+// addrToIPNet converts a netip.Addr and prefix length to a masked *net.IPNet.
+func addrToIPNet(addr netip.Addr, bits int) *net.IPNet {
+	masked := netip.PrefixFrom(addr, bits).Masked()
+	a := masked.Addr().As16()
+	ip := make(net.IP, 16)
+	copy(ip, a[:])
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(masked.Bits(), 128)}
+}
+
+// addrToNetIP converts a netip.Addr to net.IP (16-byte form).
+func addrToNetIP(addr netip.Addr) net.IP {
+	a := addr.As16()
+	ip := make(net.IP, 16)
+	copy(ip, a[:])
+	return ip
+}
+
+// probeRouteWrite verifies that the process holds the privileges needed to
+// install kernel routes into tableID. It installs a test host route from the
+// RFC 3849 documentation range (2001:db8::/32) — which can never conflict with
+// real VPC traffic — then immediately removes it. This catches a missing
+// runAsUser:0 or CAP_NET_ADMIN before the first real EVPN best-path event
+// arrives, rather than silently failing minutes later.
+func probeRouteWrite(tableID uint32) error {
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("lookup loopback for probe: %w", err)
+	}
+	_, dst, _ := net.ParseCIDR("2001:db8:ffff:ffff:ffff:ffff:ffff:fffe/128")
+	probe := &netlink.Route{
+		Dst:       dst,
+		Table:     int(tableID),
+		LinkIndex: lo.Attrs().Index,
+	}
+	if err := netlink.RouteReplace(probe); err != nil {
+		return fmt.Errorf("route write probe (missing root or CAP_NET_ADMIN?): %w", err)
+	}
+	_ = netlink.RouteDel(probe)
+	return nil
+}

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -21,12 +21,23 @@ import (
 //
 // routerID is the BGP router-ID (IPv4 dotted-decimal) and is used to derive the
 // per-router route distinguisher (Type 1 IP-address: routerID:0). adv.NextHop
-// must be the node's primary IPv6 address; it becomes both the MpReachNLRI
-// next-hop and the EVPNIPPrefixRoute GW address.
+// is the transit-reachable BGP peering address placed in MpReachNLRI. adv.SRv6SID,
+// when set, is the End.DT46 SID placed in the EVPN GWIPAddress field — this is
+// the SRv6 segment that remote nodes install in their seg6 encap kernel routes.
+// When adv.SRv6SID is empty the next-hop is used for both (non-SRv6 fallback).
 func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, routerID string, withdraw bool) error {
 	nextHop, err := netip.ParseAddr(adv.NextHop)
 	if err != nil {
 		return fmt.Errorf("invalid EVPN next-hop %q: %w", adv.NextHop, err)
+	}
+
+	gwIP := nextHop
+	if adv.SRv6SID != "" {
+		sid, err := netip.ParseAddr(adv.SRv6SID)
+		if err != nil {
+			return fmt.Errorf("invalid SRv6 SID %q: %w", adv.SRv6SID, err)
+		}
+		gwIP = sid
 	}
 
 	// Type 1 (IP-address:local-admin) RD, unique per router.
@@ -49,13 +60,15 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 
 		// EVPN Type 5 IP Prefix route. ESI all-zeros (Type 0 = not multihomed),
 		// ETag 0, label 0 (SRv6 — MPLS label unused).
+		// gwIP is the End.DT46 SRv6 SID when adv.SRv6SID is set; otherwise falls
+		// back to nextHop. Remote nodes use this as the seg6 encap segment.
 		nlri, err := bgp.NewEVPNIPPrefixRoute(
 			rd,
 			bgp.EthernetSegmentIdentifier{},
 			0,
 			uint8(prefix.Bits()),
 			prefix.Addr(),
-			nextHop,
+			gwIP,
 			0,
 		)
 		if err != nil {

--- a/internal/runtime/gobgp/peers.go
+++ b/internal/runtime/gobgp/peers.go
@@ -58,7 +58,8 @@ func familyFromModel(af model.AddressFamily) *api.Family {
 
 // peerFromDesired converts a DesiredPeer to a GoBGP api.Peer.
 // localAddress, if non-empty, is set as the TCP source address for the session.
-func peerFromDesired(p model.DesiredPeer, localAddress string) *api.Peer {
+// routeReflectorMode, when true, marks this peer as an iBGP route-reflector client.
+func peerFromDesired(p model.DesiredPeer, localAddress string, routeReflectorMode bool) *api.Peer {
 	peer := &api.Peer{
 		Conf: &api.PeerConf{
 			NeighborAddress: p.Address,
@@ -93,6 +94,12 @@ func peerFromDesired(p model.DesiredPeer, localAddress string) *api.Peer {
 		RemotePort:   1790,
 		PassiveMode:  false,
 		LocalAddress: localAddress,
+	}
+
+	if routeReflectorMode {
+		peer.RouteReflector = &api.RouteReflector{
+			RouteReflectorClient: true,
+		}
 	}
 
 	return peer

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -42,6 +42,10 @@ type GoBGPRuntime struct {
 	appliedVRFs map[string]struct{}
 	// serverCtxCancel cancels the goroutine running server.Start.
 	serverCtxCancel context.CancelFunc
+	// srvCtx is the context passed to server.Start; monitor goroutines use it.
+	srvCtx context.Context
+	// monitorOnce ensures the EVPN RIB watcher goroutine is started at most once.
+	monitorOnce sync.Once
 }
 
 // NewRuntimeFactory returns a RuntimeFactory that creates a GoBGPRuntime per key.
@@ -85,6 +89,8 @@ func (r *GoBGPRuntime) Apply(ctx context.Context, desired model.DesiredRouter) e
 		return err
 	}
 
+	r.startRIBMonitor(b, desired.VRFInstance)
+
 	if err := r.applyEVPN(b, desired.Advertisements, desired.RouterID); err != nil {
 		return err
 	}
@@ -102,6 +108,7 @@ func (r *GoBGPRuntime) startGoBGP(ctx context.Context) (*gobgpserver.BgpServer, 
 	if b == nil {
 		srvCtx, cancel := context.WithCancel(context.Background())
 		r.serverCtxCancel = cancel
+		r.srvCtx = srvCtx
 		go func() {
 			_ = r.server.Start(srvCtx)
 		}()
@@ -167,7 +174,7 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 	}
 
 	for _, p := range peers {
-		peer := peerFromDesired(p, r.localAddress)
+		peer := peerFromDesired(p, r.localAddress, r.listenPort > 0)
 		addErr := b.AddPeer(ctx, &api.AddPeerRequest{Peer: peer})
 		if addErr != nil {
 			if strings.Contains(addErr.Error(), "can't overwrite") {


### PR DESCRIPTION
## Summary

The local IPAM implement in the CNI exposed a bug with how SRv6 routes were being programmed for the data plane.  The routes are now properly programmed with the correct next hop address.

## Changes

- Encode End.DT46 SID in galactic-cni and write it to the BGPAdvertisement annotation so galactic-router can advertise the correct seg6 encap target
- Place SRv6SID in EVPN Type 5 GWIPAddress instead of the BGP peering loopback so receiving nodes install SEG6 encap routes targeting the actual decap SID
- Add watchEVPNRIB goroutine that installs and removes kernel SEG6 encap routes into the VRF routing table as EVPN best paths are added or withdrawn
- Add probeRouteWrite startup check that fails fast with a clear hint when the container lacks root or CAP_NET_ADMIN, before the first EVPN event arrives
- Fix subnet-router anycast absorption  by using /128 for the host veth gateway address and explicitly installing the pod subnet route into the VRF
- Add runAsUser: 0 to containerlab overlay and production DaemonSet manifests; fix Dockerfile to build the full cmd/galactic-router package directory
- Thread BGP_LOCAL_ADDRESS through Reconciler as the EVPN next-hop override for environments where the node InternalIP is not transit-reachable