### PR TITLE
chore: Switch containerlab VPC CRDs to datum-cloud/cloud

### DIFF
--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -215,7 +215,7 @@ task test  # automated: bgp-transit, bgp-fabric, bgp-peers, srv6, evpn
 
 - All three Kind clusters use `disableDefaultCNI: true`. Cilium and Multus are installed
   by `scripts/deploy-cni.sh` (task `deploy:cni`); the BGP (datum-cloud/network) and VPC
-  (Cosmos) CRDs are installed by `scripts/deploy-system.sh` (task `deploy:system`).
+  (datum-cloud/cloud) CRDs are installed by `scripts/deploy-system.sh` (task `deploy:system`).
   Neither is baked into the `kindest/node:galactic` image.
 - Worker–TR links use numbered IPv6 subnets (/64) with eBGP peering.
 - Cilium's iptables rules block BGP by default; the worker bootstrap script

--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # deploy-system.sh — Install BGP CRDs (datum-cloud/network) and VPC CRDs
-# (Cosmos), then apply the galactic-system namespace and shared RBAC
-# (galactic-cni, galactic-router) to every cluster. The namespace and
+# (datum-cloud/cloud), then apply the galactic-system namespace and shared
+# RBAC (galactic-cni, galactic-router) to every cluster. The namespace and
 # ServiceAccount/RBAC manifests are applied straight from the repo's
 # config/ — the same ones used in production — so the lab never forks them.
 set -euo pipefail
@@ -15,14 +15,13 @@ source "${SCRIPT_DIR}/lib.sh"
 NETWORK_SHA=$(awk '/go\.datum\.net\/network/ {print $2}' "${SCRIPT_DIR}/../../../go.mod" | sed 's/.*-//')
 NETWORK_CRD_URL="https://raw.githubusercontent.com/datum-cloud/network/${NETWORK_SHA}/config/crd"
 
-# VPC/VPCAttachment CRDs still come from Cosmos — they're owned by the
-# separate companion VPC operator. Unlike datum-cloud/network, nothing in
-# this repo's Go code imports Cosmos (the CNI plugin only reads VPC/
-# VPCAttachment identifiers as plain JSON fields off the NAD), so there's
-# no go.mod pseudo-version to derive a SHA from — pin one explicitly here
-# and bump it by hand when Cosmos's VPC CRD schema changes.
-COSMOS_SHA="1b617fd1bad488cefa48462b9db1587b1108fd96"
-COSMOS_CRD_URL="https://raw.githubusercontent.com/milo-os/cosmos/${COSMOS_SHA}/config/crd"
+# VPC/VPCAttachment CRDs come from the separate companion VPC operator,
+# datum-cloud/cloud. Nothing in this repo's Go code imports it (the CNI
+# plugin only reads VPC/VPCAttachment identifiers as plain JSON fields off
+# the NAD), so there's no go.mod pseudo-version to derive a SHA from — pin
+# one explicitly here and bump it by hand when the VPC CRD schema changes.
+CLOUD_SHA="71a4f0f9c12166a758da4e2b90c80a17709804f2"
+CLOUD_CRD_URL="https://raw.githubusercontent.com/datum-cloud/cloud/${CLOUD_SHA}/config/crd"
 
 network_crds=(
   network.datumapis.com_bgpadvertisements.yaml
@@ -32,9 +31,9 @@ network_crds=(
   network.datumapis.com_bgpvrfinstances.yaml
 )
 
-cosmos_crds=(
-  vpc.miloapis.com_vpcs.yaml
-  vpc.miloapis.com_vpcattachments.yaml
+cloud_crds=(
+  cloud.datumapis.com_vpcs.yaml
+  cloud.datumapis.com_vpcattachments.yaml
 )
 
 for site in dfw sjc iad; do
@@ -45,8 +44,8 @@ for site in dfw sjc iad; do
   for crd in "${network_crds[@]}"; do
     curl -sL "${NETWORK_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -
   done
-  for crd in "${cosmos_crds[@]}"; do
-    curl -sL "${COSMOS_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -
+  for crd in "${cloud_crds[@]}"; do
+    curl -sL "${CLOUD_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -
   done
 
   copy_config "${node}"

--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -19,7 +19,7 @@ GoBGP server. GoBGP distributes the path to a BGP route reflector, enabling pods
 on different nodes or clusters to reach each other via SRv6-encapsulated traffic.
 
 VPC and VPCAttachment CRDs are owned by a separate companion operator
-(`go.miloapis.com/cosmos`). Galactic receives pre-populated identifiers through the
+(`go.datum.net/cloud`). Galactic receives pre-populated identifiers through the
 CNI config and acts on them. `galactic-router` reconciles BGP CRDs
 (`go.datum.net/network`) directly — no gRPC sidecar, no provider CRD lifecycle.
 

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -19,16 +19,10 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-const (
-	// annotationAllocatedSubnet is the annotation key prefix used by the
-	// CNI plugin to store allocated subnets keyed by container ID.
-	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
-
-	// annotationNetNS is the annotation key prefix used by the CNI plugin
-	// to store the netns path it was invoked with, keyed by container ID.
-	// This is the liveness signal GC uses — see cni.netnsAnnotationKey.
-	annotationNetNS = "galactic.datum.net/netns"
-)
+// annotationNetNS is the annotation key prefix used by the CNI plugin
+// to store the netns path it was invoked with, keyed by container ID.
+// This is the liveness signal GC uses — see cni.netnsAnnotationKey.
+const annotationNetNS = "galactic.datum.net/netns"
 
 // OrphanedCRD represents a BGP CRD that appears to be orphaned because its
 // associated container is no longer present on the node.
@@ -60,7 +54,9 @@ var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})([A-Za-z0-9]{3})V$`)
 // deny liveness for containers that actually ran here. Callers must use this
 // to skip CRDs belonging to other nodes entirely, rather than risk deleting
 // another node's live resources because they look orphaned from here.
-func routerNamesForNode(ctx context.Context, k8s client.Client, namespace, nodeName string) (map[string]struct{}, error) {
+func routerNamesForNode(
+	ctx context.Context, k8s client.Client, namespace, nodeName string,
+) (map[string]struct{}, error) {
 	routerList := &bgpv1alpha1.BGPRouterList{}
 	if err := k8s.List(ctx, routerList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPRouters: %w", err)


### PR DESCRIPTION
## Summary
- The VPC/VPCAttachment companion operator moved from `milo-os/cosmos` to `datum-cloud/cloud`, changing the CRD API group from `vpc.miloapis.com` to `cloud.datumapis.com`.
- Updates `deploy/containerlab/scripts/deploy-system.sh` to pin a `datum-cloud/cloud` commit SHA and fetch the renamed CRD manifests instead of the old Cosmos ones.
- Updates matching references in `deploy/containerlab/README.md` and `docs/agents/ARCHITECTURE.md`.

## Test plan
- [ ] Run `task deploy:system` (or equivalent containerlab bring-up) and confirm `vpcs.cloud.datumapis.com` / `vpcattachments.cloud.datumapis.com` CRDs install cleanly on all three clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)