### PR TITLE
chore: harden golangci-lint config and fix all resulting issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,23 @@
 version: "2"
 run:
   allow-parallel-runners: true
+
 linters:
-  default: none
   enable:
     - copyloopvar
-    - dupl
     - errcheck
+    - errname
+    - errorlint
     - goconst
     - gocyclo
     - govet
     - ineffassign
+    - intrange
     - lll
     - misspell
     - nakedret
+    - noctx
+    - perfsprint
     - prealloc
     - revive
     - staticcheck
@@ -21,29 +25,34 @@ linters:
     - unparam
     - unused
   settings:
+    gocyclo:
+      min-complexity: 30
+    govet:
+      enable:
+        - printf
+    nakedret:
+      max-func-lines: 30
     revive:
       rules:
         - name: comment-spacings
         - name: import-shadowing
-  exclusions:
-    generated: lax
-    rules:
-      - linters:
-          - dupl
-          - lll
-        path: internal/*
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
-      - ^lab/
+    staticcheck:
+      checks:
+        - all
+        - "-ST1000"  # don't flag missing doc comments (already covered by conventions)
+
+issues:
+  max-same-issues: 0
+  max-issues-per-linter: 0
+
 formatters:
   enable:
+    - gci
     - gofmt
     - goimports
-  exclusions:
-    generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+  settings:
+    gci:
+      sections:
+        - standard
+        - prefix(go.datum.net)
+        - default

--- a/cmd/galactic-cni/main.go
+++ b/cmd/galactic-cni/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -58,7 +59,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 // validateConfig checks that the configuration values are valid.
 func validateConfig(v *viper.Viper) error {
 	if v.GetString("galactic_cni.node_name") == "" {
-		return fmt.Errorf("--node-name is required (or set GALACTIC_CNI_NODE_NAME)")
+		return errors.New("--node-name is required (or set GALACTIC_CNI_NODE_NAME)")
 	}
 	return nil
 }
@@ -72,7 +73,7 @@ func newRootCommand() *cobra.Command {
 		Use:   appName,
 		Short: strings.Split(appDesc, "\n")[0],
 		Long:  appDesc,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
 				fmt.Println(metadata.BuildInfo(appName))
 				return nil

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -12,11 +13,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 	"google.golang.org/grpc"
 	grpchealth "google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
-
-	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -120,10 +120,10 @@ func validateConfig(v *viper.Viper) error {
 	grpcHealthPort := v.GetInt("galactic_router.grpc_health_port")
 
 	if nodeName == "" {
-		return fmt.Errorf("--node-name is required")
+		return errors.New("--node-name is required")
 	}
 	if routerRole == "" {
-		return fmt.Errorf("--router-role is required")
+		return errors.New("--router-role is required")
 	}
 	if routerRole != roleTenant && routerRole != roleFabric {
 		return fmt.Errorf("GALACTIC_ROUTER_ROUTER_ROLE must be 'tenant' or 'fabric', got %q", routerRole)
@@ -187,15 +187,15 @@ func runCmd(v *viper.Viper) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("create manager: %v", err)
+		return fmt.Errorf("create manager: %w", err)
 	}
 
 	ctx := ctrl.SetupSignalHandler()
 
 	// Start gRPC health server.
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcHealthPort))
+	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcHealthPort))
 	if err != nil {
-		return fmt.Errorf("listen on gRPC health port %d: %v", grpcHealthPort, err)
+		return fmt.Errorf("listen on gRPC health port %d: %w", grpcHealthPort, err)
 	}
 	grpcSrv := grpc.NewServer()
 	healthSrv := grpchealth.NewServer()
@@ -216,7 +216,7 @@ func runCmd(v *viper.Viper) error {
 
 	// Register field indexes.
 	if err := controller.RegisterIndexes(ctx, mgr); err != nil {
-		return fmt.Errorf("register field indexes: %v", err)
+		return fmt.Errorf("register field indexes: %w", err)
 	}
 
 	// Create runtime manager.
@@ -235,7 +235,7 @@ func runCmd(v *viper.Viper) error {
 		NodeName:       nodeName,
 		RouterRole:     routerRole,
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup BGPRouter controller: %v", err)
+		return fmt.Errorf("setup BGPRouter controller: %w", err)
 	}
 
 	// Register BGPPeer controller.
@@ -243,7 +243,7 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup BGPPeer controller: %v", err)
+		return fmt.Errorf("setup BGPPeer controller: %w", err)
 	}
 
 	// Register BGPAdvertisement controller.
@@ -251,7 +251,7 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup BGPAdvertisement controller: %v", err)
+		return fmt.Errorf("setup BGPAdvertisement controller: %w", err)
 	}
 
 	// Register BGPVRFInstance controller.
@@ -259,7 +259,7 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup BGPVRFInstance controller: %v", err)
+		return fmt.Errorf("setup BGPVRFInstance controller: %w", err)
 	}
 
 	// Register BGPPolicy controller.
@@ -267,7 +267,7 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup BGPPolicy controller: %v", err)
+		return fmt.Errorf("setup BGPPolicy controller: %w", err)
 	}
 
 	// Register Secret controller.
@@ -275,7 +275,7 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup Secret controller: %v", err)
+		return fmt.Errorf("setup Secret controller: %w", err)
 	}
 
 	// Register Node controller.
@@ -283,11 +283,11 @@ func runCmd(v *viper.Viper) error {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("setup Node controller: %v", err)
+		return fmt.Errorf("setup Node controller: %w", err)
 	}
 
 	if err := mgr.Start(ctx); err != nil {
-		return fmt.Errorf("manager exited: %v", err)
+		return fmt.Errorf("manager exited: %w", err)
 	}
 
 	return nil
@@ -302,7 +302,7 @@ func newRootCommand() *cobra.Command {
 		Use:   appName,
 		Short: strings.Split(appDesc, "\n")[0],
 		Long:  appDesc,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
 				fmt.Println(metadata.BuildInfo(appName))
 				return nil

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -7,6 +7,7 @@ package cni
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -114,7 +115,7 @@ func RunPlugin() {
 			Del: cmdDel,
 		},
 		version.All,
-		fmt.Sprintf("CNI galactic plugin %s", metadata.Version),
+		"CNI galactic plugin "+metadata.Version,
 	)
 }
 
@@ -208,7 +209,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		return fmt.Errorf("NODE_NAME environment variable is not set")
+		return errors.New("NODE_NAME environment variable is not set")
 	}
 
 	namespace := pluginConf.Namespace
@@ -420,7 +421,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("host-device DEL: %w", err)
 	}
 	for _, termination := range pluginConf.Terminations {
-		if err := route.Delete(pluginConf.VPC, pluginConf.VPCAttachment, termination.Network, termination.Via, dev); err != nil {
+		if err := route.Delete(
+			pluginConf.VPC, pluginConf.VPCAttachment,
+			termination.Network, termination.Via, dev,
+		); err != nil {
 			return fmt.Errorf("delete route %s: %w", termination.Network, err)
 		}
 	}
@@ -765,7 +769,10 @@ func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) 
 		IfName:        skelArgs.IfName,
 		Path:          skelArgs.Path,
 	}
-	if _, err := invokeExec.ExecPlugin(context.Background(), hostDeviceExecutable(), conf, invokeArgs.AsEnv()); err != nil {
+	if _, err := invokeExec.ExecPlugin(
+		context.Background(), hostDeviceExecutable(), conf,
+		invokeArgs.AsEnv(),
+	); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -60,8 +61,13 @@ func TestParseConf(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "valid config",
-			input:   `{"cniVersion":"1.0.0","name":"test","type":"galactic-cni","vpc":"` + testVPC + `","vpcattachment":"` + testAttachment + `","srv6_locator":"2001:db8::/48"}`,
+			name: "valid config",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"2001:db8::/48"}`,
+				testVPC, testAttachment,
+			),
 			wantVPC: testVPC,
 		},
 		{

--- a/internal/cni/ipam/ipam.go
+++ b/internal/cni/ipam/ipam.go
@@ -89,13 +89,13 @@ func NewPoolAllocator(poolCIDR, gateway string, subnetLen int) (*PoolAllocator, 
 // Allocate assigns the next available IPv6 subnet from the pool for the
 // given container ID. Returns the allocated subnet CIDR or an error if the
 // pool is exhausted. Thread-safe.
-func (a *PoolAllocator) Allocate(containerID string) (*net.IPNet, error) {
+func (a *PoolAllocator) Allocate(_ string) (*net.IPNet, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	// Collect currently allocated subnets for fast lookup.
 	used := make(map[string]struct{})
-	a.allocations.Range(func(key, value any) bool {
+	a.allocations.Range(func(key, _ any) bool {
 		used[key.(string)] = struct{}{}
 		return true
 	})
@@ -153,7 +153,7 @@ func NewStaticAllocator() *StaticAllocator {
 
 // Allocate validates the given IPv6 address and returns it.
 // The address must be a well-formed IPv6 address.
-func (a *StaticAllocator) Allocate(containerID, addr string) (net.IP, error) {
+func (a *StaticAllocator) Allocate(_ string, addr string) (net.IP, error) {
 	ip := net.ParseIP(addr)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid IPv6 address: %s", addr)

--- a/internal/cni/route/route.go
+++ b/internal/cni/route/route.go
@@ -8,14 +8,13 @@ import (
 	"fmt"
 	"net"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-func assembleRoute(vrfId uint32, prefix, nextHop, dev string) (*netlink.Route, error) {
+func assembleRoute(vrfID uint32, prefix, nextHop, dev string) (*netlink.Route, error) {
 	_, routeDst, err := net.ParseCIDR(prefix)
 	if err != nil {
 		return nil, err
@@ -29,7 +28,7 @@ func assembleRoute(vrfId uint32, prefix, nextHop, dev string) (*netlink.Route, e
 		return &netlink.Route{
 			Dst:   routeDst,
 			Gw:    routeGw,
-			Table: int(vrfId),
+			Table: int(vrfID),
 		}, nil
 	}
 
@@ -39,18 +38,18 @@ func assembleRoute(vrfId uint32, prefix, nextHop, dev string) (*netlink.Route, e
 	}
 	return &netlink.Route{
 		Dst:       routeDst,
-		Table:     int(vrfId),
+		Table:     int(vrfID),
 		LinkIndex: link.Attrs().Index,
 		Scope:     unix.RT_SCOPE_LINK,
 	}, nil
 }
 
 func Add(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
-	vrfId, err := vrf.TableID(vpc, vpcAttachment)
+	vrfID, err := vrf.TableID(vpc, vpcAttachment)
 	if err != nil {
 		return err
 	}
-	route, err := assembleRoute(vrfId, prefix, nextHop, dev)
+	route, err := assembleRoute(vrfID, prefix, nextHop, dev)
 	if err != nil {
 		return err
 	}
@@ -58,11 +57,11 @@ func Add(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
 }
 
 func Delete(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
-	vrfId, err := vrf.TableID(vpc, vpcAttachment)
+	vrfID, err := vrf.TableID(vpc, vpcAttachment)
 	if err != nil {
 		return err
 	}
-	route, err := assembleRoute(vrfId, prefix, nextHop, dev)
+	route, err := assembleRoute(vrfID, prefix, nextHop, dev)
 	if err != nil {
 		return err
 	}

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
+
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
 // errIptablesMissing is returned when the iptables binary is not available.
 // Callers can use errors.Is to check for this and skip iptables rules.
-var errIptablesMissing = fmt.Errorf("iptables binary not available")
+var errIptablesMissing = errors.New("iptables binary not available")
 
 // isLinkNotFoundError reports whether err indicates that a network link
 // does not exist. This covers both ENOENT and ENODEV errors from netlink.

--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -234,7 +234,10 @@ func (r *BGPRouterReconciler) updateRouterStatus(router *bgpv1alpha1.BGPRouter, 
 // updatePeerStatuses updates BGPPeer status only for peers that target this router.
 // It uses the routerRef name index for direct references and evaluates routerSelector
 // for selector-based bindings.
-func (r *BGPRouterReconciler) updatePeerStatuses(ctx context.Context, router *bgpv1alpha1.BGPRouter, rs model.RuntimeStatus) {
+func (r *BGPRouterReconciler) updatePeerStatuses(
+	ctx context.Context, router *bgpv1alpha1.BGPRouter,
+	rs model.RuntimeStatus,
+) {
 	logger := log.FromContext(ctx)
 
 	// Build a lookup map by peer address.
@@ -311,7 +314,10 @@ func (r *BGPRouterReconciler) updatePeerStatuses(ctx context.Context, router *bg
 }
 
 // updateAdvertisementStatuses updates BGPAdvertisement status.
-func (r *BGPRouterReconciler) updateAdvertisementStatuses(ctx context.Context, router *bgpv1alpha1.BGPRouter, rs model.RuntimeStatus) {
+func (r *BGPRouterReconciler) updateAdvertisementStatuses(
+	ctx context.Context, router *bgpv1alpha1.BGPRouter,
+	rs model.RuntimeStatus,
+) {
 	logger := log.FromContext(ctx)
 
 	advByName := make(map[string]model.AdvertisementStatus, len(rs.Advertisements))

--- a/internal/controller/indexer.go
+++ b/internal/controller/indexer.go
@@ -93,16 +93,19 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}
 
 	// BGPVRFInstance: index by routerRef.name.
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPVRFInstance{}, BGPVRFInstanceByRouterName, func(obj client.Object) []string {
-		vrf, ok := obj.(*bgpv1alpha1.BGPVRFInstance)
-		if !ok {
-			return nil
-		}
-		if vrf.Spec.RouterRef == nil {
-			return nil
-		}
-		return []string{vrf.Spec.RouterRef.Name}
-	}); err != nil {
+	if err := cache.IndexField(
+		ctx, &bgpv1alpha1.BGPVRFInstance{},
+		BGPVRFInstanceByRouterName,
+		func(obj client.Object) []string {
+			vrf, ok := obj.(*bgpv1alpha1.BGPVRFInstance)
+			if !ok {
+				return nil
+			}
+			if vrf.Spec.RouterRef == nil {
+				return nil
+			}
+			return []string{vrf.Spec.RouterRef.Name}
+		}); err != nil {
 		return fmt.Errorf("index BGPVRFInstance by routerRef.name: %w", err)
 	}
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -40,6 +41,16 @@ var (
 
 // BuildInfo returns a multi-line string with all build metadata fields.
 func BuildInfo(appName string) string {
-	return fmt.Sprintf("Name:       %s\nVersion:    %s\nCommit:     %s\nTree:       %s\nBuild Date: %s\nLicense:    %s\nURL:        %s\nGo:         %s\nPlatform:   %s\nPath:       %s",
-		appName, Version, GitCommit, GitTreeState, BuildDate, SPDXLicense, GitURL, GoVersion, Platform, Executable)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Name:       %s\n", appName)
+	fmt.Fprintf(&b, "Version:    %s\n", Version)
+	fmt.Fprintf(&b, "Commit:     %s\n", GitCommit)
+	fmt.Fprintf(&b, "Tree:       %s\n", GitTreeState)
+	fmt.Fprintf(&b, "Build Date: %s\n", BuildDate)
+	fmt.Fprintf(&b, "License:    %s\n", SPDXLicense)
+	fmt.Fprintf(&b, "URL:        %s\n", GitURL)
+	fmt.Fprintf(&b, "Go:         %s\n", GoVersion)
+	fmt.Fprintf(&b, "Platform:   %s\n", Platform)
+	fmt.Fprintf(&b, "Path:       %s", Executable)
+	return b.String()
 }

--- a/internal/plumbing/intf/intf.go
+++ b/internal/plumbing/intf/intf.go
@@ -8,6 +8,7 @@ package intf
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -62,7 +63,7 @@ func EncodeSRv6Endpoint(srv6Net, vpc, vpcAttachment string) (string, error) {
 	}
 	maskLen, _ := ipnet.Mask.Size()
 	if maskLen > 64 {
-		return "", fmt.Errorf("srv6Net must be at least 64 bits long")
+		return "", errors.New("srv6Net must be at least 64 bits long")
 	}
 
 	vpcInt, err := strconv.ParseUint(vpc, 16, 64)

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -8,20 +8,21 @@
 package vrf
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"slices"
 	"sync"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/vishvananda/netlink"
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
-const minVRFId = uint32(1)
-const maxVRFId = uint32(math.MaxUint32 - 1)
+const minVRFID = uint32(1)
+const maxVRFID = uint32(math.MaxUint32 - 1)
 
 // vrfMu serializes VRF creation to prevent two concurrent CNI ADD calls from
 // scanning the same free table ID and both attempting to create a VRF with it.
@@ -42,12 +43,12 @@ func Add(vpc, vpcAttachment string) error {
 		return nil
 	}
 
-	vrfId, err := findNextAvailableVRFId()
+	vrfID, err := findNextAvailableVRFID()
 	if err != nil {
 		return err
 	}
 
-	if err := flush(vrfId); err != nil {
+	if err := flush(vrfID); err != nil {
 		return err
 	}
 
@@ -55,7 +56,7 @@ func Add(vpc, vpcAttachment string) error {
 		LinkAttrs: netlink.LinkAttrs{
 			Name: name,
 		},
-		Table: vrfId,
+		Table: vrfID,
 	}
 
 	if err := netlink.LinkAdd(vrf); err != nil {
@@ -74,12 +75,12 @@ func Add(vpc, vpcAttachment string) error {
 func Delete(vpc, vpcAttachment string) error {
 	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
 
-	vrfId, err := getVRFIdForInterface(name)
+	vrfID, err := getVRFIDForInterface(name)
 	if err != nil {
 		return err
 	}
 
-	if err := flush(vrfId); err != nil {
+	if err := flush(vrfID); err != nil {
 		return err
 	}
 
@@ -94,14 +95,14 @@ func Delete(vpc, vpcAttachment string) error {
 // TableID returns the Linux routing table ID for the VRF associated with the
 // given base62-encoded VPC and VPCAttachment.
 func TableID(vpc, vpcAttachment string) (uint32, error) {
-	return getVRFIdForInterface(intf.GenerateInterfaceNameVRF(vpc, vpcAttachment))
+	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc, vpcAttachment))
 }
 
-func flush(vrfId uint32) error {
+func flush(vrfID uint32) error {
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		routes, err := netlink.RouteListFiltered(
 			family,
-			&netlink.Route{Table: int(vrfId)},
+			&netlink.Route{Table: int(vrfID)},
 			netlink.RT_FILTER_TABLE,
 		)
 		if err != nil {
@@ -131,7 +132,7 @@ func listVRFLinks() ([]*netlink.Vrf, error) {
 	return vrfLinks, nil
 }
 
-func findNextAvailableVRFId() (uint32, error) {
+func findNextAvailableVRFID() (uint32, error) {
 	vrfs, err := listVRFLinks()
 	if err != nil {
 		return 0, err
@@ -142,16 +143,16 @@ func findNextAvailableVRFId() (uint32, error) {
 		used = append(used, vrf.Table)
 	}
 
-	for vrfId := minVRFId; vrfId <= maxVRFId; vrfId++ {
-		if !slices.Contains(used, vrfId) {
-			return vrfId, nil
+	for vrfID := minVRFID; vrfID <= maxVRFID; vrfID++ {
+		if !slices.Contains(used, vrfID) {
+			return vrfID, nil
 		}
 	}
 
-	return 0, fmt.Errorf("could not find any available VRF id")
+	return 0, errors.New("could not find any available VRF id")
 }
 
-func getVRFIdForInterface(name string) (uint32, error) {
+func getVRFIDForInterface(name string) (uint32, error) {
 	vrfs, err := listVRFLinks()
 	if err != nil {
 		return 0, err

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -42,7 +42,9 @@ func New(c client.Client, nodeName, routerRole string) *Reconciler {
 // BuildDesiredRouter assembles the full DesiredRouter from Cosmos CRDs for
 // the given BGPRouter. It returns (nil, nil) if the router should be silently
 // skipped (wrong node or wrong role). It returns (nil, err) on error.
-func (r *Reconciler) BuildDesiredRouter(ctx context.Context, router *bgpv1alpha1.BGPRouter) (*model.DesiredRouter, error) {
+func (r *Reconciler) BuildDesiredRouter(
+	ctx context.Context, router *bgpv1alpha1.BGPRouter,
+) (*model.DesiredRouter, error) {
 	// Node check: skip routers that don't target this node.
 	if router.Spec.TargetRef.Name != r.nodeName {
 		return nil, nil

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -221,7 +221,10 @@ func (r *GoBGPRuntime) applyEVPN(b *gobgpserver.BgpServer, advs []model.DesiredA
 }
 
 // applyPolicies adds, updates, and removes BGP policies to match desired state.
-func (r *GoBGPRuntime) applyPolicies(ctx context.Context, b *gobgpserver.BgpServer, policies []model.DesiredPolicy) error {
+func (r *GoBGPRuntime) applyPolicies(
+	ctx context.Context, b *gobgpserver.BgpServer,
+	policies []model.DesiredPolicy,
+) error {
 	desiredPolicies := make(map[string]model.BGPPolicyDirection, len(policies))
 	for _, policy := range policies {
 		desiredPolicies[policy.Name] = policy.Direction

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -12,6 +12,7 @@
 package e2e_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, "SKIP: kubectl not found in PATH")
 		os.Exit(0)
 	}
-	if out, err := kubectl("cluster-info"); err != nil {
+	if out, err := kubectl(context.Background(), "cluster-info"); err != nil {
 		fmt.Fprintf(os.Stderr, "SKIP: cluster not reachable: %v\n%s\n", err, out)
 		os.Exit(0)
 	}
@@ -59,6 +60,7 @@ func TestCNIPluginVersionReport(t *testing.T) {
 	deletePod(t, name)
 
 	_, err := kubectl(
+		context.Background(),
 		"run", name,
 		"--image="+image(),
 		"--image-pull-policy=Never",
@@ -75,7 +77,7 @@ func TestCNIPluginVersionReport(t *testing.T) {
 		t.Fatalf("pod did not succeed: %v", err)
 	}
 
-	logs, err := kubectl("logs", name)
+	logs, err := kubectl(context.Background(), "logs", name)
 	if err != nil {
 		t.Fatalf("kubectl logs failed: %v", err)
 	}
@@ -130,6 +132,7 @@ func TestKernelCapabilities(t *testing.T) {
 			deletePod(t, name)
 
 			_, err := kubectl(
+				t.Context(),
 				"run", name,
 				"--image=busybox:stable",
 				"--image-pull-policy=IfNotPresent",
@@ -144,7 +147,7 @@ func TestKernelCapabilities(t *testing.T) {
 
 			if err := waitForPodPhase(t, name, "Succeeded", podReadyTimeout); err != nil {
 				// Fetch logs to aid debugging before failing.
-				if logs, logErr := kubectl("logs", name); logErr == nil && logs != "" {
+				if logs, logErr := kubectl(t.Context(), "logs", name); logErr == nil && logs != "" {
 					t.Logf("pod logs:\n%s", logs)
 				}
 				t.Fatalf("kernel capability check %q failed: %v", tt.name, err)
@@ -154,8 +157,8 @@ func TestKernelCapabilities(t *testing.T) {
 }
 
 // kubectl runs kubectl with the given arguments and returns combined output.
-func kubectl(args ...string) (string, error) {
-	out, err := exec.Command("kubectl", args...).CombinedOutput()
+func kubectl(ctx context.Context, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, "kubectl", args...).CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
 
@@ -165,7 +168,7 @@ func waitForPodPhase(t *testing.T, name, wantPhase string, timeout time.Duration
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		out, err := kubectl("get", "pod", name, "-o", "jsonpath={.status.phase}")
+		out, err := kubectl(t.Context(), "get", "pod", name, "-o", "jsonpath={.status.phase}")
 		if err == nil && out == wantPhase {
 			return nil
 		}
@@ -174,12 +177,12 @@ func waitForPodPhase(t *testing.T, name, wantPhase string, timeout time.Duration
 		}
 		time.Sleep(podPollInterval)
 	}
-	out, _ := kubectl("get", "pod", name, "-o", "jsonpath={.status.phase}")
+	out, _ := kubectl(t.Context(), "get", "pod", name, "-o", "jsonpath={.status.phase}")
 	return fmt.Errorf("timed out after %v waiting for phase %q; last phase: %q", timeout, wantPhase, out)
 }
 
 // deletePod removes a pod by name, ignoring not-found errors.
 func deletePod(t *testing.T, name string) {
 	t.Helper()
-	kubectl("delete", "pod", name, "--ignore-not-found", "--wait=false") //nolint:errcheck
+	kubectl(t.Context(), "delete", "pod", name, "--ignore-not-found", "--wait=false") //nolint:errcheck
 }


### PR DESCRIPTION
## Summary

Upgrade golint to v2 and tight up the rules.   Run ci and update all
files that do not conform to the new project linting rules.

## Changes

- Enable errname, errorlint, intrange, noctx, and perfsprint linters; remove dupl
- Add per-linter settings for gocyclo complexity, govet printf check, and nakedret func-lines limit
- Enable staticcheck all-checks minus ST1000 (doc-comment rule already covered by conventions)
- Replace fmt.Errorf with errors.New for static strings; use %w instead of %v for wrapped errors
- Rename vrfId, vrfID constants and helpers to satisfy Go initialism conventions
- Pass context to exec.CommandContext in e2e kubectl helper to satisfy noctx linter
- Add gci import formatter with standard → first-party → default section ordering