### PR TITLE
feat: deploy galactic-cni via a hostPath installer daemonset

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,7 +62,8 @@ galactic/
 │       ├── sysctl/          # Interface sysctl helpers
 │       └── vrf/             # Linux VRF create/delete/lookup
 ├── deploy/
-│   ├── galactic-router/     # Kustomize: DaemonSet, RBAC, ServiceAccount
+│   ├── galactic-router/     # DaemonSet, RBAC, ServiceAccount
+│   ├── galactic-cni/        # DaemonSet installing galactic-cni onto /opt/cni/bin via hostPath
 │   └── containerlab/        # ContainerLab lab topology and scripts
 └── containers/
     └── galactic/            # Production Dockerfile

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -123,11 +123,12 @@ deploy/containerlab/
 ├── gvpc.clab.yaml
 ├── Taskfile.yaml
 ├── containers/
-│   ├── kindest-node-galactic/   # Custom Kind node image (Cilium, Multus, cert-manager, galactic)
+│   ├── kindest-node-galactic/   # Custom Kind node image (Cilium, Multus, cert-manager)
 │   ├── galactic-router/         # galactic-router container built from Go source
 │   └── frr/                     # FRR container built from Alpine edge
 ├── resources/
 │   ├── system/                  # galactic-system namespace provisioning
+│   ├── cni/                     # galactic-cni installer DaemonSet + ConfigMap
 │   ├── fabric/                  # FRR DaemonSet manifests (dfw, iad, sjc)
 │   ├── tenant/                  # galactic-router DaemonSet + vpc10/vpc20 NAD manifests (dfw, iad, sjc)
 │   ├── vpc/                     # vpc10/vpc20 test workload Deployments (dfw, iad, sjc)
@@ -178,27 +179,28 @@ task deploy
 
 ## Tasks
 
-| Task                    | Description                                                        |
-|-------------------------|--------------------------------------------------------------------|
-| `build`                 | Build all container images (node, galactic-router, frr)            |
-| `build:node`            | Build the custom `kindest/node:galactic` image                     |
-| `build:galactic-router` | Build the galactic-router container from Go source                 |
-| `build:frr`             | Build the FRR container from Alpine edge                           |
-| `deploy`                | Build images, apply host sysctls, and deploy the lab               |
-| `deploy:topology`       | Deploy the ContainerLab topology (transit routers + clusters)      |
-| `deploy:images`         | Load container images into Kind clusters                           |
-| `deploy:system`         | Apply the galactic-system namespace and shared RBAC                |
-| `deploy:cni`            | Push a galactic-cni kubeconfig to each worker                      |
-| `deploy:fabric`         | Apply FRR DaemonSets to all clusters                               |
-| `deploy:tenant`         | Apply galactic-router DaemonSets and BGP CRs                       |
-| `deploy:vpc`            | Deploy vpc10 and vpc20 test workloads across all clusters (6 pods) |
-| `destroy`               | Destroy the lab and remove all Kind clusters                       |
-| `reload`                | Full rebuild — destroy then redeploy                               |
-| `inspect`               | Show running nodes and management addresses                        |
-| `graph`                 | Generate a draw.io diagram for the topology                        |
-| `host-setup`            | Apply required host sysctls (IPv6 forwarding, inotify limits)      |
-| `clean`                 | Destroy lab, delete built images, and remove lab artifacts         |
-| `test`                  | Run all verification checks                                        |
+| Task                    | Description                                                           |
+|-------------------------|-----------------------------------------------------------------------|
+| `build`                 | Build all container images (node, galactic-router, galactic-cni, frr) |
+| `build:node`            | Build the custom `kindest/node:galactic` image                        |
+| `build:galactic-router` | Build the galactic-router container from Go source                    |
+| `build:galactic-cni`    | Build the galactic-cni installer image                                |
+| `build:frr`             | Build the FRR container from Alpine edge                              |
+| `deploy`                | Build images, apply host sysctls, and deploy the lab                  |
+| `deploy:topology`       | Deploy the ContainerLab topology (transit routers + clusters)         |
+| `deploy:images`         | Load container images into Kind clusters                              |
+| `deploy:system`         | Apply the galactic-system namespace and shared RBAC                   |
+| `deploy:cni`            | Install the galactic-cni DaemonSet on each cluster                    |
+| `deploy:fabric`         | Apply FRR DaemonSets to all clusters                                  |
+| `deploy:tenant`         | Apply galactic-router DaemonSets and BGP CRs                          |
+| `deploy:vpc`            | Deploy vpc10 and vpc20 test workloads across all clusters (6 pods)    |
+| `destroy`               | Destroy the lab and remove all Kind clusters                          |
+| `reload`                | Full rebuild — destroy then redeploy                                  |
+| `inspect`               | Show running nodes and management addresses                           |
+| `graph`                 | Generate a draw.io diagram for the topology                           |
+| `host-setup`            | Apply required host sysctls (IPv6 forwarding, inotify limits)         |
+| `clean`                 | Destroy lab, delete built images, and remove lab artifacts            |
+| `test`                  | Run all verification checks                                           |
 
 ## Verification
 

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -20,9 +20,10 @@ tasks:
       - task: "build:node"
       - task: "build:frr"
       - task: "build:galactic-router"
+      - task: "build:galactic-cni"
 
   "build:node":
-    desc: Build the Kind node image with the galactic CNI plugin
+    desc: Build the Kind node image (Cilium, Multus, CNI plugin bins)
     cmds:
       - docker build --network=host -t kindest/node:galactic -f containers/kindest-node-galactic/Dockerfile ../..
 
@@ -37,6 +38,11 @@ tasks:
     desc: Build the galactic-router container image
     cmds:
       - docker build --network=host -t galactic-router:latest -f containers/galactic-router/Dockerfile ../..
+
+  "build:galactic-cni":
+    desc: Build the galactic-cni installer image
+    cmds:
+      - docker build --network=host -t galactic-cni:latest -f ../../containers/galactic/Dockerfile ../..
 
   deploy:
     desc: Build images and deploy the full lab end-to-end
@@ -99,6 +105,14 @@ tasks:
         vars: {IMAGE: galactic-router:latest, NODE: sjc-worker}
       - task: load-image
         vars: {IMAGE: galactic-router:latest, NODE: dfw-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: iad-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: iad-worker-control}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: sjc-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: dfw-worker}
 
   "deploy:system":
     desc: Apply the galactic-system namespace and shared RBAC to all clusters
@@ -106,7 +120,7 @@ tasks:
       - ./scripts/deploy-system.sh
 
   "deploy:cni":
-    desc: Push a galactic-cni kubeconfig to each worker
+    desc: Install the galactic-cni DaemonSet on each cluster
     cmds:
       - ./scripts/deploy-cni.sh
 
@@ -224,6 +238,7 @@ tasks:
       - task: destroy
       - docker rmi kindest/node:galactic || true
       - docker rmi galactic-router:latest || true
+      - docker rmi galactic-cni:latest || true
       - docker rmi {{.FRR_IMAGE}} || true
       - rm -rf clab-{{.LAB}} build/
       - rm -f dfw.kubeconfig sjc.kubeconfig iad.kubeconfig

--- a/deploy/containerlab/containers/kindest-node-galactic/Dockerfile
+++ b/deploy/containerlab/containers/kindest-node-galactic/Dockerfile
@@ -1,11 +1,5 @@
 ARG KINDEST_VER=v1.36.1
 
-FROM golang:1.26 AS builder
-WORKDIR /src
-COPY . .
-RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/galactic-cni cmd/galactic-cni/main.go
-
 FROM kindest/node:${KINDEST_VER}
 
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
@@ -18,7 +12,6 @@ RUN apt-get update \
 
 WORKDIR /galactic
 
-COPY --from=builder /src/bin/galactic-cni ./bin/galactic-cni
 COPY deploy/containerlab/resources/ ./resources/
 COPY --chmod=0755 deploy/containerlab/containers/kindest-node-galactic/scripts/ ./scripts/
 

--- a/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
+++ b/deploy/containerlab/containers/kindest-node-galactic/scripts/install.sh
@@ -55,25 +55,9 @@ else # worker
   done
 
   # CNI Plugins
+  # (galactic-cni and host-device are installed by the galactic-cni
+  # DaemonSet -- see scripts/deploy-cni.sh -- not baked into this image.)
   curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGIN_VERSION}.tgz" |tar xvfz - -C /opt/cni/bin
-
-  # Galactic CNI plugin and agent
-  # Install the binary under a .bin suffix and front it with a wrapper that
-  # exports NODE_NAME and GALACTIC_CNI_NODE_NAME from the container hostname,
-  # and points KUBECONFIG at the file deploy-cni.sh pushes at runtime once
-  # the cluster and RBAC exist. CNI binaries are exec'd directly by the
-  # kubelet and do not inherit NODE_NAME from the pod downward API; in Kind
-  # the container hostname equals the Kubernetes node name.
-  install -m 0755 /galactic/bin/galactic-cni /opt/cni/bin/galactic-cni.bin
-  install -m 0755 /galactic/bin/galactic-cni /usr/local/bin/galactic-cni
-  cat > /opt/cni/bin/galactic-cni <<'EOF'
-#!/bin/sh
-export NODE_NAME=$(hostname)
-export GALACTIC_CNI_NODE_NAME=$(hostname)
-export KUBECONFIG=/etc/galactic/kubeconfig
-exec /opt/cni/bin/galactic-cni.bin "$@"
-EOF
-  chmod 0755 /opt/cni/bin/galactic-cni
 
   # Bring up the transit-facing data-plane interface
   ip link set dev eth1 up

--- a/deploy/containerlab/resources/cni/configmap.yaml
+++ b/deploy/containerlab/resources/cni/configmap.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: galactic-cni-install
+  namespace: galactic-system
+data:
+  install.sh: |-
+    #!/bin/sh
+    # Installs the galactic-cni and host-device binaries onto the host CNI
+    # bin dir, and maintains a kubeconfig the binaries use at exec time.
+    # CNI plugins are exec'd by the kubelet directly on the node, outside
+    # this pod's cgroup, so they cannot read this pod's mounted
+    # ServiceAccount token or in-cluster config -- everything they need
+    # (kubeconfig, node name) must be written to files on the host.
+    #
+    # Run as `install.sh install` (initContainer, one-shot) then
+    # `install.sh refresh` (main container, loops forever) -- see
+    # daemonset.yaml.
+    set -eu
+
+    HOST_CNI_BIN_DIR=/opt/cni/bin
+    HOST_ETC_DIR=/etc/galactic
+    CNI_BIN_DIR="/host${HOST_CNI_BIN_DIR}"
+    ETC_DIR="/host${HOST_ETC_DIR}"
+    STATE_DIR=/host/var/run/galactic-cni
+    SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+    REFRESH_INTERVAL=${REFRESH_INTERVAL:-300}
+
+    log() { echo "[galactic-cni-install] $*"; }
+
+    # install_file SRC DEST MODE
+    # Copies SRC to a temp file in DEST's directory and renames it into
+    # place so the kubelet never execs a partially-written binary.
+    install_file() {
+      tmp="${2}.tmp.$$"
+      cp -f "$1" "${tmp}"
+      chmod "$3" "${tmp}"
+      mv -f "${tmp}" "$2"
+    }
+
+    install_binaries() {
+      mkdir -p "${CNI_BIN_DIR}" "${STATE_DIR}"
+      chmod 1777 "${STATE_DIR}"
+      install_file /galactic-cni "${CNI_BIN_DIR}/galactic-cni.bin" 0755
+      install_file /host-device "${CNI_BIN_DIR}/host-device" 0755
+
+      # Wrapper the kubelet execs directly: exports the node name (read
+      # from the downward API, not hostname -- hostname isn't guaranteed
+      # to equal the Kubernetes node name outside of Kind) and points
+      # KUBECONFIG at the file write_kubeconfig maintains below.
+      wrapper="${CNI_BIN_DIR}/galactic-cni.tmp.$$"
+      cat > "${wrapper}" <<EOF
+    #!/bin/sh
+    export GALACTIC_CNI_NODE_NAME="${NODE_NAME}"
+    export KUBECONFIG="${HOST_ETC_DIR}/kubeconfig"
+    exec "${HOST_CNI_BIN_DIR}/galactic-cni.bin" "\$@"
+    EOF
+      chmod 0755 "${wrapper}"
+      mv -f "${wrapper}" "${CNI_BIN_DIR}/galactic-cni"
+    }
+
+    # write_kubeconfig regenerates the host-side kubeconfig from this pod's
+    # mounted ServiceAccount token. The kubelet auto-refreshes that token
+    # in place before it expires, so re-running this on an interval keeps
+    # the host copy valid for the life of the node.
+    write_kubeconfig() {
+      mkdir -p "${ETC_DIR}"
+      install_file "${SA_DIR}/ca.crt" "${ETC_DIR}/ca.crt" 0644
+
+      token=$(cat "${SA_DIR}/token")
+      # Bracket the host if it's an IPv6 literal (e.g. IPv6-only clusters);
+      # IPv4 hosts and DNS names pass through unchanged.
+      api_host="${KUBERNETES_SERVICE_HOST}"
+      case "${api_host}" in
+        *:*) api_host="[${api_host}]" ;;
+      esac
+      tmp="${ETC_DIR}/kubeconfig.tmp.$$"
+      cat > "${tmp}" <<EOF
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: galactic
+        cluster:
+          server: https://${api_host}:${KUBERNETES_SERVICE_PORT}
+          certificate-authority: ${HOST_ETC_DIR}/ca.crt
+    contexts:
+      - name: galactic
+        context:
+          cluster: galactic
+          user: galactic-cni
+    current-context: galactic
+    users:
+      - name: galactic-cni
+        user:
+          token: ${token}
+    EOF
+      chmod 0600 "${tmp}"
+      mv -f "${tmp}" "${ETC_DIR}/kubeconfig"
+    }
+
+    case "${1:-}" in
+      install)
+        install_binaries
+        write_kubeconfig
+        log "installed galactic-cni on node ${NODE_NAME}"
+        ;;
+      refresh)
+        # Deliberately never removes the installed binaries: doing so on
+        # pod termination would break CNI ADD for any pod scheduled on
+        # this node during a rolling update of this DaemonSet.
+        while true; do
+          sleep "${REFRESH_INTERVAL}"
+          write_kubeconfig
+        done
+        ;;
+      *)
+        echo "usage: $0 {install|refresh}" >&2
+        exit 1
+        ;;
+    esac

--- a/deploy/containerlab/resources/cni/daemonset.yaml
+++ b/deploy/containerlab/resources/cni/daemonset.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-cni
+  namespace: galactic-system
+  labels:
+    app.kubernetes.io/name: galactic-cni
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: galactic-cni
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: galactic-cni
+    spec:
+      serviceAccountName: galactic-cni
+      tolerations:
+        - operator: Exists
+      # Only worker nodes run VPC pods; skip the Kind control-plane nodes so
+      # the galactic-cni:latest image only needs loading onto workers.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      initContainers:
+        - name: install-cni
+          image: galactic-cni:latest
+          imagePullPolicy: Never
+          command: ["/bin/sh", "/scripts/install.sh", "install"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: install-script
+              mountPath: /scripts
+            - name: cni-bin-dir
+              mountPath: /host/opt/cni/bin
+            - name: galactic-etc
+              mountPath: /host/etc/galactic
+            - name: galactic-state
+              mountPath: /host/var/run/galactic-cni
+      containers:
+        - name: credential-refresh
+          image: galactic-cni:latest
+          imagePullPolicy: Never
+          command: ["/bin/sh", "/scripts/install.sh", "refresh"]
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          volumeMounts:
+            - name: install-script
+              mountPath: /scripts
+            - name: galactic-etc
+              mountPath: /host/etc/galactic
+      volumes:
+        - name: install-script
+          configMap:
+            name: galactic-cni-install
+            defaultMode: 0555
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: galactic-etc
+          hostPath:
+            path: /etc/galactic
+            type: DirectoryOrCreate
+        - name: galactic-state
+          hostPath:
+            path: /var/run/galactic-cni
+            type: DirectoryOrCreate

--- a/deploy/containerlab/scripts/deploy-cni.sh
+++ b/deploy/containerlab/scripts/deploy-cni.sh
@@ -1,62 +1,22 @@
 #!/bin/bash
-# deploy-cni.sh — Mint a long-lived token for the galactic-cni ServiceAccount
-# and push a kubeconfig to each worker so galactic-cni can reach the API
-# server. Every pod attach (CNI ADD/DEL) depends on this, not just test VPCs.
-# Requires deploy:system (RBAC) first. The CNI wrapper that points
-# KUBECONFIG at /etc/galactic/kubeconfig is baked into the node image by
-# containers/kindest-node-galactic/scripts/install.sh.
+# deploy-cni.sh — Install the galactic-cni DaemonSet on every cluster. The
+# DaemonSet copies the galactic-cni and host-device binaries onto each
+# node's /opt/cni/bin via a hostPath mount and maintains a kubeconfig built
+# from its own ServiceAccount token, so pod attach (CNI ADD/DEL) works
+# without any manual credential setup. Requires deploy:system (galactic-cni
+# RBAC) and deploy:images (galactic-cni:latest loaded) first.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "${SCRIPT_DIR}/lib.sh"
 
-setup_cni_kubeconfig() {
-  local control_plane="$1"
-  shift
-  local workers=("$@")
-
-  echo "Setting up galactic-cni on ${control_plane}..."
-
-  # Resolve the API server IPv6 address on the Docker bridge.
-  local api_ip
-  api_ip=$(docker inspect "${control_plane}" \
-    --format '{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}' \
-    | head -1)
-
-  # Mint a long-lived token and fetch the CA cert.
-  local token ca_data
-  token=$(docker exec "${control_plane}" \
-    kubectl create token galactic-cni -n galactic-system --duration=87600h)
-  ca_data=$(docker exec "${control_plane}" \
-    kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
-
-  for worker in "${workers[@]}"; do
-    echo "  -> ${worker}"
-    docker exec "${worker}" mkdir -p /etc/galactic
-    cat <<EOF | docker exec -i "${worker}" tee /etc/galactic/kubeconfig > /dev/null
-apiVersion: v1
-kind: Config
-clusters:
-  - name: galactic
-    cluster:
-      server: https://[${api_ip}]:6443
-      certificate-authority-data: ${ca_data}
-contexts:
-  - name: galactic
-    context:
-      cluster: galactic
-      user: galactic-cni
-current-context: galactic
-users:
-  - name: galactic-cni
-    user:
-      token: ${token}
-EOF
-  done
-}
-
-setup_cni_kubeconfig "$(control_plane dfw)" dfw-worker
-setup_cni_kubeconfig "$(control_plane sjc)" sjc-worker
-setup_cni_kubeconfig "$(control_plane iad)" iad-worker iad-worker-control
+for site in dfw sjc iad; do
+  node=$(control_plane "${site}")
+  echo "Installing galactic-cni on ${site}..."
+  copy_to "${node}" cni
+  apply_f "${node}" /galactic/resources/cni/configmap.yaml
+  apply_f "${node}" /galactic/resources/cni/daemonset.yaml
+  docker exec "${node}" kubectl -n galactic-system rollout status daemonset galactic-cni
+done
 
 echo "Done."

--- a/deploy/galactic-cni/configmap.yaml
+++ b/deploy/galactic-cni/configmap.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: galactic-cni-install
+  namespace: galactic-system
+data:
+  install.sh: |-
+    #!/bin/sh
+    # Installs the galactic-cni and host-device binaries onto the host CNI
+    # bin dir, and maintains a kubeconfig the binaries use at exec time.
+    # CNI plugins are exec'd by the kubelet directly on the node, outside
+    # this pod's cgroup, so they cannot read this pod's mounted
+    # ServiceAccount token or in-cluster config -- everything they need
+    # (kubeconfig, node name) must be written to files on the host.
+    #
+    # Run as `install.sh install` (initContainer, one-shot) then
+    # `install.sh refresh` (main container, loops forever) -- see
+    # daemonset.yaml.
+    set -eu
+
+    HOST_CNI_BIN_DIR=/opt/cni/bin
+    HOST_ETC_DIR=/etc/galactic
+    CNI_BIN_DIR="/host${HOST_CNI_BIN_DIR}"
+    ETC_DIR="/host${HOST_ETC_DIR}"
+    STATE_DIR=/host/var/run/galactic-cni
+    SA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
+    REFRESH_INTERVAL=${REFRESH_INTERVAL:-300}
+
+    log() { echo "[galactic-cni-install] $*"; }
+
+    # install_file SRC DEST MODE
+    # Copies SRC to a temp file in DEST's directory and renames it into
+    # place so the kubelet never execs a partially-written binary.
+    install_file() {
+      tmp="${2}.tmp.$$"
+      cp -f "$1" "${tmp}"
+      chmod "$3" "${tmp}"
+      mv -f "${tmp}" "$2"
+    }
+
+    install_binaries() {
+      mkdir -p "${CNI_BIN_DIR}" "${STATE_DIR}"
+      chmod 1777 "${STATE_DIR}"
+      install_file /galactic-cni "${CNI_BIN_DIR}/galactic-cni.bin" 0755
+      install_file /host-device "${CNI_BIN_DIR}/host-device" 0755
+
+      # Wrapper the kubelet execs directly: exports the node name (read
+      # from the downward API, not hostname -- hostname isn't guaranteed
+      # to equal the Kubernetes node name outside of Kind) and points
+      # KUBECONFIG at the file write_kubeconfig maintains below.
+      wrapper="${CNI_BIN_DIR}/galactic-cni.tmp.$$"
+      cat > "${wrapper}" <<EOF
+    #!/bin/sh
+    export GALACTIC_CNI_NODE_NAME="${NODE_NAME}"
+    export KUBECONFIG="${HOST_ETC_DIR}/kubeconfig"
+    exec "${HOST_CNI_BIN_DIR}/galactic-cni.bin" "\$@"
+    EOF
+      chmod 0755 "${wrapper}"
+      mv -f "${wrapper}" "${CNI_BIN_DIR}/galactic-cni"
+    }
+
+    # write_kubeconfig regenerates the host-side kubeconfig from this pod's
+    # mounted ServiceAccount token. The kubelet auto-refreshes that token
+    # in place before it expires, so re-running this on an interval keeps
+    # the host copy valid for the life of the node.
+    write_kubeconfig() {
+      mkdir -p "${ETC_DIR}"
+      install_file "${SA_DIR}/ca.crt" "${ETC_DIR}/ca.crt" 0644
+
+      token=$(cat "${SA_DIR}/token")
+      # Bracket the host if it's an IPv6 literal (e.g. IPv6-only clusters);
+      # IPv4 hosts and DNS names pass through unchanged.
+      api_host="${KUBERNETES_SERVICE_HOST}"
+      case "${api_host}" in
+        *:*) api_host="[${api_host}]" ;;
+      esac
+      tmp="${ETC_DIR}/kubeconfig.tmp.$$"
+      cat > "${tmp}" <<EOF
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: galactic
+        cluster:
+          server: https://${api_host}:${KUBERNETES_SERVICE_PORT}
+          certificate-authority: ${HOST_ETC_DIR}/ca.crt
+    contexts:
+      - name: galactic
+        context:
+          cluster: galactic
+          user: galactic-cni
+    current-context: galactic
+    users:
+      - name: galactic-cni
+        user:
+          token: ${token}
+    EOF
+      chmod 0600 "${tmp}"
+      mv -f "${tmp}" "${ETC_DIR}/kubeconfig"
+    }
+
+    case "${1:-}" in
+      install)
+        install_binaries
+        write_kubeconfig
+        log "installed galactic-cni on node ${NODE_NAME}"
+        ;;
+      refresh)
+        # Deliberately never removes the installed binaries: doing so on
+        # pod termination would break CNI ADD for any pod scheduled on
+        # this node during a rolling update of this DaemonSet.
+        while true; do
+          sleep "${REFRESH_INTERVAL}"
+          write_kubeconfig
+        done
+        ;;
+      *)
+        echo "usage: $0 {install|refresh}" >&2
+        exit 1
+        ;;
+    esac

--- a/deploy/galactic-cni/daemonset.yaml
+++ b/deploy/galactic-cni/daemonset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-cni
+  namespace: galactic-system
+  labels:
+    app.kubernetes.io/name: galactic-cni
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: galactic-cni
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: galactic-cni
+    spec:
+      serviceAccountName: galactic-cni
+      tolerations:
+        - operator: Exists
+      initContainers:
+        - name: install-cni
+          image: ghcr.io/datum-cloud/galactic:latest
+          command: ["/bin/sh", "/scripts/install.sh", "install"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: install-script
+              mountPath: /scripts
+            - name: cni-bin-dir
+              mountPath: /host/opt/cni/bin
+            - name: galactic-etc
+              mountPath: /host/etc/galactic
+            - name: galactic-state
+              mountPath: /host/var/run/galactic-cni
+      containers:
+        - name: credential-refresh
+          image: ghcr.io/datum-cloud/galactic:latest
+          command: ["/bin/sh", "/scripts/install.sh", "refresh"]
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          volumeMounts:
+            - name: install-script
+              mountPath: /scripts
+            - name: galactic-etc
+              mountPath: /host/etc/galactic
+      volumes:
+        - name: install-script
+          configMap:
+            name: galactic-cni-install
+            defaultMode: 0555
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: galactic-etc
+          hostPath:
+            path: /etc/galactic
+            type: DirectoryOrCreate
+        - name: galactic-state
+          hostPath:
+            path: /var/run/galactic-cni
+            type: DirectoryOrCreate

--- a/deploy/galactic-cni/rbac.yaml
+++ b/deploy/galactic-cni/rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-cni
+rules:
+  - apiGroups: ["bgp.miloapis.com"]
+    resources:
+      - bgprouters
+    verbs: ["get", "list"]
+  - apiGroups: ["bgp.miloapis.com"]
+    resources:
+      - bgpadvertisements
+      - bgpvrfinstances
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: galactic-cni
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galactic-cni
+subjects:
+  - kind: ServiceAccount
+    name: galactic-cni
+    namespace: galactic-system

--- a/deploy/galactic-cni/serviceaccount.yaml
+++ b/deploy/galactic-cni/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: galactic-cni
+  namespace: galactic-system


### PR DESCRIPTION
galactic-cni previously had no real deployment path — it was compiled directly into the kindest-node-galactic Kind image and only worked in containerlab, with a script that manually minted a long-lived ServiceAccount token to build its kubeconfig. Add a production DaemonSet, modeled on Calico/Cilium's CNI installers, and rewire containerlab to use it instead of baking the binary into the node.

- Add deploy/galactic-cni/{daemonset,configmap,rbac,serviceaccount}.yaml: an initContainer copies galactic-cni and host-device onto the host via hostPath and writes a wrapper that resolves the node name from the downward API, then a lightweight main container refreshes the kubeconfig from the pod's own ServiceAccount token on an interval
- Bracket IPv6 literals when building the kubeconfig server URL, since KUBERNETES_SERVICE_HOST is an IPv6 address on IPv6-only clusters
- Mirror the manifests into deploy/containerlab/resources/cni with imagePullPolicy: Never and a nodeAffinity excluding control-plane nodes, and rewrite deploy-cni.sh to apply them instead of manually pushing a kubeconfig
- Drop the golang builder stage and CNI install block from the Kind node image and install.sh now that the DaemonSet handles it
- Wire build:galactic-cni and its image load/cleanup into the containerlab Taskfile, and update README/ARCHITECTURE docs