### PR TITLE
fix: share Kubernetes client across cmdAdd and cmdDel operations

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -547,11 +547,6 @@ func cmdDel(args *skel.CmdArgs) error {
 		return nil
 	}
 
-	// Deallocate IPAM subnet before any other cleanup (veth-only).
-	if pluginConf.InterfaceType == interfaceTypeVeth && (pluginConf.IPAM.Type != "" || enableLocalIPAM) {
-		deallocateIPAM(args, pluginConf)
-	}
-
 	namespace := pluginConf.Namespace
 	if namespace == "" {
 		namespace = defaultNamespace
@@ -559,9 +554,14 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	k8s, k8sErr := newK8sClient()
 	if k8sErr != nil {
-		slog.Error("DEL: failed to create k8s client, skipping CRD cleanup", "err", k8sErr,
+		slog.Error("DEL: failed to create k8s client, skipping IPAM deallocation and CRD cleanup", "err", k8sErr,
 			"containerID", args.ContainerID)
 		errs = append(errs, fmt.Errorf("create k8s client: %w", k8sErr))
+	}
+
+	// Deallocate IPAM subnet before any other cleanup (veth-only).
+	if k8s != nil && pluginConf.InterfaceType == interfaceTypeVeth && (pluginConf.IPAM.Type != "" || enableLocalIPAM) {
+		deallocateIPAM(args, pluginConf, k8s)
 	}
 
 	// Best-effort cleanup of all resources.
@@ -968,9 +968,9 @@ func cleanupContainerNetns(netnsPath, ifName string) error {
 // Reads the allocated subnet from the BGPAdvertisement CRD annotation, then
 // deallocates it from the in-memory pool. When enableLocalIPAM is true and
 // no explicit ipam block is configured, uses the default pool CIDR.
-func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) {
+func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf, k8s client.Client) {
 	// Look up the allocated subnet from the BGPAdvertisement annotation.
-	subnetCIDR := getAllocatedSubnetFromCRD(args.ContainerID, pluginConf)
+	subnetCIDR := getAllocatedSubnetFromCRD(args.ContainerID, pluginConf, k8s)
 	if subnetCIDR == "" {
 		// No allocation found — either allocation was never completed,
 		// or the advertisement was already deleted. Nothing to clean up.
@@ -1001,15 +1001,10 @@ func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) {
 
 // getAllocatedSubnetFromCRD reads the allocated subnet for the given container
 // from the BGPAdvertisement CRD annotation. Returns empty string if not found.
-func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf) string {
+func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf, k8s client.Client) string {
 	namespace := pluginConf.Namespace
 	if namespace == "" {
 		namespace = defaultNamespace
-	}
-
-	k8s, err := newK8sClient()
-	if err != nil {
-		return ""
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)


### PR DESCRIPTION
Eliminate redundant Kubernetes client creation by threading a single client instance through the cmdAdd and cmdDel call chains. Previously, deallocateIPAM and getAllocatedSubnetFromCRD each created their own client via newK8sClient(), resulting in four separate client instances per CNI invocation.

- Accept client.Client as a parameter in deallocateIPAM and getAllocatedSubnetFromCRD
- Move k8s client creation before deallocateIPAM in cmdDel so the same instance is threaded through
- Remove newK8sClient() call from getAllocatedSubnetFromCRD so it uses the caller-provided client
- Log that both IPAM deallocation and CRD cleanup are skipped when client creation fails in cmdDel
- Reduce newK8sClient() calls from four per invocation down to one per cmdAdd and one per cmdDel