### PR TITLE
feat: migrate from SRv6 locator encoding to per-endpoint USID

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,11 +25,10 @@ cosmos API group directly — no gRPC sidecar, no provider CRD lifecycle.
 
 ### SRv6 SID encoding
 
-Each container endpoint is assigned a deterministic SRv6 SID:
-
-```
-[SRv6 locator prefix (≤64 bits)] | [VPC ID (48 bits)] | [VPCAttachment ID (16 bits)]
-```
+Each container endpoint is assigned a /128 USID (Unique Local SID, RFC 8986 Section 3.2).
+The companion operator allocates a unique /128 per (VPC, VPCAttachment) pair and injects
+it into the NAD as `srv6_sid`. The CNI installs an END.DT46 decap route for that exact
+/128 and advertises it as the EVPN Type 5 GWIPAddress.
 
 All nodes in the same VPC derive the same BGP Route Target via `fnv32a(vpcHex)`,
 enabling automatic cross-node path import without explicit RT configuration.
@@ -58,7 +57,7 @@ galactic/
 │   │   ├── route/           # Host-side static routes via netlink
 │   │   └── veth/            # veth pair management
 │   └── plumbing/            # Low-level kernel and network primitives
-│       ├── intf/            # Interface naming, base62↔hex encoding, SRv6 endpoint encode/decode
+│       ├── intf/            # Interface naming, base62↔hex encoding
 │       ├── srv6/            # SRv6 ingress route add/del (END.DT46)
 │       ├── sysctl/          # Interface sysctl helpers
 │       └── vrf/             # Linux VRF create/delete/lookup
@@ -91,7 +90,7 @@ See [docs/agent-startup.md](docs/agent-startup.md) for the router startup sequen
 | `internal/hash` | `galactic-router` | Change detection |
 | `internal/metadata` | both | Build-time version info stamped via `-ldflags` |
 | `internal/cni` | `galactic-cni` | CNI cmdAdd / cmdDel |
-| `internal/plumbing/intf` | both | Interface naming, base62↔hex encoding, SRv6 endpoint encode/decode |
+| `internal/plumbing/intf` | both | Interface naming, base62↔hex encoding |
 | `internal/plumbing/srv6` | both | SRv6 ingress route add/del (END.DT46) |
 | `internal/plumbing/vrf` | both | Linux VRF create/delete/lookup |
 | `internal/plumbing/sysctl` | both | Interface sysctl helpers |
@@ -134,7 +133,7 @@ Calls `cni.RunPlugin()` which hands control to `skel.PluginMainFuncs`. Reads con
 | `vpc`           | string   | Base62-encoded 48-bit VPC identifier                                    |
 | `vpcattachment` | string   | Base62-encoded 16-bit VPCAttachment identifier                          |
 | `interface_type`| string   | `veth` (default) or `tap`; tap mode omits IPAM and guest-side config   |
-| `srv6_locator`  | string   | IPv6 CIDR (≤/64) used as SRv6 locator prefix                           |
+| `srv6_sid`      | string   | USID (/128) for this endpoint; bare IPv6 or CIDR form                       |
 | `namespace`     | string   | Kubernetes namespace for BGP CRDs; defaults to `default`               |
 | `mtu`           | int      | MTU for the veth pair; 0 uses kernel default                            |
 | `terminations`  | array    | Static routes to install on the host-side veth (`network`, `via`)      |
@@ -194,7 +193,7 @@ On DEL, the result contains only `cniVersion` (empty result is correct since the
 | `internal/cni`                | galactic-cni    | `cmdAdd` / `cmdDel`; CNI PluginConf parsing; BGPAdvertisement lifecycle; delegates kernel work to plumbing | No         |
 | `internal/cni/route`          | galactic-cni    | Host-side static route add/delete via netlink                                                        | No         |
 | `internal/cni/veth`           | galactic-cni    | veth pair create/delete                                                                               | No         |
-| `internal/plumbing/intf`      | both            | Deterministic interface naming (`G{vpc9}{att3}V/H/G`); base62↔hex encoding; `EncodeSRv6Endpoint` / `DecodeSRv6Endpoint` | No |
+| `internal/plumbing/intf`      | both            | Deterministic interface naming (`G{vpc9}{att3}V/H/G`); base62↔hex encoding | No |
 | `internal/plumbing/srv6`      | galactic-cni    | SRv6 END.DT46 ingress route add/delete via netlink                                                   | No         |
 | `internal/plumbing/vrf`       | galactic-cni    | Linux VRF create/delete/lookup via netlink                                                           | No         |
 | `internal/plumbing/sysctl`    | galactic-cni    | Per-interface sysctl helpers                                                                          | No         |
@@ -220,7 +219,7 @@ On DEL, the result contains only `cniVersion` (empty result is correct since the
 
 ## Key Design Decisions
 
-- **Identifiers in the SID.** VPC (48-bit) and VPCAttachment (16-bit) identifiers are packed into the low 64 bits of the SRv6 SID, making forwarding state fully self-describing without a lookup table.
+- **USID per endpoint.** Each (VPC, VPCAttachment) pair is assigned a unique /128 USID by the companion operator. The CNI installs an END.DT46 decap route for that /128 and advertises it as the EVPN GWIPAddress. VPC identity is not encoded in the SID.
 - **Base62 interface names.** Kernel interface names use the format `G{9-char-vpc-base62}{3-char-att-base62}{suffix}` (suffix: `V` = VRF, `H` = host veth, `G` = guest veth), fitting in the 14-character kernel limit. The hex form is used for BGP and SRv6; base62 for kernel interfaces.
 - **GoBGP embedded, lazy-started.** GoBGP runs in-process and starts only when the first `BGPRouter` is reconciled (`listenPort=-1`, outbound-only). ASN or RouterID changes trigger a full `Reconfigure` (fresh `BgpServer` — `StopBgp` is not called because it permanently terminates the v4 Serve loop).
 - **CRD-driven config, no sidecar gRPC.** `galactic-router` watches cosmos BGP CRDs directly via controller-runtime. The CNI writes a `BGPAdvertisement` CRD; the router reconciler picks it up. No in-node gRPC calls.
@@ -279,7 +278,7 @@ Triggered by `v*` tags. Builds and pushes `ghcr.io/datum-cloud/galactic:{version
 | BGP peer / advertisement / policy CRUD     | `internal/runtime/gobgp/peers.go`, `paths.go`, `policies.go`|
 | Controller watch graph                     | `internal/controller/bgprouter_controller.go:SetupWithManager` |
 | CRD status update logic                    | `internal/controller/status.go`, `bgprouter_controller.go:updateRouterStatus` |
-| Interface naming / SRv6 SID encoding       | `internal/plumbing/intf/intf.go`                             |
+| Interface naming / base62 encoding         | `internal/plumbing/intf/intf.go`                             |
 | Hash-based no-op suppression               | `internal/hash/hash.go`; annotation `galactic.datum.net/config-hash` on BGPRouter |
 | GoBGP server lifecycle (start/reconfigure) | `internal/runtime/gobgp/server.go`                          |
 

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -73,6 +73,8 @@ func newViper() *viper.Viper {
 	v.BindEnv("galactic_router.gc_namespace", "GALACTIC_ROUTER_GC_NAMESPACE")
 	//nolint:errcheck
 	v.BindEnv("galactic_router.gc_interval", "GALACTIC_ROUTER_GC_INTERVAL")
+	//nolint:errcheck
+	v.BindEnv("reflector", "GALACTIC_ROUTER_REFLECTOR")
 
 	return v
 }

--- a/deploy/containerlab/AGENTS.md
+++ b/deploy/containerlab/AGENTS.md
@@ -9,7 +9,7 @@
 - **galactic-router image**: Uses `galactic-router:latest` with `imagePullPolicy: Never` — stale images persist across rebuilds.
 - **Kind serviceSubnet**: All clusters use `/108` service subnet (non-standard; may cause issues with some services).
 - **BGP listen port**: galactic-router tenant DaemonSets run with `GALACTIC_ROUTER_BGP_LISTEN_PORT=-1` (outbound-only, all sessions initiated outbound).
-- **Worker SRv6 loopback**: The `lo-galactic` dummy interface with the SRv6 node SID is created via `exec` commands in the ContainerLab topology (not in the Kind bootstrap script).
+- **Worker SRv6 loopback**: The `lo-galactic` dummy interface is created via `exec` commands in the ContainerLab topology. The USID is **not** configured as an address on this interface — instead a blackhole route (`metric 2048`) prevents the default route from matching the USID. The seg6local route (`metric 1024`) in the main table handles SRv6 decapsulation. If the USID were an interface address, the kernel's local table route (metric 0) would shadow the seg6local route and break decapsulation.
 - **Node labels**: Workers use `galactic.datum.net/node: edge` (not `galactic.io/role: pop`). The control node uses `galactic.datum.net/node: control` with a matching `NoSchedule` taint.
 - **GC namespace**: The tenant DaemonSet sets `GALACTIC_ROUTER_GC_NAMESPACE=galactic-system` for namespace-scoped garbage collection.
 - **FRR config**: Transit router configs omit the `frr version` directive (managed by the FRR image, not the config).

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -85,20 +85,18 @@ AS 65000 (sjc-tenant / galactic-router)    ──iBGP──  iad-control-tenant 
 
 ### Cluster SRv6 addressing
 
-| Cluster   | FRR loopback / SID block | SRv6 forwarding prefix | galactic-router address |
-|-----------|--------------------------|------------------------|-------------------------|
-| dfw       | fc00:0:2::1/48           | 2001:db8:ff01::/48     | fc00:0:2::1             |
-| iad       | fc00:0:4::1/48           | 2001:db8:ff03::/48     | fc00:0:4::1             |
-| iad-control | fc00:0:8::1/48         | —                      | fc00:0:8::1             |
-| sjc       | fc00:0:3::1/48           | 2001:db8:ff02::/48     | fc00:0:3::1             |
+Each worker has a `lo-galactic` dummy interface with a blackhole route for its
+/128 USID (metric 2048, lower priority than the seg6local route at metric 1024).
+The blackhole prevents the default route from matching the USID while the
+seg6local route handles SRv6 decapsulation. The FRR fabric DaemonSet advertises
+the USID into the transit mesh via a static Null0 route + BGP `network` statement.
 
-Worker SRv6 node SIDs (on `lo-galactic`):
-
-| Node          | Address                                    |
-|---------------|--------------------------------------------|
-| dfw-worker    | 2001:db8:ff01:100:ffff:ffff:ffff:ffff/128  |
-| iad-worker    | 2001:db8:ff03:100:ffff:ffff:ffff:ffff/128  |
-| sjc-worker    | 2001:db8:ff02:100:ffff:ffff:ffff:ffff/128  |
+| Cluster   | FRR loopback       | USID (lo-galactic)         | galactic-router address |
+|-----------|--------------------|----------------------------|-------------------------|
+| dfw       | fc00:0:2::1/48     | 2001:db8:ff00:1010::1/128  | fc00:0:2::1             |
+| iad       | fc00:0:4::1/48     | 2001:db8:ff00:1010::3/128  | fc00:0:4::1             |
+| iad-control | fc00:0:8::1/48   | 2001:db8:ff00:1010::4/128  | fc00:0:8::1             |
+| sjc       | fc00:0:3::1/48     | 2001:db8:ff00:1010::2/128  | fc00:0:3::1             |
 
 ### Management network (172.20.20.0/24)
 

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -144,10 +144,10 @@ tasks:
     cmds:
       - ./scripts/install-tenant.sh
 
-  "deploy:nettools":
+  "deploy:testvpc":
     desc: Deploy test VPC across all clusters
     cmds:
-      - ./scripts/install-nettools.sh
+      - ./scripts/install-testvpc.sh
 
   test:
     desc: Run all verification checks
@@ -183,11 +183,11 @@ tasks:
           -- vtysh -c "show bgp ipv6 unicast summary"
 
   "test:srv6":
-    desc: Verify SRv6 forwarding prefixes on tr1
+    desc: Verify USID prefixes on tr1
     cmds:
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff01::/48"
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff02::/48"
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff03::/48"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::1/128"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::2/128"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::3/128"
 
   "test:evpn":
     desc: Verify EVPN BGP routes on iad, sjc, and dfw via BGPRouter status

--- a/deploy/containerlab/docs/testvpc.md
+++ b/deploy/containerlab/docs/testvpc.md
@@ -8,13 +8,13 @@ to create a VRF, veth pair, SRv6 encapsulation route, and `BGPAdvertisement` CRD
 `galactic-router` controller then advertises the pod's EVPN route to the route reflector,
 distributing reachability across sites.
 
-Each site assigns addresses from a distinct IPv6 pool:
+Each site assigns addresses from a distinct IPv6 pool and uses a unique /128 USID:
 
-| Site | SRv6 locator       | IPAM pool            | Gateway          |
-|------|---------------------|----------------------|------------------|
-| dfw  | `2001:db8:ff01::/48` | `fd00:10:ff01::/48`  | `fd00:10:ff01::1` |
-| sjc  | `2001:db8:ff02::/48` | `fd00:10:ff02::/48`  | `fd00:10:ff02::1` |
-| iad  | `2001:db8:ff03::/48` | `fd00:10:ff03::/48`  | `fd00:10:ff03::1` |
+| Site | USID                       | IPAM pool            | Gateway          |
+|------|-----------------------------|----------------------|------------------|
+| dfw  | `2001:db8:ff00:1010::1/128` | `fd00:10:ff01::/48`  | `fd00:10:ff01::1` |
+| sjc  | `2001:db8:ff00:1010::2/128` | `fd00:10:ff02::/48`  | `fd00:10:ff02::1` |
+| iad  | `2001:db8:ff00:1010::3/128` | `fd00:10:ff03::/48`  | `fd00:10:ff03::1` |
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ This does the following:
    create `BGPAdvertisement` CRDs on pod attach (requires `deploy:system` for RBAC).
 2. **Patches the CNI wrapper** (`/opt/cni/bin/galactic-cni`) to export `KUBECONFIG` and
    `GALACTIC_CNI_NODE_NAME`.
-3. **Applies the nettools Deployment** to each cluster's `vpc` namespace.
+3. **Applies the testvpc Deployment** to each cluster's `vpc` namespace.
 
 ## Verify Pods Are Running
 
@@ -56,7 +56,7 @@ docker exec iad-control-plane kubectl get pods -n vpc -o wide
 docker exec sjc-control-plane kubectl get pods -n vpc -o wide
 ```
 
-Each should show one `nettools` pod in `Running` state.
+Each should show one `testvpc` pod in `Running` state.
 
 ### Inspect pod VPC interface
 
@@ -158,19 +158,19 @@ docker exec dfw-worker dmesg | grep galactic
    docker exec dfw-control-plane kubectl get bgprouters -A -o yaml | grep -A 5 advertised
    ```
 
-2. Check the SRv6 underlay — transit routers should have all SRv6 locator prefixes:
+2. Check the SRv6 underlay — transit routers should have all USIDs:
 
    ```bash
-   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff01::/48"
-   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff02::/48"
-   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff03::/48"
+   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::1/128"
+   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::2/128"
+   docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::3/128"
    ```
 
 3. Verify the pod's VRF and SRv6 route on the worker:
 
    ```bash
-   docker exec dfw-worker ip -6 route show table vrf-vpc-nettools-*
-   docker exec dfw-worker ip -6 neigh show table vrf-vpc-nettools-*
+   docker exec dfw-worker ip -6 route show table vrf-vpc-testvpc-*
+   docker exec dfw-worker ip -6 neigh show table vrf-vpc-testvpc-*
    ```
 
 ### Regenerate CNI kubeconfigs

--- a/deploy/containerlab/docs/verification.md
+++ b/deploy/containerlab/docs/verification.md
@@ -8,10 +8,10 @@ Run these checks after `task deploy` to confirm the lab is healthy end-to-end.
 # iBGP full mesh — expect all sessions Established
 docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast summary"
 
-# Worker SRv6 prefixes should be present on all TR nodes
-docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff01::/48"
-docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff02::/48"
-docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff03::/48"
+# Worker USIDs should be present on all TR nodes
+docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::1/128"
+docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::2/128"
+docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff00:1010::3/128"
 ```
 
 ## FRR DaemonSets (eBGP fabric)

--- a/deploy/containerlab/gvpc.clab.yaml
+++ b/deploy/containerlab/gvpc.clab.yaml
@@ -55,7 +55,7 @@ topology:
       exec:
         - ip link add lo-galactic type dummy
         - ip link set lo-galactic up
-        - ip -6 addr add 2001:db8:ff01:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
+        - ip -6 route add blackhole 2001:db8:ff00:1010::1/128 metric 2048
         - /galactic/scripts/install.sh
 
     sjc-control-plane:
@@ -95,7 +95,7 @@ topology:
       exec:
         - ip link add lo-galactic type dummy
         - ip link set lo-galactic up
-        - ip -6 addr add 2001:db8:ff02:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
+        - ip -6 route add blackhole 2001:db8:ff00:1010::2/128 metric 2048
         - /galactic/scripts/install.sh
 
     iad-control-plane:
@@ -135,7 +135,7 @@ topology:
       exec:
         - ip link add lo-galactic type dummy
         - ip link set lo-galactic up
-        - ip -6 addr add 2001:db8:ff03:100:ffff:ffff:ffff:ffff/128 dev lo-galactic
+        - ip -6 route add blackhole 2001:db8:ff00:1010::3/128 metric 2048
         - /galactic/scripts/install.sh
 
     iad-worker2:
@@ -157,7 +157,7 @@ topology:
       exec:
         - ip link add lo-galactic type dummy
         - ip link set lo-galactic up
-        - ip -6 addr add 2001:db8:ff03:200:ffff:ffff:ffff:ffff/128 dev lo-galactic
+        - ip -6 route add blackhole 2001:db8:ff00:1010::4/128 metric 2048
         - /galactic/scripts/install.sh
 
     tr1:

--- a/deploy/containerlab/resources/bgp/tenant/dfw/bgpadvertisement.yaml
+++ b/deploy/containerlab/resources/bgp/tenant/dfw/bgpadvertisement.yaml
@@ -10,4 +10,4 @@ spec:
     afi: l2vpn
     safi: evpn
   prefixes:
-    - "2001:db8:ff01:100:ffff:ffff:ffff:ffff/128"
+    - "2001:db8:ff00:1010::1/128"

--- a/deploy/containerlab/resources/bgp/tenant/iad/bgpadvertisement.yaml
+++ b/deploy/containerlab/resources/bgp/tenant/iad/bgpadvertisement.yaml
@@ -10,4 +10,4 @@ spec:
     afi: l2vpn
     safi: evpn
   prefixes:
-    - "2001:db8:ff03:100:ffff:ffff:ffff:ffff/128"
+    - "2001:db8:ff00:1010::3/128"

--- a/deploy/containerlab/resources/bgp/tenant/sjc/bgpadvertisement.yaml
+++ b/deploy/containerlab/resources/bgp/tenant/sjc/bgpadvertisement.yaml
@@ -10,4 +10,4 @@ spec:
     afi: l2vpn
     safi: evpn
   prefixes:
-    - "2001:db8:ff02:100:ffff:ffff:ffff:ffff/128"
+    - "2001:db8:ff00:1010::2/128"

--- a/deploy/containerlab/resources/control/tenant/iad/daemonset.yaml
+++ b/deploy/containerlab/resources/control/tenant/iad/daemonset.yaml
@@ -47,6 +47,8 @@ spec:
               value: tenant
             - name: GALACTIC_ROUTER_BGP_LISTEN_PORT
               value: "1790"
+            - name: GALACTIC_ROUTER_REFLECTOR
+              value: "true"
             - name: GALACTIC_ROUTER_GC_NAMESPACE
               value: galactic-system
           securityContext:

--- a/deploy/containerlab/resources/fabric/dfw/configmap.yaml
+++ b/deploy/containerlab/resources/fabric/dfw/configmap.yaml
@@ -34,7 +34,7 @@ data:
     log syslog informational
 
     interface lo
-     ! /48 assigns the full SRv6 SID block to this node; eBGP advertises the /48 as the SID range.
+     ! BGP peering address for this fabric node.
      ipv6 address fc00:0:2::1/48
     !
     interface eth1
@@ -42,7 +42,7 @@ data:
      ipv6 address 2001:db8:1:10::2/64
     !
 
-    ipv6 route 2001:db8:ff01::/48 Null0
+    ipv6 route 2001:db8:ff00:1010::1/128 Null0
     !
     route-map SET_SRC permit 10
      set src fc00:0:2::1
@@ -58,7 +58,7 @@ data:
       neighbor 2001:db8:1:10::1 activate
       neighbor 2001:db8:1:10::1 allowas-in 1
       neighbor 2001:db8:1:10::1 route-map SET_SRC in
-      network 2001:db8:ff01::/48
+      network 2001:db8:ff00:1010::1/128
       network fc00:0:2::/48
      exit-address-family
     !

--- a/deploy/containerlab/resources/fabric/iad/configmap.yaml
+++ b/deploy/containerlab/resources/fabric/iad/configmap.yaml
@@ -34,7 +34,7 @@ data:
     log syslog informational
 
     interface lo
-     ! /48 assigns the full SRv6 SID block to this node; eBGP advertises the /48 as the SID range.
+     ! BGP peering address for this fabric node.
      ipv6 address fc00:0:4::1/48
     !
     interface eth1
@@ -42,7 +42,7 @@ data:
      ipv6 address 2001:db8:1:30::2/64
     !
 
-    ipv6 route 2001:db8:ff03::/48 Null0
+    ipv6 route 2001:db8:ff00:1010::3/128 Null0
     !
     route-map SET_SRC permit 10
      set src fc00:0:4::1
@@ -58,7 +58,7 @@ data:
       neighbor 2001:db8:1:30::1 activate
       neighbor 2001:db8:1:30::1 allowas-in 1
       neighbor 2001:db8:1:30::1 route-map SET_SRC in
-      network 2001:db8:ff03::/48
+      network 2001:db8:ff00:1010::3/128
       network fc00:0:4::/48
      exit-address-family
     !

--- a/deploy/containerlab/resources/fabric/sjc/configmap.yaml
+++ b/deploy/containerlab/resources/fabric/sjc/configmap.yaml
@@ -34,7 +34,7 @@ data:
     log syslog informational
 
     interface lo
-     ! /48 assigns the full SRv6 SID block to this node; eBGP advertises the /48 as the SID range.
+     ! BGP peering address for this fabric node.
      ipv6 address fc00:0:3::1/48
     !
     interface eth1
@@ -42,7 +42,7 @@ data:
      ipv6 address 2001:db8:1:20::2/64
     !
 
-    ipv6 route 2001:db8:ff02::/48 Null0
+    ipv6 route 2001:db8:ff00:1010::2/128 Null0
     !
     route-map SET_SRC permit 10
      set src fc00:0:3::1
@@ -58,7 +58,7 @@ data:
       neighbor 2001:db8:1:20::1 activate
       neighbor 2001:db8:1:20::1 allowas-in 1
       neighbor 2001:db8:1:20::1 route-map SET_SRC in
-      network 2001:db8:ff02::/48
+      network 2001:db8:ff00:1010::2/128
       network fc00:0:3::/48
      exit-address-family
     !

--- a/deploy/containerlab/resources/tenant/dfw/nad.yaml
+++ b/deploy/containerlab/resources/tenant/dfw/nad.yaml
@@ -12,7 +12,7 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "srv6_locator": "2001:db8:ff01::/48",
+      "srv6_sid": "2001:db8:ff00:1010::1/128",
       "ipam": {
         "type": "pool",
         "pool": "fd00:10:ff01::/48",

--- a/deploy/containerlab/resources/tenant/iad/nad.yaml
+++ b/deploy/containerlab/resources/tenant/iad/nad.yaml
@@ -12,7 +12,7 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "srv6_locator": "2001:db8:ff03::/48",
+      "srv6_sid": "2001:db8:ff00:1010::3/128",
       "ipam": {
         "type": "pool",
         "pool": "fd00:10:ff03::/48",

--- a/deploy/containerlab/resources/tenant/sjc/nad.yaml
+++ b/deploy/containerlab/resources/tenant/sjc/nad.yaml
@@ -12,7 +12,7 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "srv6_locator": "2001:db8:ff02::/48",
+      "srv6_sid": "2001:db8:ff00:1010::2/128",
       "ipam": {
         "type": "pool",
         "pool": "fd00:10:ff02::/48",

--- a/deploy/containerlab/resources/testvpc/dfw/testvpc.yaml
+++ b/deploy/containerlab/resources/testvpc/dfw/testvpc.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nettools
+  name: testvpc
   namespace: vpc
   labels:
-    app: nettools
+    app: testvpc
     site: dfw
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nettools
+      app: testvpc
   template:
     metadata:
       labels:
-        app: nettools
+        app: testvpc
         site: dfw
       annotations:
         k8s.v1.cni.cncf.io/networks: testvpc

--- a/deploy/containerlab/resources/testvpc/iad/testvpc.yaml
+++ b/deploy/containerlab/resources/testvpc/iad/testvpc.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nettools
+  name: testvpc
   namespace: vpc
   labels:
-    app: nettools
-    site: sjc
+    app: testvpc
+    site: iad
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nettools
+      app: testvpc
   template:
     metadata:
       labels:
-        app: nettools
-        site: sjc
+        app: testvpc
+        site: iad
       annotations:
         k8s.v1.cni.cncf.io/networks: testvpc
     spec:

--- a/deploy/containerlab/resources/testvpc/sjc/testvpc.yaml
+++ b/deploy/containerlab/resources/testvpc/sjc/testvpc.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nettools
+  name: testvpc
   namespace: vpc
   labels:
-    app: nettools
-    site: iad
+    app: testvpc
+    site: sjc
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nettools
+      app: testvpc
   template:
     metadata:
       labels:
-        app: nettools
-        site: iad
+        app: testvpc
+        site: sjc
       annotations:
         k8s.v1.cni.cncf.io/networks: testvpc
     spec:

--- a/deploy/containerlab/scripts/install-testvpc.sh
+++ b/deploy/containerlab/scripts/install-testvpc.sh
@@ -66,7 +66,7 @@ for site_node in dfw-control-plane:dfw sjc-control-plane:sjc iad-control-plane:i
   IFS=: read -r node site <<< "${site_node}"
   echo "Applying testvpc/${site} to ${node}..."
   docker cp "${RESOURCES_DIR}/testvpc/${site}" "${node}:/galactic/resources/testvpc-${site}/"
-  docker exec "${node}" kubectl apply -f "/galactic/resources/testvpc-${site}/nettools.yaml"
+  docker exec "${node}" kubectl apply -f "/galactic/resources/testvpc-${site}/testvpc.yaml"
 done
 
 setup_cni_kubeconfig dfw-control-plane dfw-worker

--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -189,11 +189,8 @@ func publishBGPState(
 	if err != nil {
 		return fmt.Errorf("decode VPC: %w", err)
 	}
-	vpcAttHex, err := intf.Base62ToHex(pluginConf.VPCAttachment)
-	if err != nil {
-		return fmt.Errorf("decode VPCAttachment: %w", err)
-	}
-	srv6SIDStr, err := setupSRv6Ingress(pluginConf.SRv6Locator, vpcHex, vpcAttHex)
+
+	srv6SIDStr, err := setupSRv6Ingress(pluginConf.SRv6SID, pluginConf.VPC, pluginConf.VPCAttachment)
 	if err != nil {
 		return err
 	}
@@ -378,16 +375,12 @@ func configureHostVethGateway(vpc, vpcAttachment string, res *ipamResult) error 
 }
 
 // setupSRv6Ingress installs the End.DT46 SRv6 ingress decap route for the given
-// locator and returns the SID string. Returns empty string when locator is empty.
-func setupSRv6Ingress(locator, vpcHex, vpcAttHex string) (string, error) {
-	if locator == "" {
+// USID and returns the SID string. Returns empty string when SID is not configured.
+func setupSRv6Ingress(sid, vpc, vpcAttachment string) (string, error) {
+	if sid == "" {
 		return "", nil
 	}
-	sid, err := intf.EncodeSRv6Endpoint(locator, vpcHex, vpcAttHex)
-	if err != nil {
-		return "", fmt.Errorf("encode SRv6 endpoint: %w", err)
-	}
-	if err := srv6.RouteIngressAdd(sid); err != nil {
+	if err := srv6.RouteIngressAdd(sid, vpc, vpcAttachment); err != nil {
 		return "", fmt.Errorf("add SRv6 ingress route: %w", err)
 	}
 	return sid, nil

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -83,7 +83,7 @@ func TestParseConf(t *testing.T) {
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"2001:db8::/48"}`,
+					`"vpcattachment":"%s","srv6_sid":"2001:db8::1/128"}`,
 				testVPC, testAttachment,
 			),
 			wantVPC:    testVPC,
@@ -219,40 +219,40 @@ func TestParseConf(t *testing.T) {
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name: "valid srv6_locator with /48 prefix",
+			name: "valid srv6_sid with /128",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"2001:db8::/48"}`,
+					`"vpcattachment":"%s","srv6_sid":"2001:db8::1/128"}`,
 				testVPC, testAttachment,
 			),
 			wantVPC:    testVPC,
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name: "valid srv6_locator with /64 prefix",
+			name: "valid srv6_sid bare IPv6 address",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"fd00:1:2::/64"}`,
+					`"vpcattachment":"%s","srv6_sid":"2001:db8::1"}`,
 				testVPC, testAttachment,
 			),
 			wantVPC:    testVPC,
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name: "valid srv6_locator empty is allowed",
+			name: "srv6_sid empty is allowed",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":""}`,
+					`"vpcattachment":"%s","srv6_sid":""}`,
 				testVPC, testAttachment,
 			),
 			wantVPC:    testVPC,
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name: "srv6_locator missing is allowed",
+			name: "srv6_sid missing is allowed",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
@@ -263,44 +263,34 @@ func TestParseConf(t *testing.T) {
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name: "srv6_locator invalid mask /65 too long",
+			name: "srv6_sid invalid mask /64 rejected",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"fd00:1:2::/65"}`,
+					`"vpcattachment":"%s","srv6_sid":"fd00:1:2::/64"}`,
 				testVPC, testAttachment,
 			),
-			wantErr: srv6LocatorErrMsg,
+			wantErr: srv6SIDErrMsg,
 		},
 		{
-			name: "srv6_locator invalid IPv4 address",
+			name: "srv6_sid invalid IPv4 address",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"192.168.1.0/24"}`,
+					`"vpcattachment":"%s","srv6_sid":"192.168.1.1"}`,
 				testVPC, testAttachment,
 			),
-			wantErr: srv6LocatorErrMsg,
+			wantErr: srv6SIDErrMsg,
 		},
 		{
-			name: "srv6_locator not a valid CIDR",
+			name: "srv6_sid not a valid address",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"not-a-cidr"}`,
+					`"vpcattachment":"%s","srv6_sid":"not-an-address"}`,
 				testVPC, testAttachment,
 			),
-			wantErr: srv6LocatorErrMsg,
-		},
-		{
-			name: "srv6_locator plain IPv6 without mask",
-			input: fmt.Sprintf(
-				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
-					`"vpcattachment":"%s","srv6_locator":"2001:db8::1"}`,
-				testVPC, testAttachment,
-			),
-			wantErr: srv6LocatorErrMsg,
+			wantErr: srv6SIDErrMsg,
 		},
 		{
 			name: "prevResult valid JSON result is accepted",
@@ -377,35 +367,31 @@ func TestIsValidBase62(t *testing.T) {
 	}
 }
 
-// ---- isValidSRv6Locator --------------------------------------------------
+// ---- isValidSRv6SID --------------------------------------------------
 
-func TestIsValidSRv6Locator(t *testing.T) {
+func TestIsValidSRv6SID(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
 		want  bool
 	}{
 		{"empty allowed", "", true},
-		{"valid /48", "2001:db8::/48", true},
-		{"valid /64", "fd00:1:2::/64", true},
-		{"valid /0", "::/0", true},
-		{"valid /63", "fd00::/63", true},
-		{"invalid /65 too long", "fd00::/65", false},
-		{"invalid /128", "fd00::1/128", false},
-		{"invalid IPv4", "192.168.1.0/24", false},
-		{"invalid IPv4 with IPv6-looking mask", "10.0.0.0/8", false},
-		{"not a CIDR", "not-a-cidr", false},
-		{"plain IPv6 no mask", "2001:db8::1", false},
-		{"plain IPv4 no mask", "192.168.1.1", false},
-		{"valid with host bits set", "2001:db8:1234::/48", true},
-		{"all zeros valid", "::/0", true},
+		{"valid /128", "2001:db8::1/128", true},
+		{"valid bare IPv6", "2001:db8:10:10::1", true},
+		{"valid all zeros /128", "::/128", true},
+		{"invalid /64", "fd00:1:2::/64", false},
+		{"invalid /48", "2001:db8::/48", false},
+		{"invalid IPv4", "192.168.1.1", false},
+		{"invalid IPv4 CIDR", "192.168.1.0/24", false},
+		{"not an address", "not-an-address", false},
+		{"invalid /0", "::/0", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isValidSRv6Locator(tt.input)
+			got := isValidSRv6SID(tt.input)
 			if got != tt.want {
-				t.Errorf("isValidSRv6Locator(%q) = %v, want %v", tt.input, got, tt.want)
+				t.Errorf("isValidSRv6SID(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -16,13 +16,13 @@ import (
 
 const sanitizeForErrorBinary = "<binary>"
 
-// srv6LocatorErrMsg is the error message prefix for invalid SRv6 locator values.
-const srv6LocatorErrMsg = "invalid srv6_locator"
+// srv6SIDErrMsg is the error message prefix for invalid SRv6 SID values.
+const srv6SIDErrMsg = "invalid srv6_sid"
 
 // isValidBase62 reports whether s contains only valid base62 characters
 // ([0-9a-zA-Z]) and is non-empty. VPC and VPCAttachment identifiers are
 // base62-encoded and used throughout the ADD path (interface naming,
-// SRv6 SID encoding). Rejecting them early in parseConf prevents cryptic
+// BGP CRD population). Rejecting them early in parseConf prevents cryptic
 // errors deep in the stack after partial kernel state has been created.
 func isValidBase62(s string) bool {
 	if len(s) == 0 {
@@ -36,23 +36,43 @@ func isValidBase62(s string) bool {
 	return true
 }
 
-// isValidSRv6Locator reports whether s is a valid IPv6 CIDR prefix suitable
-// for SRv6 SID encoding. The locator must be non-empty, parseable as an IPv6
-// prefix with a mask length of 64 or less (leaving at least 64 bits of
-// address space for embedding VPC/VPCAttachment identifiers).
-func isValidSRv6Locator(s string) bool {
+// isValidSRv6SID reports whether s is a valid USID — a /128 IPv6 address
+// suitable for use as an SRv6 endpoint identifier. The SID may be empty
+// (SRv6 ingress setup is skipped) or provided as a bare IPv6 address or
+// a /128 CIDR.
+func isValidSRv6SID(s string) bool {
 	if s == "" {
-		return true // empty locator is valid — setupSRv6Ingress is a no-op
+		return true
 	}
-	_, ipnet, err := net.ParseCIDR(s)
-	if err != nil {
+	// Accept both "addr" and "addr/128" forms.
+	addr := s
+	if idx := stringsIndex(s, "/"); idx >= 0 {
+		prefix := s[idx+1:]
+		if prefix != "128" {
+			return false
+		}
+		addr = s[:idx]
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil || ip.To4() != nil {
 		return false
 	}
-	if ipnet.IP.To4() != nil {
-		return false // must be IPv6
+	return true
+}
+
+// stringsIndex is a minimal strings.Index to avoid importing "strings"
+// alongside "encoding/json" in this file.
+func stringsIndex(s, substr string) int {
+	n := len(s) - len(substr)
+	if n < 0 {
+		return -1
 	}
-	maskLen, _ := ipnet.Mask.Size()
-	return maskLen <= 64
+	for i := 0; i <= n; i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
 }
 
 // statusConf holds the minimal CNI config fields needed for STATUS validation.
@@ -168,11 +188,10 @@ func parseConf(data []byte) (*PluginConf, error) {
 		}
 		return nil, fmt.Errorf("invalid base62 value for field 'vpcattachment': %q", sanitizeForError(conf.VPCAttachment))
 	}
-	if !isValidSRv6Locator(conf.SRv6Locator) {
+	if !isValidSRv6SID(conf.SRv6SID) {
 		return nil, fmt.Errorf(
-			"%s %q: must be a valid "+
-				"IPv6 CIDR prefix with mask length <= 64",
-			srv6LocatorErrMsg, sanitizeForError(conf.SRv6Locator),
+			"%s %q: must be a valid IPv6 address or /128 CIDR",
+			srv6SIDErrMsg, sanitizeForError(conf.SRv6SID),
 		)
 	}
 	if conf.PrevResult != nil {

--- a/internal/cni/resource.go
+++ b/internal/cni/resource.go
@@ -86,7 +86,7 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 
 	// 3. Delete SRv6 ingress route (only if we got a SID)
 	if rt.srv6SID != "" {
-		if err := srv6.RouteIngressDel(rt.srv6SID); err != nil {
+		if err := srv6.RouteIngressDel(rt.srv6SID, rt.vpc, rt.vpcAttachment); err != nil {
 			slog.Error("Rollback: failed to delete SRv6 ingress route", "err", err,
 				"sid", rt.srv6SID)
 		}

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -48,7 +48,7 @@ type PluginConf struct {
 	InterfaceType string        `json:"interface_type,omitempty"` // interfaceTypeVeth or interfaceTypeTap
 	Terminations  []Termination `json:"terminations,omitempty"`
 	IPAM          IPAM          `json:"ipam"`
-	SRv6Locator   string        `json:"srv6_locator"`
+	SRv6SID       string        `json:"srv6_sid"`
 	Namespace     string        `json:"namespace,omitempty"`
 }
 

--- a/internal/plumbing/intf/intf.go
+++ b/internal/plumbing/intf/intf.go
@@ -2,16 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package intf provides deterministic interface naming, base62↔hex ID
-// encoding, and SRv6 endpoint encode/decode for Galactic VPC identifiers.
+// Package intf provides deterministic interface naming and base62↔hex ID
+// encoding for Galactic VPC identifiers.
 package intf
 
 import (
-	"encoding/binary"
-	"errors"
 	"fmt"
-	"net"
-	"strconv"
 	"strings"
 
 	"github.com/kenshaw/baseconv"
@@ -39,7 +35,7 @@ func GenerateInterfaceNameGuest(vpc, vpcAttachment string) string {
 }
 
 // HexToBase62 converts a hex string to base62. VPC and VPCAttachment
-// identifiers are hex in SRv6 SIDs but base62 in kernel interface names to
+// identifiers are hex in BGP artifacts but base62 in kernel interface names to
 // stay within the 15-character limit.
 func HexToBase62(value string) (string, error) {
 	return baseconv.Convert(strings.ToLower(value), baseconv.DigitsHex, baseconv.Digits62)
@@ -48,48 +44,4 @@ func HexToBase62(value string) (string, error) {
 // Base62ToHex converts a base62 string to lowercase hex.
 func Base62ToHex(value string) (string, error) {
 	return baseconv.Convert(value, baseconv.Digits62, baseconv.DigitsHex)
-}
-
-// EncodeSRv6Endpoint packs hex VPC (48-bit) and VPCAttachment (16-bit)
-// identifiers into the low 64 bits of an IPv6 address within srv6Net.
-// srv6Net must be an IPv6 prefix of /64 or shorter.
-func EncodeSRv6Endpoint(srv6Net, vpc, vpcAttachment string) (string, error) {
-	ip, ipnet, err := net.ParseCIDR(srv6Net)
-	if err != nil {
-		return "", err
-	}
-	if ip.To4() != nil {
-		return "", fmt.Errorf("provided srv6Net is not IPv6: %s", srv6Net)
-	}
-	maskLen, _ := ipnet.Mask.Size()
-	if maskLen > 64 {
-		return "", errors.New("srv6Net must be at least 64 bits long")
-	}
-
-	vpcInt, err := strconv.ParseUint(vpc, 16, 64)
-	if err != nil {
-		return "", fmt.Errorf("invalid vpc %q: %w", vpc, err)
-	}
-	vpcAttachmentInt, err := strconv.ParseUint(vpcAttachment, 16, 16)
-	if err != nil {
-		return "", fmt.Errorf("invalid vpcAttachment %q: %w", vpcAttachment, err)
-	}
-
-	binary.BigEndian.PutUint64(ip[8:16], (vpcInt<<16)|vpcAttachmentInt)
-	return ip.String(), nil
-}
-
-// DecodeSRv6Endpoint extracts the 12-digit hex VPC and 4-digit hex
-// VPCAttachment identifiers from the low 64 bits of an SRv6 SID produced by
-// EncodeSRv6Endpoint. endpoint must be an IPv6 address.
-func DecodeSRv6Endpoint(endpoint net.IP) (string, string, error) {
-	ep := endpoint.To16()
-	if ep == nil || endpoint.To4() != nil {
-		return "", "", fmt.Errorf("provided endpoint is not an IPv6 address: %s", endpoint)
-	}
-
-	id := binary.BigEndian.Uint64(ep[8:16])
-	vpc := (id >> 16) & 0xFFFFFFFFFFFF
-	vpcAttachment := id & 0xFFFF
-	return fmt.Sprintf("%012x", vpc), fmt.Sprintf("%04x", vpcAttachment), nil
 }

--- a/internal/plumbing/intf/intf_test.go
+++ b/internal/plumbing/intf/intf_test.go
@@ -5,7 +5,6 @@
 package intf_test
 
 import (
-	"net"
 	"testing"
 
 	"go.datum.net/galactic/internal/plumbing/intf"
@@ -21,9 +20,7 @@ const (
 	testVPC           = "0000000jU" // base62 of 1234, right-padded to 9 chars
 	testVPCAttachment = "00G"       // base62 of 42, right-padded to 3 chars
 
-	testLocator    = "2607:ed40:ff00::/64"
-	testSIDEncoded = "2607:ed40:ff00::4d2:2a"
-	testMaxVPCAtt  = "ffff"
+	testMaxVPCAtt = "ffff"
 )
 
 func TestGenerateInterfaceNameVRF(t *testing.T) {
@@ -116,133 +113,6 @@ func TestHexBase62RoundTrip(t *testing.T) {
 		}
 		if got != hex {
 			t.Errorf("round-trip %s → %s → %s", hex, b62, got)
-		}
-	}
-}
-
-func TestEncodeSRv6Endpoint(t *testing.T) {
-	tests := []struct {
-		name          string
-		srv6Net       string
-		vpc           string
-		vpcAttachment string
-		want          string
-		wantError     bool
-	}{
-		{
-			name:          "Valid64BitMask",
-			srv6Net:       testLocator,
-			vpc:           testVPCHex,
-			vpcAttachment: testVPCAttachmentHex,
-			want:          testSIDEncoded,
-		},
-		{
-			name:          "Valid48BitMask",
-			srv6Net:       "2607:ed40:ff00::/48",
-			vpc:           testVPCHex,
-			vpcAttachment: testVPCAttachmentHex,
-			want:          testSIDEncoded,
-		},
-		{
-			name:          "ZeroIDs",
-			srv6Net:       "2607:ed40:ff00::/64",
-			vpc:           "000000000000",
-			vpcAttachment: "0000",
-			want:          "2607:ed40:ff00::",
-		},
-		{
-			name:      "IPv4NetworkRejected",
-			srv6Net:   "192.168.0.0/24",
-			wantError: true,
-		},
-		{
-			name:      "MaskTooNarrow",
-			srv6Net:   "2607:ed40:ff00::/96",
-			wantError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := intf.EncodeSRv6Endpoint(tt.srv6Net, tt.vpc, tt.vpcAttachment)
-			if (err != nil) != tt.wantError {
-				t.Errorf("EncodeSRv6Endpoint() error = %v, wantError = %v", err, tt.wantError)
-			}
-			if !tt.wantError && got != tt.want {
-				t.Errorf("EncodeSRv6Endpoint() = %s, want %s", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestDecodeSRv6Endpoint(t *testing.T) {
-	tests := []struct {
-		name              string
-		endpoint          string
-		wantVPC           string
-		wantVPCAttachment string
-		wantError         bool
-	}{
-		{
-			name:              "Valid",
-			endpoint:          testSIDEncoded,
-			wantVPC:           testVPCHex,
-			wantVPCAttachment: testVPCAttachmentHex,
-		},
-		{
-			name:              "ZeroIDs",
-			endpoint:          "2607:ed40:ff00::",
-			wantVPC:           "000000000000",
-			wantVPCAttachment: "0000",
-		},
-		{
-			name:              "MaxVPCAttachment",
-			endpoint:          "2607:ed40:ff00::" + testMaxVPCAtt,
-			wantVPC:           "000000000000",
-			wantVPCAttachment: testMaxVPCAtt,
-		},
-		{
-			name:      "IPv4Rejected",
-			endpoint:  "192.168.0.1",
-			wantError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotVPC, gotAtt, err := intf.DecodeSRv6Endpoint(net.ParseIP(tt.endpoint))
-			if (err != nil) != tt.wantError {
-				t.Errorf("DecodeSRv6Endpoint() error = %v, wantError = %v", err, tt.wantError)
-			}
-			if !tt.wantError && (gotVPC != tt.wantVPC || gotAtt != tt.wantVPCAttachment) {
-				t.Errorf("DecodeSRv6Endpoint(%s) = %s, %s, want %s, %s",
-					tt.endpoint, gotVPC, gotAtt, tt.wantVPC, tt.wantVPCAttachment)
-			}
-		})
-	}
-}
-
-func TestEncodeDecodeSRv6RoundTrip(t *testing.T) {
-	cases := []struct{ vpc, att string }{
-		{testVPCHex, testVPCAttachmentHex},
-		{"000000000000", "0000"},
-		{"ffffffffffff", testMaxVPCAtt},
-		{"000000000001", "0001"},
-	}
-
-	for _, c := range cases {
-		encoded, err := intf.EncodeSRv6Endpoint(testLocator, c.vpc, c.att)
-		if err != nil {
-			t.Errorf("EncodeSRv6Endpoint(%s, %s) unexpected error: %v", c.vpc, c.att, err)
-			continue
-		}
-		gotVPC, gotAtt, err := intf.DecodeSRv6Endpoint(net.ParseIP(encoded))
-		if err != nil {
-			t.Errorf("DecodeSRv6Endpoint(%s) unexpected error: %v", encoded, err)
-			continue
-		}
-		if gotVPC != c.vpc || gotAtt != c.att {
-			t.Errorf("round-trip vpc=%s att=%s → %s → vpc=%s att=%s", c.vpc, c.att, encoded, gotVPC, gotAtt)
 		}
 	}
 }

--- a/internal/plumbing/srv6/srv6.go
+++ b/internal/plumbing/srv6/srv6.go
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package srv6 manages kernel SRv6 END.DT46 ingress routes for Galactic VPC
-// endpoints. It decodes SRv6 SIDs to extract VPC identity and delegates route
-// installation to the Linux kernel via netlink. Requires CAP_NET_ADMIN.
+// endpoints. It accepts a USID (/128) and VPC identifiers to install the
+// decap route on the correct host interface and VRF routing table.
+// Requires CAP_NET_ADMIN.
 package srv6
 
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
@@ -18,52 +20,45 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// RouteIngressAdd installs an SRv6 END.DT46 ingress route for the given SRv6
-// SID, decoding the embedded VPC and VPCAttachment to locate the correct host
-// interface and VRF routing table.
-func RouteIngressAdd(ipStr string) error {
-	ip := net.ParseIP(ipStr)
+// parseSID returns the /128 IPNet for the given SID string.
+// It accepts both bare IPv6 addresses and /128 CIDR notation.
+func parseSID(sid string) (*net.IPNet, error) {
+	if strings.Contains(sid, "/") {
+		_, ipnet, err := net.ParseCIDR(sid)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sid %q: %w", sid, err)
+		}
+		return ipnet, nil
+	}
+	ip := net.ParseIP(sid)
 	if ip == nil {
-		return fmt.Errorf("invalid ip: %s", ipStr)
+		return nil, fmt.Errorf("invalid sid %q: not an IP address", sid)
 	}
-	vpc, vpcAttachment, err := intf.DecodeSRv6Endpoint(ip)
+	return netlink.NewIPNet(ip), nil
+}
+
+// RouteIngressAdd installs an SRv6 END.DT46 ingress route for the given USID.
+// The VPC and VPCAttachment identifiers (base62-encoded) are used to resolve
+// the host interface and VRF routing table.
+func RouteIngressAdd(sid, vpc, vpcAttachment string) error {
+	ipnet, err := parseSID(sid)
 	if err != nil {
-		return fmt.Errorf("could not extract SRv6 endpoint: %w", err)
+		return err
 	}
-	vpc, err = intf.HexToBase62(vpc)
-	if err != nil {
-		return fmt.Errorf("invalid vpc: %w", err)
-	}
-	vpcAttachment, err = intf.HexToBase62(vpcAttachment)
-	if err != nil {
-		return fmt.Errorf("invalid vpcattachment: %w", err)
-	}
-	if err := addIngressRoute(netlink.NewIPNet(ip), vpc, vpcAttachment); err != nil {
+	if err := addIngressRoute(ipnet, vpc, vpcAttachment); err != nil {
 		return fmt.Errorf("add ingress route failed: %w", err)
 	}
 	return nil
 }
 
 // RouteIngressDel removes the SRv6 END.DT46 ingress route previously installed
-// by RouteIngressAdd for the given SRv6 SID.
-func RouteIngressDel(ipStr string) error {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return fmt.Errorf("invalid ip: %s", ipStr)
-	}
-	vpc, vpcAttachment, err := intf.DecodeSRv6Endpoint(ip)
+// by RouteIngressAdd for the given USID.
+func RouteIngressDel(sid, vpc, vpcAttachment string) error {
+	ipnet, err := parseSID(sid)
 	if err != nil {
-		return fmt.Errorf("could not extract SRv6 endpoint: %w", err)
+		return err
 	}
-	vpc, err = intf.HexToBase62(vpc)
-	if err != nil {
-		return fmt.Errorf("invalid vpc: %w", err)
-	}
-	vpcAttachment, err = intf.HexToBase62(vpcAttachment)
-	if err != nil {
-		return fmt.Errorf("invalid vpcattachment: %w", err)
-	}
-	if err := deleteIngressRoute(netlink.NewIPNet(ip), vpc, vpcAttachment); err != nil {
+	if err := deleteIngressRoute(ipnet, vpc, vpcAttachment); err != nil {
 		return fmt.Errorf("delete ingress route failed: %w", err)
 	}
 	return nil

--- a/internal/plumbing/srv6/srv6_test.go
+++ b/internal/plumbing/srv6/srv6_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package srv6
+
+import (
+	"testing"
+)
+
+const testUSID = "2001:db8:ff00:1010::1"
+
+func TestParseSID(t *testing.T) {
+	tests := []struct {
+		name    string
+		sid     string
+		wantIP  string
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "bare IPv6",
+			sid:     testUSID,
+			wantIP:  testUSID,
+			wantLen: 128,
+		},
+		{
+			name:    "CIDR /128",
+			sid:     testUSID + "/128",
+			wantIP:  testUSID,
+			wantLen: 128,
+		},
+		{
+			name:    "invalid IP",
+			sid:     "not-an-ip",
+			wantErr: true,
+		},
+		{
+			name:    "invalid CIDR",
+			sid:     testUSID + "/256",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSID(tt.sid)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseSID(%q) error = nil, want error", tt.sid)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSID(%q) error = %v, want nil", tt.sid, err)
+			}
+			if got.IP.String() != tt.wantIP {
+				t.Errorf("parseSID(%q).IP = %s, want %s", tt.sid, got.IP, tt.wantIP)
+			}
+			if _, bits := got.Mask.Size(); bits != tt.wantLen {
+				t.Errorf("parseSID(%q).Mask.Size() = %d, want %d", tt.sid, bits, tt.wantLen)
+			}
+		})
+	}
+}
+
+func Example_parseSID_bareIP() {
+	// Bare IPv6 is wrapped in a /128 via netlink.NewIPNet.
+	ipnet, err := parseSID("2001:db8::1")
+	if err != nil {
+		panic(err)
+	}
+	_, bits := ipnet.Mask.Size()
+	_ = bits // 128
+}

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -7,6 +7,7 @@ package gobgp
 import (
 	"fmt"
 	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
@@ -15,6 +16,15 @@ import (
 
 	"go.datum.net/galactic/internal/model"
 )
+
+// parseSIDAddr parses an SRv6 SID string that may be a bare IPv6 address or a
+// /128 CIDR (e.g. "2001:db8::1/128"). It strips the CIDR suffix before parsing.
+func parseSIDAddr(sid string) (netip.Addr, error) {
+	if idx := strings.Index(sid, "/"); idx != -1 {
+		sid = sid[:idx]
+	}
+	return netip.ParseAddr(sid)
+}
 
 // buildEVPNPaths adds or withdraws EVPN Type 5 IP Prefix paths for each prefix
 // in adv into the local GoBGP RIB.
@@ -33,7 +43,7 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 
 	gwIP := nextHop
 	if adv.SRv6SID != "" {
-		sid, err := netip.ParseAddr(adv.SRv6SID)
+		sid, err := parseSIDAddr(adv.SRv6SID)
 		if err != nil {
 			return fmt.Errorf("invalid SRv6 SID %q: %w", adv.SRv6SID, err)
 		}

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -335,6 +335,7 @@ func fsmStateToModel(state api.PeerState_SessionState) model.BGPPeerState {
 }
 
 // applyVRF configures a VRF in GoBGP via AddVrf.
+// If the VRF already exists, the call is treated as idempotent (no-op).
 func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredVRFInstance) error {
 	// Parse the route distinguisher.
 	rd, err := bgp.ParseRouteDistinguisher(vrf.RouteDistinguisher)
@@ -358,7 +359,7 @@ func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredV
 		return fmt.Errorf("parse export route targets: %w", err)
 	}
 
-	return b.AddVrf(ctx, &api.AddVrfRequest{
+	err = b.AddVrf(ctx, &api.AddVrfRequest{
 		Vrf: &api.Vrf{
 			Name:     vrf.Name,
 			Rd:       apiRD,
@@ -366,6 +367,10 @@ func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredV
 			ExportRt: exportRTs,
 		},
 	})
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+		return nil // idempotent: VRF already configured
+	}
+	return err
 }
 
 // deleteVRF removes a VRF from GoBGP.


### PR DESCRIPTION
Each (VPC, VPCAttachment) pair now receives a unique /128 USID allocated by the companion operator and injected into the NAD as srv6_sid. The CNI no longer encodes VPC/VPCAttachment identifiers into the SID — it accepts the SID as a pre-populated input. This removes the 64-bit locator constraint, eliminates the encode/decode roundtrip, and simplifies the ingress path by passing VPC identifiers explicitly to the plumbing layer.

- Remove EncodeSRv6Endpoint and DecodeSRv6Endpoint from intf package
- Rename CNI config field from srv6_locator to srv6_sid (accepts bare IPv6 or /128 CIDR)
- Replace isValidSRv6Locator with isValidSRv6SID that rejects non-/128 masks
- Update RouteIngressAdd/Del to take explicit vpc and vpcAttachment parameters
- Add parseSIDAddr in gobgp paths to strip /128 suffix before netip.ParseAddr
- Make applyVRF idempotent by swallowing "already exists" errors
- Add unit tests for parseSID in srv6 package
- Wire GALACTIC_ROUTER_REFLECTOR env var for route reflector enablement
- Update containerlab NADs to use srv6_sid with per-site USIDs
- Rename nettools deployment to testvpc across all containerlab resources
- Update ARCHITECTURE.md to reflect USID-based SID model