### PR TITLE
fix: make cmdDel fully idempotent per CNI spec

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -415,9 +416,21 @@ func publishBGPState(
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	pluginConf, err := parseConf(args.StdinData)
-	if err != nil {
-		return err
+	// DEL is idempotent per the CNI spec: always return success.
+	// Missing resources are not errors. We collect all cleanup errors,
+	// log them, and return nil so the CNI runtime does not retry.
+	var errs []error
+
+	// Parse config — if we can't parse it we still return success but
+	// won't be able to clean up any resources.
+	pluginConf, parseErr := parseConf(args.StdinData)
+	if parseErr != nil {
+		slog.Error("DEL: failed to parse CNI config, skipping cleanup", "err", parseErr,
+			"containerID", args.ContainerID)
+		// Cannot determine what to clean up without a valid config.
+		result := &type100.Result{}
+		_ = types.PrintResult(result, cniVersion100)
+		return nil
 	}
 
 	// Deallocate IPAM subnet before any other cleanup (veth-only).
@@ -430,53 +443,67 @@ func cmdDel(args *skel.CmdArgs) error {
 		namespace = defaultNamespace
 	}
 
-	// Signal BGP route withdrawal immediately to notify remote peers.
-	// cosmos reconciles async.
-	// IgnoreNotFound handles concurrent DEL races.
-	k8s, err := newK8sClient()
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)
-	defer cancel()
-
-	// Delete the BGPAdvertisement first to withdraw prefixes, then the VRF instance.
-	adv := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
-			Namespace: namespace,
-		},
-	}
-	if err := k8s.Get(ctx, client.ObjectKeyFromObject(adv), adv); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("get BGPAdvertisement: %w", err)
-	}
-	if err := k8s.Delete(ctx, adv); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("delete BGPAdvertisement: %w", err)
+	k8s, k8sErr := newK8sClient()
+	if k8sErr != nil {
+		slog.Error("DEL: failed to create k8s client, skipping CRD cleanup", "err", k8sErr,
+			"containerID", args.ContainerID)
+		errs = append(errs, fmt.Errorf("create k8s client: %w", k8sErr))
 	}
 
-	vrfInst := &bgpv1alpha1.BGPVRFInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      bgpVRFInstanceName(pluginConf.VPC, pluginConf.VPCAttachment),
-			Namespace: namespace,
-		},
-	}
-	if err := k8s.Delete(ctx, vrfInst); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("delete BGPVRFInstance: %w", err)
+	// Best-effort cleanup of all resources.
+	if k8s != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)
+		defer cancel()
+
+		// Delete the BGPAdvertisement first to withdraw prefixes, then the VRF instance.
+		adv := &bgpv1alpha1.BGPAdvertisement{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
+				Namespace: namespace,
+			},
+		}
+		if err := k8s.Get(ctx, client.ObjectKeyFromObject(adv), adv); client.IgnoreNotFound(err) != nil {
+			slog.Error("DEL: failed to get BGPAdvertisement", "err", err,
+				"name", adv.Name, "namespace", namespace)
+			errs = append(errs, fmt.Errorf("get BGPAdvertisement %s: %w", adv.Name, err))
+		} else if err := k8s.Delete(ctx, adv); client.IgnoreNotFound(err) != nil {
+			slog.Error("DEL: failed to delete BGPAdvertisement", "err", err,
+				"name", adv.Name, "namespace", namespace)
+			errs = append(errs, fmt.Errorf("delete BGPAdvertisement %s: %w", adv.Name, err))
+		}
+
+		vrfInst := &bgpv1alpha1.BGPVRFInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bgpVRFInstanceName(pluginConf.VPC, pluginConf.VPCAttachment),
+				Namespace: namespace,
+			},
+		}
+		if err := k8s.Delete(ctx, vrfInst); client.IgnoreNotFound(err) != nil {
+			slog.Error("DEL: failed to delete BGPVRFInstance", "err", err,
+				"name", vrfInst.Name, "namespace", namespace)
+			errs = append(errs, fmt.Errorf("delete BGPVRFInstance %s: %w", vrfInst.Name, err))
+		}
 	}
 
 	dev := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
+
 	// host-device DEL is veth-only; tap has no guest interface to remove.
 	if pluginConf.InterfaceType == interfaceTypeVeth {
 		if err := hostDevice("DEL", args, pluginConf); err != nil {
-			return fmt.Errorf("host-device DEL: %w", err)
+			slog.Error("DEL: failed to delete host-device", "err", err,
+				"containerID", args.ContainerID)
+			errs = append(errs, fmt.Errorf("host-device DEL: %w", err))
 		}
 	}
+
 	for _, termination := range pluginConf.Terminations {
 		if err := route.Delete(
 			pluginConf.VPC, pluginConf.VPCAttachment,
 			termination.Network, termination.Via, dev,
 		); err != nil {
-			return fmt.Errorf("delete route %s: %w", termination.Network, err)
+			slog.Error("DEL: failed to delete route", "err", err,
+				"network", termination.Network, "via", termination.Via)
+			errs = append(errs, fmt.Errorf("delete route %s: %w", termination.Network, err))
 		}
 	}
 
@@ -486,26 +513,43 @@ func cmdDel(args *skel.CmdArgs) error {
 			if vpcHex, hexErr := intf.Base62ToHex(pluginConf.VPC); hexErr == nil {
 				if vpcAttHex, attErr := intf.Base62ToHex(pluginConf.VPCAttachment); attErr == nil {
 					if sid, sidErr := intf.EncodeSRv6Endpoint(pluginConf.SRv6Locator, vpcHex, vpcAttHex); sidErr == nil {
-						_ = srv6.RouteIngressDel(sid)
+						if err := srv6.RouteIngressDel(sid); err != nil {
+							slog.Error("DEL: failed to delete SRv6 ingress route", "err", err,
+								"sid", sid)
+							errs = append(errs, fmt.Errorf("delete SRv6 ingress route: %w", err))
+						}
 					}
 				}
 			}
 		}
 		if err := veth.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
-			return fmt.Errorf("delete veth: %w", err)
+			slog.Error("DEL: failed to delete veth", "err", err,
+				"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
+			errs = append(errs, fmt.Errorf("delete veth: %w", err))
 		}
 	case interfaceTypeTap:
 		if err := tap.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
-			return fmt.Errorf("delete tap: %w", err)
+			slog.Error("DEL: failed to delete tap", "err", err,
+				"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
+			errs = append(errs, fmt.Errorf("delete tap: %w", err))
 		}
 	}
 
 	if err := vrf.Delete(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
-		return fmt.Errorf("delete VRF: %w", err)
+		slog.Error("DEL: failed to delete VRF", "err", err,
+			"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
+		errs = append(errs, fmt.Errorf("delete VRF: %w", err))
 	}
 
 	result := &type100.Result{}
-	return types.PrintResult(result, cniVersion100)
+	_ = types.PrintResult(result, cniVersion100)
+
+	if len(errs) > 0 {
+		slog.Error("DEL: completed with cleanup errors",
+			"count", len(errs), "containerID", args.ContainerID)
+	}
+
+	return nil
 }
 
 // ipamResult holds the IPAM allocation details for building the CNI result.

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -508,6 +509,47 @@ func TestBuildTapResult(t *testing.T) {
 
 	if len(result.IPs) != 0 {
 		t.Errorf("IPs count = %d, want 0", len(result.IPs))
+	}
+}
+
+// ---- cmdDel idempotency --------------------------------------------------
+
+// TestCmdDelIdempotent returns nil even when the CNI config is invalid.
+// Per the CNI spec, DEL is idempotent: missing resources are not errors.
+func TestCmdDelIdempotent(t *testing.T) {
+	args := &skel.CmdArgs{
+		ContainerID: "test-container",
+		StdinData:   []byte("not valid json"),
+	}
+
+	// DEL must return nil regardless of config validity.
+	if err := cmdDel(args); err != nil {
+		t.Fatalf("cmdDel with invalid config returned error = %v, want nil", err)
+	}
+}
+
+// TestCmdDelIdempotentMissingResources returns nil even when the config is
+// valid but all resources are missing (k8s client creation fails in tests).
+func TestCmdDelIdempotentMissingResources(t *testing.T) {
+	// Save and restore the original enableLocalIPAM state.
+	original := enableLocalIPAM
+	defer func() { enableLocalIPAM = original }()
+
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s","interface_type":"veth"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: "test-container",
+		StdinData:   []byte(conf),
+	}
+
+	// DEL must return nil even though k8s client creation will fail
+	// (no in-cluster config in tests) and all kernel resources are missing.
+	if err := cmdDel(args); err != nil {
+		t.Fatalf("cmdDel with missing resources returned error = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
cmdDel now always returns nil regardless of cleanup failures, logging errors via slog instead. Per the CNI spec, DEL is idempotent and missing resources are not errors. This prevents the CNI runtime from retrying on transient failures and avoids leaving pods in a failed state when resources are already gone (e.g. after a node crash).