### PR TITLE
chore: Make CNI and tenant router node selection opt-in

### DIFF
--- a/config/cni/daemonset.yaml
+++ b/config/cni/daemonset.yaml
@@ -18,7 +18,8 @@ spec:
       tolerations:
         - operator: Exists
       # Only worker nodes run VPC pods; galactic-cni has nothing to do on
-      # control-plane nodes.
+      # control-plane nodes. Opt-in only so new node types (GPU, monitoring,
+      # etc.) don't accidentally pick up the CNI.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -26,6 +27,10 @@ spec:
               - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane
                     operator: DoesNotExist
+                  - key: galactic.datum.net/node
+                    operator: In
+                    values:
+                      - edge
       initContainers:
         - name: install-cni
           image: ghcr.io/datum-cloud/galactic:latest

--- a/config/router/tenant/daemonset-patch.yaml
+++ b/config/router/tenant/daemonset-patch.yaml
@@ -13,10 +13,12 @@ spec:
       labels:
         app.kubernetes.io/name: galactic-router-tenant
     spec:
-      # Tenant pods run on every worker; skip Kubernetes control-plane nodes
-      # (no VPC pods to serve there, same as galactic-cni) and skip nodes
-      # labeled for the tenant-control (route-reflector) role so the two
-      # roles never double-schedule onto the same node.
+      # Tenant pods run on worker nodes explicitly labeled for it;
+      # opt-in only so new node types (GPU, monitoring, etc.) don't
+      # accidentally pick up the tenant. Also excludes Kubernetes
+      # control-plane nodes outright — the base DaemonSet's blanket
+      # toleration would otherwise let it land there if one ever
+      # carried the galactic.datum.net/node=edge label.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -25,9 +27,9 @@ spec:
                   - key: node-role.kubernetes.io/control-plane
                     operator: DoesNotExist
                   - key: galactic.datum.net/node
-                    operator: NotIn
+                    operator: In
                     values:
-                      - control
+                      - edge
       containers:
         - name: galactic-router
           env:


### PR DESCRIPTION
## Summary
- Switch `config/cni/daemonset.yaml` and `config/router/tenant/daemonset-patch.yaml` node affinity from excluding control/control-plane nodes to requiring the `galactic.datum.net/node: edge` label
- Prevents new node types (GPU, monitoring, etc.) from silently picking up `galactic-cni` or the tenant `galactic-router` role

## Test plan
- [ ] `kubectl apply -k config/` on a cluster with nodes labeled `galactic.datum.net/node: edge` and confirm both DaemonSets schedule only there
- [ ] Confirm nodes without the label (including any new/unlabeled worker) do not run either DaemonSet

🤖 Generated with [Claude Code](https://claude.com/claude-code)