### PR TITLE
fix(containerlab): pin Cosmos CRD SHA instead of deriving from go.mod

### DIFF
--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -16,11 +16,13 @@ NETWORK_SHA=$(awk '/go\.datum\.net\/network/ {print $2}' "${SCRIPT_DIR}/../../..
 NETWORK_CRD_URL="https://raw.githubusercontent.com/datum-cloud/network/${NETWORK_SHA}/config/crd"
 
 # VPC/VPCAttachment CRDs still come from Cosmos — they're owned by the
-# separate companion VPC operator, not part of this migration. Cosmos was
-# never a Go dependency of Galactic for these types (no Go structs are
-# imported — see CLAUDE.md), so there's no go.mod line to pin a SHA from;
-# track Cosmos's main branch instead.
-COSMOS_CRD_URL="https://raw.githubusercontent.com/milo-os/cosmos/main/config/crd"
+# separate companion VPC operator. Unlike datum-cloud/network, nothing in
+# this repo's Go code imports Cosmos (the CNI plugin only reads VPC/
+# VPCAttachment identifiers as plain JSON fields off the NAD), so there's
+# no go.mod pseudo-version to derive a SHA from — pin one explicitly here
+# and bump it by hand when Cosmos's VPC CRD schema changes.
+COSMOS_SHA="1b617fd1bad488cefa48462b9db1587b1108fd96"
+COSMOS_CRD_URL="https://raw.githubusercontent.com/milo-os/cosmos/${COSMOS_SHA}/config/crd"
 
 network_crds=(
   network.datumapis.com_bgpadvertisements.yaml


### PR DESCRIPTION
## Summary
- `go.miloapis.com/cosmos` was fully removed from `go.mod` when BGP CRD types moved to `go.datum.net/network` — nothing in this repo's Go code imports Cosmos anymore (the CNI plugin only reads VPC/VPCAttachment identifiers as plain JSON fields off the NAD).
- `deploy-system.sh`'s `awk`-based `COSMOS_SHA` extraction silently matched nothing, producing a malformed CRD URL. The resulting GitHub 404 page got piped straight into `kubectl apply -f -`, failing with `error validating "STDIN": ... apiVersion not set, kind not set`.
- Pin `COSMOS_SHA` explicitly in the script instead, with a comment explaining why it can't be derived from `go.mod` and that it needs a manual bump if Cosmos's VPC CRD schema changes.

## Test plan
- [x] Verified both `vpc.miloapis.com_vpcs.yaml` and `vpc.miloapis.com_vpcattachments.yaml` fetch and validate (`kubectl apply --dry-run=client`) at the pinned SHA.
- [x] Confirmed the `datum-cloud/network` CRD fetch (unaffected by this change) still works.
- [x] Reproduced the original failure and confirmed this fixes it end-to-end against a running containerlab deployment.