### PR TITLE
fix: Move galactic-cni's host kubeconfig off /etc for Talos

### DIFF
--- a/config/cni/configmap.yaml
+++ b/config/cni/configmap.yaml
@@ -19,7 +19,10 @@ data:
     set -eu
 
     HOST_CNI_BIN_DIR=/opt/cni/bin
-    HOST_ETC_DIR=/etc/galactic
+    # /var/lib rather than /etc: on immutable-root distros (e.g. Talos)
+    # only /var (and a handful of explicitly whitelisted /etc, /opt
+    # paths) is writable without a host-level extraMounts entry.
+    HOST_ETC_DIR=/var/lib/galactic
     CNI_BIN_DIR="/host${HOST_CNI_BIN_DIR}"
     ETC_DIR="/host${HOST_ETC_DIR}"
     STATE_DIR=/host/var/run/galactic-cni

--- a/config/cni/daemonset.yaml
+++ b/config/cni/daemonset.yaml
@@ -55,7 +55,7 @@ spec:
             - name: cni-bin-dir
               mountPath: /host/opt/cni/bin
             - name: galactic-etc
-              mountPath: /host/etc/galactic
+              mountPath: /host/var/lib/galactic
             - name: galactic-state
               mountPath: /host/var/run/galactic-cni
       containers:
@@ -75,7 +75,7 @@ spec:
             - name: install-script
               mountPath: /scripts
             - name: galactic-etc
-              mountPath: /host/etc/galactic
+              mountPath: /host/var/lib/galactic
       volumes:
         - name: install-script
           configMap:
@@ -87,7 +87,7 @@ spec:
             type: DirectoryOrCreate
         - name: galactic-etc
           hostPath:
-            path: /etc/galactic
+            path: /var/lib/galactic
             type: DirectoryOrCreate
         - name: galactic-state
           hostPath:

--- a/deploy/containerlab/docs/vpc.md
+++ b/deploy/containerlab/docs/vpc.md
@@ -140,8 +140,8 @@ docker exec dfw-control-plane kubectl exec -n vpc "${DFW_VPC10_POD}" -- ping -6 
 Check that `galactic-cni` can reach the API server:
 
 ```bash
-docker exec dfw-worker cat /etc/galactic/kubeconfig
-docker exec dfw-worker kubectl --kubeconfig /etc/galactic/kubeconfig get ns
+docker exec dfw-worker cat /var/lib/galactic/kubeconfig
+docker exec dfw-worker kubectl --kubeconfig /var/lib/galactic/kubeconfig get ns
 ```
 
 ### BGPAdvertisements not created

--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -355,6 +355,7 @@ Runs on every PR and push to `main`. Two tiers:
 - **`cmdDel` does not tear down shared kernel/CRD state.** By design (see Key Design Decisions above) — cleanup of VRF, veth/tap, routes, SRv6 ingress, and BGP CRDs is deferred to `galactic-router`'s asynchronous GC controller, not performed synchronously in `cmdDel`.
 - **`internal/plumbing/vrf` has no unit tests.** It requires `CAP_NET_ADMIN` and a real kernel. `internal/cni` and `internal/plumbing/srv6` do now have unit coverage for their pure-logic paths. `internal/plumbing/intf` is fully unit-testable (pure functions only). Kernel-path coverage otherwise comes from the e2e suite (`task test:e2e`).
 - **`--mode=transit` is unimplemented.** Accepted by CLI/env validation, but `runCmd` returns an error at startup ("mode=transit is not yet supported").
+- **`galactic-cni`'s install DaemonSet requires two writable host paths.** `config/cni/daemonset.yaml`'s `install.sh` (`config/cni/configmap.yaml`) writes the CNI binaries to `/opt/cni/bin` and a kubeconfig it maintains for kubelet-exec'd CNI invocations to `/var/lib/galactic` (chosen over `/etc/galactic` specifically so it lands under `/var`, the one path immutable-root distros like Talos allow hostPath writes to without a host-level `extraMounts` entry). `/opt/cni/bin` is fixed by the CNI/kubelet plugin-discovery convention and can't be relocated by this DaemonSet alone — on Talos it needs its own `extraMounts` entry in the machine config if it isn't writable by default.
 
 ---
 


### PR DESCRIPTION
## Summary

`galactic-cni`'s installer DaemonSet writes a kubeconfig and CA cert to the host at `/etc/galactic`, so the kubelet-exec'd CNI binary (which runs outside any pod's cgroup and can't read the pod's own ServiceAccount token) has something to authenticate with. On Talos Linux, the host root filesystem is immutable — only `/var` is writable via `hostPath` without an explicit `extraMounts` entry in the machine config — so `mkdir /etc/galactic` fails immediately and the CNI DaemonSet never comes up.

This moves that state to `/var/lib/galactic`, which sits on Talos's writable EPHEMERAL partition (`/var`) with no machine-config changes required. The CNI binary path, `/opt/cni/bin`, is untouched — it already matches Talos's expected location and isn't affected by this bug.

## Test plan

- [x] `kubectl kustomize config/cni` builds cleanly with the new path in both the initContainer and main container mounts, and the `galactic-etc` volume's `hostPath.path`
- [x] `task lint` (golangci-lint + yamlfmt) passes
- [ ] Live deploy against a Talos cluster (not available in this environment)