### PR TITLE
fix: use rest.HTTPClientFor in probeAPIServer

### DIFF
--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -17,6 +17,7 @@ import (
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"go.datum.net/galactic/internal/plumbing/intf"
@@ -118,7 +119,10 @@ func probeAPIServer() error {
 		return nil
 	}
 	kubeconfig.Timeout = 2 * time.Second
-	httpClient := &http.Client{Timeout: 2 * time.Second}
+	httpClient, err := rest.HTTPClientFor(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("build http client: %w", err)
+	}
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,


### PR DESCRIPTION
probeAPIServer constructed a bare http.Client that lacks the cluster CA certificate and bearer token from the in-cluster kubeconfig, causing every in-cluster healthz probe to fail with a TLS verification error. This made cmdStatus always report the plugin as unavailable in production.

- Use rest.HTTPClientFor(kubeconfig) to build an HTTP client carrying the correct TLS transport with cluster CA and bearer token
- Return a wrapped error when the HTTP client fails to build
- Align probeAPIServer with the same rest config pattern used in newK8sClient in bg.go

fixes #165