### PR TITLE
Revert "feat: Pull galactic-cni/galactic-router from GHCR in containerlab lab"

### DIFF
--- a/deploy/containerlab/AGENTS.md
+++ b/deploy/containerlab/AGENTS.md
@@ -4,9 +4,9 @@
 
 - **YAML extensions**: Always use `.yaml`, never `.yml`.
 - **FRR image pinning**: Taskfile and DaemonSets pin FRR to `10.6.1`. Transit routers in `gvpc.clab.yaml` default to `frrouting/frr:latest` — this is a known mismatch (see review findings).
-- **Image loading**: The Kind node image and FRR are still built locally and loaded with `ctr --namespace k8s.io images import` (not `kind load docker-image`) due to containerd v2 incompatibility.
+- **Image loading**: Uses `ctr --namespace k8s.io images import` (not `kind load docker-image`) due to containerd v2 incompatibility.
 - **iad-worker-control**: Created as `iad-worker2` in the topology, renamed post-deploy via `deploy:rename-control`. The Kind config sets the hostname via `kubeadmConfigPatches`. Runs the galactic-router route reflector (RR) for the iad region.
-- **galactic-cni/galactic-router images**: Pulled from `ghcr.io/datum-cloud/galactic-{cni,router}` (published by `.github/workflows/publish.yaml`), not built locally. The tag comes from the Taskfile's `GALACTIC_TAG` var (default `v0.0.0-main`, the floating tag tracking the latest push to main — override with `task deploy GALACTIC_TAG=v0.0.0-<sha>` to pin a commit). `lib.sh` substitutes `GALACTIC_CNI_IMAGE`/`GALACTIC_ROUTER_IMAGE` into the `__GALACTIC_CNI_IMAGE__`/`__GALACTIC_ROUTER_IMAGE__` placeholders in `resources/cni/daemonset-patch.yaml` and `resources/{tenant/base,control/tenant/iad}/router-lab-patch.yaml` before copying them onto each node; `imagePullPolicy: Always` on both keeps a floating tag from going stale.
+- **galactic-router image**: Uses `galactic-router:latest` with `imagePullPolicy: Never` — stale images persist across rebuilds.
 - **Kind serviceSubnet**: All clusters use `/108` service subnet (non-standard; may cause issues with some services).
 - **BGP listen port**: Tenant worker DaemonSets run with `GALACTIC_ROUTER_BGP_LISTEN_PORT=-1` (outbound-only). The RR role listens on `1790` (set in `config/router/tenant-control/daemonset-patch.yaml`).
 - **BGP remote port**: Tenant BGPPeer CRDs in `resources/bgp/tenant/` explicitly set `remotePort: 1790` to connect to the RR. The control/RR-side peers rely on galactic-router's default of `1790`.

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -126,6 +126,7 @@ deploy/containerlab/
 ├── Taskfile.yaml
 ├── containers/
 │   ├── kindest-node-galactic/   # Custom Kind node image (git/tcpdump, kubectl DooD wrapper)
+│   ├── galactic-router/         # galactic-router container built from Go source
 │   └── frr/                     # FRR container built from Alpine edge
 ├── resources/
 │   ├── cni/                     # galactic-cni installer DaemonSet + ConfigMap
@@ -166,22 +167,14 @@ deploy/containerlab/
 
 ```bash
 cd deploy/containerlab
-task deploy   # build local images, pull galactic-cni/galactic-router, apply host sysctls, deploy lab end-to-end
-```
-
-`galactic-cni` and `galactic-router` are pulled from `ghcr.io/datum-cloud/galactic-{cni,router}`
-(published by `.github/workflows/publish.yaml`), not built locally. The tag defaults to
-`v0.0.0-main` (floating, tracks the latest push to `main`); override it to pin a commit:
-
-```bash
-task deploy GALACTIC_TAG=v0.0.0-<short-sha>
+task deploy   # build all images, apply host sysctls, deploy lab end-to-end
 ```
 
 To tear down and start fresh:
 
 ```bash
 task destroy  # remove all lab containers and Kind clusters
-task clean    # destroy + delete locally-built images and lab artifacts
+task clean    # destroy + delete built images and lab artifacts
 task deploy
 ```
 
@@ -189,18 +182,20 @@ task deploy
 
 | Task                    | Description                                                              |
 |-------------------------|--------------------------------------------------------------------------|
-| `build`                 | Build locally-built container images (node, frr)                        |
+| `build`                 | Build all container images (node, galactic-router, galactic-cni, frr)    |
 | `build:node`            | Build the custom `kindest/node:galactic` image                           |
+| `build:galactic-router` | Build the galactic-router container from Go source                       |
+| `build:galactic-cni`    | Build the galactic-cni installer image                                   |
 | `build:frr`             | Build the FRR container from Alpine edge                                 |
-| `deploy`                | Build local images, apply host sysctls, and deploy the lab               |
+| `deploy`                | Build images, apply host sysctls, and deploy the lab                     |
 | `deploy:topology`       | Deploy the ContainerLab topology (transit routers)                       |
 | `deploy:clusters`       | Create the three Kind clusters and export their kubeconfigs              |
 | `deploy:rename-control` | Rename the `iad-worker2` Docker container to `iad-worker-control`        |
-| `deploy:images`         | Load locally-built container images (node, frr) into Kind clusters       |
+| `deploy:images`         | Load container images into Kind clusters                                 |
 | `deploy:system`         | Install BGP and VPC CRDs; apply the galactic-system namespace and shared RBAC |
-| `deploy:cni`            | Install Cilium and Multus, then the galactic-cni DaemonSet (pulled from GHCR) |
+| `deploy:cni`            | Install Cilium and Multus, then the galactic-cni DaemonSet               |
 | `deploy:fabric`         | Apply FRR DaemonSets to all clusters                                     |
-| `deploy:tenant`         | Apply galactic-router DaemonSets (pulled from GHCR) and BGP CRs          |
+| `deploy:tenant`         | Apply galactic-router DaemonSets and BGP CRs                             |
 | `deploy:vpc`            | Deploy vpc10 and vpc20 test workloads across all clusters (6 pods)       |
 | `destroy`               | Destroy the lab and remove all Kind clusters                             |
 | `reload`                | Full rebuild — destroy then redeploy                                     |
@@ -208,7 +203,7 @@ task deploy
 | `inspect`               | Show running nodes and management addresses                              |
 | `graph`                 | Generate a draw.io diagram for the topology                              |
 | `host-setup`            | Apply required host sysctls (IPv6 forwarding, inotify limits)            |
-| `clean`                 | Destroy lab, delete locally-built images, and remove lab artifacts       |
+| `clean`                 | Destroy lab, delete built images, and remove lab artifacts               |
 | `test`                  | Run all verification checks                                              |
 
 ## Verification

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -7,18 +7,6 @@ vars:
     sh: echo *.clab.yaml
   FRR_VERSION: "10.6.1"
   FRR_IMAGE: frr:{{.FRR_VERSION}}
-  # GALACTIC_TAG selects which published ghcr.io/datum-cloud image tag the
-  # lab pulls (galactic-cni/galactic-router are built and pushed by
-  # .github/workflows/publish.yaml, not built locally). v0.0.0-main tracks
-  # the latest push to main; override per-run for a pinned commit, e.g.
-  # `task deploy GALACTIC_TAG=v0.0.0-cc37dbb`.
-  GALACTIC_TAG: v0.0.0-main
-  GALACTIC_CNI_IMAGE: ghcr.io/datum-cloud/galactic-cni:{{.GALACTIC_TAG}}
-  GALACTIC_ROUTER_IMAGE: ghcr.io/datum-cloud/galactic-router:{{.GALACTIC_TAG}}
-
-env:
-  GALACTIC_CNI_IMAGE: "{{.GALACTIC_CNI_IMAGE}}"
-  GALACTIC_ROUTER_IMAGE: "{{.GALACTIC_ROUTER_IMAGE}}"
 
 tasks:
   default:
@@ -27,10 +15,12 @@ tasks:
       - task --list
 
   build:
-    desc: Build all locally-built container images (node, frr)
+    desc: Build all container images
     cmds:
       - task: "build:node"
       - task: "build:frr"
+      - task: "build:galactic-router"
+      - task: "build:galactic-cni"
 
   "build:node":
     desc: Build the Kind node image
@@ -44,8 +34,18 @@ tasks:
     cmds:
       - docker build --build-arg FRR_VERSION={{.FRR_VERSION}} -t {{.FRR_IMAGE}} containers/frr/
 
+  "build:galactic-router":
+    desc: Build the galactic-router container image
+    cmds:
+      - docker build --network=host -t galactic-router:latest -f containers/galactic-router/Dockerfile ../..
+
+  "build:galactic-cni":
+    desc: Build the galactic-cni installer image
+    cmds:
+      - docker build --network=host -t galactic-cni:latest -f ../../containers/galactic-cni/Dockerfile ../..
+
   deploy:
-    desc: Build local images, pull published galactic-cni/galactic-router images, and deploy the full lab end-to-end
+    desc: Build images and deploy the full lab end-to-end
     deps: [build, host-setup]
     cmds:
       - task: "deploy:clusters"
@@ -87,7 +87,7 @@ tasks:
       - docker save {{.IMAGE}} | docker exec -i {{.NODE}} ctr --namespace k8s.io images import -
 
   "deploy:images":
-    desc: Load locally-built container images into the Kind clusters
+    desc: Load all container images into the Kind clusters
     cmds:
       - task: load-image
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: iad-worker}
@@ -97,6 +97,22 @@ tasks:
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: sjc-worker}
       - task: load-image
         vars: {IMAGE: "{{.FRR_IMAGE}}", NODE: dfw-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-router:latest, NODE: iad-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-router:latest, NODE: iad-worker-control}
+      - task: load-image
+        vars: {IMAGE: galactic-router:latest, NODE: sjc-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-router:latest, NODE: dfw-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: iad-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: iad-worker-control}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: sjc-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-cni:latest, NODE: dfw-worker}
 
   "deploy:system":
     desc: Install BGP and VPC CRDs; apply galactic-system namespace and shared RBAC
@@ -222,6 +238,8 @@ tasks:
     cmds:
       - task: destroy
       - docker rmi kindest/node:galactic || true
+      - docker rmi galactic-router:latest || true
+      - docker rmi galactic-cni:latest || true
       - docker rmi {{.FRR_IMAGE}} || true
       - rm -rf clab-{{.LAB}} build/
       - rm -f dfw.kubeconfig sjc.kubeconfig iad.kubeconfig

--- a/deploy/containerlab/containers/galactic-router/Dockerfile
+++ b/deploy/containerlab/containers/galactic-router/Dockerfile
@@ -1,0 +1,38 @@
+# Build galactic-router binary
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY internal/ internal/
+
+# Build router
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
+      -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
+      -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
+      -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE}" \
+    -o galactic-router ./cmd/galactic-router
+
+# Use distroless as minimal base image to package the router binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/galactic-router .
+USER 65532:65532
+
+ENTRYPOINT ["/galactic-router"]

--- a/deploy/containerlab/resources/cni/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/cni/daemonset-patch.yaml
@@ -7,9 +7,9 @@ spec:
     spec:
       initContainers:
         - name: install-cni
-          image: __GALACTIC_CNI_IMAGE__
-          imagePullPolicy: Always
+          image: galactic-cni:latest
+          imagePullPolicy: Never
       containers:
         - name: credential-refresh
-          image: __GALACTIC_CNI_IMAGE__
-          imagePullPolicy: Always
+          image: galactic-cni:latest
+          imagePullPolicy: Never

--- a/deploy/containerlab/resources/control/tenant/iad/router-lab-patch.yaml
+++ b/deploy/containerlab/resources/control/tenant/iad/router-lab-patch.yaml
@@ -7,5 +7,5 @@ spec:
     spec:
       containers:
         - name: galactic-router
-          image: __GALACTIC_ROUTER_IMAGE__
-          imagePullPolicy: Always
+          image: galactic-router:latest
+          imagePullPolicy: Never

--- a/deploy/containerlab/resources/tenant/base/router-lab-patch.yaml
+++ b/deploy/containerlab/resources/tenant/base/router-lab-patch.yaml
@@ -7,5 +7,5 @@ spec:
     spec:
       containers:
         - name: galactic-router
-          image: __GALACTIC_ROUTER_IMAGE__
-          imagePullPolicy: Always
+          image: galactic-router:latest
+          imagePullPolicy: Never

--- a/deploy/containerlab/scripts/deploy-cni.sh
+++ b/deploy/containerlab/scripts/deploy-cni.sh
@@ -4,8 +4,8 @@
 # host-device binaries onto each node's /opt/cni/bin via a hostPath mount
 # and maintains a kubeconfig built from its own ServiceAccount token, so pod
 # attach (CNI ADD/DEL) works without any manual credential setup. Requires
-# deploy:system (galactic-cni RBAC) first; the image itself is pulled from
-# ghcr.io/datum-cloud/galactic-cni (see GALACTIC_CNI_IMAGE in lib.sh).
+# deploy:system (galactic-cni RBAC) and deploy:images (galactic-cni:latest
+# loaded) first.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/deploy/containerlab/scripts/lib.sh
+++ b/deploy/containerlab/scripts/lib.sh
@@ -2,31 +2,8 @@
 # lib.sh — shared helpers for containerlab deploy-*.sh scripts. Sourced, not executed.
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+RESOURCES_DIR="${SCRIPT_DIR}/../resources"
 CONFIG_DIR="${SCRIPT_DIR}/../../../config"
-
-# GALACTIC_CNI_IMAGE / GALACTIC_ROUTER_IMAGE (set by the Taskfile from the
-# GALACTIC_TAG var) select which published ghcr.io/datum-cloud image tag
-# the lab pulls; galactic-cni/galactic-router are no longer built locally.
-# resources/cni/daemonset-patch.yaml and resources/{tenant/base,control/
-# tenant/iad}/router-lab-patch.yaml reference these as literal
-# __GALACTIC_*_IMAGE__ placeholders so the checked-in files stay
-# tag-agnostic; render them into a scratch copy of resources/ so copy_to
-# ships the substituted files instead of the placeholders.
-: "${GALACTIC_CNI_IMAGE:?GALACTIC_CNI_IMAGE must be set (see Taskfile)}"
-: "${GALACTIC_ROUTER_IMAGE:?GALACTIC_ROUTER_IMAGE must be set (see Taskfile)}"
-
-RESOURCES_DIR=$(mktemp -d)
-trap 'rm -rf "${RESOURCES_DIR}"' EXIT
-cp -r "${SCRIPT_DIR}/../resources/." "${RESOURCES_DIR}/"
-
-for f in "${RESOURCES_DIR}/cni/daemonset-patch.yaml" \
-         "${RESOURCES_DIR}/tenant/base/router-lab-patch.yaml" \
-         "${RESOURCES_DIR}/control/tenant/iad/router-lab-patch.yaml"; do
-  content=$(<"${f}")
-  content="${content//__GALACTIC_CNI_IMAGE__/${GALACTIC_CNI_IMAGE}}"
-  content="${content//__GALACTIC_ROUTER_IMAGE__/${GALACTIC_ROUTER_IMAGE}}"
-  printf '%s\n' "${content}" > "${f}"
-done
 
 control_plane() {
   echo "$1-control-plane"


### PR DESCRIPTION
## Summary

Reverts #226.

This restores the containerlab lab's local build/load path for `galactic-cni` and `galactic-router` (`task build:galactic-cni`, `task build:galactic-router`, side-loaded into Kind nodes) instead of pulling published `ghcr.io/datum-cloud/galactic-{cni,router}` images.

No file overlap with #227 (the Talos `/etc/galactic` hostPath fix, merged after #226) — this revert applies cleanly on top of current `main`.

## Test plan

- [x] Clean revert with no merge conflicts
- [x] `deploy/containerlab/Taskfile.yaml` confirmed restored to the pre-#226 local build tasks
- [x] Live `task deploy` run against Kind clusters (not run in this environment)