### PR TITLE
feat: register cmdCheck handler for CNI network state validation

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -133,8 +133,9 @@ type PluginConf struct {
 func RunPlugin() {
 	skel.PluginMainFuncs(
 		skel.CNIFuncs{
-			Add: cmdAdd,
-			Del: cmdDel,
+			Add:   cmdAdd,
+			Check: cmdCheck,
+			Del:   cmdDel,
 		},
 		version.All,
 		"CNI galactic plugin "+metadata.Version,
@@ -309,6 +310,118 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	return publishBGPState(args, pluginConf, nodeName, namespace, ipamResult)
+}
+
+// cmdCheck validates that the container's network state matches what was
+// established during cmdAdd. Per the CNI spec, CHECK is called by the runtime
+// to probe the status of an existing container and should return an error if
+// managed resources are missing or in an invalid state.
+func cmdCheck(args *skel.CmdArgs) error {
+	pluginConf, err := parseConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	// Check VRF interface exists.
+	if err := vrf.Exists(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+		errs = append(errs, fmt.Errorf("vrf %s-%s: %w", pluginConf.VPC, pluginConf.VPCAttachment, err))
+	}
+
+	// Check the host-side interface exists.
+	hostName := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
+	if _, err := netlink.LinkByName(hostName); err != nil {
+		errs = append(errs, fmt.Errorf("host interface %q: %w", hostName, err))
+	}
+
+	// For veth mode, verify the guest interface is in the container netns.
+	if pluginConf.InterfaceType == interfaceTypeVeth {
+		guestName := intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment)
+		if err := checkGuestInterface(args.Netns, guestName); err != nil {
+			errs = append(errs, fmt.Errorf("guest interface %q: %w", guestName, err))
+		}
+
+		// Verify termination routes exist in the VRF table.
+		if err := checkTerminationRoutes(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.Terminations); err != nil {
+			errs = append(errs, fmt.Errorf("termination routes: %w", err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("CHECK failed: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// checkGuestInterface verifies that the named interface exists inside the
+// given network namespace. Returns nil when the interface is present.
+func checkGuestInterface(netnsPath, ifName string) error {
+	containerNS, err := ns.GetNS(netnsPath)
+	if err != nil {
+		return fmt.Errorf("get container netns %q: %w", netnsPath, err)
+	}
+	defer containerNS.Close() //nolint:errcheck // netns close on teardown
+
+	return containerNS.Do(func(_ ns.NetNS) error {
+		handle, err := netlink.NewHandle()
+		if err != nil {
+			return fmt.Errorf("create netlink handle: %w", err)
+		}
+		defer handle.Close() //nolint:errcheck // netlink cleanup on teardown
+
+		if _, err := handle.LinkByName(ifName); err != nil {
+			return fmt.Errorf("find interface %q: %w", ifName, err)
+		}
+		return nil
+	})
+}
+
+// checkTerminationRoutes verifies that all termination routes exist in the
+// VRF table for the given VPC/VPCAttachment pair.
+func checkTerminationRoutes(vpc, vpcAttachment string, terminations []Termination) error {
+	tableID, err := vrf.TableID(vpc, vpcAttachment)
+	if err != nil {
+		return fmt.Errorf("get VRF table ID: %w", err)
+	}
+
+	handle, err := netlink.NewHandle()
+	if err != nil {
+		return fmt.Errorf("create netlink handle: %w", err)
+	}
+	defer handle.Close() //nolint:errcheck // netlink cleanup on teardown
+
+	routes, err := handle.RouteList(nil, netlink.FAMILY_V6)
+	if err != nil {
+		return fmt.Errorf("list routes: %w", err)
+	}
+
+	dev := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	for _, term := range terminations {
+		viaIP := net.ParseIP(term.Via)
+		if viaIP == nil {
+			return fmt.Errorf("invalid termination gateway %q", term.Via)
+		}
+		found := false
+		for _, r := range routes {
+			if r.Table == int(tableID) &&
+				r.Dst != nil &&
+				r.Dst.String() == term.Network &&
+				r.Gw != nil &&
+				r.Gw.Equal(viaIP) &&
+				r.LinkIndex > 0 {
+				// Verify the link name matches (defers to the veth/tap device).
+				if link, linkErr := handle.LinkByIndex(r.LinkIndex); linkErr == nil && link.Attrs().Name == dev {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return fmt.Errorf("missing route %s via %s in VRF table %d", term.Network, term.Via, tableID)
+		}
+	}
+	return nil
 }
 
 // publishBGPState configures the host veth gateway, sets up the SRv6 ingress

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -20,10 +20,11 @@ import (
 )
 
 const (
-	testVPC        = "abc"
-	testAttachment = "def"
-	testVPCHex1234 = "0000000004d2" // decimal 1234
-	testRD65000_1  = "65000:1"      // RD/RT for ASN 65000, NN 1
+	testVPC         = "abc"
+	testAttachment  = "def"
+	testVPCHex1234  = "0000000004d2" // decimal 1234
+	testRD65000_1   = "65000:1"      // RD/RT for ASN 65000, NN 1
+	testContainerID = "test-container"
 )
 
 func fakeClient(objs ...client.Object) client.Client {
@@ -518,7 +519,7 @@ func TestBuildTapResult(t *testing.T) {
 // Per the CNI spec, DEL is idempotent: missing resources are not errors.
 func TestCmdDelIdempotent(t *testing.T) {
 	args := &skel.CmdArgs{
-		ContainerID: "test-container",
+		ContainerID: testContainerID,
 		StdinData:   []byte("not valid json"),
 	}
 
@@ -542,7 +543,7 @@ func TestCmdDelIdempotentMissingResources(t *testing.T) {
 		testVPC, testAttachment,
 	)
 	args := &skel.CmdArgs{
-		ContainerID: "test-container",
+		ContainerID: testContainerID,
 		StdinData:   []byte(conf),
 	}
 
@@ -560,4 +561,103 @@ func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
 		t.Fatalf("parse CIDR %q: %v", cidr, err)
 	}
 	return ipnet
+}
+
+// ---- cmdCheck ----------------------------------------------------------
+
+func TestCmdCheckInvalidConfig(t *testing.T) {
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte("not valid json"),
+	}
+
+	err := cmdCheck(args)
+	if err == nil {
+		t.Fatalf("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse CNI config") {
+		t.Fatalf("error %q does not contain 'parse CNI config'", err.Error())
+	}
+}
+
+func TestCmdCheckInvalidInterfaceType(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s","interface_type":"bogus"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdCheck(args)
+	if err == nil {
+		t.Fatalf("expected error for invalid interface_type, got nil")
+	}
+	if !strings.Contains(err.Error(), `invalid interface_type "bogus"`) {
+		t.Fatalf("error %q does not contain expected message", err.Error())
+	}
+}
+
+func TestCmdCheckValidConfigMissingResources(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		Netns:       "/proc/1/ns/net",
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdCheck(args)
+	if err == nil {
+		t.Fatalf("expected CHECK failure for missing resources, got nil")
+	}
+	// Should report CHECK failed with VRF not found.
+	if !strings.Contains(err.Error(), "CHECK failed") {
+		t.Fatalf("error %q does not contain 'CHECK failed'", err.Error())
+	}
+}
+
+func TestCmdCheckTapModeValidConfigMissingResources(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s","interface_type":"tap"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdCheck(args)
+	if err == nil {
+		t.Fatalf("expected CHECK failure for missing resources, got nil")
+	}
+	if !strings.Contains(err.Error(), "CHECK failed") {
+		t.Fatalf("error %q does not contain 'CHECK failed'", err.Error())
+	}
+}
+
+func TestCmdCheckMissingVPC(t *testing.T) {
+	conf := `{"cniVersion":"1.0.0","name":"test","type":"galactic-cni"}`
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdCheck(args)
+	if err == nil {
+		t.Fatalf("expected error for missing VPC, got nil")
+	}
+	// parseConf allows empty VPC; the error comes from intf generation.
+	if !strings.Contains(err.Error(), "CHECK failed") {
+		t.Fatalf("error %q does not contain 'CHECK failed'", err.Error())
+	}
 }

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -98,6 +98,16 @@ func TableID(vpc, vpcAttachment string) (uint32, error) {
 	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc, vpcAttachment))
 }
 
+// Exists reports whether a VRF interface for the given VPC and VPCAttachment
+// exists in the kernel.
+func Exists(vpc, vpcAttachment string) error {
+	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	if _, err := netlink.LinkByName(name); err != nil {
+		return fmt.Errorf("VRF interface %q not found", name)
+	}
+	return nil
+}
+
 func flush(vrfID uint32) error {
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		routes, err := netlink.RouteListFiltered(


### PR DESCRIPTION
- Register cmdCheck in RunPlugin() to satisfy CNI spec v1.1.0 CHECK requirement
- Validate VRF interface and host-side veth/tap endpoint exist in the kernel
- For veth mode, verify the guest interface is present inside the container netns
- For veth mode, validate termination routes in the VRF table (destination, gateway, link)
- Add vrf.Exists helper to check VRF interface presence without side effects
- Add five unit tests covering invalid config, missing resources, and tap-mode paths