### PR TITLE
fix: install latest Cosmos CRDs

### DIFF
--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
-# deploy-system.sh — Apply the galactic-system namespace and shared RBAC
-# (galactic-cni, galactic-router) to every cluster.
+# deploy-system.sh — Install Cosmos CRDs, then apply the galactic-system
+# namespace and shared RBAC (galactic-cni, galactic-router) to every cluster.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "${SCRIPT_DIR}/lib.sh"
 
+# Extract the cosmos commit SHA from go.mod (pseudo-version suffix after the
+# last hyphen, e.g. v0.0.0-20260625022501-1b617fd1bad4 → 1b617fd1bad4).
+COSMOS_SHA=$(awk '/go\.miloapis\.com\/cosmos/ {print $2}' "${SCRIPT_DIR}/../../../go.mod" | sed 's/.*-//')
+COSMOS_CRD_URL="https://raw.githubusercontent.com/milo-os/cosmos/${COSMOS_SHA}/config/crd"
+
+cosmos_crds=(
+  bgp.miloapis.com_bgpadvertisements.yaml
+  bgp.miloapis.com_bgppeers.yaml
+  bgp.miloapis.com_bgppolicies.yaml
+  bgp.miloapis.com_bgprouters.yaml
+  bgp.miloapis.com_bgpvrfinstances.yaml
+  vpc.miloapis.com_vpcs.yaml
+  vpc.miloapis.com_vpcattachments.yaml
+)
+
 for site in dfw sjc iad; do
   node=$(control_plane "${site}")
   echo "Applying system to ${node}..."
+
+  # Install CRDs from GitHub before any namespace-scoped resources.
+  for crd in "${cosmos_crds[@]}"; do
+    curl -sL "${COSMOS_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -
+  done
+
   copy_to "${node}" system
   apply_f "${node}" /galactic/resources/system/
 done

--- a/deploy/containerlab/scripts/lib.sh
+++ b/deploy/containerlab/scripts/lib.sh
@@ -23,7 +23,7 @@ apply_k() {
 
 apply_f() {
   local node="$1" path="$2"
-  docker exec "${node}" kubectl apply -f "${path}"
+  docker exec -i "${node}" kubectl apply -f "${path}"
 }
 
 ensure_namespace() {


### PR DESCRIPTION
deploy:system skipped installing the BGPRouter, BGPPeer, BGPAdvertisement, BGPPolicy, and BGPVRFInstance CRDs, causing deploy:tenant to fail with "no matches for kind" errors. The CRDs are owned by the companion cosmos module; they're now fetched from GitHub using the commit SHA pinned in go.mod.

- Extract the cosmos commit SHA from go.mod in deploy-system.sh
- Fetch CRD manifests from raw.githubusercontent.com for each cluster
- Apply all 7 CRDs (5 BGP + 2 VPC) before namespace and RBAC resources