### PR TITLE
fix: return CNI error code 50 from cmdStatus on failure

### DIFF
--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -103,7 +104,10 @@ func cmdStatus(args *skel.CmdArgs) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("STATUS failed: %w", errors.Join(errs...))
+		// Code 50 = plugin not available. Per CNI spec v1.1.0 §4.4, STATUS
+		// errors must use a typed error code so runtimes can distinguish
+		// plugin unavailability (retry/reschedule) from generic failures.
+		return types.NewError(50, "STATUS failed", errors.Join(errs...).Error())
 	}
 	return nil
 }


### PR DESCRIPTION
cmdStatus previously returned a generic fmt.Errorf on failure, which the CNI runtime converts to ErrInternal (code 0). Per CNI spec v1.1.0, STATUS errors must carry a typed error code so runtimes can distinguish plugin unavailability (retry/reschedule) from generic failures.

- Replace fmt.Errorf with types.NewError(code 50, "plugin not available") so runtimes correctly recognize STATUS as an unavailability signal
- Add types import to ops_check.go and document the code 50 rationale inline for future maintainers
- Retain the same error message text ("STATUS failed") so existing log-based monitors and tests remain unaffected

fixes #163