### PR TITLE
Fix/gc cross node orphan detection

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -293,6 +293,7 @@ func runCmd(v *viper.Viper) error {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Namespace: gcNamespace,
+		NodeName:  nodeName,
 		Interval:  gcInterval,
 	}
 	if err := gcRec.SetupWithManager(mgr); err != nil {

--- a/config/router/base/daemonset.yaml
+++ b/config/router/base/daemonset.yaml
@@ -61,3 +61,17 @@ spec:
               memory: 64Mi
             limits:
               memory: 256Mi
+          volumeMounts:
+            # GC (internal/gc) checks whether a container's netns bind-mount
+            # still exists on the host to decide whether shared BGP CRDs/VRFs
+            # are orphaned. Without this mount the container has no
+            # visibility into /var/run/netns at all, so that check always
+            # (and incorrectly) reports every namespace as gone.
+            - name: netns
+              mountPath: /var/run/netns
+              readOnly: true
+      volumes:
+        - name: netns
+          hostPath:
+            path: /var/run/netns
+            type: DirectoryOrCreate

--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -260,18 +260,21 @@ func publishBGPState(
 				Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(podSubnet)},
 				Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community(rtValue)},
 			}
-			if ipamResult != nil || srv6SIDStr != "" {
-				if adv.Annotations == nil {
-					adv.Annotations = make(map[string]string)
-				}
-				// Store the allocated subnet keyed by container ID so cmdDel can look it up.
-				if ipamResult != nil {
-					adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
-				}
-				// Store the End.DT46 SID so galactic-router uses it as the EVPN GWIPAddress.
-				if srv6SIDStr != "" {
-					adv.Annotations[annotationSRv6SID] = srv6SIDStr
-				}
+			if adv.Annotations == nil {
+				adv.Annotations = make(map[string]string)
+			}
+			// Record the netns path this container attached with, so the GC
+			// controller can check whether it still exists rather than
+			// guessing a name from the container ID (see
+			// gc.ContainerNetNSExistsByPath).
+			adv.Annotations[netnsAnnotationKey(args.ContainerID)] = args.Netns
+			// Store the allocated subnet keyed by container ID so cmdDel can look it up.
+			if ipamResult != nil {
+				adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
+			}
+			// Store the End.DT46 SID so galactic-router uses it as the EVPN GWIPAddress.
+			if srv6SIDStr != "" {
+				adv.Annotations[annotationSRv6SID] = srv6SIDStr
 			}
 			return nil
 		})

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -41,6 +41,16 @@ const (
 	// encap routes.
 	annotationSRv6SID = "galactic.datum.net/srv6-sid"
 
+	// annotationNetNS is the BGPAdvertisement annotation key prefix holding
+	// the CNI-provided network namespace path for a container ID. The GC
+	// controller checks whether this exact path still exists to decide if
+	// the container is still live — it cannot reconstruct the path from the
+	// container ID alone, since netns bind-mounts are named by the
+	// runtime's own convention (e.g. containerd's "cni-<uuid>"), which is
+	// unrelated to the container ID. The full key appends a truncated
+	// container ID; see netnsAnnotationKey.
+	annotationNetNS = "galactic.datum.net/netns"
+
 	// annotationContainerIDLen is the number of characters used from a
 	// container ID in annotation keys. Kubernetes limits the name part of an
 	// annotation key to 63 bytes; "allocated-subnet." is 17 bytes, leaving 46

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -235,3 +235,13 @@ func subnetAnnotationKey(containerID string) string {
 	}
 	return fmt.Sprintf("%s.%s", annotationAllocatedSubnet, id)
 }
+
+// netnsAnnotationKey returns the annotation key for storing the network
+// namespace path used by the given container ID. Mirrors subnetAnnotationKey.
+func netnsAnnotationKey(containerID string) string {
+	id := containerID
+	if len(id) > annotationContainerIDLen {
+		id = id[:annotationContainerIDLen]
+	}
+	return fmt.Sprintf("%s.%s", annotationNetNS, id)
+}

--- a/internal/controller/gc_controller.go
+++ b/internal/controller/gc_controller.go
@@ -24,6 +24,7 @@ type GCReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	Namespace string
+	NodeName  string
 	Interval  time.Duration
 }
 
@@ -36,7 +37,7 @@ func (r *GCReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Resu
 	}
 
 	k8s := r.Client
-	result := gc.RunGC(ctx, k8s, r.Namespace)
+	result := gc.RunGC(ctx, k8s, r.Namespace, r.NodeName)
 
 	if result.Errors > 0 {
 		slog.Info("GC: completed with errors",
@@ -65,7 +66,7 @@ func (r *GCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // RunGC runs a single garbage collection pass in the given context.
 // This is the public API for triggering GC from outside the reconciler.
 func (r *GCReconciler) RunGC(ctx context.Context) gc.CleanupResult {
-	return gc.RunGC(ctx, r.Client, r.Namespace)
+	return gc.RunGC(ctx, r.Client, r.Namespace, r.NodeName)
 }
 
 // GCRequest returns a reconcile.Request that triggers the GC reconciler.

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -23,6 +23,11 @@ const (
 	// annotationAllocatedSubnet is the annotation key prefix used by the
 	// CNI plugin to store allocated subnets keyed by container ID.
 	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
+
+	// annotationNetNS is the annotation key prefix used by the CNI plugin
+	// to store the netns path it was invoked with, keyed by container ID.
+	// This is the liveness signal GC uses — see cni.netnsAnnotationKey.
+	annotationNetNS = "galactic.datum.net/netns"
 )
 
 // OrphanedCRD represents a BGP CRD that appears to be orphaned because its
@@ -46,18 +51,50 @@ type CleanupResult struct {
 // %03s is the base62 VPCAttachment. Base62 includes digits and letters.
 var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})([A-Za-z0-9]{3})V$`)
 
-// CollectOrphanedCRDs scans all BGPAdvertisement and BGPVRFInstance CRDs in
-// the given namespace and returns those whose associated container no longer
-// exists on this node.
+// routerNamesForNode returns the names of every BGPRouter in the namespace
+// whose TargetRef points at nodeName. BGPAdvertisement/BGPVRFInstance CRDs
+// are namespace-scoped, not node-scoped — a namespace can hold CRDs created
+// by routers on other nodes (e.g. the tenant and tenant-control roles both
+// watch the same namespace in the containerlab lab), and this node's local
+// kernel/filesystem state (VRFs, /var/run/netns) can only ever confirm or
+// deny liveness for containers that actually ran here. Callers must use this
+// to skip CRDs belonging to other nodes entirely, rather than risk deleting
+// another node's live resources because they look orphaned from here.
+func routerNamesForNode(ctx context.Context, k8s client.Client, namespace, nodeName string) (map[string]struct{}, error) {
+	routerList := &bgpv1alpha1.BGPRouterList{}
+	if err := k8s.List(ctx, routerList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPRouters: %w", err)
+	}
+
+	names := make(map[string]struct{})
+	for _, r := range routerList.Items {
+		if r.Spec.TargetRef.Name == nodeName {
+			names[r.Name] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+// CollectOrphanedCRDs scans BGPAdvertisement and BGPVRFInstance CRDs owned by
+// nodeName's BGPRouter(s) in the given namespace and returns those whose
+// associated container no longer exists on this node.
 //
 // A CRD is considered orphaned when:
-//   - It is a BGPAdvertisement with an allocated-subnet annotation whose
-//     container ID prefix does not correspond to a live network namespace
-//     under /var/run/netns.
+//   - It is a BGPAdvertisement targeting one of nodeName's BGPRouters, with
+//     at least one netns annotation, and NONE of the recorded paths exist
+//     under /var/run/netns. A vpc/vpcAttachment is shared across every pod
+//     that has ever attached to it on this node (pod churn adds a new
+//     annotation entry without removing old ones — see cmdDel in
+//     internal/cni/ops_del.go), so the object is only orphaned once every
+//     container that ever referenced it is gone, not just one.
 //   - It is a BGPVRFInstance whose name matches a BGPAdvertisement that
 //     is itself orphaned (same vpc-vpcattachment name).
-func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace string) ([]OrphanedCRD, error) {
-	// Collect all orphaned BGPAdvertisements first.
+func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]OrphanedCRD, error) {
+	routerNames, err := routerNamesForNode(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return nil, err
+	}
+
 	advList := &bgpv1alpha1.BGPAdvertisementList{}
 	if err := k8s.List(ctx, advList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPAdvertisements: %w", err)
@@ -67,22 +104,45 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace strin
 	orphanedAdvNames := make(map[string]struct{})
 
 	for _, adv := range advList.Items {
-		containerID := findContainerID(&adv)
-		if containerID == "" {
-			// No container ID annotation — skip (might be legacy or
-			// manually created). We cannot determine if it is orphaned.
+		if _, ownedByThisNode := routerNames[adv.Spec.RouterRef.Name]; !ownedByThisNode {
+			// Belongs to a router on another node — not ours to judge.
 			continue
 		}
 
-		if !ContainerNetNSExists(containerID) {
-			orphaned = append(orphaned, OrphanedCRD{
-				Name:        adv.Name,
-				Namespace:   adv.Namespace,
-				Kind:        "BGPAdvertisement",
-				ContainerID: containerID,
-			})
-			orphanedAdvNames[adv.Name] = struct{}{}
+		netnsPaths := collectNetNSPaths(&adv)
+		if len(netnsPaths) == 0 {
+			// No netns annotations — skip (might be legacy or manually
+			// created). We cannot determine if it is orphaned.
+			continue
 		}
+
+		liveContainerID := ""
+		for containerID, netnsPathStr := range netnsPaths {
+			if NetNSExists(netnsPathStr) {
+				liveContainerID = containerID
+				break
+			}
+		}
+		if liveContainerID != "" {
+			// At least one container that attached to this
+			// vpc/vpcAttachment is still alive — not orphaned.
+			continue
+		}
+
+		// None of the recorded containers are alive. Report an arbitrary
+		// one purely for logging context.
+		var anyContainerID string
+		for containerID := range netnsPaths {
+			anyContainerID = containerID
+			break
+		}
+		orphaned = append(orphaned, OrphanedCRD{
+			Name:        adv.Name,
+			Namespace:   adv.Namespace,
+			Kind:        "BGPAdvertisement",
+			ContainerID: anyContainerID,
+		})
+		orphanedAdvNames[adv.Name] = struct{}{}
 	}
 
 	// BGPVRFInstance CRDs share the same name as their corresponding
@@ -147,20 +207,28 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 }
 
 // CollectOrphanedVRFs scans all VRF interfaces on this node and returns the
-// vpc/vpcAttachment pairs for VRFs whose corresponding BGPAdvertisement CRD
-// no longer exists in the given namespace.
+// vpc/vpcAttachment pairs for VRFs whose corresponding BGPAdvertisement CRD,
+// owned by nodeName's BGPRouter(s), no longer exists in the given namespace.
 //
 // A VRF is considered orphaned when:
 //   - Its interface name matches the Galactic VRF naming pattern.
-//   - The derived BGPAdvertisement CRD (name = vpc-vpcattachment) does not
-//     exist in Kubernetes.
-func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace string) ([]string, error) {
+//   - No BGPAdvertisement owned by this node (name = vpc-vpcattachment,
+//     RouterRef pointing at one of nodeName's BGPRouters) exists for it.
+//     Other nodes sharing this namespace may coincidentally reuse the same
+//     vpc-vpcattachment name for their own, unrelated attachment — only
+//     this node's own BGPAdvertisements can vouch for a local VRF.
+func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]string, error) {
 	vrfs, err := vrf.ListVRFLinks()
 	if err != nil {
 		return nil, fmt.Errorf("list VRF links: %w", err)
 	}
 
-	// Build a set of active BGPAdvertisement names for this namespace.
+	routerNames, err := routerNamesForNode(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a set of active BGPAdvertisement names owned by this node.
 	advList := &bgpv1alpha1.BGPAdvertisementList{}
 	if err := k8s.List(ctx, advList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPAdvertisements: %w", err)
@@ -168,6 +236,9 @@ func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace strin
 
 	activeAdvNames := make(map[string]struct{}, len(advList.Items))
 	for _, adv := range advList.Items {
+		if _, ownedByThisNode := routerNames[adv.Spec.RouterRef.Name]; !ownedByThisNode {
+			continue
+		}
 		activeAdvNames[adv.Name] = struct{}{}
 	}
 
@@ -230,11 +301,13 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 
 // RunGC performs a full garbage collection pass: removes orphaned BGP CRDs
 // and orphaned VRF interfaces. Returns a summary of what was cleaned up.
-func RunGC(ctx context.Context, k8s client.Client, namespace string) CleanupResult {
+// nodeName scopes the pass to CRDs owned by this node's BGPRouter(s) — see
+// routerNamesForNode.
+func RunGC(ctx context.Context, k8s client.Client, namespace, nodeName string) CleanupResult {
 	var result CleanupResult
 
 	// Phase 1: Remove orphaned BGP CRDs.
-	orphans, err := CollectOrphanedCRDs(ctx, k8s, namespace)
+	orphans, err := CollectOrphanedCRDs(ctx, k8s, namespace, nodeName)
 	if err != nil {
 		slog.Error("GC: failed to collect orphaned CRDs", "err", err)
 		result.Errors++
@@ -246,7 +319,7 @@ func RunGC(ctx context.Context, k8s client.Client, namespace string) CleanupResu
 	}
 
 	// Phase 2: Remove orphaned VRF interfaces.
-	orphanedVRFs, err := CollectOrphanedVRFs(ctx, k8s, namespace)
+	orphanedVRFs, err := CollectOrphanedVRFs(ctx, k8s, namespace, nodeName)
 	if err != nil {
 		slog.Error("GC: failed to collect orphaned VRFs", "err", err)
 		result.Errors++
@@ -267,20 +340,24 @@ func RunGC(ctx context.Context, k8s client.Client, namespace string) CleanupResu
 	return result
 }
 
-// findContainerID extracts the container ID prefix from a BGPAdvertisement's
-// allocated-subnet annotations. Returns the first container ID prefix found.
-func findContainerID(adv *bgpv1alpha1.BGPAdvertisement) string {
+// collectNetNSPaths extracts every (containerID, netnsPath) pair recorded on
+// a BGPAdvertisement's netns annotations — one per container that has ever
+// attached to this vpc/vpcAttachment on this node. Pod churn adds a new
+// annotation entry without removing old ones (see cmdDel in
+// internal/cni/ops_del.go), so an object can carry several.
+func collectNetNSPaths(adv *bgpv1alpha1.BGPAdvertisement) map[string]string {
+	paths := make(map[string]string)
 	if adv.Annotations == nil {
-		return ""
+		return paths
 	}
-	prefix := annotationAllocatedSubnet + "."
-	for key := range adv.Annotations {
+	prefix := annotationNetNS + "."
+	for key, value := range adv.Annotations {
 		if strings.HasPrefix(key, prefix) {
-			// The key format is "galactic.datum.net/allocated-subnet.<containerID-prefix>"
-			return key[len(prefix):]
+			// The key format is "galactic.datum.net/netns.<containerID-prefix>"
+			paths[key[len(prefix):]] = value
 		}
 	}
-	return ""
+	return paths
 }
 
 // parseVRFName extracts the base62-encoded VPC and VPCAttachment from a

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -19,16 +19,16 @@ const (
 	testEth0         = "eth0"
 )
 
-func TestFindContainerID(t *testing.T) {
+func TestCollectNetNSPaths(t *testing.T) {
 	tests := []struct {
-		name   string
-		adv    *bgpv1alpha1.BGPAdvertisement
-		wantID string
+		name string
+		adv  *bgpv1alpha1.BGPAdvertisement
+		want map[string]string
 	}{
 		{
-			name:   "nil annotations",
-			adv:    &bgpv1alpha1.BGPAdvertisement{},
-			wantID: "",
+			name: "nil annotations",
+			adv:  &bgpv1alpha1.BGPAdvertisement{},
+			want: map[string]string{},
 		},
 		{
 			name: "empty annotations",
@@ -37,10 +37,10 @@ func TestFindContainerID(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			wantID: "",
+			want: map[string]string{},
 		},
 		{
-			name: "no allocated-subnet annotation",
+			name: "no netns annotation",
 			adv: &bgpv1alpha1.BGPAdvertisement{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -48,47 +48,47 @@ func TestFindContainerID(t *testing.T) {
 					},
 				},
 			},
-			wantID: "",
+			want: map[string]string{},
 		},
 		{
-			name: "single allocated-subnet annotation",
+			name: "single netns annotation",
 			adv: &bgpv1alpha1.BGPAdvertisement{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"galactic.datum.net/allocated-subnet.abc123def456": "fd00:10:ff01::1234/80",
+						"galactic.datum.net/netns.abc123def456": "/var/run/netns/cni-1234",
 					},
 				},
 			},
-			wantID: "abc123def456",
+			want: map[string]string{"abc123def456": "/var/run/netns/cni-1234"},
 		},
 		{
-			name: "multiple annotations returns one",
+			name: "multiple annotations returns all",
 			adv: &bgpv1alpha1.BGPAdvertisement{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"galactic.datum.net/allocated-subnet.aaa111bbb222": "fd00:10:ff01::1234/80",
-						"galactic.datum.net/allocated-subnet.ccc333ddd444": "fd00:10:ff01::5678/80",
-						"galactic.datum.net/srv6-sid":                      "2001:db8::1234:5678",
+						"galactic.datum.net/netns.aaa111bbb222": "/var/run/netns/cni-aaa",
+						"galactic.datum.net/netns.ccc333ddd444": "/var/run/netns/cni-ccc",
+						"galactic.datum.net/srv6-sid":           "2001:db8::1234:5678",
 					},
 				},
 			},
-			wantID: "", // non-deterministic — map iteration order varies
+			want: map[string]string{
+				"aaa111bbb222": "/var/run/netns/cni-aaa",
+				"ccc333ddd444": "/var/run/netns/cni-ccc",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findContainerID(tt.adv)
-			if tt.name == "multiple annotations returns one" {
-				// Multiple allocated-subnet annotations — map iteration
-				// order is non-deterministic. Accept any matching prefix.
-				if got != "" && got != "aaa111bbb222" && got != "ccc333ddd444" {
-					t.Errorf("findContainerID() = %q, want one of the allocated-subnet container IDs", got)
-				}
-				return
+			got := collectNetNSPaths(tt.adv)
+			if len(got) != len(tt.want) {
+				t.Fatalf("collectNetNSPaths() = %v, want %v", got, tt.want)
 			}
-			if got != tt.wantID {
-				t.Errorf("findContainerID() = %q, want %q", got, tt.wantID)
+			for id, path := range tt.want {
+				if got[id] != path {
+					t.Errorf("collectNetNSPaths()[%q] = %q, want %q", id, got[id], path)
+				}
 			}
 		})
 	}

--- a/internal/gc/netns.go
+++ b/internal/gc/netns.go
@@ -13,40 +13,19 @@ import (
 
 const netnsPath = "/var/run/netns"
 
-// ContainerNetNSExists checks whether a network namespace for the given
-// container ID is still present on this node. It does this by listing the
-// bind-mounts under /var/run/netns and checking whether any of them is
-// named after the container ID prefix.
+// NetNSExists checks whether the network namespace at the given path (as
+// recorded by the CNI plugin at ADD time — see cni.netnsAnnotationKey) is
+// still present on this node.
 //
-// CNI plugins (and the kubelet) create netns bind-mounts under
-// /var/run/netns/<container-id-prefix>. When the container is fully
-// torn down, these mounts are removed.
-func ContainerNetNSExists(containerID string) bool {
-	// Use the full container ID and the first 46 characters (same as
-	// annotationContainerIDLen used in the CNI plugin for annotation keys).
-	id := containerID
-	if len(id) > 46 {
-		id = id[:46]
-	}
-
-	entries, err := os.ReadDir(netnsPath)
-	if err != nil {
-		// If we can't read /var/run/netns, assume the namespace
-		// does not exist (we cannot prove it does).
+// This cannot be reconstructed from a container ID: netns bind-mounts are
+// named by the container runtime's own convention (e.g. containerd's
+// "cni-<uuid>"), which has no relationship to the container ID the CNI
+// plugin receives. The exact path used at ADD time must be recorded and
+// checked verbatim.
+func NetNSExists(netnsPathStr string) bool {
+	if netnsPathStr == "" {
 		return false
 	}
-
-	for _, entry := range entries {
-		if entry.Name() == id {
-			return true
-		}
-	}
-	return false
-}
-
-// ContainerNetNSExistsByPath checks whether a network namespace at the
-// given path still exists. Returns true if the path is accessible.
-func ContainerNetNSExistsByPath(netnsPathStr string) bool {
 	_, err := os.Stat(filepath.Join(netnsPath, filepath.Base(netnsPathStr)))
 	return err == nil
 }


### PR DESCRIPTION
GC's orphan check (ContainerNetNSExists) reconstructed a netns bind-mount name from the container ID and looked for it under /var/run/netns. Real netns mounts are named by the container runtime's own convention (e.g. containerd's "cni-<uuid>"), which has no relationship to the container ID CNI receives — so the check always returned false, and every live VPC's shared BGPAdvertisement/BGPVRFInstance/kernel VRF got deleted as "orphaned" on GC's very first pass (5 minutes after deploy), breaking pod-to-pod connectivity across sites.

The CNI plugin now records the exact netns path it was invoked with (args.Netns) as a new annotation at attach time; GC checks that exact path via NetNSExists instead of guessing. A vpc/vpcAttachment can carry several such entries from pod churn (cmdDel never deletes the shared annotation, by design — see internal/cni/ops_del.go), so it's only orphaned once none of the recorded paths exist, not just one.

Also adds the hostPath volume mount for /var/run/netns to the router DaemonSet, which was missing entirely — without it the container has no filesystem visibility into the host's netns state under any naming scheme.