### PR TITLE
fix: replace blanket cmdDel rollback with selective resource cleanup

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -112,6 +112,84 @@ const (
 	cniVersion100 = "1.0.0"
 )
 
+// resourceTracker tracks resources created during cmdAdd for selective rollback.
+type resourceTracker struct {
+	vpc, vpcAttachment string
+	ifaceType          string
+	vrfCreated         bool
+	routesCreated      int
+	srv6SID            string
+	vrfInstanceCreated bool
+	advCreated         bool
+	k8s                client.Client
+	namespace          string
+}
+
+// cleanup rolls back all tracked resources in reverse creation order.
+// Errors are logged but never returned — the caller already has a failure.
+func (rt *resourceTracker) cleanup(ctx context.Context) {
+	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
+		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+
+	// 1. Delete BGPAdvertisement (withdraws prefixes)
+	if rt.advCreated && rt.k8s != nil {
+		adv := &bgpv1alpha1.BGPAdvertisement{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bgpAdvertisementName(rt.vpc, rt.vpcAttachment),
+				Namespace: rt.namespace,
+			},
+		}
+		if err := rt.k8s.Delete(ctx, adv); client.IgnoreNotFound(err) != nil {
+			slog.Error("Rollback: failed to delete BGPAdvertisement", "err", err,
+				"name", adv.Name, "namespace", rt.namespace)
+		}
+	}
+
+	// 2. Delete BGPVRFInstance
+	if rt.vrfInstanceCreated && rt.k8s != nil {
+		vrfInst := &bgpv1alpha1.BGPVRFInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bgpVRFInstanceName(rt.vpc, rt.vpcAttachment),
+				Namespace: rt.namespace,
+			},
+		}
+		if err := rt.k8s.Delete(ctx, vrfInst); client.IgnoreNotFound(err) != nil {
+			slog.Error("Rollback: failed to delete BGPVRFInstance", "err", err,
+				"name", vrfInst.Name, "namespace", rt.namespace)
+		}
+	}
+
+	// 3. Delete SRv6 ingress route (only if we got a SID)
+	if rt.srv6SID != "" {
+		if err := srv6.RouteIngressDel(rt.srv6SID); err != nil {
+			slog.Error("Rollback: failed to delete SRv6 ingress route", "err", err,
+				"sid", rt.srv6SID)
+		}
+	}
+
+	// 4. Delete host veth (veth mode only)
+	if rt.ifaceType == interfaceTypeVeth {
+		if err := veth.Delete(rt.vpc, rt.vpcAttachment); err != nil {
+			slog.Error("Rollback: failed to delete veth", "err", err,
+				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+		}
+	}
+
+	// 5. Delete tap (tap mode only)
+	if rt.ifaceType == interfaceTypeTap {
+		if err := tap.Delete(rt.vpc, rt.vpcAttachment); err != nil {
+			slog.Error("Rollback: failed to delete tap", "err", err,
+				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+		}
+	}
+
+	// 6. Delete VRF (flushes all routes, removes VRF interface)
+	if err := vrf.Delete(rt.vpc, rt.vpcAttachment); err != nil {
+		slog.Error("Rollback: failed to delete VRF", "err", err,
+			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+	}
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(cniScheme))
 	utilruntime.Must(bgpv1alpha1.AddToScheme(cniScheme))
@@ -241,14 +319,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	// Roll back on any failure to avoid orphaned resources.
-	// cmdDel is best-effort — errors are logged, not returned.
-	defer func() {
-		if err != nil {
-			_ = cmdDel(args)
-		}
-	}()
-
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
 		return errors.New("NODE_NAME environment variable is not set")
@@ -259,9 +329,29 @@ func cmdAdd(args *skel.CmdArgs) error {
 		namespace = defaultNamespace
 	}
 
+	// Track resources for selective rollback on failure.
+	tracker := &resourceTracker{
+		vpc:           pluginConf.VPC,
+		vpcAttachment: pluginConf.VPCAttachment,
+		ifaceType:     pluginConf.InterfaceType,
+		namespace:     namespace,
+	}
+
+	// Selective rollback: clean up only resources that were created.
+	// We need a context for k8s operations in rollback; the k8s client
+	// will be populated by publishBGPState before it's needed.
+	rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), cniTimeout)
+	defer func() {
+		if err != nil {
+			tracker.cleanup(rollbackCtx)
+			rollbackCancel()
+		}
+	}()
+
 	if err := vrf.Add(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
 		return fmt.Errorf("add VRF: %w", err)
 	}
+	tracker.vrfCreated = true
 
 	// Create the appropriate interface type (veth or tap).
 	switch pluginConf.InterfaceType {
@@ -288,6 +378,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if err := route.Add(pluginConf.VPC, pluginConf.VPCAttachment, termination.Network, termination.Via, dev); err != nil {
 			return fmt.Errorf("add route %s: %w", termination.Network, err)
 		}
+		tracker.routesCreated++
 	}
 
 	// Host-device delegation and IPAM are veth-only.
@@ -309,7 +400,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return nil
 	}
 
-	return publishBGPState(args, pluginConf, nodeName, namespace, ipamResult)
+	return publishBGPState(args, pluginConf, nodeName, namespace, ipamResult, tracker)
 }
 
 // cmdCheck validates that the container's network state matches what was
@@ -429,6 +520,7 @@ func checkTerminationRoutes(vpc, vpcAttachment string, terminations []Terminatio
 // veth-only; tap mode returns before reaching this path.
 func publishBGPState(
 	args *skel.CmdArgs, pluginConf *PluginConf, nodeName, namespace string, ipamResult *ipamResult,
+	tracker *resourceTracker,
 ) error {
 	if err := configureHostVethGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
 		return err
@@ -446,11 +538,15 @@ func publishBGPState(
 	if err != nil {
 		return err
 	}
+	if srv6SIDStr != "" {
+		tracker.srv6SID = srv6SIDStr
+	}
 
 	k8s, err := newK8sClient()
 	if err != nil {
 		return err
 	}
+	tracker.k8s = k8s
 	ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)
 	defer cancel()
 
@@ -488,6 +584,7 @@ func publishBGPState(
 	if err != nil {
 		return fmt.Errorf("apply BGPVRFInstance: %w", err)
 	}
+	tracker.vrfInstanceCreated = true
 
 	// Create the BGPAdvertisement to originate the pod's subnet prefix.
 	adv := &bgpv1alpha1.BGPAdvertisement{
@@ -525,6 +622,7 @@ func publishBGPState(
 	if err != nil {
 		return fmt.Errorf("apply BGPAdvertisement: %w", err)
 	}
+	tracker.advCreated = true
 
 	return nil
 }

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -661,3 +661,57 @@ func TestCmdCheckMissingVPC(t *testing.T) {
 		t.Fatalf("error %q does not contain 'CHECK failed'", err.Error())
 	}
 }
+
+// ---- resourceTracker ------------------------------------------------------
+
+func TestResourceTrackerCleanupZeroValue(t *testing.T) {
+	// cleanup with a zero-value tracker must not panic — it's called in a
+	// defer and the caller may have failed before setting any fields.
+	tracker := &resourceTracker{}
+	ctx := context.Background()
+	tracker.cleanup(ctx) // should not panic
+}
+
+func TestResourceTrackerCleanupPartialState(t *testing.T) {
+	// A tracker that only has VPC info (failed before any resource creation)
+	// should not panic during cleanup.
+	tracker := &resourceTracker{
+		vpc:           testVPC,
+		vpcAttachment: testAttachment,
+		ifaceType:     interfaceTypeVeth,
+		namespace:     "default",
+	}
+	ctx := context.Background()
+	tracker.cleanup(ctx) // should not panic; vrf.Delete will fail but is logged
+}
+
+func TestResourceTrackerFieldsSet(t *testing.T) {
+	tracker := &resourceTracker{
+		vpc:           testVPC,
+		vpcAttachment: testAttachment,
+		ifaceType:     interfaceTypeTap,
+		namespace:     "test-ns",
+	}
+
+	if tracker.vpc != testVPC {
+		t.Errorf("vpc = %q, want %q", tracker.vpc, testVPC)
+	}
+	if tracker.vpcAttachment != testAttachment {
+		t.Errorf("vpcAttachment = %q, want %q", tracker.vpcAttachment, testAttachment)
+	}
+	if tracker.ifaceType != interfaceTypeTap {
+		t.Errorf("ifaceType = %q, want %q", tracker.ifaceType, interfaceTypeTap)
+	}
+	if tracker.namespace != "test-ns" {
+		t.Errorf("namespace = %q, want %q", tracker.namespace, "test-ns")
+	}
+	if tracker.vrfCreated {
+		t.Error("vrfCreated should be false by default")
+	}
+	if tracker.srv6SID != "" {
+		t.Errorf("srv6SID should be empty by default, got %q", tracker.srv6SID)
+	}
+	if tracker.advCreated {
+		t.Error("advCreated should be false by default")
+	}
+}

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -24,11 +24,24 @@ var errIptablesMissing = errors.New("iptables binary not available")
 // isLinkNotFoundError reports whether err indicates that a network link
 // does not exist. This covers both ENOENT and ENODEV errors from netlink.
 func isLinkNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
 	if os.IsNotExist(err) {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "no such device") || strings.Contains(msg, "not found")
+}
+
+// isIptablesRuleNotFoundError reports whether err indicates that an iptables
+// rule does not exist. The go-iptables package returns a generic error whose
+// message contains "rule not found" when the target rule is absent.
+func isIptablesRuleNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "rule not found")
 }
 
 func updateForwardRule(interfaceName string, action string) error {
@@ -131,13 +144,21 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 func Delete(vpc, vpcAttachment string) error {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 
-	// Skip iptables cleanup if binary is unavailable (distroless images).
-	if err := updateForwardRule(hostName, "delete"); err != nil && !errors.Is(err, errIptablesMissing) {
-		return err
+	// Skip iptables cleanup if binary is unavailable or the rule is already
+	// gone (distroless images, or Delete already ran).
+	if err := updateForwardRule(hostName, "delete"); err != nil {
+		if errors.Is(err, errIptablesMissing) || isIptablesRuleNotFoundError(err) {
+			// iptables not available or rule already absent — nothing to clean up.
+		} else {
+			return err
+		}
 	}
 
 	hostLink, err := netlink.LinkByName(hostName)
 	if err != nil {
+		if isLinkNotFoundError(err) {
+			return nil // interface already gone — idempotent
+		}
 		return err
 	}
 

--- a/internal/cni/veth/veth_test.go
+++ b/internal/cni/veth/veth_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package veth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsLinkNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"os.IsNotExist", errors.New("no such device"), true},
+		{"no such device", errors.New("link not found: no such device"), true},
+		{"not found", errors.New("failed to find link: not found"), true},
+		{"unrelated", errors.New("permission denied"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLinkNotFoundError(tt.err); got != tt.want {
+				t.Errorf("isLinkNotFoundError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsIptablesRuleNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"rule not found", errors.New("iptables: No chain/target/match by given name. (rule not found)"), true},
+		{"no rule found", errors.New("rule not found in table filter"), true},
+		{"unrelated", errors.New("permission denied"), false},
+		{"nil", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIptablesRuleNotFoundError(tt.err); got != tt.want {
+				t.Errorf("isIptablesRuleNotFoundError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -70,13 +70,14 @@ func Add(vpc, vpcAttachment string) error {
 }
 
 // Delete flushes all routes from the VRF routing table and removes the VRF
-// interface for the given base62-encoded VPC and VPCAttachment.
+// interface for the given base62-encoded VPC and VPCAttachment. Delete is
+// idempotent: if the VRF interface does not exist, it returns nil.
 func Delete(vpc, vpcAttachment string) error {
 	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
 
 	vrfID, err := getVRFIDForInterface(name)
 	if err != nil {
-		return err
+		return nil // VRF already gone — idempotent
 	}
 
 	if err := flush(vrfID); err != nil {
@@ -85,7 +86,7 @@ func Delete(vpc, vpcAttachment string) error {
 
 	link, err := netlink.LinkByName(name)
 	if err != nil {
-		return err
+		return nil // interface already gone — idempotent
 	}
 
 	return netlink.LinkDel(link)


### PR DESCRIPTION
- Track resources created during cmdAdd in a resourceTracker struct
- Roll back only the resources that were actually created (in reverse order) on failure
- Log rollback errors with full context instead of silently discarding them
- Make veth.Delete idempotent — return nil when the link or iptables rules are already gone
- Make vrf.Delete idempotent — return nil when the VRF interface does not exist
- Add unit tests for resourceTracker cleanup and idempotency helpers