### PR TITLE
feat: implement CNI STATUS operation

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -211,9 +212,10 @@ type PluginConf struct {
 func RunPlugin() {
 	skel.PluginMainFuncs(
 		skel.CNIFuncs{
-			Add:   cmdAdd,
-			Check: cmdCheck,
-			Del:   cmdDel,
+			Add:    cmdAdd,
+			Check:  cmdCheck,
+			Del:    cmdDel,
+			Status: cmdStatus,
 		},
 		version.All,
 		"CNI galactic plugin "+metadata.Version,
@@ -442,6 +444,70 @@ func cmdCheck(args *skel.CmdArgs) error {
 	if len(errs) > 0 {
 		return fmt.Errorf("CHECK failed: %w", errors.Join(errs...))
 	}
+	return nil
+}
+
+// cmdStatus implements the CNI spec STATUS operation. It is called by the
+// runtime to determine whether the plugin is ready to service ADD requests.
+// Unlike cmdCheck, no container is attached so there is no Netns to inspect.
+// STATUS validates the plugin's own readiness: config is parseable, managed
+// kernel resources (VRF, host interface) exist, and the API server is
+// reachable for BGPAdvertisement CRD operations.
+func cmdStatus(args *skel.CmdArgs) error {
+	pluginConf, err := parseConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	// Check VRF interface exists.
+	if err := vrf.Exists(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+		errs = append(errs, fmt.Errorf("vrf %s-%s: %w", pluginConf.VPC, pluginConf.VPCAttachment, err))
+	}
+
+	// Check the host-side interface exists.
+	hostName := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
+	if _, err := netlink.LinkByName(hostName); err != nil {
+		errs = append(errs, fmt.Errorf("host interface %q: %w", hostName, err))
+	}
+
+	// Check API server reachability with a lightweight GET.
+	if err := probeAPIServer(); err != nil {
+		errs = append(errs, fmt.Errorf("api server: %w", err))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("STATUS failed: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// probeAPIServer performs a lightweight GET against the in-cluster API server
+// to verify reachability. Returns nil when the server responds (any HTTP
+// status code) or when running outside a cluster with no kubeconfig.
+func probeAPIServer() error {
+	kubeconfig, err := ctrl.GetConfig()
+	if err != nil {
+		// No kubeconfig (running outside a cluster); skip API check.
+		return nil
+	}
+	kubeconfig.Timeout = 2 * time.Second
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		kubeconfig.Host+"/healthz",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("build healthz request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("healthz request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort probe
 	return nil
 }
 

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -715,3 +715,102 @@ func TestResourceTrackerFieldsSet(t *testing.T) {
 		t.Error("advCreated should be false by default")
 	}
 }
+
+// ---- cmdStatus ---------------------------------------------------------
+
+func TestCmdStatusInvalidConfig(t *testing.T) {
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte("not valid json"),
+	}
+
+	err := cmdStatus(args)
+	if err == nil {
+		t.Fatalf("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse CNI config") {
+		t.Fatalf("error %q does not contain 'parse CNI config'", err.Error())
+	}
+}
+
+func TestCmdStatusInvalidInterfaceType(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s","interface_type":"bogus"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdStatus(args)
+	if err == nil {
+		t.Fatalf("expected error for invalid interface_type, got nil")
+	}
+	if !strings.Contains(err.Error(), `invalid interface_type "bogus"`) {
+		t.Fatalf("error %q does not contain expected message", err.Error())
+	}
+}
+
+func TestCmdStatusValidConfigMissingResources(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdStatus(args)
+	if err == nil {
+		t.Fatalf("expected error for missing resources, got nil")
+	}
+	if !strings.Contains(err.Error(), "STATUS failed") {
+		t.Fatalf("error %q does not contain 'STATUS failed'", err.Error())
+	}
+}
+
+func TestCmdStatusMissingVPC(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpcattachment":"%s"}`,
+		testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdStatus(args)
+	if err == nil {
+		t.Fatalf("expected error for missing VPC, got nil")
+	}
+	if !strings.Contains(err.Error(), "STATUS failed") {
+		t.Fatalf("error %q does not contain 'STATUS failed'", err.Error())
+	}
+}
+
+func TestCmdStatusMissingVPCAttachment(t *testing.T) {
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s"}`,
+		testVPC,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdStatus(args)
+	if err == nil {
+		t.Fatalf("expected error for missing VPCAttachment, got nil")
+	}
+	if !strings.Contains(err.Error(), "STATUS failed") {
+		t.Fatalf("error %q does not contain 'STATUS failed'", err.Error())
+	}
+}


### PR DESCRIPTION
The galactic-cni plugin now implements the CNI spec STATUS operation, allowing the runtime to probe plugin readiness before scheduling containers. The STATUS handler validates that managed kernel resources (VRF, host interface) exist and that the API server is reachable for BGPAdvertisement CRD operations.

- Register cmdStatus in skel.CNIFuncs alongside Add, Check, and Del
- Validate VRF interface and host-side interface existence
- Probe API server reachability via GET /healthz with 2s timeout
- Skip API check when running outside a cluster (no kubeconfig)
- Add five unit tests for invalid config, missing resources, and missing fields