### PR TITLE
refactor: rename --router-role to --mode with route reflector flag

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,7 +225,7 @@ On DEL, the result contains only `cniVersion` (empty result is correct since the
 - **GoBGP embedded, lazy-started.** GoBGP runs in-process and starts only when the first `BGPRouter` is reconciled (`listenPort=-1`, outbound-only). ASN or RouterID changes trigger a full `Reconfigure` (fresh `BgpServer` — `StopBgp` is not called because it permanently terminates the v4 Serve loop).
 - **CRD-driven config, no sidecar gRPC.** `galactic-router` watches cosmos BGP CRDs directly via controller-runtime. The CNI writes a `BGPAdvertisement` CRD; the router reconciler picks it up. No in-node gRPC calls.
 - **Hash-based no-op suppression.** SHA-256 over the sorted `DesiredRouter` prevents redundant GoBGP Apply calls on every CRD event.
-- **RuntimeFactory pattern.** `GALACTIC_ROUTER_ROUTER_ROLE=tenant` selects GoBGP; `GALACTIC_ROUTER_ROUTER_ROLE=fabric` selects FRR (Phase 2 stub). The binary is selected at startup; no controller changes are needed for Phase 2.
+- **RuntimeFactory pattern.** `GALACTIC_ROUTER_ROUTER_MODE=tenant` selects GoBGP; `GALACTIC_ROUTER_ROUTER_MODE=fabric` selects FRR (Phase 2 stub). The binary is selected at startup; no controller changes are needed for Phase 2.
 - **gRPC health on :5000.** Liveness and readiness probes use the gRPC health protocol (`google.golang.org/grpc/health`) on port 5000. No HTTP health endpoint.
 
 ---

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -60,7 +60,7 @@ func newViper() *viper.Viper {
 	//nolint:errcheck // keys are controlled, BindEnv cannot fail here
 	v.BindEnv("galactic_router.node_name", "GALACTIC_ROUTER_NODE_NAME")
 	//nolint:errcheck
-	v.BindEnv("galactic_router.router_role", "GALACTIC_ROUTER_ROUTER_ROLE")
+	v.BindEnv("galactic_router.router_mode", "GALACTIC_ROUTER_ROUTER_MODE")
 	//nolint:errcheck
 	v.BindEnv("galactic_router.bgp_listen_port", "GALACTIC_ROUTER_BGP_LISTEN_PORT")
 	//nolint:errcheck
@@ -78,33 +78,36 @@ func newViper() *viper.Viper {
 }
 
 const (
-	roleTenant = "tenant"
-	roleFabric = "fabric"
+	modeTransit = "transit"
+	modeFabric  = "fabric"
+	modeTenant  = "tenant"
 )
 
 // bindFlags registers each viper-configured flag on the command so that
 // `viper.BindPFlags` can resolve flag values at runtime.
 func bindFlags(cmd *cobra.Command, v *viper.Viper) { //nolint:lll // cobra flag defs are inherently long
 	cmd.Flags().StringP("node-name", "n", "", "Kubernetes node name (required)")
-	cmd.Flags().StringP("router-role", "r", "",
-		"Router role: 'tenant' or 'fabric' (required)")
+	cmd.Flags().StringP("mode", "m", "",
+		"Operating mode: 'transit', 'fabric', or 'tenant' (required)")
+	cmd.Flags().Bool("reflector", false,
+		"Enable route reflector mode (requires --mode=fabric or --mode=tenant)")
 	cmd.Flags().IntP("bgp-listen-port", "p", v.GetInt("galactic_router.bgp_listen_port"),
-		"TCP port GoBGP binds for inbound BGP")
+		"BGP listen port")
 	cmd.Flags().StringP("bgp-local-address", "",
 		v.GetString("galactic_router.bgp_local_address"),
-		"Source address for outgoing BGP TCP connections")
+		"Source address for outgoing BGP connections")
 	cmd.Flags().IntP("metrics-port", "",
 		v.GetInt("galactic_router.metrics_port"),
-		"Port for the controller-runtime metrics server")
+		"Metrics listen port")
 	cmd.Flags().IntP("grpc-health-port", "",
 		v.GetInt("galactic_router.grpc_health_port"),
-		"Port for the gRPC health check server")
+		"gRPC health check port")
 	cmd.Flags().StringP("gc-namespace", "",
 		v.GetString("galactic_router.gc_namespace"),
-		"Namespace for GC controller to scan for orphaned BGP CRDs")
+		"Namespace for orphaned CRD cleanup")
 	cmd.Flags().DurationP("gc-interval", "",
 		v.GetDuration("galactic_router.gc_interval"),
-		"GC collection interval")
+		"Cleanup interval")
 
 	if err := v.BindPFlags(cmd.Flags()); err != nil {
 		log.Fatalf("bind flags: %v", err)
@@ -114,7 +117,8 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) { //nolint:lll // cobra flag 
 // validateConfig checks that the configuration values are valid.
 func validateConfig(v *viper.Viper) error {
 	nodeName := v.GetString("galactic_router.node_name")
-	routerRole := v.GetString("galactic_router.router_role")
+	mode := v.GetString("galactic_router.router_mode")
+	reflector := v.GetBool("reflector")
 	bgpListenPort := v.GetInt("galactic_router.bgp_listen_port")
 	metricsPort := v.GetInt("galactic_router.metrics_port")
 	grpcHealthPort := v.GetInt("galactic_router.grpc_health_port")
@@ -122,11 +126,14 @@ func validateConfig(v *viper.Viper) error {
 	if nodeName == "" {
 		return errors.New("--node-name is required")
 	}
-	if routerRole == "" {
-		return errors.New("--router-role is required")
+	if mode == "" {
+		return errors.New("--mode is required (valid values: 'transit', 'fabric', 'tenant')")
 	}
-	if routerRole != roleTenant && routerRole != roleFabric {
-		return fmt.Errorf("GALACTIC_ROUTER_ROUTER_ROLE must be 'tenant' or 'fabric', got %q", routerRole)
+	if mode != modeTransit && mode != modeFabric && mode != modeTenant {
+		return fmt.Errorf("GALACTIC_ROUTER_ROUTER_MODE must be 'transit', 'fabric', or 'tenant', got %q", mode)
+	}
+	if reflector && mode != modeFabric && mode != modeTenant {
+		return errors.New("--reflector is only valid when --mode=fabric or --mode=tenant")
 	}
 	if bgpListenPort < -1 || bgpListenPort > 65535 {
 		return fmt.Errorf("GALACTIC_ROUTER_BGP_LISTEN_PORT must be -1 or a valid port number, got %d", bgpListenPort)
@@ -148,18 +155,20 @@ func runCmd(v *viper.Viper) error {
 	}
 
 	nodeName := v.GetString("galactic_router.node_name")
-	routerRole := v.GetString("galactic_router.router_role")
+	mode := v.GetString("galactic_router.router_mode")
 	bgpListenPort := v.GetInt("galactic_router.bgp_listen_port")
 	bgpLocalAddr := v.GetString("galactic_router.bgp_local_address")
 	metricsPort := v.GetInt("galactic_router.metrics_port")
 	grpcHealthPort := v.GetInt("galactic_router.grpc_health_port")
 
 	var factory galacticruntime.RuntimeFactory
-	switch routerRole {
-	case "tenant":
+	switch mode {
+	case modeTenant:
 		factory = gobgp.NewRuntimeFactory(int32(bgpListenPort), bgpLocalAddr)
-	case roleFabric:
+	case modeFabric:
 		factory = frr.NewRuntimeFactory()
+	case modeTransit:
+		return errors.New("mode=transit is not yet supported")
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -212,7 +221,7 @@ func runCmd(v *viper.Viper) error {
 	runtimeMgr := galacticruntime.NewRuntimeManager(factory)
 
 	// Create reconciler.
-	rec := reconcile.New(mgr.GetClient(), nodeName, routerRole, bgpLocalAddr)
+	rec := reconcile.New(mgr.GetClient(), nodeName, mode, bgpLocalAddr)
 
 	// Register BGPRouter controller.
 	if err := (&controller.BGPRouterReconciler{
@@ -222,7 +231,7 @@ func runCmd(v *viper.Viper) error {
 		RuntimeManager: runtimeMgr,
 		Hasher:         hash.DesiredRouter,
 		NodeName:       nodeName,
-		RouterRole:     routerRole,
+		RouterMode:     mode,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup BGPRouter controller: %w", err)
 	}

--- a/cmd/galactic-router/root_test.go
+++ b/cmd/galactic-router/root_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -50,7 +51,7 @@ func TestRequiredFlags(t *testing.T) {
 
 func TestEnvVarDefaults(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
 
 	v := cmdWithViper(t)
 	if err := validateConfig(v); err != nil {
@@ -58,20 +59,20 @@ func TestEnvVarDefaults(t *testing.T) {
 	}
 }
 
-func TestInvalidRouterRole(t *testing.T) {
+func TestInvalidMode(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "invalid")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "invalid")
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
 	if err == nil {
-		t.Error("validateConfig with invalid router role returned nil error")
+		t.Error("validateConfig with invalid mode returned nil error")
 	}
 }
 
 func TestBGPListenPortMinusOne(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
 	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "-1")
 
 	v := cmdWithViper(t)
@@ -82,7 +83,7 @@ func TestBGPListenPortMinusOne(t *testing.T) {
 
 func TestBGPListenPortOverflow(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
 	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "70000")
 
 	v := cmdWithViper(t)
@@ -100,39 +101,63 @@ func TestNodeNameRequired(t *testing.T) {
 	}
 }
 
-func TestRouterRoleRequired(t *testing.T) {
+func TestModeRequired(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	// GALACTIC_ROUTER_ROUTER_ROLE unset
+	// GALACTIC_ROUTER_ROUTER_MODE unset
 
 	v := cmdWithViper(t)
 	err := validateConfig(v)
 	if err == nil {
-		t.Error("validateConfig with empty router-role returned nil error")
+		t.Error("validateConfig with empty mode returned nil error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "--mode is required") {
+		t.Errorf("expected --mode required error, got: %v", err)
 	}
 }
 
-func TestValidRoles(t *testing.T) {
-	for _, role := range []string{"tenant", "fabric"} {
-		t.Run(role, func(t *testing.T) {
+func TestValidModes(t *testing.T) {
+	for _, mode := range []string{"transit", "fabric", "tenant"} {
+		t.Run(mode, func(t *testing.T) {
 			t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-			t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", role)
+			t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", mode)
 
 			v := cmdWithViper(t)
-			// Verify the role is read correctly.
-			if v.GetString("galactic_router.router_role") != role {
-				t.Errorf("router_role = %q, want %q", v.GetString("galactic_router.router_role"), role)
+			// Verify the mode is read correctly.
+			if v.GetString("galactic_router.router_mode") != mode {
+				t.Errorf("router_mode = %q, want %q", v.GetString("galactic_router.router_mode"), mode)
 			}
 			// Verify validation passes.
 			if err := validateConfig(v); err != nil {
-				t.Errorf("validateConfig with role %q: %v", role, err)
+				t.Errorf("validateConfig with mode %q: %v", mode, err)
 			}
 		})
 	}
 }
 
+func TestReflectorInvalidMode(t *testing.T) {
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "transit")
+
+	v := cmdWithViper(t)
+	// Simulate --reflector being set via flag.
+	cmd := &cobra.Command{Use: "test"}
+	bindFlags(cmd, v)
+	//nolint:errcheck // flag exists, setting it is safe
+	cmd.Flags().Set("reflector", "true")
+	_ = v.BindPFlags(cmd.Flags())
+
+	err := validateConfig(v)
+	if err == nil {
+		t.Error("validateConfig with --reflector and --mode=transit returned nil error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "--reflector is only valid") {
+		t.Errorf("expected --reflector validation error, got: %v", err)
+	}
+}
+
 func TestMetricsPortOverride(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
 	t.Setenv("GALACTIC_ROUTER_METRICS_PORT", "9090")
 
 	v := cmdWithViper(t)
@@ -143,7 +168,7 @@ func TestMetricsPortOverride(t *testing.T) {
 
 func TestGRPCHealthPortOverride(t *testing.T) {
 	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_ROLE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
 	t.Setenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT", "9091")
 
 	v := cmdWithViper(t)
@@ -161,7 +186,7 @@ func TestVersionFlag(t *testing.T) {
 func TestDefaults(t *testing.T) {
 	// Clear all relevant env vars.
 	_ = os.Unsetenv("GALACTIC_ROUTER_NODE_NAME")
-	_ = os.Unsetenv("GALACTIC_ROUTER_ROUTER_ROLE")
+	_ = os.Unsetenv("GALACTIC_ROUTER_ROUTER_MODE")
 	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LISTEN_PORT")
 	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LOCAL_ADDRESS")
 	_ = os.Unsetenv("GALACTIC_ROUTER_METRICS_PORT")

--- a/deploy/containerlab/resources/overlay/base/daemonset.yaml
+++ b/deploy/containerlab/resources/overlay/base/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: GALACTIC_ROUTER_ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_MODE
               value: tenant
             - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "-1"

--- a/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/overlay/iad/rr/daemonset-patch.yaml
@@ -32,7 +32,7 @@ spec:
           env:
             - name: GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
               value: "fc00:0:8::1"
-            - name: GALACTIC_ROUTER_ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_MODE
               value: tenant
             - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "1790"

--- a/deploy/galactic-router/daemonset.yaml
+++ b/deploy/galactic-router/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: GALACTIC_ROUTER_ROUTER_ROLE
+            - name: GALACTIC_ROUTER_ROUTER_MODE
               value: tenant
           ports:
             - name: metrics

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -8,7 +8,8 @@ or a combination of both. CLI flags take precedence over environment variables.
 | Option | Environment Variable | CLI Flag | Default |
 |---|---|---|---|
 | Node name | `GALACTIC_ROUTER_NODE_NAME` | `--node-name` | _(required)_ |
-| Router role | `GALACTIC_ROUTER_ROUTER_ROLE` | `--router-role` | _(required)_ |
+| Router mode | `GALACTIC_ROUTER_ROUTER_MODE` | `--mode` | _(required)_ |
+| Route reflector | _(none)_ | `--reflector` | `false` |
 | BGP listen port | `GALACTIC_ROUTER_BGP_LISTEN_PORT` | `--bgp-listen-port` | `179` |
 | BGP local address | `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` | `--bgp-local-address` | `""` |
 | Metrics port | `GALACTIC_ROUTER_METRICS_PORT` | `--metrics-port` | `8080` |
@@ -20,7 +21,7 @@ The following options are **required**. If unset, `galactic-router` exits with
 an error:
 
 - `--node-name` (`GALACTIC_ROUTER_NODE_NAME`) — Kubernetes node name where the router runs.
-- `--router-role` (`GALACTIC_ROUTER_ROUTER_ROLE`) — Router role: `tenant` or `fabric`.
+- `--mode` (`GALACTIC_ROUTER_ROUTER_MODE`) — Router mode: `transit`, `fabric`, or `tenant`.
 
 ## Option Details
 
@@ -32,16 +33,20 @@ used to scope BGP configuration to the correct node.
 **Type:** string
 **Required:** yes
 
-### `--router-role` / `GALACTIC_ROUTER_ROUTER_ROLE`
+### `--mode` / `GALACTIC_ROUTER_ROUTER_MODE`
 
-The routing role of this instance. Determines which BGP backend is used:
+The operating mode of this instance. Determines which BGP backend is used:
 
-- `tenant` — uses GoBGP for EVPN path distribution (production role).
+- `tenant` — uses GoBGP for EVPN path distribution (production mode).
 - `fabric` — uses the FRR stub backend (not yet implemented).
+- `transit` — reserved for future transit mode (not yet implemented).
 
-**Type:** string
-**Required:** yes
-**Valid values:** `tenant`, `fabric`
+### `--reflector`
+
+Enable route reflector mode. Only valid when `--mode=fabric` or `--mode=tenant`.
+
+**Type:** boolean
+**Default:** `false`
 
 ### `--bgp-listen-port` / `GALACTIC_ROUTER_BGP_LISTEN_PORT`
 
@@ -109,7 +114,7 @@ command:
   - /galactic-router
 args:
   - --node-name=$(GALACTIC_ROUTER_NODE_NAME)
-  - --router-role=tenant
+  - --mode=tenant
   - --metrics-port=9090
 env:
   - name: GALACTIC_ROUTER_NODE_NAME
@@ -128,7 +133,7 @@ env:
     valueFrom:
       fieldRef:
         fieldPath: status.nodeName
-  - name: GALACTIC_ROUTER_ROUTER_ROLE
+  - name: GALACTIC_ROUTER_ROUTER_MODE
     value: tenant
   - name: GALACTIC_ROUTER_METRICS_PORT
     value: "9090"
@@ -136,6 +141,6 @@ command:
   - /galactic-router
 args:
   - --node-name=$(GALACTIC_ROUTER_NODE_NAME)
-  - --router-role=tenant
+  - --mode=tenant
   - --metrics-port=9100   # overrides GALACTIC_ROUTER_METRICS_PORT env var
 ```

--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -44,7 +44,7 @@ type BGPRouterReconciler struct {
 	RuntimeManager galacticruntime.RuntimeManager
 	Hasher         func(model.DesiredRouter) (string, error)
 	NodeName       string
-	RouterRole     string
+	RouterMode     string
 }
 
 // Reconcile reconciles a single BGPRouter.

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -27,19 +27,19 @@ import (
 type Reconciler struct {
 	client       client.Client
 	nodeName     string
-	routerRole   string
+	routerMode   string
 	localAddress string
 }
 
-// New returns a Reconciler for the given node, router role, and local BGP address.
+// New returns a Reconciler for the given node, router mode, and local BGP address.
 // localAddress, when non-empty, is used as the EVPN next-hop instead of the
 // node's first IPv6 InternalIP — required when the node InternalIP is not
 // reachable via the SRv6 transit mesh (e.g. Kind/ContainerLab Docker bridge).
-func New(c client.Client, nodeName, routerRole, localAddress string) *Reconciler {
+func New(c client.Client, nodeName, routerMode, localAddress string) *Reconciler {
 	return &Reconciler{
 		client:       c,
 		nodeName:     nodeName,
-		routerRole:   routerRole,
+		routerMode:   routerMode,
 		localAddress: localAddress,
 	}
 }
@@ -56,7 +56,7 @@ func (r *Reconciler) BuildDesiredRouter(
 	}
 
 	// Role check.
-	wantRole := bgpv1alpha1.RouterRole(r.routerRole)
+	wantRole := bgpv1alpha1.RouterRole(r.routerMode)
 	if !slices.Contains(router.Spec.Roles, wantRole) {
 		return nil, nil
 	}


### PR DESCRIPTION
Replace the --router-role CLI flag and GALACTIC_ROUTER_ROUTER_MODE environment variable with --mode, expanding valid values from 'tenant'/'fabric' to include 'transit'. Add a --reflector flag restricted to fabric and tenant modes.

- Rename --router-role/-r to --mode/-m across CLI, env vars, and viper keys
- Add --reflector boolean flag, validated against --mode at startup
- Add transit mode to valid values; transit errors at runtime as unsupported
- Rename internal routerRole fields to routerMode in reconcile and controller
- Update all deployment manifests and documentation references
- Add TestReflectorInvalidMode test and update existing tests for new naming