### PR TITLE
fix: validate SRv6Locator format in parseConf

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -209,6 +209,90 @@ func TestParseConf(t *testing.T) {
 			wantVPC:    "Abc123XYZ",
 			wantIfType: interfaceTypeVeth,
 		},
+		{
+			name: "valid srv6_locator with /48 prefix",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"2001:db8::/48"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "valid srv6_locator with /64 prefix",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"fd00:1:2::/64"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "valid srv6_locator empty is allowed",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":""}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "srv6_locator missing is allowed",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "srv6_locator invalid mask /65 too long",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"fd00:1:2::/65"}`,
+				testVPC, testAttachment,
+			),
+			wantErr: srv6LocatorErrMsg,
+		},
+		{
+			name: "srv6_locator invalid IPv4 address",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"192.168.1.0/24"}`,
+				testVPC, testAttachment,
+			),
+			wantErr: srv6LocatorErrMsg,
+		},
+		{
+			name: "srv6_locator not a valid CIDR",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"not-a-cidr"}`,
+				testVPC, testAttachment,
+			),
+			wantErr: srv6LocatorErrMsg,
+		},
+		{
+			name: "srv6_locator plain IPv6 without mask",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","srv6_locator":"2001:db8::1"}`,
+				testVPC, testAttachment,
+			),
+			wantErr: srv6LocatorErrMsg,
+		},
 	}
 
 	for _, tt := range tests {
@@ -267,6 +351,40 @@ func TestIsValidBase62(t *testing.T) {
 			got := isValidBase62(tt.input)
 			if got != tt.want {
 				t.Errorf("isValidBase62(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---- isValidSRv6Locator --------------------------------------------------
+
+func TestIsValidSRv6Locator(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"empty allowed", "", true},
+		{"valid /48", "2001:db8::/48", true},
+		{"valid /64", "fd00:1:2::/64", true},
+		{"valid /0", "::/0", true},
+		{"valid /63", "fd00::/63", true},
+		{"invalid /65 too long", "fd00::/65", false},
+		{"invalid /128", "fd00::1/128", false},
+		{"invalid IPv4", "192.168.1.0/24", false},
+		{"invalid IPv4 with IPv6-looking mask", "10.0.0.0/8", false},
+		{"not a CIDR", "not-a-cidr", false},
+		{"plain IPv6 no mask", "2001:db8::1", false},
+		{"plain IPv4 no mask", "192.168.1.1", false},
+		{"valid with host bits set", "2001:db8:1234::/48", true},
+		{"all zeros valid", "::/0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidSRv6Locator(tt.input)
+			if got != tt.want {
+				t.Errorf("isValidSRv6Locator(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -8,9 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 )
 
 const sanitizeForErrorBinary = "<binary>"
+
+// srv6LocatorErrMsg is the error message prefix for invalid SRv6 locator values.
+const srv6LocatorErrMsg = "invalid srv6_locator"
 
 // isValidBase62 reports whether s contains only valid base62 characters
 // ([0-9a-zA-Z]) and is non-empty. VPC and VPCAttachment identifiers are
@@ -27,6 +31,25 @@ func isValidBase62(s string) bool {
 		}
 	}
 	return true
+}
+
+// isValidSRv6Locator reports whether s is a valid IPv6 CIDR prefix suitable
+// for SRv6 SID encoding. The locator must be non-empty, parseable as an IPv6
+// prefix with a mask length of 64 or less (leaving at least 64 bits of
+// address space for embedding VPC/VPCAttachment identifiers).
+func isValidSRv6Locator(s string) bool {
+	if s == "" {
+		return true // empty locator is valid — setupSRv6Ingress is a no-op
+	}
+	_, ipnet, err := net.ParseCIDR(s)
+	if err != nil {
+		return false
+	}
+	if ipnet.IP.To4() != nil {
+		return false // must be IPv6
+	}
+	maskLen, _ := ipnet.Mask.Size()
+	return maskLen <= 64
 }
 
 // parseConf unmarshals the CNI configuration from stdin data and validates
@@ -52,6 +75,13 @@ func parseConf(data []byte) (*PluginConf, error) {
 			return nil, errors.New("vpcattachment is required and must be a non-empty base62 string")
 		}
 		return nil, fmt.Errorf("invalid base62 value for field 'vpcattachment': %q", sanitizeForError(conf.VPCAttachment))
+	}
+	if !isValidSRv6Locator(conf.SRv6Locator) {
+		return nil, fmt.Errorf(
+			"%s %q: must be a valid "+
+				"IPv6 CIDR prefix with mask length <= 64",
+			srv6LocatorErrMsg, sanitizeForError(conf.SRv6Locator),
+		)
 	}
 	if conf.InterfaceType == "" {
 		conf.InterfaceType = interfaceTypeVeth


### PR DESCRIPTION
Add validation for the srv6_locator CNI config field in parseConf so malformed values fail fast at config parse time, before any kernel state is created. This prevents late-stage failures deep in the stack that can leave orphaned VRF, veth, and route state.

- Add isValidSRv6Locator helper that checks for valid IPv6 CIDR prefix with mask length <= 64
- Call the validator in parseConf after VPC/VPCAttachment checks, before any kernel operations
- Allow empty or missing srv6_locator since setupSRv6Ingress is a no-op for empty values
- Add unit tests covering valid/invalid srv6_locator inputs including IPv4 rejection, mask overflow, and non-CIDR strings

fixes #160