### PR TITLE
fix: resolve four Talos lab deployment blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [galactic DevContainer](./.devcontainer/galactic/) for development envir
 
 ### Production Deployment
 
-Manifests for a real cluster live under [`config/`](./config/), composed with [Kustomize](https://kustomize.io). One command deploys the `galactic-system` namespace, the `galactic-cni` DaemonSet, and both `galactic-router` roles — `tenant` (per-node, runs everywhere except control-plane nodes) and `tenant-control` (BGP route reflector, opt-in — stays at zero replicas until nodes are labeled `galactic.datumapis.com/node: control`):
+Manifests for a real cluster live under [`config/`](./config/), composed with [Kustomize](https://kustomize.io). One command deploys the `galactic-system` namespace (labeled `pod-security.kubernetes.io/enforce: privileged` — both DaemonSets need it, for hostPath volumes, hostNetwork, and elevated capabilities), the `galactic-cni` DaemonSet, and both `galactic-router` roles — `tenant` (per-node, runs everywhere except control-plane nodes) and `tenant-control` (BGP route reflector, opt-in — stays at zero replicas until nodes are labeled `galactic.datumapis.com/node: control`):
 
 ```bash
 kubectl apply -k config/
@@ -40,10 +40,20 @@ kubectl apply -k config/
 
 Each component can also be applied on its own, e.g. `kubectl apply -k config/router` for just the router (both roles) or `kubectl apply -k config/router/tenant` for just the per-node role.
 
-`.github/workflows/publish.yaml` publishes `ghcr.io/datum-cloud/galactic-cni:latest` and
-`ghcr.io/datum-cloud/galactic-router:latest` (built from `containers/galactic-cni/Dockerfile`
-and `containers/galactic-router/Dockerfile` respectively) on every push and release, which
-is what these manifests pull.
+#### Prerequisites
+
+- **Container images.** `.github/workflows/publish.yaml` builds `ghcr.io/datum-cloud/galactic-cni` and `ghcr.io/datum-cloud/galactic-router` (from `containers/galactic-cni/Dockerfile` and `containers/galactic-router/Dockerfile` respectively) on every push and release — but it never publishes a `:latest` tag, only date-stamped tags per push/release (e.g. `v0.0.0-main-20260713-170924`) and, for tagged releases, semver tags. The `image:` references committed in `config/cni/daemonset.yaml` and `config/router/base/daemonset.yaml` say `:latest` only as a placeholder that CI substitutes with a real published tag when it builds the `ghcr.io/datum-cloud/galactic-kustomize` OCI Kustomize bundle — that substitution never happens in the git checkout itself. Applying `config/` directly from a clone will therefore fail to pull `:latest`. Before applying, resolve the current tag (check the [package pages](https://github.com/orgs/datum-cloud/packages?repo_name=galactic) or the latest successful run of `publish.yaml` on `main`) and pin it, e.g.:
+
+  ```bash
+  cd config/cni && kustomize edit set image ghcr.io/datum-cloud/galactic-cni=ghcr.io/datum-cloud/galactic-cni:<resolved-tag>
+  cd config/router/base && kustomize edit set image ghcr.io/datum-cloud/galactic-router=ghcr.io/datum-cloud/galactic-router:<resolved-tag>
+  ```
+
+- **Talos: gRPC health port.** `galactic-router` runs `hostNetwork: true` and defaults to gRPC health checks on port `5000`, which collides with Talos's built-in dashboard (`/sbin/dashboard` permanently binds `127.0.0.1:5000` on every Talos node). `config/router/base/daemonset.yaml` already ships with `GALACTIC_ROUTER_GRPC_HEALTH_PORT=5179` (and matching probe/containerPort) to avoid this; if you run `galactic-router` outside these manifests on Talos, set `GALACTIC_ROUTER_GRPC_HEALTH_PORT` to something other than `5000` yourself.
+
+- **`galactic-router` tenant mode: BGP local address.** The node needs a global-unicast IPv6 address assigned to `lo` (typically by an underlay/fabric BGP daemon that starts before `galactic-router`), or you must set `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` explicitly — this is required even when `GALACTIC_ROUTER_BGP_LISTEN_PORT=-1` (no inbound listener), since `galactic-router` still needs a source address for outbound BGP connections. Without one of these, startup fails with `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS not set and no address could be detected on lo: no global-unicast IPv6 address found on lo`. See [`docs/router/configuration.md`](./docs/router/configuration.md) for details.
+
+See [`docs/router/configuration.md`](./docs/router/configuration.md) for the full `galactic-router` CLI flag / environment variable reference — note that env var names generally follow `GALACTIC_ROUTER_<FLAG_NAME>` but aren't always the naive uppercased guess (e.g. `--mode` is `GALACTIC_ROUTER_ROUTER_MODE`, not `GALACTIC_ROUTER_MODE`); the reference table has the exact name for every flag.
 
 ## Development
 

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -112,8 +112,27 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) { //nolint:lll // cobra flag 
 		v.GetDuration("galactic_router.gc_interval"),
 		"Cleanup interval")
 
-	if err := v.BindPFlags(cmd.Flags()); err != nil {
-		log.Fatalf("bind flags: %v", err)
+	// v.BindPFlags binds each flag under its own flag name (e.g.
+	// "grpc-health-port") as the viper key, but validateConfig/runCmd only
+	// ever read the "galactic_router.*"-prefixed keys set up by newViper —
+	// so a blanket BindPFlags leaves every flag here disconnected from the
+	// config it's meant to override. Bind each flag explicitly to the key
+	// it actually needs to reach.
+	flagKeys := map[string]string{
+		"node-name":         "galactic_router.node_name",
+		"mode":              "galactic_router.router_mode",
+		"reflector":         "reflector",
+		"bgp-listen-port":   "galactic_router.bgp_listen_port",
+		"bgp-local-address": "galactic_router.bgp_local_address",
+		"metrics-port":      "galactic_router.metrics_port",
+		"grpc-health-port":  "galactic_router.grpc_health_port",
+		"gc-namespace":      "galactic_router.gc_namespace",
+		"gc-interval":       "galactic_router.gc_interval",
+	}
+	for flagName, key := range flagKeys {
+		if err := v.BindPFlag(key, cmd.Flags().Lookup(flagName)); err != nil {
+			log.Fatalf("bind flag %s: %v", flagName, err)
+		}
 	}
 }
 

--- a/cmd/galactic-router/root_test.go
+++ b/cmd/galactic-router/root_test.go
@@ -16,13 +16,15 @@ import (
 	"go.datum.net/galactic/internal/metadata"
 )
 
+const testCmdUse = "test"
+
 // cmdWithViper creates a cobra command with a fresh viper instance and
 // binds all flags. This is used to test flag defaults and cobra integration.
 func cmdWithViper(t *testing.T) *viper.Viper {
 	t.Helper()
 	v := newViper()
 	cmd := &cobra.Command{
-		Use: "test",
+		Use: testCmdUse,
 	}
 	bindFlags(cmd, v)
 	return v
@@ -141,7 +143,7 @@ func TestReflectorInvalidMode(t *testing.T) {
 
 	v := cmdWithViper(t)
 	// Simulate --reflector being set via flag.
-	cmd := &cobra.Command{Use: "test"}
+	cmd := &cobra.Command{Use: testCmdUse}
 	bindFlags(cmd, v)
 	//nolint:errcheck // flag exists, setting it is safe
 	cmd.Flags().Set("reflector", "true")
@@ -175,6 +177,39 @@ func TestGRPCHealthPortOverride(t *testing.T) {
 	v := cmdWithViper(t)
 	if v.GetInt("galactic_router.grpc_health_port") != 9091 {
 		t.Errorf("grpc_health_port = %d, want 9091", v.GetInt("galactic_router.grpc_health_port"))
+	}
+}
+
+func TestModeFlagOverridesEnv(t *testing.T) {
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "fabric")
+
+	v := newViper()
+	cmd := &cobra.Command{Use: testCmdUse}
+	bindFlags(cmd, v)
+	if err := cmd.Flags().Set("mode", "tenant"); err != nil {
+		t.Fatalf("set --mode flag: %v", err)
+	}
+
+	if got := v.GetString("galactic_router.router_mode"); got != "tenant" {
+		t.Errorf("router_mode = %q, want %q (flag should override env var)", got, "tenant")
+	}
+}
+
+func TestGRPCHealthPortFlagOverridesEnv(t *testing.T) {
+	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
+	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
+	t.Setenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT", "9091")
+
+	v := newViper()
+	cmd := &cobra.Command{Use: testCmdUse}
+	bindFlags(cmd, v)
+	if err := cmd.Flags().Set("grpc-health-port", "9092"); err != nil {
+		t.Fatalf("set --grpc-health-port flag: %v", err)
+	}
+
+	if got := v.GetInt("galactic_router.grpc_health_port"); got != 9092 {
+		t.Errorf("grpc_health_port = %d, want %d (flag should override env var)", got, 9092)
 	}
 }
 

--- a/config/cni/daemonset.yaml
+++ b/config/cni/daemonset.yaml
@@ -33,6 +33,13 @@ spec:
                       - edge
       initContainers:
         - name: install-cni
+          # ":latest" is a placeholder only: no such tag is ever pushed to
+          # GHCR. CI resolves and stamps a real version tag here when it
+          # publishes the ghcr.io/datum-cloud/galactic-kustomize OCI bundle
+          # (see .github/workflows/publish.yaml); applying this manifest
+          # directly from a git checkout will fail to pull the image unless
+          # you override the tag first — see the README's "Production
+          # Deployment" section.
           image: ghcr.io/datum-cloud/galactic-cni:latest
           command: ["/bin/sh", "/scripts/install.sh", "install"]
           env:
@@ -60,6 +67,8 @@ spec:
               mountPath: /host/var/run/galactic-cni
       containers:
         - name: credential-refresh
+          # See the install-cni initContainer above: ":latest" is a
+          # placeholder, not a published tag.
           image: ghcr.io/datum-cloud/galactic-cni:latest
           command: ["/bin/sh", "/scripts/install.sh", "refresh"]
           securityContext:

--- a/config/router/base/daemonset.yaml
+++ b/config/router/base/daemonset.yaml
@@ -20,6 +20,13 @@ spec:
         - operator: Exists
       containers:
         - name: galactic-router
+          # ":latest" is a placeholder only: no such tag is ever pushed to
+          # GHCR. CI resolves and stamps a real version tag here when it
+          # publishes the ghcr.io/datum-cloud/galactic-kustomize OCI bundle
+          # (see .github/workflows/publish.yaml); applying this manifest
+          # directly from a git checkout will fail to pull the image unless
+          # you override the tag first — see the README's "Production
+          # Deployment" section.
           image: ghcr.io/datum-cloud/galactic-router:latest
           command:
             - /galactic-router
@@ -32,21 +39,27 @@ spec:
               value: tenant
             - name: GALACTIC_ROUTER_GC_NAMESPACE
               value: galactic-system
+            # Talos nodes permanently bind 127.0.0.1:5000 for the built-in
+            # /sbin/dashboard; since this DaemonSet runs hostNetwork: true,
+            # the default gRPC health port (5000) always collides on Talos.
+            # See docs/router/configuration.md for details.
+            - name: GALACTIC_ROUTER_GRPC_HEALTH_PORT
+              value: "5179"
           ports:
             - name: metrics
               containerPort: 8080
               protocol: TCP
             - name: grpc-health
-              containerPort: 5000
+              containerPort: 5179
               protocol: TCP
           livenessProbe:
             grpc:
-              port: 5000
+              port: 5179
             initialDelaySeconds: 15
             periodSeconds: 20
           readinessProbe:
             grpc:
-              port: 5000
+              port: 5179
             initialDelaySeconds: 5
             periodSeconds: 10
           securityContext:

--- a/config/system/namespace.yaml
+++ b/config/system/namespace.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: galactic-system
+  labels:
+    # Both the galactic-cni and galactic-router DaemonSets require
+    # privileged access (hostPath volumes, hostNetwork, NET_ADMIN and
+    # elevated capabilities). Without this, first-time `kubectl apply -k`
+    # against a cluster with the restricted/baseline PodSecurity default
+    # fails admission with no pointer to the fix.
+    pod-security.kubernetes.io/enforce: privileged

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -70,6 +70,13 @@ that. This requires `hostNetwork: true` and an address already assigned to
 before `galactic-router` starts. Startup fails with an error if no explicit
 value is set and no such address is found on `lo`.
 
+This detection always runs, even when `--bgp-listen-port`/
+`GALACTIC_ROUTER_BGP_LISTEN_PORT` is `-1` (no inbound listener) —
+`galactic-router` still needs a source address for outbound BGP connections.
+In practice this means every node running `galactic-router` in `tenant` mode
+needs a global-unicast IPv6 address on `lo` before startup, or an explicit
+`GALACTIC_ROUTER_BGP_LOCAL_ADDRESS`.
+
 **Type:** string
 **Default:** _(auto-detected from `lo`)_
 

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -5,6 +5,13 @@ or a combination of both. CLI flags take precedence over environment variables.
 
 ## Quick Reference
 
+Environment variable names are not a naive uppercased guess from the CLI
+flag name — every flag is bound to its own explicit `GALACTIC_ROUTER_*`
+variable (see `newViper()` in `cmd/galactic-router/root.go`), and several
+don't match what `AutomaticEnv` alone would produce from the flag name. The
+most common trip-up: `--mode` is `GALACTIC_ROUTER_ROUTER_MODE`, not
+`GALACTIC_ROUTER_MODE`. Always use the exact name from the table below.
+
 | Option | Environment Variable | CLI Flag | Default |
 |---|---|---|---|
 | Node name | `GALACTIC_ROUTER_NODE_NAME` | `--node-name` | _(required)_ |

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -91,6 +91,13 @@ readiness probes.
 **Default:** `5000`
 **Valid values:** `1`–`65535`
 
+> **Talos:** `/sbin/dashboard` permanently binds `127.0.0.1:5000` on every
+> Talos node. Since `galactic-router` runs with `hostNetwork: true`, the
+> default `5000` always collides on Talos-based clusters. The shipped
+> `config/router/base/daemonset.yaml` sets this to `5179` for exactly this
+> reason; if you run `galactic-router` outside those manifests on Talos, set
+> it to something other than `5000` yourself.
+
 ### `--gc-namespace` / `GALACTIC_ROUTER_GC_NAMESPACE`
 
 Namespace the GC controller scans for orphaned `BGPAdvertisement` and


### PR DESCRIPTION
## Summary

Four issues surfaced while manually deploying `galactic-cni` and `galactic-router` (tenant role) to a Talos-based cluster.

| # | Issue | Fix | Breaking? |
|---|---|---|---|
| 1 | README documented a `:latest` GHCR tag that is never published (only date-stamped `main` builds exist) | Added a README "Prerequisites" section explaining the real tag scheme and how to pin a real tag before applying; added inline comments on the `:latest` placeholder in both DaemonSet manifests | Docs-only |
| 2 | `config/system/namespace.yaml` has no PodSecurity level, so first-time `kubectl apply` fails admission on clusters with a restricted/baseline default, with no pointer to the fix | Added `pod-security.kubernetes.io/enforce: privileged` to the namespace | Non-breaking (additive; fixes a hard-fail) |
| 3 | `galactic-router`'s default gRPC health port (`5000`) collides with Talos's built-in dashboard (`/sbin/dashboard` permanently binds `127.0.0.1:5000`) on every Talos node, since the router runs `hostNetwork: true` | Set `GALACTIC_ROUTER_GRPC_HEALTH_PORT=5179` in the shipped DaemonSet (with matching `containerPort`/probe ports); documented the collision | **Breaking** — changes the shipped default health-check port |
| 4 | Tenant router requires a global-unicast IPv6 address on `lo` (or explicit `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS`), even with `GALACTIC_ROUTER_BGP_LISTEN_PORT=-1` — undocumented | Documented in the README and `docs/router/configuration.md`. The startup error already names the fixing env var directly, so no code change was needed there | Docs-only |
| 5 | `--mode` maps to `GALACTIC_ROUTER_ROUTER_MODE`, not the naively-guessed `GALACTIC_ROUTER_MODE` | Documented the naming clearly in `docs/router/configuration.md`. Also found and fixed a related bug: `bindFlags` used a blanket `v.BindPFlags(cmd.Flags())`, which binds each flag under its own flag name (e.g. `grpc-health-port`) — but `runCmd`/`validateConfig` only ever read the `galactic_router.*`-prefixed keys, so **every CLI flag except `--reflector` was silently disconnected from the config it was supposed to override**, despite the docs documenting CLI-flag precedence with a working example. Fixed by binding each flag explicitly to the key it needs to reach, with regression tests that fail against the old behavior | Restores previously-documented-but-nonfunctional behavior; not expected to be breaking in practice since no flag ever took effect before |

## Test plan

- [x] `task lint` — 0 issues
- [x] `task build` — builds both binaries
- [x] `task test:unit` — all unit tests pass, including two new regression tests (`TestModeFlagOverridesEnv`, `TestGRPCHealthPortFlagOverridesEnv`) verified to fail against the pre-fix code
- [x] `kubectl kustomize config/` and `kubectl kustomize config/router/tenant` verified to render the expected PodSecurity label and port 5179 end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)