### PR TITLE
fix: improve error observability in SRv6 egress and probe route cleanup

### DIFF
--- a/.devcontainer/galactic/devcontainer.json
+++ b/.devcontainer/galactic/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
 	"features": {
 		"ghcr.io/devcontainers/features/go:1": {
-			"version": "1.24.2"
+			"version": "1.26.0"
 		},
 		"ghcr.io/devcontainers/features/python:1": {
 			"version": "3.13",
@@ -54,7 +54,7 @@
 				"go.lintFlags": [
 					"--fast"
 				],
-				"go.formatTool": "gofmt",
+				"go.formatTool": "gopls",
 				"go.testEnvVars": {
 					"GOOS": "linux"
 				},
@@ -69,7 +69,7 @@
 					}
 				},
 				"gopls": {
-					"formatting.gofumpt": true,
+					"formatting.gofumpt": false,
 					"ui.semanticTokens": true,
 					"ui.codelenses": {
 						"gc_details": false,

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ coverage.html
 /bin/
 /dist/
 /galactic
+/galactic-router
+/galactic-cni
 
 # Go workspace
 go.work
@@ -106,6 +108,7 @@ skaffold.local.yaml
 .agent/
 .agents/
 .claude/scratch/
+.claude/settings.local.json
 
 # ============================================================
 # IDEs and editors

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -18,8 +18,11 @@ import (
 // gateway so the encapsulated outer packet can be L2-resolved on egress.
 func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	routes, err := netlink.RouteGet(gateway)
-	if err != nil || len(routes) == 0 {
+	if err != nil {
 		return fmt.Errorf("no route to gateway %s: %w", gateway, err)
+	}
+	if len(routes) == 0 {
+		return fmt.Errorf("no route to gateway %s", gateway)
 	}
 	encap := &netlink.SEG6Encap{
 		Mode:     nl.SEG6_IPTUN_MODE_ENCAP,

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -180,6 +180,8 @@ func probeRouteWrite(tableID uint32) error {
 	if err := netlink.RouteReplace(probe); err != nil {
 		return fmt.Errorf("route write probe (missing root or CAP_NET_ADMIN?): %w", err)
 	}
-	_ = netlink.RouteDel(probe)
+	if err := netlink.RouteDel(probe); err != nil {
+		slog.Warn("probeRouteWrite: failed to remove probe route", "dst", probe.Dst, "err", err)
+	}
 	return nil
 }


### PR DESCRIPTION
- RouteEgressAdd: split nil-error and zero-routes cases so the error message never wraps a nil sentinel
- probeRouteWrite: log RouteDel failure instead of silently discarding, making leaked probe routes observable in production

Also bump devcontainer Go to 1.26.0 to match go.mod (eliminates the incomplete module-proxy toolchain download that was missing covdata), route formatting through gopls only to fix the double-format warning, and add /galactic-router, /galactic-cni, .claude/settings.local.json to .gitignore.