### PR TITLE
fix: harden host-device plugin invocation path

### DIFF
--- a/internal/cni/host_device.go
+++ b/internal/cni/host_device.go
@@ -7,8 +7,11 @@ package cni
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -18,13 +21,24 @@ import (
 	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
-func hostDeviceExecutable() string {
-	path, _ := os.Executable()
-	dir := filepath.Dir(path)
-	return filepath.Join(dir, "host-device")
+func hostDeviceExecutable() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	path := filepath.Join(filepath.Dir(exe), "host-device")
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("host-device binary not found at %s: %w", path, err)
+	}
+	return path, nil
 }
 
 func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) error {
+	hostDevicePath, err := hostDeviceExecutable()
+	if err != nil {
+		return fmt.Errorf("resolve host-device binary: %w", err)
+	}
+
 	conf, err := json.Marshal(HostDevicePluginConf{
 		PluginConf: types.PluginConf{
 			CNIVersion: pluginConf.CNIVersion,
@@ -49,11 +63,15 @@ func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) 
 		IfName:        skelArgs.IfName,
 		Path:          skelArgs.Path,
 	}
-	if _, err := invokeExec.ExecPlugin(
-		context.Background(), hostDeviceExecutable(), conf,
-		invokeArgs.AsEnv(),
-	); err != nil {
-		return err
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result, err := invokeExec.ExecPlugin(ctx, hostDevicePath, conf, invokeArgs.AsEnv())
+	if err != nil {
+		return fmt.Errorf("host-device plugin failed: %w", err)
 	}
+	if result == nil {
+		return errors.New("host-device plugin returned nil result")
+	}
+	_ = result // Result validated as non-nil; host-device is a delegation helper, not an IPAM provider.
 	return nil
 }


### PR DESCRIPTION
The host-device plugin invocation path had three deficiencies that made it fragile and hard to debug: no binary existence check, no timeout on ExecPlugin, and discarded return values. This commit addresses all three issues to improve reliability and error reporting.

- Return an error from hostDeviceExecutable when the binary cannot be located or does not exist on disk
- Apply a 5-second timeout to ExecPlugin calls to prevent indefinite hangs
- Validate that ExecPlugin returns a non-nil result before proceeding
- Wrap all host-device errors with context identifying the plugin as the source

fixes #155