### PR TITLE
feat: add garbage collector for orphaned BGP CRDs and VRFs

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -50,6 +51,8 @@ func newViper() *viper.Viper {
 	v.SetDefault("galactic_router.gobgp_grpc_server_enabled", false)
 	v.SetDefault("galactic_router.metrics_port", 8080)
 	v.SetDefault("galactic_router.grpc_health_port", 5000)
+	v.SetDefault("galactic_router.gc_namespace", "default")
+	v.SetDefault("galactic_router.gc_interval", 5*time.Minute)
 
 	v.AutomaticEnv()
 
@@ -72,6 +75,10 @@ func newViper() *viper.Viper {
 	v.BindEnv("galactic_router.metrics_port", "GALACTIC_ROUTER_METRICS_PORT")
 	//nolint:errcheck
 	v.BindEnv("galactic_router.grpc_health_port", "GALACTIC_ROUTER_GRPC_HEALTH_PORT")
+	//nolint:errcheck
+	v.BindEnv("galactic_router.gc_namespace", "GALACTIC_ROUTER_GC_NAMESPACE")
+	//nolint:errcheck
+	v.BindEnv("galactic_router.gc_interval", "GALACTIC_ROUTER_GC_INTERVAL")
 
 	return v
 }
@@ -104,6 +111,12 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) { //nolint:lll // cobra flag 
 	cmd.Flags().IntP("grpc-health-port", "",
 		v.GetInt("galactic_router.grpc_health_port"),
 		"Port for the gRPC health check server")
+	cmd.Flags().StringP("gc-namespace", "",
+		v.GetString("galactic_router.gc_namespace"),
+		"Namespace for GC controller to scan for orphaned BGP CRDs")
+	cmd.Flags().DurationP("gc-interval", "",
+		v.GetDuration("galactic_router.gc_interval"),
+		"GC collection interval")
 
 	if err := v.BindPFlags(cmd.Flags()); err != nil {
 		log.Fatalf("bind flags: %v", err)
@@ -285,6 +298,38 @@ func runCmd(v *viper.Viper) error {
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup Node controller: %w", err)
 	}
+
+	// Register GC controller for cleaning up orphaned BGP CRDs and VRFs.
+	gcNamespace := v.GetString("galactic_router.gc_namespace")
+	gcInterval := v.GetDuration("galactic_router.gc_interval")
+	gcRec := &controller.GCReconciler{
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Namespace: gcNamespace,
+		Interval:  gcInterval,
+	}
+	if err := gcRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("setup GC controller: %w", err)
+	}
+
+	// Start the GC ticker goroutine. It runs until the manager's context
+	// is cancelled.
+	go func() {
+		ticker := time.NewTicker(gcInterval)
+		defer ticker.Stop()
+
+		// Run an initial GC pass immediately.
+		gcRec.RunGC(ctx)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				gcRec.RunGC(ctx)
+			}
+		}
+	}()
 
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("manager exited: %w", err)

--- a/internal/controller/gc_controller.go
+++ b/internal/controller/gc_controller.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.datum.net/galactic/internal/gc"
+)
+
+// GCReconciler runs periodic garbage collection to clean up stale BGP CRDs
+// and orphaned VRF interfaces left behind when containers are force-terminated
+// and CNI DEL never fires.
+type GCReconciler struct {
+	client.Client
+	Scheme    *runtime.Scheme
+	Namespace string
+	Interval  time.Duration
+}
+
+// Reconcile runs a GC pass at the configured interval. It does not watch any
+// Kubernetes resources — it is purely time-driven.
+func (r *GCReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	if r.Namespace == "" {
+		slog.Debug("GC: namespace not configured, skipping")
+		return ctrl.Result{RequeueAfter: r.Interval}, nil
+	}
+
+	k8s := r.Client
+	result := gc.RunGC(ctx, k8s, r.Namespace)
+
+	if result.Errors > 0 {
+		slog.Info("GC: completed with errors",
+			"crdsRemoved", result.OrphanedCRDsRemoved,
+			"vrfsRemoved", result.OrphanedVRFsRemoved,
+			"errors", result.Errors)
+	} else if result.OrphanedCRDsRemoved > 0 || result.OrphanedVRFsRemoved > 0 {
+		slog.Info("GC: cleanup complete",
+			"crdsRemoved", result.OrphanedCRDsRemoved,
+			"vrfsRemoved", result.OrphanedVRFsRemoved)
+	}
+
+	return ctrl.Result{RequeueAfter: r.Interval}, nil
+}
+
+// SetupWithManager registers the GCReconciler with the manager. The GC
+// reconciler is started by a ticker goroutine launched from root.go where
+// the manager's context is available.
+func (r *GCReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Interval == 0 {
+		r.Interval = 5 * time.Minute
+	}
+	return nil
+}
+
+// RunGC runs a single garbage collection pass in the given context.
+// This is the public API for triggering GC from outside the reconciler.
+func (r *GCReconciler) RunGC(ctx context.Context) gc.CleanupResult {
+	return gc.RunGC(ctx, r.Client, r.Namespace)
+}
+
+// GCRequest returns a reconcile.Request that triggers the GC reconciler.
+// Used for manual GC triggers (e.g., from metrics or health endpoints).
+func GCRequest() ctrl.Request {
+	return ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "gc"},
+	}
+}

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -1,0 +1,302 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gc
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.datum.net/galactic/internal/plumbing/vrf"
+)
+
+const (
+	// annotationAllocatedSubnet is the annotation key prefix used by the
+	// CNI plugin to store allocated subnets keyed by container ID.
+	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
+)
+
+// OrphanedCRD represents a BGP CRD that appears to be orphaned because its
+// associated container is no longer present on the node.
+type OrphanedCRD struct {
+	Name        string
+	Namespace   string
+	Kind        string // "BGPAdvertisement" or "BGPVRFInstance"
+	ContainerID string // truncated container ID prefix from annotation
+}
+
+// CleanupResult tracks the outcome of a GC pass.
+type CleanupResult struct {
+	OrphanedCRDsRemoved int
+	OrphanedVRFsRemoved int
+	Errors              int
+}
+
+// vrfNameRegex matches the deterministic VRF interface name pattern used by
+// Galactic. The template is "G%09s%03sV" where %09s is the base62 VPC and
+// %03s is the base62 VPCAttachment. Base62 includes digits and letters.
+var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})([A-Za-z0-9]{3})V$`)
+
+// CollectOrphanedCRDs scans all BGPAdvertisement and BGPVRFInstance CRDs in
+// the given namespace and returns those whose associated container no longer
+// exists on this node.
+//
+// A CRD is considered orphaned when:
+//   - It is a BGPAdvertisement with an allocated-subnet annotation whose
+//     container ID prefix does not correspond to a live network namespace
+//     under /var/run/netns.
+//   - It is a BGPVRFInstance whose name matches a BGPAdvertisement that
+//     is itself orphaned (same vpc-vpcattachment name).
+func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace string) ([]OrphanedCRD, error) {
+	// Collect all orphaned BGPAdvertisements first.
+	advList := &bgpv1alpha1.BGPAdvertisementList{}
+	if err := k8s.List(ctx, advList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPAdvertisements: %w", err)
+	}
+
+	var orphaned []OrphanedCRD
+	orphanedAdvNames := make(map[string]struct{})
+
+	for _, adv := range advList.Items {
+		containerID := findContainerID(&adv)
+		if containerID == "" {
+			// No container ID annotation — skip (might be legacy or
+			// manually created). We cannot determine if it is orphaned.
+			continue
+		}
+
+		if !ContainerNetNSExists(containerID) {
+			orphaned = append(orphaned, OrphanedCRD{
+				Name:        adv.Name,
+				Namespace:   adv.Namespace,
+				Kind:        "BGPAdvertisement",
+				ContainerID: containerID,
+			})
+			orphanedAdvNames[adv.Name] = struct{}{}
+		}
+	}
+
+	// BGPVRFInstance CRDs share the same name as their corresponding
+	// BGPAdvertisement (both use vpc-vpcattachment naming). If a
+	// BGPAdvertisement is orphaned, its BGPVRFInstance counterpart is
+	// also orphaned.
+	for name := range orphanedAdvNames {
+		orphaned = append(orphaned, OrphanedCRD{
+			Name:      name,
+			Namespace: namespace,
+			Kind:      "BGPVRFInstance",
+		})
+	}
+
+	return orphaned, nil
+}
+
+// RemoveOrphanedCRDs deletes the given orphaned CRDs from Kubernetes.
+// Errors are logged but do not abort the cleanup — best-effort semantics.
+func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []OrphanedCRD) CleanupResult {
+	result := CleanupResult{}
+
+	for _, o := range orphans {
+		switch o.Kind {
+		case "BGPAdvertisement":
+			adv := &bgpv1alpha1.BGPAdvertisement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      o.Name,
+					Namespace: o.Namespace,
+				},
+			}
+			if err := k8s.Delete(ctx, adv); err != nil {
+				slog.Error("GC: failed to delete orphaned BGPAdvertisement",
+					"name", o.Name, "namespace", o.Namespace, "err", err)
+				result.Errors++
+				continue
+			}
+			slog.Info("GC: removed orphaned BGPAdvertisement",
+				"name", o.Name, "namespace", o.Namespace, "containerID", o.ContainerID)
+			result.OrphanedCRDsRemoved++
+
+		case "BGPVRFInstance":
+			vrfInst := &bgpv1alpha1.BGPVRFInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      o.Name,
+					Namespace: o.Namespace,
+				},
+			}
+			if err := k8s.Delete(ctx, vrfInst); err != nil {
+				slog.Error("GC: failed to delete orphaned BGPVRFInstance",
+					"name", o.Name, "namespace", o.Namespace, "err", err)
+				result.Errors++
+				continue
+			}
+			slog.Info("GC: removed orphaned BGPVRFInstance",
+				"name", o.Name, "namespace", o.Namespace)
+			result.OrphanedCRDsRemoved++
+		}
+	}
+
+	return result
+}
+
+// CollectOrphanedVRFs scans all VRF interfaces on this node and returns the
+// vpc/vpcAttachment pairs for VRFs whose corresponding BGPAdvertisement CRD
+// no longer exists in the given namespace.
+//
+// A VRF is considered orphaned when:
+//   - Its interface name matches the Galactic VRF naming pattern.
+//   - The derived BGPAdvertisement CRD (name = vpc-vpcattachment) does not
+//     exist in Kubernetes.
+func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace string) ([]string, error) {
+	vrfs, err := vrf.ListVRFLinks()
+	if err != nil {
+		return nil, fmt.Errorf("list VRF links: %w", err)
+	}
+
+	// Build a set of active BGPAdvertisement names for this namespace.
+	advList := &bgpv1alpha1.BGPAdvertisementList{}
+	if err := k8s.List(ctx, advList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPAdvertisements: %w", err)
+	}
+
+	activeAdvNames := make(map[string]struct{}, len(advList.Items))
+	for _, adv := range advList.Items {
+		activeAdvNames[adv.Name] = struct{}{}
+	}
+
+	var orphaned []string
+	for _, v := range vrfs {
+		vpc, vpcAtt, ok := parseVRFName(v.Name)
+		if !ok {
+			// Not a Galactic VRF — skip.
+			continue
+		}
+
+		// Check if the corresponding BGPAdvertisement exists.
+		advName := fmt.Sprintf("%s-%s", vpc, vpcAtt)
+		if _, exists := activeAdvNames[advName]; !exists {
+			orphaned = append(orphaned, v.Name)
+		}
+	}
+
+	return orphaned, nil
+}
+
+// RemoveOrphanedVRFs deletes the given orphaned VRF interfaces from the
+// kernel. Errors are logged but do not abort the cleanup — best-effort
+// semantics.
+func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
+	result := CleanupResult{}
+
+	for _, name := range vrfNames {
+		// We need the vpc/vpcAttachment to call vrf.Delete. Parse the name
+		// back to get those values.
+		vpc, vpcAtt, ok := parseVRFName(name)
+		if !ok {
+			// Try to delete by name directly.
+			link, err := netlink.LinkByName(name)
+			if err != nil {
+				// Already gone — not an error.
+				continue
+			}
+			if delErr := netlink.LinkDel(link); delErr != nil {
+				slog.Error("GC: failed to delete orphaned VRF (parse failed)",
+					"name", name, "err", delErr)
+				result.Errors++
+			}
+			continue
+		}
+
+		if err := vrf.Delete(vpc, vpcAtt); err != nil {
+			slog.Error("GC: failed to delete orphaned VRF",
+				"name", name, "vpc", vpc, "vpcAttachment", vpcAtt, "err", err)
+			result.Errors++
+			continue
+		}
+		slog.Info("GC: removed orphaned VRF",
+			"name", name, "vpc", vpc, "vpcAttachment", vpcAtt)
+		result.OrphanedVRFsRemoved++
+	}
+
+	return result
+}
+
+// RunGC performs a full garbage collection pass: removes orphaned BGP CRDs
+// and orphaned VRF interfaces. Returns a summary of what was cleaned up.
+func RunGC(ctx context.Context, k8s client.Client, namespace string) CleanupResult {
+	var result CleanupResult
+
+	// Phase 1: Remove orphaned BGP CRDs.
+	orphans, err := CollectOrphanedCRDs(ctx, k8s, namespace)
+	if err != nil {
+		slog.Error("GC: failed to collect orphaned CRDs", "err", err)
+		result.Errors++
+	} else if len(orphans) > 0 {
+		slog.Info("GC: found orphaned CRDs", "count", len(orphans))
+		crResult := RemoveOrphanedCRDs(ctx, k8s, orphans)
+		result.OrphanedCRDsRemoved += crResult.OrphanedCRDsRemoved
+		result.Errors += crResult.Errors
+	}
+
+	// Phase 2: Remove orphaned VRF interfaces.
+	orphanedVRFs, err := CollectOrphanedVRFs(ctx, k8s, namespace)
+	if err != nil {
+		slog.Error("GC: failed to collect orphaned VRFs", "err", err)
+		result.Errors++
+	} else if len(orphanedVRFs) > 0 {
+		slog.Info("GC: found orphaned VRFs", "count", len(orphanedVRFs))
+		vrfResult := RemoveOrphanedVRFs(orphanedVRFs)
+		result.OrphanedVRFsRemoved += vrfResult.OrphanedVRFsRemoved
+		result.Errors += vrfResult.Errors
+	}
+
+	if result.OrphanedCRDsRemoved > 0 || result.OrphanedVRFsRemoved > 0 {
+		slog.Info("GC: cleanup complete",
+			"crdsRemoved", result.OrphanedCRDsRemoved,
+			"vrfsRemoved", result.OrphanedVRFsRemoved,
+			"errors", result.Errors)
+	}
+
+	return result
+}
+
+// findContainerID extracts the container ID prefix from a BGPAdvertisement's
+// allocated-subnet annotations. Returns the first container ID prefix found.
+func findContainerID(adv *bgpv1alpha1.BGPAdvertisement) string {
+	if adv.Annotations == nil {
+		return ""
+	}
+	prefix := annotationAllocatedSubnet + "."
+	for key := range adv.Annotations {
+		if strings.HasPrefix(key, prefix) {
+			// The key format is "galactic.datum.net/allocated-subnet.<containerID-prefix>"
+			return key[len(prefix):]
+		}
+	}
+	return ""
+}
+
+// parseVRFName extracts the base62-encoded VPC and VPCAttachment from a
+// Galactic VRF interface name. Returns the parsed values and whether the
+// name matched the expected pattern.
+func parseVRFName(name string) (vpc, vpcAttachment string, ok bool) {
+	// Use the intf package's GenerateInterfaceNameVRF to reverse-engineer
+	// the name. Since we can't directly parse, we check if it matches the
+	// pattern and extract the components.
+	//
+	// The template is "G%09s%03sV" — 1 + 9 + 3 + 1 = 14 characters.
+	// But base62 encoding can produce mixed alphanumeric, so we need a
+	// regex approach.
+	matches := vrfNameRegex.FindStringSubmatch(name)
+	if matches == nil {
+		return "", "", false
+	}
+	return matches[1], matches[2], true
+}

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gc
+
+import (
+	"testing"
+
+	bgpv1alpha1 "go.miloapis.com/cosmos/api/bgp/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testVRFName      = "G0000000jU00GV"
+	testVRFNameHost  = "G0000000jU00GH"
+	testVRFNameGuest = "G0000000jU00GG"
+	testEth0         = "eth0"
+)
+
+func TestFindContainerID(t *testing.T) {
+	tests := []struct {
+		name   string
+		adv    *bgpv1alpha1.BGPAdvertisement
+		wantID string
+	}{
+		{
+			name:   "nil annotations",
+			adv:    &bgpv1alpha1.BGPAdvertisement{},
+			wantID: "",
+		},
+		{
+			name: "empty annotations",
+			adv: &bgpv1alpha1.BGPAdvertisement{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			wantID: "",
+		},
+		{
+			name: "no allocated-subnet annotation",
+			adv: &bgpv1alpha1.BGPAdvertisement{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"galactic.datum.net/srv6-sid": "2001:db8::1234:5678",
+					},
+				},
+			},
+			wantID: "",
+		},
+		{
+			name: "single allocated-subnet annotation",
+			adv: &bgpv1alpha1.BGPAdvertisement{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"galactic.datum.net/allocated-subnet.abc123def456": "fd00:10:ff01::1234/80",
+					},
+				},
+			},
+			wantID: "abc123def456",
+		},
+		{
+			name: "multiple annotations returns first",
+			adv: &bgpv1alpha1.BGPAdvertisement{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"galactic.datum.net/allocated-subnet.aaa111bbb222": "fd00:10:ff01::1234/80",
+						"galactic.datum.net/allocated-subnet.ccc333ddd444": "fd00:10:ff01::5678/80",
+						"galactic.datum.net/srv6-sid":                      "2001:db8::1234:5678",
+					},
+				},
+			},
+			wantID: "aaa111bbb222",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findContainerID(tt.adv)
+			if got != tt.wantID {
+				t.Errorf("findContainerID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestParseVRFName(t *testing.T) {
+	tests := []struct {
+		name       string
+		vrfName    string
+		wantVPC    string
+		wantVPCAtt string
+		wantOk     bool
+	}{
+		{
+			name:       "valid VRF name",
+			vrfName:    testVRFName,
+			wantVPC:    "0000000jU",
+			wantVPCAtt: "00G",
+			wantOk:     true,
+		},
+		{
+			name:       "valid VRF name with digits",
+			vrfName:    "G000000123001V",
+			wantVPC:    "000000123",
+			wantVPCAtt: "001",
+			wantOk:     true,
+		},
+		{
+			name:    "not a VRF name (host interface)",
+			vrfName: testVRFNameHost,
+			wantOk:  false,
+		},
+		{
+			name:    "not a VRF name (guest interface)",
+			vrfName: testVRFNameGuest,
+			wantOk:  false,
+		},
+		{
+			name:    "random name",
+			vrfName: testEth0,
+			wantOk:  false,
+		},
+		{
+			name:    "empty name",
+			vrfName: "",
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVPC, gotVPCAtt, gotOk := parseVRFName(tt.vrfName)
+			if gotOk != tt.wantOk {
+				t.Errorf("parseVRFName(%q) ok = %v, want %v", tt.vrfName, gotOk, tt.wantOk)
+				return
+			}
+			if gotVPC != tt.wantVPC {
+				t.Errorf("parseVRFName(%q) vpc = %q, want %q", tt.vrfName, gotVPC, tt.wantVPC)
+			}
+			if gotVPCAtt != tt.wantVPCAtt {
+				t.Errorf("parseVRFName(%q) vpcAttachment = %q, want %q", tt.vrfName, gotVPCAtt, tt.wantVPCAtt)
+			}
+		})
+	}
+}
+
+func TestVRFNameRegex(t *testing.T) {
+	// Verify the regex matches the expected VRF naming pattern.
+	// The template is "G%09s%03sV" where %09s is base62-padded VPC
+	// and %03s is base62-padded VPCAttachment.
+	testCases := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{testVRFName, testVRFName, true},
+		{"G000000000000V", "G000000000000V", true},
+		{"G123456789001V", "G123456789001V", true},
+		// Non-VRF names should not match.
+		{testVRFNameHost, testVRFNameHost, false},
+		{testVRFNameGuest, testVRFNameGuest, false},
+		{testEth0, testEth0, false},
+		{"vrf0", "vrf0", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := vrfNameRegex.MatchString(tc.input)
+			if matches != tc.expect {
+				t.Errorf("vrfNameRegex.MatchString(%q) = %v, want %v", tc.input, matches, tc.expect)
+			}
+		})
+	}
+}

--- a/internal/gc/netns.go
+++ b/internal/gc/netns.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package gc provides garbage collection for stale Galactic resources left
+// behind when containers are force-terminated and CNI DEL never fires.
+package gc
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const netnsPath = "/var/run/netns"
+
+// ContainerNetNSExists checks whether a network namespace for the given
+// container ID is still present on this node. It does this by listing the
+// bind-mounts under /var/run/netns and checking whether any of them is
+// named after the container ID prefix.
+//
+// CNI plugins (and the kubelet) create netns bind-mounts under
+// /var/run/netns/<container-id-prefix>. When the container is fully
+// torn down, these mounts are removed.
+func ContainerNetNSExists(containerID string) bool {
+	// Use the full container ID and the first 46 characters (same as
+	// annotationContainerIDLen used in the CNI plugin for annotation keys).
+	id := containerID
+	if len(id) > 46 {
+		id = id[:46]
+	}
+
+	entries, err := os.ReadDir(netnsPath)
+	if err != nil {
+		// If we can't read /var/run/netns, assume the namespace
+		// does not exist (we cannot prove it does).
+		return false
+	}
+
+	for _, entry := range entries {
+		if entry.Name() == id {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainerNetNSExistsByPath checks whether a network namespace at the
+// given path still exists. Returns true if the path is accessible.
+func ContainerNetNSExistsByPath(netnsPathStr string) bool {
+	_, err := os.Stat(filepath.Join(netnsPath, filepath.Base(netnsPathStr)))
+	return err == nil
+}

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -117,7 +117,8 @@ func flush(vrfID uint32) error {
 	return nil
 }
 
-func listVRFLinks() ([]*netlink.Vrf, error) {
+// ListVRFLinks returns all VRF interfaces currently present on the host.
+func ListVRFLinks() ([]*netlink.Vrf, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return nil, err
@@ -125,11 +126,15 @@ func listVRFLinks() ([]*netlink.Vrf, error) {
 
 	vrfLinks := make([]*netlink.Vrf, 0, len(links))
 	for _, link := range links {
-		if vrf, ok := link.(*netlink.Vrf); ok {
-			vrfLinks = append(vrfLinks, vrf)
+		if v, ok := link.(*netlink.Vrf); ok {
+			vrfLinks = append(vrfLinks, v)
 		}
 	}
 	return vrfLinks, nil
+}
+
+func listVRFLinks() ([]*netlink.Vrf, error) {
+	return ListVRFLinks()
 }
 
 func findNextAvailableVRFID() (uint32, error) {


### PR DESCRIPTION
Add a periodic garbage collection pass to galactic-router that cleans up stale BGPAdvertisement and BGPVRFInstance CRDs, plus orphaned VRF interfaces left behind when containers are force-terminated and CNI DEL never fires.

The GC runs every 5 minutes by default (configurable via flags or env vars). It operates in two phases: first it removes BGP CRDs whose associated container network namespace no longer exists on the node, then it removes VRF interfaces whose corresponding BGPAdvertisement CRD is missing.

- Detect orphaned BGPAdvertisement CRDs by checking if the container netns bind-mount still exists under /var/run/netns
- Remove corresponding BGPVRFInstance CRDs that share the same name
- Detect orphaned VRF interfaces by matching Galactic naming pattern and checking for a live BGPAdvertisement CRD
- Export vrf.ListVRFLinks() from the VRF plumbing package
- Add gc-namespace and gc-interval CLI flags with env var bindings
- Run an initial GC pass immediately on startup, then on each tick