### PR TITLE
chore: disable Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
+    ":disableDependencyDashboard",
     ":semanticCommits"
   ],
   "schedule": ["before 6am on Monday"],


### PR DESCRIPTION
Remove the :dependencyDashboard extension from Renovate extends, replacing it with :disableDependencyDashboard. This stops Renovate from generating the dependency summary PR, reducing noise in the repository.