### PR TITLE
chore: improve .yamlfmt config

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -4,7 +4,11 @@ formatter:
   line_ending: lf
   trim_trailing_whitespace: true
   eof_newline: true
+  keep_line_progressions: true
+  indent_anchors: true
+  formatter_version: "2"
 include:
   - "**/*.yaml"
 exclude:
-  - "bin/**"
+  - ".git/**"
+  - "vendor/**"


### PR DESCRIPTION
Add keep_line_progressions, indent_anchors, and formatter_version to prevent noisy diffs on K8s manifests and ContainerLab topologies. Tighten exclude patterns to .git/** and vendor/**.