### PR TITLE
fix: correct guest interface name and CNI version in veth result path

### DIFF
--- a/deploy/containerlab/resources/overlay/dfw/nad.yaml
+++ b/deploy/containerlab/resources/overlay/dfw/nad.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   config: |
     {
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "name": "testvpc",
       "type": "galactic-cni",
       "vpc": "10",

--- a/deploy/containerlab/resources/overlay/iad/nad.yaml
+++ b/deploy/containerlab/resources/overlay/iad/nad.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   config: |
     {
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "name": "testvpc",
       "type": "galactic-cni",
       "vpc": "10",

--- a/deploy/containerlab/resources/overlay/sjc/nad.yaml
+++ b/deploy/containerlab/resources/overlay/sjc/nad.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   config: |
     {
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "name": "testvpc",
       "type": "galactic-cni",
       "vpc": "10",

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -293,7 +293,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	var ipamResult *ipamResult
 	switch pluginConf.InterfaceType {
 	case interfaceTypeVeth:
-		ipamResult, err = buildVethResult(args, pluginConf, hostName, args.IfName, hostMac, hostMTU)
+		guestName := intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment)
+		ipamResult, err = buildVethResult(args, pluginConf, hostName, guestName, hostMac, hostMTU)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The buildVethResult caller passed args.IfName ("net1") as the guestName parameter, but netlink.LinkByName(guestName) operates on the host namespace where the veth guest-end is named G{vpc}{vpcAttachment}G. This caused host-device ADD to be skipped entirely, leaving the veth on the host and IPAM failing with "Link not found".

Also update the NAD configs to declare cniVersion "1.0.0" to match the plugin's result version. The previous "0.3.1" declaration caused the CNI framework to attempt a version conversion that panicked with "types.Result is *types100.Result, not *types040.Result".