### PR TITLE
feat: add tap interface support for VM-based workloads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,11 +133,12 @@ Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads con
 |-----------------|----------|-------------------------------------------------------------------------|
 | `vpc`           | string   | Base62-encoded 48-bit VPC identifier                                    |
 | `vpcattachment` | string   | Base62-encoded 16-bit VPCAttachment identifier                          |
+| `interface_type`| string   | `veth` (default) or `tap`; tap mode omits IPAM and guest-side config   |
 | `srv6_locator`  | string   | IPv6 CIDR (≤/64) used as SRv6 locator prefix                           |
 | `namespace`     | string   | Kubernetes namespace for BGP CRDs; defaults to `default`               |
 | `mtu`           | int      | MTU for the veth pair; 0 uses kernel default                            |
 | `terminations`  | array    | Static routes to install on the host-side veth (`network`, `via`)      |
-| `ipam`          | object   | Passed through to the IPAM plugin                                       |
+| `ipam`          | object   | Passed through to the IPAM plugin (ignored in tap mode)                |
 
 ### galactic-cni environment variables
 

--- a/containers/galactic/Dockerfile
+++ b/containers/galactic/Dockerfile
@@ -50,24 +50,25 @@ COPY --from=builder /workspace/galactic-cni /galactic-cni
 COPY --from=builder /workspace/host-device /host-device
 COPY --from=builder /var/run/galactic-cni /var/run/galactic-cni
 
-# Final image: busybox (provides sh, nsenter, ip for e2e tests)
-FROM docker.io/library/busybox:stable
+# Final image: alpine (provides full iproute2, sh, nsenter for e2e tests)
+# Alpine is used instead of busybox because BusyBox's ip utility lacks
+# support for netns, "ip link add type vrf", and other subcommands the
+# CNI plugin exercises at runtime.
+FROM docker.io/library/alpine:latest
 
 # Copy binaries from the production (distroless) image
 COPY --from=production /galactic-cni /galactic-cni
 COPY --from=production /host-device /host-device
 COPY --from=production /var/run/galactic-cni /var/run/galactic-cni
 
-# busybox dispatches commands based on symlink name; create symlinks so
-# standard tools (sh, nsenter, ip) are found on PATH.
-# Also create /var/run/netns with world-writable perms so the CNI plugin
-# (which creates network namespaces at runtime) can write there regardless
-# of the user the container runs as.
-RUN mkdir -p /usr/local/bin /var/run/netns && \
+# Install iproute2 (provides full-featured ip, nsenter) and create the
+# netns directory with world-writable perms so the CNI plugin can create
+# network namespaces regardless of the container user.
+RUN apk add --no-cache iproute2 && \
+    mkdir -p /usr/local/bin /var/run/netns && \
     chmod 1777 /var/run/netns && \
-    ln -sf /bin/busybox /usr/local/bin/nsenter && \
-    ln -sf /bin/busybox /usr/local/bin/sh && \
-    ln -sf /bin/busybox /usr/local/bin/ip
+    ln -sf /usr/sbin/ip /usr/local/bin/ip && \
+    ln -sf /usr/sbin/nsenter /usr/local/bin/nsenter
 
 # Run as root so nsenter (setns) and netlink operations work in e2e tests.
 # In production the CNI is invoked by the Kubelet as root anyway.

--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -56,14 +56,35 @@ the standard CNI `PluginConf` with Galactic-specific fields.
 |---|---|---|---|---|
 | `vpc` | `"vpc"` | **Yes** | `string` | Base62-encoded VPC identifier (48-bit value). Used to derive VRF names, interface names, and BGP route targets. |
 | `vpcattachment` | `"vpcattachment"` | **Yes** | `string` | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming. |
+| `interface_type` | `"interface_type"` | No | `string` | Interface mode: `"veth"` (default, for containers) or `"tap"` (for VMs such as Kata, Firecracker, QEMU). |
 | `srv6_locator` | `"srv6_locator"` | **Yes** | `string` | IPv6 prefix (e.g. `2001:db8:ff01::/48`). VPC and VPCAttachment identifiers are encoded into the low 64 bits to produce SRv6 endpoints for BGP advertisements. |
-| `mtu` | `"mtu"` | No | `int` | MTU for the host-side veth pair. Passed to `veth.Add()`. |
+| `mtu` | `"mtu"` | No | `int` | MTU for the host-side interface. For `veth` mode this applies to both veth endpoints; for `tap` mode it applies to the tap interface. |
 | `terminations` | `"terminations"` | No | `[]Termination` | Array of static routes to add on the host side (see Termination sub-fields below). |
 | `namespace` | `"namespace"` | No | `string` | Kubernetes namespace used to look up the `BGPRouter` CRD. Defaults to `"default"` if omitted. |
-| `ipam` | `"ipam"` | No* | `IPAM` | IP address management configuration (see IPAM sub-fields below). *Required unless `--enable-local-ipam` is set. |
+| `ipam` | `"ipam"` | No* | `IPAM` | IP address management configuration (see IPAM sub-fields below). *Required unless `--enable-local-ipam` is set or `interface_type` is `"tap"`. |
 
 Standard CNI fields (`cniVersion`, `name`, `dns`, `runtimeConfig`) are also
 supported via the embedded `types.PluginConf`.
+
+### Interface Types
+
+#### `veth` (default)
+
+Creates a veth pair: one endpoint stays in the host namespace (named
+`H<base62vpc><base62att>`) and the other is moved into the container via the
+host-device CNI plugin (named per the `CNI_IFNAME` env var, typically `eth0`).
+The guest interface receives an IP address from IPAM and a default route via
+the pool gateway.
+
+#### `tap`
+
+Creates a tap interface in the host namespace (named
+`H<base62vpc><base62att>`) and enslaves it to the VRF. No interface is moved
+into the container — the tap fd is managed directly by the guest VM hypervisor.
+IPAM is not used in tap mode; the VM configures its own networking.
+
+> **Note:** Tap mode is intended for VM-based workloads (Kata, Firecracker,
+> QEMU) where the hypervisor opens the tap fd and handles guest networking.
 
 ### IPAM Fields
 
@@ -182,3 +203,23 @@ built-in pool.
 
 The first termination installs a specific next-hop route; the second installs
 a link-local route via the host-side device.
+
+### Tap interface configuration (VM workloads)
+
+```json
+{
+  "cniVersion": "0.3.1",
+  "name": "galactic-tap",
+  "type": "galactic-cni",
+  "vpc": "1",
+  "vpcattachment": "1",
+  "interface_type": "tap",
+  "srv6_locator": "2001:db8:ff01::/48",
+  "mtu": 9000
+}
+```
+
+Tap mode creates a tap interface in the host namespace, enslaves it to the
+VRF, and applies forwarding sysctls. No IPAM is configured — the guest VM
+manages its own IP addresses. The tap fd is opened by the VM hypervisor
+(Kata, Firecracker, QEMU) at runtime.

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -34,6 +34,7 @@ import (
 
 	"go.datum.net/galactic/internal/cni/ipam"
 	"go.datum.net/galactic/internal/cni/route"
+	"go.datum.net/galactic/internal/cni/tap"
 	"go.datum.net/galactic/internal/cni/veth"
 	"go.datum.net/galactic/internal/metadata"
 	"go.datum.net/galactic/internal/plumbing/intf"
@@ -100,6 +101,16 @@ func SetEnableLocalIPAM(v bool) {
 	enableLocalIPAM = v
 }
 
+const (
+	// interfaceTypeVeth is the default interface type: veth pair for containers.
+	interfaceTypeVeth = "veth"
+	// interfaceTypeTap is the tap interface type: L2 fd for VMs (Kata, Firecracker).
+	interfaceTypeTap = "tap"
+
+	// cniVersion100 is the CNI spec version this plugin reports.
+	cniVersion100 = "1.0.0"
+)
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(cniScheme))
 	utilruntime.Must(bgpv1alpha1.AddToScheme(cniScheme))
@@ -111,6 +122,7 @@ type PluginConf struct {
 	VPC           string        `json:"vpc"`
 	VPCAttachment string        `json:"vpcattachment"`
 	MTU           int           `json:"mtu,omitempty"`
+	InterfaceType string        `json:"interface_type,omitempty"` // interfaceTypeVeth or interfaceTypeTap
 	Terminations  []Termination `json:"terminations,omitempty"`
 	IPAM          IPAM          `json:"ipam"`
 	SRv6Locator   string        `json:"srv6_locator"`
@@ -132,6 +144,17 @@ func parseConf(data []byte) (*PluginConf, error) {
 	conf := &PluginConf{}
 	if err := json.Unmarshal(data, &conf); err != nil {
 		return nil, fmt.Errorf("parse CNI config: %w", err)
+	}
+	if conf.InterfaceType == "" {
+		conf.InterfaceType = interfaceTypeVeth
+	}
+	switch conf.InterfaceType {
+	case interfaceTypeVeth, interfaceTypeTap:
+	default:
+		return nil, fmt.Errorf(
+			"invalid interface_type %q: must be %q or %q",
+			conf.InterfaceType, interfaceTypeVeth, interfaceTypeTap,
+		)
 	}
 	return conf, nil
 }
@@ -216,6 +239,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	// Roll back on any failure to avoid orphaned resources.
+	// cmdDel is best-effort — errors are logged, not returned.
+	defer func() {
+		if err != nil {
+			_ = cmdDel(args)
+		}
+	}()
+
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
 		return errors.New("NODE_NAME environment variable is not set")
@@ -229,16 +260,23 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err := vrf.Add(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
 		return fmt.Errorf("add VRF: %w", err)
 	}
-	if err := veth.Add(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.MTU); err != nil {
-		return fmt.Errorf("add veth: %w", err)
+
+	// Create the appropriate interface type (veth or tap).
+	switch pluginConf.InterfaceType {
+	case interfaceTypeVeth:
+		if err := veth.Add(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.MTU); err != nil {
+			return fmt.Errorf("add veth: %w", err)
+		}
+	case interfaceTypeTap:
+		if err := tap.Add(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.MTU); err != nil {
+			return fmt.Errorf("add tap: %w", err)
+		}
 	}
 
-	// Read host veth attributes immediately after creation; they do not change
-	// when the guest end is moved into the container netns.
 	hostName := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
 	hostLink, err := netlink.LinkByName(hostName)
 	if err != nil {
-		return fmt.Errorf("get host veth %q: %w", hostName, err)
+		return fmt.Errorf("get host interface %q: %w", hostName, err)
 	}
 	hostMac := hostLink.Attrs().HardwareAddr.String()
 	hostMTU := hostLink.Attrs().MTU
@@ -249,39 +287,23 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return fmt.Errorf("add route %s: %w", termination.Network, err)
 		}
 	}
-	// Only call host-device ADD if the guest interface is still in the host
-	// namespace. If a prior attempt already moved it to the container netns but
-	// failed at a later step, we must not try to move it again.
-	guestName := intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment)
-	if _, linkErr := netlink.LinkByName(guestName); linkErr == nil {
-		// Clean up any stale interface in the container netns left by a
-		// previous run. The host-device plugin renames the moved interface
-		// to args.IfName, so a prior run may have left that name behind.
-		if err := cleanupContainerNetns(args.Netns, args.IfName); err != nil {
-			return fmt.Errorf("cleanup container netns: %w", err)
-		}
-		if err := hostDevice("ADD", args, pluginConf); err != nil {
-			return fmt.Errorf("host-device ADD: %w", err)
-		}
-	}
 
-	// Configure IP address on the guest interface inside the container netns.
-	// After hostDevice("ADD"), the guest interface is named args.IfName inside
-	// the container (host-device renames it), not the original guestName.
+	// Host-device delegation and IPAM are veth-only.
+	// In tap mode the guest VM manages its own networking.
 	var ipamResult *ipamResult
-	if pluginConf.IPAM.Type != "" || enableLocalIPAM {
-		result, err := configureIPAM(args, pluginConf, args.IfName)
+	switch pluginConf.InterfaceType {
+	case interfaceTypeVeth:
+		ipamResult, err = buildVethResult(args, pluginConf, hostName, args.IfName, hostMac, hostMTU)
 		if err != nil {
-			return fmt.Errorf("configure IPAM: %w", err)
+			return err
 		}
-		ipamResult = result
-	}
-
-	// Read guest veth attributes inside the container netns.
-	// Always read regardless of IPAM config — the CNI result requires them.
-	guestMac, guestMTU, err := readGuestInterface(args.Netns, args.IfName)
-	if err != nil {
-		return fmt.Errorf("read guest interface: %w", err)
+	case interfaceTypeTap:
+		result := buildTapResult(pluginConf, hostName, hostMac, hostMTU)
+		if err := types.PrintResult(result, cniVersion100); err != nil {
+			return fmt.Errorf("print CNI result: %w", err)
+		}
+		// Tap mode: no IPAM, no BGP — the guest VM manages its own networking.
+		return nil
 	}
 
 	if err := configureHostVethGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
@@ -301,33 +323,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	// Build and print the CNI result before Kubernetes operations so that the
-	// result is available on stdout even when K8s is unreachable. The CNI
-	// framework will append an error JSON after the result if the plugin
-	// returns an error; the test's JSON parser picks up the first JSON object.
-	result := buildResult(pluginConf, ipamResult, hostName, args.IfName, hostMac, guestMac, hostMTU, guestMTU, args.Netns)
-	if err := types.PrintResult(result, "1.0.0"); err != nil {
-		return fmt.Errorf("print CNI result: %w", err)
-	}
-
-	err = applyBGPObjects(nodeName, namespace, args.ContainerID, pluginConf, vpcHex, ipamResult, srv6SIDStr)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// applyBGPObjects creates or updates the BGPVRFInstance and BGPAdvertisement
-// CRDs for the given VPC attachment. It is called after the CNI result is
-// printed so that K8s unavailability does not suppress the result.
-func applyBGPObjects(
-	nodeName, namespace, containerID string,
-	pluginConf *PluginConf,
-	vpcHex string,
-	ipamResult *ipamResult,
-	srv6SIDStr string,
-) error {
 	k8s, err := newK8sClient()
 	if err != nil {
 		return err
@@ -394,7 +389,7 @@ func applyBGPObjects(
 			}
 			// Store the allocated subnet keyed by container ID so cmdDel can look it up.
 			if ipamResult != nil {
-				adv.Annotations[subnetAnnotationKey(containerID)] = podSubnet
+				adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
 			}
 			// Store the End.DT46 SID so galactic-router uses it as the EVPN GWIPAddress.
 			if srv6SIDStr != "" {
@@ -416,8 +411,8 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	// Deallocate IPAM subnet before any other cleanup.
-	if pluginConf.IPAM.Type != "" || enableLocalIPAM {
+	// Deallocate IPAM subnet before any other cleanup (veth-only).
+	if pluginConf.InterfaceType == interfaceTypeVeth && (pluginConf.IPAM.Type != "" || enableLocalIPAM) {
 		deallocateIPAM(args, pluginConf)
 	}
 
@@ -461,8 +456,11 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	dev := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
-	if err := hostDevice("DEL", args, pluginConf); err != nil {
-		return fmt.Errorf("host-device DEL: %w", err)
+	// host-device DEL is veth-only; tap has no guest interface to remove.
+	if pluginConf.InterfaceType == interfaceTypeVeth {
+		if err := hostDevice("DEL", args, pluginConf); err != nil {
+			return fmt.Errorf("host-device DEL: %w", err)
+		}
 	}
 	for _, termination := range pluginConf.Terminations {
 		if err := route.Delete(
@@ -472,24 +470,33 @@ func cmdDel(args *skel.CmdArgs) error {
 			return fmt.Errorf("delete route %s: %w", termination.Network, err)
 		}
 	}
-	if pluginConf.SRv6Locator != "" {
-		if vpcHex, hexErr := intf.Base62ToHex(pluginConf.VPC); hexErr == nil {
-			if vpcAttHex, attErr := intf.Base62ToHex(pluginConf.VPCAttachment); attErr == nil {
-				if sid, sidErr := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex); sidErr == nil {
-					_ = srv6.RouteIngressDel(sid) // best-effort; veth deletion follows
+
+	switch pluginConf.InterfaceType {
+	case interfaceTypeVeth:
+		if pluginConf.SRv6Locator != "" {
+			if vpcHex, hexErr := intf.Base62ToHex(pluginConf.VPC); hexErr == nil {
+				if vpcAttHex, attErr := intf.Base62ToHex(pluginConf.VPCAttachment); attErr == nil {
+					if sid, sidErr := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex); sidErr == nil {
+						_ = srv6.RouteIngressDel(sid)
+					}
 				}
 			}
 		}
+		if err := veth.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+			return fmt.Errorf("delete veth: %w", err)
+		}
+	case interfaceTypeTap:
+		if err := tap.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+			return fmt.Errorf("delete tap: %w", err)
+		}
 	}
-	if err := veth.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
-		return fmt.Errorf("delete veth: %w", err)
-	}
+
 	if err := vrf.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
 		return fmt.Errorf("delete VRF: %w", err)
 	}
 
 	result := &type100.Result{}
-	return types.PrintResult(result, "1.0.0")
+	return types.PrintResult(result, cniVersion100)
 }
 
 // ipamResult holds the IPAM allocation details for building the CNI result.
@@ -542,6 +549,74 @@ func buildResult(
 		}
 	}
 	return result
+}
+
+// buildVethResult handles veth-specific result building: host-device
+// delegation, IPAM, guest interface reading, and result printing.
+// Returns the IPAM result for BGP advertisement, or nil if no IPAM.
+func buildVethResult(
+	args *skel.CmdArgs,
+	pluginConf *PluginConf,
+	hostName, guestName string,
+	hostMac string,
+	hostMTU int,
+) (*ipamResult, error) {
+	// Only call host-device ADD if the guest interface is still in the host
+	// namespace. If a prior attempt already moved it to the container netns but
+	// failed at a later step, we must not try to move it again.
+	if _, linkErr := netlink.LinkByName(guestName); linkErr == nil {
+		// Clean up any stale interface in the container netns left by a
+		// previous run. The host-device plugin renames the moved interface
+		// to args.IfName, so a prior run may have left that name behind.
+		if err := cleanupContainerNetns(args.Netns, args.IfName); err != nil {
+			return nil, fmt.Errorf("cleanup container netns: %w", err)
+		}
+		if err := hostDevice("ADD", args, pluginConf); err != nil {
+			return nil, fmt.Errorf("host-device ADD: %w", err)
+		}
+	}
+
+	// Configure IP address on the guest interface inside the container netns.
+	var ipamResult *ipamResult
+	if pluginConf.IPAM.Type != "" || enableLocalIPAM {
+		result, err := configureIPAM(args, pluginConf, args.IfName)
+		if err != nil {
+			return nil, fmt.Errorf("configure IPAM: %w", err)
+		}
+		ipamResult = result
+	}
+
+	// Read guest veth attributes inside the container netns.
+	guestMac, guestMTU, err := readGuestInterface(args.Netns, args.IfName)
+	if err != nil {
+		return nil, fmt.Errorf("read guest interface: %w", err)
+	}
+	result := buildResult(pluginConf, ipamResult, hostName, args.IfName, hostMac, guestMac, hostMTU, guestMTU, args.Netns)
+	if err := types.PrintResult(result, cniVersion100); err != nil {
+		return nil, fmt.Errorf("print CNI result: %w", err)
+	}
+
+	return ipamResult, nil
+}
+
+// buildTapResult constructs the CNI result for tap mode: a single host
+// interface with no IPAM or guest endpoint.
+func buildTapResult(
+	pluginConf *PluginConf,
+	hostName, hostMac string,
+	hostMTU int,
+) *type100.Result {
+	return &type100.Result{
+		CNIVersion: pluginConf.CNIVersion,
+		Interfaces: []*type100.Interface{
+			{
+				Name:    hostName,
+				Mac:     hostMac,
+				Mtu:     hostMTU,
+				Sandbox: "",
+			},
+		},
+	}
 }
 
 // configureIPAM allocates a subnet and configures the guest interface inside the

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -306,6 +306,15 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return nil
 	}
 
+	return publishBGPState(args, pluginConf, nodeName, namespace, ipamResult)
+}
+
+// publishBGPState configures the host veth gateway, sets up the SRv6 ingress
+// route, and creates the BGPVRFInstance and BGPAdvertisement CRDs. This is
+// veth-only; tap mode returns before reaching this path.
+func publishBGPState(
+	args *skel.CmdArgs, pluginConf *PluginConf, nodeName, namespace string, ipamResult *ipamResult,
+) error {
 	if err := configureHostVethGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
 		return err
 	}

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -55,10 +55,11 @@ func routerForNode(name, nodeName, namespace string, asn int64) *bgpv1alpha1.BGP
 
 func TestParseConf(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantVPC string
-		wantErr string
+		name       string
+		input      string
+		wantVPC    string
+		wantIfType string
+		wantErr    string
 	}{
 		{
 			name: "valid config",
@@ -68,7 +69,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"%s","srv6_locator":"2001:db8::/48"}`,
 				testVPC, testAttachment,
 			),
-			wantVPC: testVPC,
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
 		},
 		{
 			name:    "invalid JSON",
@@ -79,6 +81,49 @@ func TestParseConf(t *testing.T) {
 			name:    "empty input",
 			input:   "",
 			wantErr: "parse CNI config",
+		},
+		{
+			name: "interface_type=veth",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","interface_type":"veth"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "interface_type=tap",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","interface_type":"tap"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeTap,
+		},
+		{
+			name: "interface_type empty defaults to veth",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","interface_type":""}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "interface_type=unknown",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","interface_type":"unknown"}`,
+				testVPC, testAttachment,
+			),
+			wantErr: `invalid interface_type "unknown": must be "veth" or "tap"`,
 		},
 	}
 
@@ -99,6 +144,9 @@ func TestParseConf(t *testing.T) {
 			}
 			if conf.VPC != tt.wantVPC {
 				t.Errorf("VPC = %q, want %q", conf.VPC, tt.wantVPC)
+			}
+			if conf.InterfaceType != tt.wantIfType {
+				t.Errorf("InterfaceType = %q, want %q", conf.InterfaceType, tt.wantIfType)
 			}
 		})
 	}
@@ -317,7 +365,7 @@ func TestBuildResult(t *testing.T) {
 	netns := "/proc/1234/ns/net"
 
 	conf := &PluginConf{
-		PluginConf:    types.PluginConf{CNIVersion: "1.0.0"},
+		PluginConf:    types.PluginConf{CNIVersion: cniVersion100},
 		VPC:           testVPC,
 		VPCAttachment: testAttachment,
 	}
@@ -358,8 +406,8 @@ func TestBuildResult(t *testing.T) {
 				netns,
 			)
 
-			if result.CNIVersion != "1.0.0" {
-				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, "1.0.0")
+			if result.CNIVersion != cniVersion100 {
+				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, cniVersion100)
 			}
 
 			if len(result.Interfaces) != tt.wantInts {
@@ -423,6 +471,43 @@ func TestBuildResult(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ---- buildTapResult ------------------------------------------------------
+
+func TestBuildTapResult(t *testing.T) {
+	conf := &PluginConf{
+		PluginConf:    types.PluginConf{CNIVersion: cniVersion100},
+		VPC:           testVPC,
+		VPCAttachment: testAttachment,
+	}
+
+	result := buildTapResult(conf, "H0abc123", "aa:bb:cc:dd:ee:ff", 1500)
+
+	if result.CNIVersion != cniVersion100 {
+		t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, cniVersion100)
+	}
+
+	if len(result.Interfaces) != 1 {
+		t.Fatalf("Interfaces count = %d, want 1", len(result.Interfaces))
+	}
+
+	if result.Interfaces[0].Name != "H0abc123" {
+		t.Errorf("Interfaces[0].Name = %q, want %q", result.Interfaces[0].Name, "H0abc123")
+	}
+	if result.Interfaces[0].Mac != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("Interfaces[0].Mac = %q, want %q", result.Interfaces[0].Mac, "aa:bb:cc:dd:ee:ff")
+	}
+	if result.Interfaces[0].Mtu != 1500 {
+		t.Errorf("Interfaces[0].Mtu = %d, want 1500", result.Interfaces[0].Mtu)
+	}
+	if result.Interfaces[0].Sandbox != "" {
+		t.Errorf("Interfaces[0].Sandbox = %q, want empty", result.Interfaces[0].Sandbox)
+	}
+
+	if len(result.IPs) != 0 {
+		t.Errorf("IPs count = %d, want 0", len(result.IPs))
 	}
 }
 

--- a/internal/cni/tap/tap.go
+++ b/internal/cni/tap/tap.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package tap manages tap interfaces for VM-based workloads (Kata, Firecracker,
+// QEMU). Unlike veth, tap interfaces are L2 file descriptors opened by userspace
+// VMMs; the CNI plugin only configures the host side.
+package tap
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/intf"
+	"go.datum.net/galactic/internal/plumbing/sysctl"
+)
+
+// errIptablesMissing is returned when the iptables binary is not available.
+// Callers can use errors.Is to check for this and skip iptables rules.
+var errIptablesMissing = errors.New("iptables binary not available")
+
+func updateForwardRule(interfaceName string, action string) error {
+	protocols := []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6}
+	for _, proto := range protocols {
+		ipt, err := iptables.NewWithProtocol(proto)
+		if err != nil {
+			// iptables binary not available (e.g., distroless images).
+			// Return a sentinel error so callers can decide whether to fail.
+			return errIptablesMissing
+		}
+
+		rules := [][]string{
+			{"-o", interfaceName, "-j", "ACCEPT"}, // egress
+			{"-i", interfaceName, "-j", "ACCEPT"}, // ingress
+		}
+
+		for _, ruleSpec := range rules {
+			switch action {
+			case "add":
+				if err := ipt.Insert("filter", "FORWARD", 1, ruleSpec...); err != nil {
+					return err
+				}
+			case "delete":
+				if err := ipt.Delete("filter", "FORWARD", ruleSpec...); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("invalid action: '%s' (must be 'add' or 'delete')", action)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Add creates a tap interface with the given MTU, enslaves it to the VRF,
+// applies sysctls and iptables FORWARD rules. Idempotent — repairs state
+// if the tap already exists (crash-recovery).
+func Add(vpc, vpcAttachment string, mtu int) error {
+	vrfName := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	tapName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+
+	vrfLink, err := netlink.LinkByName(vrfName)
+	if err != nil {
+		return fmt.Errorf("find VRF %q: %w", vrfName, err)
+	}
+
+	// Check if tap already exists (crash-recovery or prior partial failure).
+	existingTap, err := netlink.LinkByName(tapName)
+	if err == nil {
+		return repairTap(existingTap, vrfLink, tapName)
+	}
+
+	tap := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: tapName,
+			MTU:  mtu,
+		},
+		Mode: netlink.TUNTAP_MODE_TAP,
+	}
+
+	if err := netlink.LinkAdd(tap); err != nil {
+		return fmt.Errorf("create tap %q: %w", tapName, err)
+	}
+
+	tapLink, err := netlink.LinkByName(tapName)
+	if err != nil {
+		return err
+	}
+
+	// Enslave to VRF, add iptables rules, bring up, then apply sysctls.
+	// Sysctl files (rp_filter, forwarding) are only populated by the kernel
+	// after the interface is brought UP.
+	if err := netlink.LinkSetMaster(tapLink, vrfLink); err != nil {
+		return fmt.Errorf("enslave tap to VRF: %w", err)
+	}
+
+	// Allow forwarded traffic through the tap (bidirectional).
+	if err := updateForwardRule(tapName, "add"); err != nil && !errors.Is(err, errIptablesMissing) {
+		return err
+	}
+
+	// Bring the interface up so the kernel populates sysctl entries.
+	if err := netlink.LinkSetUp(tapLink); err != nil {
+		return fmt.Errorf("bring up tap %q: %w", tapName, err)
+	}
+
+	// Apply tap-specific sysctls (rp_filter + forwarding, no proxy_arp/ndp).
+	if err := sysctl.ConfigureTapSysctls(tapName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes the tap interface and cleans up iptables rules.
+// Idempotent — silently skips if the interface does not exist.
+func Delete(vpc, vpcAttachment string) error {
+	tapName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+
+	// Skip iptables cleanup if binary is unavailable (distroless images).
+	if err := updateForwardRule(tapName, "delete"); err != nil && !errors.Is(err, errIptablesMissing) {
+		return err
+	}
+
+	tapLink, err := netlink.LinkByName(tapName)
+	if err != nil {
+		return nil // interface already gone — idempotent
+	}
+
+	return netlink.LinkDel(tapLink)
+}
+
+// repairTap verifies and repairs a pre-existing tap interface's state.
+func repairTap(tapLink netlink.Link, vrfLink netlink.Link, tapName string) error {
+	// Verify VRF enslavement.
+	if tapLink.Attrs().MasterIndex != vrfLink.Attrs().Index {
+		if err := netlink.LinkSetMaster(tapLink, vrfLink); err != nil {
+			return fmt.Errorf("re-enslave tap to VRF: %w", err)
+		}
+	}
+
+	// Ensure iptables rules exist.
+	if err := updateForwardRule(tapName, "add"); err != nil {
+		return err
+	}
+
+	// Bring up if down (ensures sysctl entries are populated).
+	if tapLink.Attrs().Flags&net.FlagUp == 0 {
+		if err := netlink.LinkSetUp(tapLink); err != nil {
+			return fmt.Errorf("bring up tap %q: %w", tapName, err)
+		}
+	}
+
+	// Apply sysctls (idempotent — sets the same values).
+	return sysctl.ConfigureTapSysctls(tapName)
+}
+
+// isLinkNotFoundError reports whether err indicates that a network link
+// does not exist. This covers both ENOENT and ENODEV errors from netlink.
+func isLinkNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if os.IsNotExist(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no such device") || strings.Contains(msg, "not found")
+}

--- a/internal/cni/tap/tap_test.go
+++ b/internal/cni/tap/tap_test.go
@@ -1,0 +1,238 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package tap
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
+)
+
+func TestIsLinkNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "os.IsNotExist",
+			err:  os.ErrNotExist,
+			want: true,
+		},
+		{
+			name: "no such device",
+			err:  errors.New("link not found: no such device"),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  errors.New("failed: not found"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLinkNotFoundError(tt.err)
+			if got != tt.want {
+				t.Errorf("isLinkNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateForwardRuleInvalidAction(t *testing.T) {
+	err := updateForwardRule("tap0", "invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid action, got nil")
+	}
+	if err.Error() != "invalid action: 'invalid' (must be 'add' or 'delete')" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// requiresRoot skips the test when not running as root.
+func requiresRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("skipping: requires root")
+	}
+}
+
+func TestDeleteNonExistent(t *testing.T) {
+	requiresRoot(t)
+
+	// Delete with a name that definitely doesn't exist.
+	err := Delete("zzz_nonexistent_vpc", "zzz_nonexistent_att")
+	if err != nil {
+		t.Errorf("Delete(nonexistent) = %v, want nil", err)
+	}
+}
+
+func TestAddCreatesTapLink(t *testing.T) {
+	requiresRoot(t)
+
+	vpc := "taptest_a"
+	att := "taptest_b"
+	t.Cleanup(func() { _ = Delete(vpc, att) })
+
+	err := Add(vpc, att, 1500)
+	if err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+
+	// Verify the link exists and is a tap.
+	link, err := findLink(t, generateInterfaceNameHost(vpc, att))
+	if err != nil {
+		t.Fatalf("link not found: %v", err)
+	}
+	if link.Type() != "tap" {
+		t.Errorf("link type = %q, want %q", link.Type(), "tap")
+	}
+}
+
+func TestAddEnslavesToVRF(t *testing.T) {
+	requiresRoot(t)
+
+	vpc := "taptest_c"
+	att := "taptest_d"
+	t.Cleanup(func() { _ = Delete(vpc, att) })
+
+	err := Add(vpc, att, 1500)
+	if err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+
+	hostName := generateInterfaceNameHost(vpc, att)
+	vrfName := generateInterfaceNameVRF(vpc, att)
+
+	link, err := findLink(t, hostName)
+	if err != nil {
+		t.Fatalf("link not found: %v", err)
+	}
+
+	master := link.Attrs().MasterIndex
+	masterLink, err := findLink(t, vrfName)
+	if err != nil {
+		t.Fatalf("VRF link not found: %v", err)
+	}
+	if master != masterLink.Attrs().Index {
+		t.Errorf("tap master index = %d, want %d (VRF)", master, masterLink.Attrs().Index)
+	}
+}
+
+func TestAddBidirectionalRules(t *testing.T) {
+	requiresRoot(t)
+
+	vpc := "taptest_e"
+	att := "taptest_f"
+	t.Cleanup(func() { _ = Delete(vpc, att) })
+
+	err := Add(vpc, att, 1500)
+	if err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+
+	hostName := generateInterfaceNameHost(vpc, att)
+
+	// Check iptables rules exist for both -i and -o.
+	for _, proto := range []int{iptablesProtocolIPv4, iptablesProtocolIPv6} {
+		ipt, err := newIptables(proto)
+		if err != nil {
+			// iptables unavailable — skip.
+			continue
+		}
+		rules, err := ipt.List("filter", "FORWARD")
+		if err != nil {
+			t.Fatalf("iptables list: %v", err)
+		}
+		foundIngress, foundEgress := false, false
+		for _, rule := range rules {
+			if rule == "-A FORWARD -i "+hostName+" -j ACCEPT" {
+				foundIngress = true
+			}
+			if rule == "-A FORWARD -o "+hostName+" -j ACCEPT" {
+				foundEgress = true
+			}
+		}
+		if !foundIngress {
+			t.Errorf("proto=%d: missing ingress (-i) rule for %s", proto, hostName)
+		}
+		if !foundEgress {
+			t.Errorf("proto=%d: missing egress (-o) rule for %s", proto, hostName)
+		}
+	}
+}
+
+func TestDeleteRemovesLink(t *testing.T) {
+	requiresRoot(t)
+
+	vpc := "taptest_g"
+	att := "taptest_h"
+
+	err := Add(vpc, att, 1500)
+	if err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+
+	hostName := generateInterfaceNameHost(vpc, att)
+	if _, err := findLink(t, hostName); err != nil {
+		t.Fatalf("link not found after Add: %v", err)
+	}
+
+	if err := Delete(vpc, att); err != nil {
+		t.Fatalf("Delete(%q, %q) = %v", vpc, att, err)
+	}
+
+	_, err = findLink(t, hostName)
+	if err == nil {
+		t.Error("link still exists after Delete, want removed")
+	}
+}
+
+// ---- helpers -------------------------------------------------------------
+
+func generateInterfaceNameHost(vpc, att string) string {
+	// Inline the intf name generation to avoid a test-time import cycle.
+	// This mirrors intf.GenerateInterfaceNameHost.
+	return "H" + vpc + att
+}
+
+func generateInterfaceNameVRF(vpc, att string) string {
+	// Inline the intf name generation to avoid a test-time import cycle.
+	// This mirrors intf.GenerateInterfaceNameVRF.
+	return "V" + vpc + att
+}
+
+const (
+	iptablesProtocolIPv4 = 0
+	iptablesProtocolIPv6 = 1
+)
+
+func newIptables(proto int) (*iptables.IPTables, error) {
+	return iptables.NewWithProtocol(iptables.Protocol(proto))
+}
+
+func findLink(t *testing.T, name string) (netlink.Link, error) {
+	t.Helper()
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return link, nil
+}

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -32,8 +32,6 @@ func isLinkNotFoundError(err error) bool {
 }
 
 func updateForwardRule(interfaceName string, action string) error {
-	ruleSpec := []string{"-o", interfaceName, "-j", "ACCEPT"}
-
 	protocols := []iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6}
 	for _, proto := range protocols {
 		ipt, err := iptables.NewWithProtocol(proto)
@@ -43,17 +41,24 @@ func updateForwardRule(interfaceName string, action string) error {
 			return errIptablesMissing
 		}
 
-		switch action {
-		case "add":
-			if err := ipt.Insert("filter", "FORWARD", 1, ruleSpec...); err != nil {
-				return err
+		rules := [][]string{
+			{"-o", interfaceName, "-j", "ACCEPT"}, // egress
+			{"-i", interfaceName, "-j", "ACCEPT"}, // ingress
+		}
+
+		for _, ruleSpec := range rules {
+			switch action {
+			case "add":
+				if err := ipt.Insert("filter", "FORWARD", 1, ruleSpec...); err != nil {
+					return err
+				}
+			case "delete":
+				if err := ipt.Delete("filter", "FORWARD", ruleSpec...); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("invalid action: '%s' (must be 'add' or 'delete')", action)
 			}
-		case "delete":
-			if err := ipt.Delete("filter", "FORWARD", ruleSpec...); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("invalid action: '%s' (must be 'add' or 'delete')", action)
 		}
 	}
 

--- a/internal/plumbing/sysctl/sysctl.go
+++ b/internal/plumbing/sysctl/sysctl.go
@@ -34,3 +34,21 @@ func ConfigureInterfaceSysctls(iface string) error {
 	}
 	return nil
 }
+
+// ConfigureTapSysctls applies sysctls appropriate for a tap interface
+// connected to a VM. Unlike ConfigureInterfaceSysctls, it skips
+// proxy_arp and proxy_ndp since the VM handles its own address resolution.
+// Silently skips sysctls that don't exist (e.g., in container environments
+// where dynamically created interfaces may not have all sysctl entries).
+func ConfigureTapSysctls(iface string) error {
+	settings := map[string]string{
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface):  "0",
+		fmt.Sprintf("net.ipv6.conf.%s.rp_filter", iface):  "0",
+		fmt.Sprintf("net.ipv4.conf.%s.forwarding", iface): "1",
+		fmt.Sprintf("net.ipv6.conf.%s.forwarding", iface): "1",
+	}
+	for key, val := range settings {
+		_ = gosysctl.Set(key, val) // silently skip missing entries
+	}
+	return nil
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -73,7 +73,7 @@ func TestCNIPluginVersionReport(t *testing.T) {
 		t.Fatalf("kubectl run failed: %v", err)
 	}
 
-	if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
+	if err := waitForPodPhase(t, name, "Succeeded"); err != nil {
 		t.Fatalf("pod did not succeed: %v", err)
 	}
 
@@ -134,8 +134,8 @@ func TestKernelCapabilities(t *testing.T) {
 			_, err := kubectl(
 				t.Context(),
 				"run", name,
-				"--image=busybox:stable",
-				"--image-pull-policy=IfNotPresent",
+				"--image="+image(),
+				"--image-pull-policy=Never",
 				"--restart=Never",
 				"--privileged",
 				"--command", "--",
@@ -145,7 +145,7 @@ func TestKernelCapabilities(t *testing.T) {
 				t.Fatalf("kubectl run failed: %v", err)
 			}
 
-			if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
+			if err := waitForPodPhase(t, name, "Succeeded"); err != nil {
 				// Fetch logs to aid debugging before failing.
 				if logs, logErr := kubectl(t.Context(), "logs", name); logErr == nil && logs != "" {
 					t.Logf("pod logs:\n%s", logs)
@@ -156,6 +156,133 @@ func TestKernelCapabilities(t *testing.T) {
 	}
 }
 
+// TestCNITapInterface exercises the galactic CNI plugin in tap interface mode.
+// It creates a pod that invokes the CNI plugin with CNI_COMMAND=ADD and a tap
+// config, then validates the CNI result JSON: a single host interface with an
+// empty sandbox and no IP addresses.
+//
+// This test requires a cluster node with VRF/tap kernel support (the same
+// prerequisites checked by TestKernelCapabilities). It will fail rather than
+// skip if those features are missing, so a clean run of TestKernelCapabilities
+// is a prerequisite.
+func TestCNITapInterface(t *testing.T) {
+	name := "e2e-cni-tap"
+	t.Cleanup(func() { deletePod(t, name) })
+	deletePod(t, name)
+
+	// Start a shell so we can later exec the CNI plugin with stdin.
+	// The galactic-cni entrypoint is overridden to "sh" so the pod stays
+	// running and we can pipe the CNI config via kubectl exec -i.
+	_, err := kubectl(
+		t.Context(),
+		"run", name,
+		"--image="+image(),
+		"--image-pull-policy=Never",
+		"--restart=Never",
+		"--privileged",
+		"--command", "--",
+		"sleep", "infinity",
+	)
+	if err != nil {
+		t.Fatalf("kubectl run failed: %v", err)
+	}
+
+	if err := waitForPodPhase(t, name, "Running"); err != nil {
+		t.Fatalf("pod did not reach Running phase: %v", err)
+	}
+
+	// Write the CNI config to a file inside the pod, then run the plugin
+	// with the config piped via stdin.  The plugin reads config from stdin
+	// (the CNI protocol) and CNI_NETNS from the environment.
+	cniConf := `{
+  "cniVersion": "1.0.0",
+  "name": "galactic",
+  "type": "galactic-cni",
+  "vpc": "1",
+  "vpcattachment": "1",
+  "interface_type": "tap",
+  "srv6_locator": "2001:db8:ff01::/48"
+}`
+	// Step 1: write the CNI config and a wrapper script into the pod.
+	script := `#!/bin/sh
+ip netns add e2e-tap-ns
+CNI_NETNS=/var/run/netns/e2e-tap-ns \
+CNI_COMMAND=ADD \
+CNI_CONTAINERID=e2e-tap-001 \
+CNI_IFNAME=eth0 \
+CNI_PATH=/opt/cni/bin \
+NODE_NAME=` + nodeName() + ` \
+	/galactic-cni < /tmp/cni.json
+`
+	_, err = kubectl(t.Context(), "exec", name, "--",
+		"sh", "-c",
+		"echo '"+cniConf+"' > /tmp/cni.json && "+
+			"echo '"+script+"' > /tmp/run-cni.sh && "+
+			"chmod +x /tmp/run-cni.sh",
+	)
+	if err != nil {
+		t.Fatalf("write cni config and script: %v", err)
+	}
+
+	// Step 2: run the wrapper script.
+	out, err := kubectl(t.Context(), "exec", name, "-i", "--", "/tmp/run-cni.sh")
+	if err != nil {
+		// Debug: check what interfaces and sysctl paths exist
+		debugCmd := "ip link show 2>&1 && echo '---' && " +
+			"ls /proc/sys/net/ipv6/conf/ 2>&1 && echo '---' && " +
+			"ls /proc/sys/net/ipv4/conf/ 2>&1"
+		if debug, dErr := kubectl(t.Context(), "exec", name, "--", "sh", "-c", debugCmd); dErr == nil {
+			t.Logf("debug output:\n%s", debug)
+		}
+		t.Logf("exec output: %s", out)
+		t.Fatalf("CNI ADD failed: %v", err)
+	}
+
+	// The CNI result is JSON; find the first '{'.
+	jsonStart := strings.Index(out, "{")
+	if jsonStart == -1 {
+		t.Fatalf("no JSON found in CNI ADD output:\n%s", out)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out[jsonStart:]), &result); err != nil {
+		t.Fatalf("CNI ADD output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+
+	// Tap mode produces exactly 1 interface (the host tap) with an empty sandbox.
+	ifaces, ok := result["interfaces"].([]any)
+	if !ok {
+		t.Fatalf("CNI result missing or invalid \"interfaces\" field; got: %v", result)
+	}
+	if len(ifaces) != 1 {
+		t.Errorf("interfaces count = %d, want 1", len(ifaces))
+	}
+
+	iface, ok := ifaces[0].(map[string]any)
+	if !ok {
+		t.Fatalf("interfaces[0] is not an object; got: %T", ifaces[0])
+	}
+	if sandbox, _ := iface["sandbox"].(string); sandbox != "" {
+		t.Errorf("interfaces[0].sandbox = %q, want empty (tap has no guest endpoint)", sandbox)
+	}
+
+	// Tap mode does not configure guest IPs.
+	if ips, ok := result["ips"]; ok && ips != nil {
+		ipsArr, ok := ips.([]any)
+		if ok && len(ipsArr) > 0 {
+			t.Errorf("CNI result has %d IP(s), want 0 for tap mode", len(ipsArr))
+		}
+	}
+}
+
+// nodeName returns the name of the node this pod runs on, or falls back to
+// "kind-worker" for single-node Kind clusters.
+func nodeName() string {
+	if v := os.Getenv("NODE_NAME"); v != "" {
+		return v
+	}
+	return "kind-worker"
+}
+
 // kubectl runs kubectl with the given arguments and returns combined output.
 func kubectl(ctx context.Context, args ...string) (string, error) {
 	out, err := exec.CommandContext(ctx, "kubectl", args...).CombinedOutput()
@@ -164,9 +291,9 @@ func kubectl(ctx context.Context, args ...string) (string, error) {
 
 // waitForPodPhase polls until the named pod reaches wantPhase or the timeout
 // expires. It returns an error describing the last observed phase on timeout.
-func waitForPodPhase(t *testing.T, name, wantPhase string, timeout time.Duration) error {
+func waitForPodPhase(t *testing.T, name, wantPhase string) error {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
+	deadline := time.Now().Add(podReadyTimeout)
 	for time.Now().Before(deadline) {
 		out, err := kubectl(t.Context(), "get", "pod", name, "-o", "jsonpath={.status.phase}")
 		if err == nil && out == wantPhase {
@@ -178,7 +305,7 @@ func waitForPodPhase(t *testing.T, name, wantPhase string, timeout time.Duration
 		time.Sleep(podPollInterval)
 	}
 	out, _ := kubectl(t.Context(), "get", "pod", name, "-o", "jsonpath={.status.phase}")
-	return fmt.Errorf("timed out after %v waiting for phase %q; last phase: %q", timeout, wantPhase, out)
+	return fmt.Errorf("timed out after %v waiting for phase %q; last phase: %q", podReadyTimeout, wantPhase, out)
 }
 
 // deletePod removes a pod by name, ignoring not-found errors.


### PR DESCRIPTION
## Summary

This patch updates the CNI to provision tap interfaces as well as veth
interfaces.   This patch is required to provision interfaces for the uVM
compute instances.   See the `docs/cni/configuration.md`

## Changes 

- Add internal/cni/tap package for L2 tap interfaces (Kata, Firecracker, QEMU)
- Refactor cmdAdd/cmdDel to dispatch between veth and tap based on interface_type config
- Add buildVethResult and buildTapResult for clean separation of result building
- Add defer-based rollback in cmdAdd to clean up on partial failure
- Refactor veth.updateForwardRule to insert both ingress and egress iptables rules
- Add ConfigureTapSysctls with rp_filter=0 and forwarding=1, skipping proxy settings
- Update e2e tests to cover tap interface attach and detach paths
- Update Dockerfile, architecture docs, and CNI configuration docs