### PR TITLE
feat(cni): add per-resource logging and a configurable log level

### DIFF
--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -246,12 +246,16 @@ the rest of the invocation:
 | Kubeconfig (`KUBECONFIG`)          | `GALACTIC_CNI_KUBECONFIG` → `HostConf.Kubeconfig` (conflist)                                            | `/var/lib/galactic/kubeconfig` |
 | Namespace                          | `conf.Namespace` (CNI config JSON) → `GALACTIC_CNI_NAMESPACE` → `HostConf.Namespace` (conflist)         | `galactic-system` |
 | Log file                           | `GALACTIC_CNI_LOG_FILE` → `HostConf.LogFile` (conflist)                                                 | `/var/log/galactic/galactic-cni.log` |
+| Log level                          | `GALACTIC_CNI_LOG_LEVEL` → `HostConf.LogLevel` (conflist)                                               | `info` |
 | `GALACTIC_CNI_ENABLE_LOCAL_IPAM`  | Read directly as an env var in `parseConf()` (no conflist or CLI-flag equivalent)                       | `false` |
 
-`HostConf` (`node_name`, `kubeconfig`, `namespace`, `log_file`) is the JSON shape
-the `init` installer subcommand writes into the `galactic-cni`-typed plugin entry
+`HostConf` (`node_name`, `kubeconfig`, `namespace`, `log_file`, `log_level`) is the JSON
+shape the `init` installer subcommand writes into the `galactic-cni`-typed plugin entry
 of the conflist at `--conf-file` (see `internal/installer/installer.go` and
-Entry Points above).
+Entry Points above). `log_level` (`debug`/`info`/`warn`/`error`) controls how much detail
+`setupLogging()` emits — `info` (the default) logs one line per operation for
+start/outcome plus all warnings/errors; `debug` adds per-resource milestones. See
+[docs/cni/configuration.md#log-verbosity](../cni/configuration.md#log-verbosity).
 
 ### galactic-cni ADD result
 

--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -4,15 +4,15 @@
 (or any CNI manager), plus node-local settings resolved at runtime from the
 conflist, environment variables, and (as a last resort) the Kubernetes API.
 
-> Last verified: 2026-07-14 against the current working tree of `internal/cni/config.go`
+> Last verified: 2026-07-16 against the current working tree of `internal/cni/config.go`
 > and `internal/installer/installer.go`.
 
 ## Runtime Configuration
 
 There is no `--node-name` or `--enable-local-ipam` CLI flag on the `galactic-cni`
 plugin invocation itself. Instead, `parseConf()` (`internal/cni/config.go`) resolves
-node name, kubeconfig, namespace, and log file on every ADD/DEL/CHECK/STATUS call,
-reading (in order) the CNI config JSON, environment variables, and a `HostConf`
+node name, kubeconfig, namespace, log file, and log level on every ADD/DEL/CHECK/STATUS
+call, reading (in order) the CNI config JSON, environment variables, and a `HostConf`
 block parsed out of the conflist at `--conf-file` (default
 `/etc/cni/net.d/10-galactic.conflist`). `HostConf` is written by the `galactic-cni init`
 subcommand (`internal/installer.Bootstrap`), which runs as the CNI DaemonSet's init
@@ -21,27 +21,46 @@ for how the DaemonSet stages it.
 
 ### `HostConf` fields (written into the conflist by `galactic-cni init`)
 
-| Field        | JSON key      | Description                                                                 |
-|--------------|---------------|-------------------------------------------------------------------------------|
-| `NodeName`   | `node_name`   | The Kubernetes node name the installer bootstrapped on.                        |
-| `Kubeconfig` | `kubeconfig`  | Path to the kubeconfig `Bootstrap`/`Run` maintain (`/var/lib/galactic/kubeconfig` by default). |
-| `Namespace`  | `namespace`   | Kubernetes namespace for BGP CRDs (`galactic-system` by default).              |
-| `LogFile`    | `log_file`    | Path the plugin logs to (`/var/log/galactic/galactic-cni.log` by default).      |
+| Field        | Description                                                                                                                      |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `NodeName`   | The Kubernetes node name the installer bootstrapped on.                                                                          |
+| `Kubeconfig` | Path to the kubeconfig `Bootstrap`/`Run` maintain (`/var/lib/galactic/kubeconfig` by default).                                   |
+| `Namespace`  | Kubernetes namespace for BGP CRDs (`galactic-system` by default).                                                                |
+| `LogFile`    | Path the plugin logs to (`/var/log/galactic/galactic-cni.log` by default).                                                       |
+| `LogLevel`   | Verbosity of plugin logging: `debug`, `info`, `warn`, or `error` (`info` by default). See [Log verbosity](#log-verbosity) below. |
 
 ### Resolution precedence
 
-| Setting              | Precedence (highest first)                                                                                   | Default (if nothing resolves) |
-|----------------------|-----------------------------------------------------------------------------------------------------------------|--------------------------------|
-| Node name            | `GALACTIC_CNI_NODE_NAME` env → `NODE_NAME` env → `HostConf.NodeName` → auto-detect via the Kubernetes API (`detectNodeNameFromAPI`: lists Nodes, matches local interface addresses against `status.addresses[].type=InternalIP`) | _(error: "node name is required")_ |
-| Kubeconfig           | `GALACTIC_CNI_KUBECONFIG` env → `HostConf.Kubeconfig`                                                            | `/var/lib/galactic/kubeconfig` |
-| Namespace            | `namespace` field in the CNI config JSON → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace`                   | `galactic-system`               |
-| Log file             | `GALACTIC_CNI_LOG_FILE` env → `HostConf.LogFile`                                                                 | `/var/log/galactic/galactic-cni.log` |
-| Enable local IPAM    | `GALACTIC_CNI_ENABLE_LOCAL_IPAM` env only (no conflist field, no CLI flag)                                        | `false`                          |
+| Setting           | Precedence (highest first)                                                                                                                                                                                                       | Default (if nothing resolves)        |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Node name         | `GALACTIC_CNI_NODE_NAME` env → `NODE_NAME` env → `HostConf.NodeName` → auto-detect via the Kubernetes API (`detectNodeNameFromAPI`: lists Nodes, matches local interface addresses against `status.addresses[].type=InternalIP`) | _(error: "node name is required")_   |
+| Kubeconfig        | `GALACTIC_CNI_KUBECONFIG` env → `HostConf.Kubeconfig`                                                                                                                                                                            | `/var/lib/galactic/kubeconfig`       |
+| Namespace         | `namespace` field in the CNI config JSON → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace`                                                                                                                                   | `galactic-system`                    |
+| Log file          | `GALACTIC_CNI_LOG_FILE` env → `HostConf.LogFile`                                                                                                                                                                                 | `/var/log/galactic/galactic-cni.log` |
+| Log level         | `GALACTIC_CNI_LOG_LEVEL` env → `HostConf.LogLevel`                                                                                                                                                                               | `info`                               |
+| Enable local IPAM | `GALACTIC_CNI_ENABLE_LOCAL_IPAM` env only (no conflist field, no CLI flag)                                                                                                                                                       | `false`                              |
 
 The resolved node name is re-exported as the `NODE_NAME` process environment variable
 and the resolved kubeconfig as `KUBECONFIG`, since other code in `internal/cni` reads
 those directly. Auto-detection exists to tolerate environments (e.g. Kind-based e2e)
 where the conflist's hostPath mount isn't populated yet.
+
+### Log verbosity
+
+`setupLogging()` (`internal/cni/config.go`) builds a JSON `slog` handler at the
+resolved level. Since each CNI invocation is a fresh, short-lived process, this
+level is re-resolved on every ADD/DEL/CHECK/STATUS call — there's no persistent
+daemon to reconfigure at runtime.
+
+| Level            | What's logged                                                                                                                                                                                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `debug`          | Everything: per-resource milestones (VRF/interface/route/IPAM ready, BGP CRDs applied, kernel-level veth/tap/route operations) in addition to `info` and above. Use this when troubleshooting a specific ADD/DEL failure.                                                                              |
+| `info` (default) | One line per operation marking start and outcome (`ADD: starting` / `ADD: BGP state published`, `DEL: starting` / `DEL: skipping shared resource cleanup`, `CHECK: starting` / `CHECK: passed`/`failed`, `STATUS: probing API server reachability` / `STATUS: ready`), plus all `warn`/`error` events. |
+| `warn`           | Recoverable anomalies only: stale-state repairs (leftover veth/tap from a prior failed ADD), iptables-missing fallback, k8s API retries.                                                                                                                                                               |
+| `error`          | Failures only.                                                                                                                                                                                                                                                                                         |
+
+An unrecognized `log_level` value does not fail the CNI operation — it logs a
+warning and falls back to `info`.
 
 ### `GALACTIC_CNI_ENABLE_LOCAL_IPAM`
 
@@ -53,11 +72,11 @@ plugin.
 When local IPAM is active but the config does not specify pool parameters,
 the following defaults are used:
 
-| Parameter | Default |
-|---|---|
-| Pool CIDR | `fd00:10:ff01::/48` |
-| Subnet length | `/80` |
-| Gateway | First usable address in the pool (`::1`) |
+| Parameter     | Default                                  |
+| ------------- | ---------------------------------------- |
+| Pool CIDR     | `fd00:10:ff01::/48`                      |
+| Subnet length | `/80`                                    |
+| Gateway       | First usable address in the pool (`::1`) |
 
 If an explicit `ipam` block is present in the CNI config, it takes precedence
 and this environment variable has no effect on the allocation behavior.
@@ -72,15 +91,15 @@ the standard CNI `PluginConf` with Galactic-specific fields.
 
 ### Top-Level Fields
 
-| Field | JSON Key | Required | Type | Description |
-|---|---|---|---|---|
-| `vpc` | `"vpc"` | **Yes** | `string` | Base62-encoded VPC identifier (48-bit value). Used to derive VRF names, interface names, and BGP route targets. |
-| `vpcattachment` | `"vpcattachment"` | **Yes** | `string` | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming. |
-| `interface_type` | `"interface_type"` | No | `string` | Interface mode: `"veth"` (default, for containers) or `"tap"` (for VMs such as Kata, Firecracker, QEMU). Both modes run IPAM and SRv6/BGP publish; `tap` mode only skips host-device delegation and guest-netns configuration (see the Tap mode section below). |
-| `mtu` | `"mtu"` | No | `int` | MTU for the host-side interface. For `veth` mode this applies to both veth endpoints; for `tap` mode it applies to the tap interface. |
-| `terminations` | `"terminations"` | No | `[]Termination` | Array of static routes to add on the host side (see Termination sub-fields below). |
-| `namespace` | `"namespace"` | No | `string` | Kubernetes namespace used to look up the `BGPRouter` CRD. Resolution order: this field → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace` (conflist) → `galactic-system`. See [Runtime Configuration](#runtime-configuration) above. |
-| `ipam` | `"ipam"` | No* | `IPAM` | IP address management configuration (see IPAM sub-fields below). *Required unless `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — applies identically in `veth` and `tap` mode. In `tap` mode `cmdAdd` (`internal/cni/ops_add.go`) calls `allocateIPAM` unconditionally (unlike `veth` mode, which checks first), so omitting both `ipam` and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` currently produces a nil-pointer panic in `tap` mode rather than a clean validation error — always set one or the other for tap. |
+| Field            | Required | Type            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---------------- | -------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vpc`            | **Yes**  | `string`        | Base62-encoded VPC identifier (48-bit value). Used to derive VRF names, interface names, and BGP route targets.                                                                                                                                                                                                                                                                                                                                                                                           |
+| `vpcattachment`  | **Yes**  | `string`        | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming.                                                                                                                                                                                                                                                                                                                                                                                              |
+| `interface_type` | No       | `string`        | Interface mode: `"veth"` (default, for containers) or `"tap"` (for VMs such as Kata, Firecracker, QEMU). Both modes run IPAM and SRv6/BGP publish; `tap` mode only skips host-device delegation and guest-netns configuration (see the Tap mode section below).                                                                                                                                                                                                                                           |
+| `mtu`            | No       | `int`           | MTU for the host-side interface. For `veth` mode this applies to both veth endpoints; for `tap` mode it applies to the tap interface.                                                                                                                                                                                                                                                                                                                                                                     |
+| `terminations`   | No       | `[]Termination` | Array of static routes to add on the host side (see Termination sub-fields below).                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `namespace`      | No       | `string`        | Kubernetes namespace used to look up the `BGPRouter` CRD. Resolution order: this field → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace` (conflist) → `galactic-system`. See [Runtime Configuration](#runtime-configuration) above.                                                                                                                                                                                                                                                                   |
+| `ipam`           | No*      | `IPAM`          | IP address management configuration (see IPAM sub-fields below). *Required unless `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — applies identically in `veth` and `tap` mode. In `tap` mode `cmdAdd` (`internal/cni/ops_add.go`) calls `allocateIPAM` unconditionally (unlike `veth` mode, which checks first), so omitting both `ipam` and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` currently produces a nil-pointer panic in `tap` mode rather than a clean validation error — always set one or the other for tap. |
 
 Standard CNI fields (`cniVersion`, `name`, `dns`, `runtimeConfig`) are also
 supported via the embedded `types.PluginConf`.
@@ -116,13 +135,13 @@ subnet/gateway describe only the host-side BGP-advertised state).
 
 ### IPAM Fields
 
-| Field | JSON Key | Required | Type | Description |
-|---|---|---|---|---|
-| `type` | `"type"` | Conditionally required | `string` | `"pool"` or `"static"`. Determines IP allocation strategy. Required whenever an `ipam` block is present; only defaults to `"pool"` when the entire `ipam` block is omitted and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — an `ipam` block with an empty `type` is a hard error. |
-| `pool` | `"pool"` | Conditionally required | `string` | IPv6 CIDR pool (e.g. `"fd00:10:ff01::/48"`) from which subnets are allocated. Required when `type` is `"pool"`. |
-| `gateway` | `"gateway"` | No | `string` | IPv6 gateway address. If omitted, uses the first usable address in the pool (host bits = 1). Must be within the pool CIDR. |
-| `subnet_len` | `"subnet_len"` | No | `int` | Prefix length per allocation. Default is `80` (giving 2^48 addresses per pod subnet). Pool prefix must be <= this value. |
-| `static_ip` | `"static_ip"` | Conditionally required | `string` | A single IPv6 address to assign when `type` is `"static"`. |
+| Field        | Required               | Type     | Description                                                                                                                                                                                                                                                                    |
+| ------------ | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`       | Conditionally required | `string` | `"pool"` or `"static"`. Determines IP allocation strategy. Required whenever an `ipam` block is present; only defaults to `"pool"` when the entire `ipam` block is omitted and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — an `ipam` block with an empty `type` is a hard error. |
+| `pool`       | Conditionally required | `string` | IPv6 CIDR pool (e.g. `"fd00:10:ff01::/48"`) from which subnets are allocated. Required when `type` is `"pool"`.                                                                                                                                                                |
+| `gateway`    | No                     | `string` | IPv6 gateway address. If omitted, uses the first usable address in the pool (host bits = 1). Must be within the pool CIDR.                                                                                                                                                     |
+| `subnet_len` | No                     | `int`    | Prefix length per allocation. Default is `80` (giving 2^48 addresses per pod subnet). Pool prefix must be <= this value.                                                                                                                                                       |
+| `static_ip`  | Conditionally required | `string` | A single IPv6 address to assign when `type` is `"static"`.                                                                                                                                                                                                                     |
 
 #### IPAM `type=pool`
 
@@ -143,10 +162,10 @@ needed.
 
 Each entry in the `terminations` array has the following fields:
 
-| Field | JSON Key | Required | Type | Description |
-|---|---|---|---|---|
-| `network` | `"network"` | **Yes** | `string` | CIDR prefix for a static route (e.g. `"fd00::/48"`). |
-| `via` | `"via"` | No | `string` | Next-hop gateway IP. If omitted, a link-local route is installed via the host-side device. |
+| Field     | Required | Type     | Description                                                                                |
+| --------- | -------- | -------- | ------------------------------------------------------------------------------------------ |
+| `network` | **Yes**  | `string` | CIDR prefix for a static route (e.g. `"fd00::/48"`).                                       |
+| `via`     | No       | `string` | Next-hop gateway IP. If omitted, a link-local route is installed via the host-side device. |
 
 Used in `cmdAdd` to install routes into the VRF table for each termination
 entry. Deleted in `cmdDel` in reverse order.

--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -190,6 +190,9 @@ func lookupBGPRouter(ctx context.Context, k8s client.Client, nodeName, namespace
 			len(matches), nodeName, namespace)
 	}
 
+	slog.Debug("BGP: router matched", "nodeName", nodeName, "router", matches[0].Name,
+		"asNumber", matches[0].Spec.LocalASN, "srv6Locator", matches[0].Spec.SRv6Locator, "nodeID", matches[0].Spec.NodeID)
+
 	return bgpConfig{
 		asNumber:    uint32(matches[0].Spec.LocalASN),
 		routerName:  matches[0].Name,
@@ -312,6 +315,8 @@ func publishBGPStateK8s(
 		}
 		if srv6SIDStr != "" {
 			tracker.srv6SID = srv6SIDStr
+			slog.Debug("BGP: SRv6 ingress route installed", "sid", srv6SIDStr,
+				"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 		}
 
 		// Create the BGPVRFInstance to configure the VRF with its VRFID and
@@ -332,6 +337,8 @@ func publishBGPStateK8s(
 			return fmt.Errorf("apply BGPVRFInstance: %w", err)
 		}
 		tracker.vrfInstanceCreated = true
+		slog.Debug("BGP: BGPVRFInstance applied", "name", vrfName, "namespace", namespace,
+			"vrfID", vrfID, "routeTarget", rtValue, "router", bgp.routerName)
 
 		// Create the BGPAdvertisement to originate the pod's subnet prefix.
 		adv := &bgpv1alpha1.BGPAdvertisement{
@@ -364,7 +371,11 @@ func publishBGPStateK8s(
 			return fmt.Errorf("apply BGPAdvertisement: %w", err)
 		}
 		tracker.advCreated = true
+		slog.Debug("BGP: BGPAdvertisement applied", "name", adv.Name, "namespace", namespace,
+			"podSubnet", podSubnet, "containerID", args.ContainerID)
 
+		slog.Info("ADD: BGP state published", "containerID", args.ContainerID,
+			"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 		return nil
 	})
 }

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -1520,7 +1520,8 @@ func TestLoadHostConf(t *testing.T) {
 				"node_name": "test-worker",
 				"kubeconfig": "/etc/custom-kubeconfig",
 				"namespace": "custom-namespace",
-				"log_file": "/var/log/custom.log"
+				"log_file": "/var/log/custom.log",
+				"log_level": "debug"
 			}
 		]
 	}`
@@ -1542,6 +1543,9 @@ func TestLoadHostConf(t *testing.T) {
 	}
 	if conf.LogFile != "/var/log/custom.log" {
 		t.Errorf("LogFile = %q, want %q", conf.LogFile, "/var/log/custom.log")
+	}
+	if conf.LogLevel != logLevelDebug {
+		t.Errorf("LogLevel = %q, want %q", conf.LogLevel, logLevelDebug)
 	}
 }
 
@@ -1586,7 +1590,7 @@ func TestLoggingSetup(t *testing.T) {
 	logPath := filepath.Join(tmpDir, "sub", "test.log")
 
 	// Setup logging, which should create the directory and open/write to the file.
-	setupLogging(logPath)
+	setupLogging(logPath, DefaultLogLevel)
 	slog.Info("test log message")
 
 	// Read the log file to verify the message was logged.
@@ -1596,5 +1600,74 @@ func TestLoggingSetup(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "test log message") {
 		t.Fatalf("log content does not contain message: %s", string(data))
+	}
+}
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    slog.Level
+		wantErr bool
+	}{
+		{"empty defaults to info", "", slog.LevelInfo, false},
+		{"debug", logLevelDebug, slog.LevelDebug, false},
+		{"info", DefaultLogLevel, slog.LevelInfo, false},
+		{"warn", logLevelWarn, slog.LevelWarn, false},
+		{"warning alias", logLevelWarning, slog.LevelWarn, false},
+		{"error", logLevelError, slog.LevelError, false},
+		{"case insensitive", "DEBUG", slog.LevelDebug, false},
+		{"surrounding whitespace", "  warn  ", slog.LevelWarn, false},
+		{"unknown falls back to info with error", "verbose", slog.LevelInfo, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLogLevel(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseLogLevel(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoggingSetupRespectsLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	setupLogging(logPath, logLevelWarn)
+	slog.Info("should be suppressed at warn level")
+	slog.Warn("should appear at warn level")
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "should be suppressed at warn level") {
+		t.Errorf("expected info message to be filtered out at warn level, got: %s", content)
+	}
+	if !strings.Contains(content, "should appear at warn level") {
+		t.Errorf("expected warn message to be present, got: %s", content)
+	}
+}
+
+func TestLoggingSetupInvalidLevelFallsBackToInfo(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "test.log")
+
+	// An invalid level must not fail the CNI operation; it should fall back
+	// to DefaultLogLevel (info) rather than panic or drop all logging.
+	setupLogging(logPath, "verbose")
+	slog.Info("should appear at fallback info level")
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(data), "should appear at fallback info level") {
+		t.Errorf("expected info message to be present after fallback, got: %s", string(data))
 	}
 }

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
@@ -27,6 +28,15 @@ const (
 	DefaultKubeconfig = "/var/lib/galactic/kubeconfig"
 	DefaultNamespace  = "galactic-system"
 	DefaultLogFile    = "/var/log/galactic/galactic-cni.log"
+	DefaultLogLevel   = "info"
+)
+
+// Recognized log_level values, other than DefaultLogLevel itself.
+const (
+	logLevelDebug   = "debug"
+	logLevelWarn    = "warn"
+	logLevelWarning = "warning"
+	logLevelError   = "error"
 )
 
 var ConfFile = DefaultConfFile
@@ -159,11 +169,39 @@ func buildDetectScheme() *runtime.Scheme {
 	return scheme
 }
 
-// setupLogging configures the slog default logger to write to the specified path.
-// If opening the file fails, it logs a warning to os.Stderr and falls back.
-func setupLogging(logPath string) {
+// parseLogLevel maps a config-supplied level name to a slog.Level. Matching is
+// case-insensitive. An empty string resolves to DefaultLogLevel. Unrecognized
+// values return an error alongside the info-level fallback, so callers can
+// warn without failing the CNI operation over a typo'd setting.
+func parseLogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return parseLogLevel(DefaultLogLevel)
+	case logLevelDebug:
+		return slog.LevelDebug, nil
+	case DefaultLogLevel:
+		return slog.LevelInfo, nil
+	case logLevelWarn, logLevelWarning:
+		return slog.LevelWarn, nil
+	case logLevelError:
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %q (want %s, %s, %s, or %s)",
+			s, logLevelDebug, DefaultLogLevel, logLevelWarn, logLevelError)
+	}
+}
+
+// setupLogging configures the slog default logger to write to the specified
+// path at the specified verbosity. If opening the file fails, it logs a
+// warning to os.Stderr and falls back. An unrecognized logLevel also logs a
+// warning and falls back to DefaultLogLevel rather than failing the operation.
+func setupLogging(logPath, logLevel string) {
 	if logPath == "" {
 		logPath = DefaultLogFile
+	}
+	level, err := parseLogLevel(logLevel)
+	if err != nil {
+		slog.Warn("Invalid log level, falling back to default", "value", logLevel, "default", DefaultLogLevel, "err", err)
 	}
 	// Ensure parent directory exists.
 	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
@@ -176,7 +214,7 @@ func setupLogging(logPath string) {
 		return
 	}
 	// Use JSON handler for structured logging to file.
-	handler := slog.NewJSONHandler(file, &slog.HandlerOptions{Level: slog.LevelInfo})
+	handler := slog.NewJSONHandler(file, &slog.HandlerOptions{Level: level})
 	slog.SetDefault(slog.New(handler))
 }
 
@@ -352,7 +390,14 @@ func parseConf(data []byte) (*PluginConf, error) {
 	if logFile == "" {
 		logFile = DefaultLogFile
 	}
-	setupLogging(logFile)
+	logLevel := os.Getenv("GALACTIC_CNI_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hostConf.LogLevel
+	}
+	if logLevel == "" {
+		logLevel = DefaultLogLevel
+	}
+	setupLogging(logFile, logLevel)
 
 	// Resolve local IPAM flag
 	if val := os.Getenv("GALACTIC_CNI_ENABLE_LOCAL_IPAM"); val != "" {

--- a/internal/cni/host_device.go
+++ b/internal/cni/host_device.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -63,6 +64,10 @@ func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) 
 		IfName:        skelArgs.IfName,
 		Path:          skelArgs.Path,
 	}
+	device := intf.GenerateInterfaceNameGuest(pluginConf.VPC, pluginConf.VPCAttachment)
+	slog.Debug("host-device: delegating", "command", command, "containerID", skelArgs.ContainerID,
+		"device", device, "ifName", skelArgs.IfName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	result, err := invokeExec.ExecPlugin(ctx, hostDevicePath, conf, invokeArgs.AsEnv())
@@ -73,5 +78,6 @@ func hostDevice(command string, skelArgs *skel.CmdArgs, pluginConf *PluginConf) 
 		return errors.New("host-device plugin returned nil result")
 	}
 	_ = result // Result validated as non-nil; host-device is a delegation helper, not an IPAM provider.
+	slog.Debug("host-device: delegation succeeded", "command", command, "containerID", skelArgs.ContainerID)
 	return nil
 }

--- a/internal/cni/ipam_ops.go
+++ b/internal/cni/ipam_ops.go
@@ -7,6 +7,7 @@ package cni
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -88,6 +89,8 @@ func allocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) (*ipamResult, erro
 		routes = append(routes, defaultRoute)
 	}
 
+	slog.Debug("IPAM: allocated", "containerID", args.ContainerID, "type", poolType, "subnet", subnet, "gateway", gateway)
+
 	return &ipamResult{
 		subnet:  subnet,
 		gateway: gateway,
@@ -123,6 +126,7 @@ func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf, k8s client.Clien
 	if subnetCIDR == "" {
 		// No allocation found — either allocation was never completed,
 		// or the advertisement was already deleted. Nothing to clean up.
+		slog.Debug("IPAM: no allocation found to deallocate", "containerID", args.ContainerID)
 		return
 	}
 
@@ -145,9 +149,12 @@ func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf, k8s client.Clien
 		pa, err := ipam.NewPoolAllocator(poolCIDR, ipamConf.Gateway, ipamConf.SubnetLen)
 		if err != nil {
 			// Pool creation failed — allocation was never completed, nothing to clean up.
+			slog.Warn("IPAM: failed to build pool allocator for deallocation, skipping", "err", err,
+				"containerID", args.ContainerID, "subnet", subnetCIDR)
 			return
 		}
 		pa.Deallocate(subnetCIDR)
+		slog.Debug("IPAM: deallocated", "containerID", args.ContainerID, "subnet", subnetCIDR)
 	case "static":
 		// Static allocations don't need deallocation.
 	}

--- a/internal/cni/netns.go
+++ b/internal/cni/netns.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -21,7 +22,7 @@ func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gatew
 	}
 	defer containerNS.Close() //nolint:errcheck // netns close on teardown
 
-	return containerNS.Do(func(_ ns.NetNS) error {
+	if err := containerNS.Do(func(_ ns.NetNS) error {
 		handle, err := netlink.NewHandle()
 		if err != nil {
 			return fmt.Errorf("create netlink handle: %w", err)
@@ -54,7 +55,13 @@ func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gatew
 		}
 
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	slog.Debug("netns: guest interface configured", "ifName", ifName, "netns", netnsPath,
+		"address", ipNet, "gateway", gateway)
+	return nil
 }
 
 // readGuestInterface reads the MAC and MTU of the guest veth endpoint
@@ -118,6 +125,8 @@ func cleanupContainerNetns(netnsPath, ifName string) error {
 		if err := handle.LinkDel(link); err != nil {
 			return fmt.Errorf("delete stale interface %q in container netns: %w", ifName, err)
 		}
+		slog.Warn("netns: removed stale interface left behind by a previous ADD attempt",
+			"ifName", ifName, "netns", netnsPath)
 		return nil
 	})
 }

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -21,7 +22,15 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-func cmdAdd(args *skel.CmdArgs) error {
+// cmdAdd uses a named return (err) so that the deferred selective rollback
+// below always observes the real failure: several branches check errors via
+// "if err := f(); err != nil" inside nested if/switch blocks, which declares
+// a block-scoped err that would otherwise shadow this function's err and
+// leave the deferred rollback thinking the call succeeded. A plain
+// "return expr" always assigns expr to a named result, regardless of that
+// local shadowing, so naming the return here is what makes rollback fire on
+// every failure path instead of just the ones using top-level "x, err := f()".
+func cmdAdd(args *skel.CmdArgs) (err error) {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
 		return err
@@ -44,6 +53,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	namespace := pluginConf.Namespace
 
+	slog.Info("ADD: starting",
+		"containerID", args.ContainerID, "netns", args.Netns, "ifName", args.IfName,
+		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment,
+		"interfaceType", pluginConf.InterfaceType, "namespace", namespace, "nodeName", nodeName)
+
 	// Track resources for selective rollback on failure.
 	tracker := &resourceTracker{
 		vpc:           pluginConf.VPC,
@@ -58,6 +72,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), cniTimeout)
 	defer func() {
 		if err != nil {
+			slog.Error("ADD: failed, rolling back created resources", "err", err,
+				"containerID", args.ContainerID, "vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 			tracker.cleanup(rollbackCtx)
 			rollbackCancel()
 		}
@@ -67,6 +83,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("add VRF: %w", err)
 	}
 	tracker.vrfCreated = true
+	slog.Debug("ADD: VRF ready", "vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 
 	// Create the appropriate interface type (veth or tap).
 	switch pluginConf.InterfaceType {
@@ -87,6 +104,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	hostMac := hostLink.Attrs().HardwareAddr.String()
 	hostMTU := hostLink.Attrs().MTU
+	slog.Debug("ADD: host interface ready", "name", hostName, "mac", hostMac, "mtu", hostMTU)
 
 	dev := hostName
 	for _, termination := range pluginConf.Terminations {
@@ -94,6 +112,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return fmt.Errorf("add route %s: %w", termination.Network, err)
 		}
 		tracker.routesCreated++
+	}
+	if tracker.routesCreated > 0 {
+		slog.Debug("ADD: termination routes installed", "count", tracker.routesCreated, "dev", dev)
 	}
 
 	// Host-device delegation and IPAM are veth-only.
@@ -106,6 +127,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if err != nil {
 			return err
 		}
+		if ipamResult != nil {
+			slog.Debug("ADD: IPAM allocated", "containerID", args.ContainerID,
+				"subnet", ipamResult.subnet, "gateway", ipamResult.gateway)
+		}
 	case interfaceTypeTap:
 		// Allocate IPAM for the tap interface (same as veth).
 		// The VM manages its own guest interface; the CNI only configures the host side.
@@ -113,10 +138,17 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if err != nil {
 			return fmt.Errorf("allocate IPAM: %w", err)
 		}
+		if ipamResult != nil {
+			slog.Debug("ADD: IPAM allocated", "containerID", args.ContainerID,
+				"subnet", ipamResult.subnet, "gateway", ipamResult.gateway)
+		}
 
 		// Configure the gateway address on the host tap and install the VRF route.
 		if err := configureHostGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
 			return err
+		}
+		if ipamResult != nil && ipamResult.gateway != nil {
+			slog.Debug("ADD: host gateway configured", "name", hostName, "gateway", ipamResult.gateway)
 		}
 
 		// Print the CNI result with IP info.
@@ -141,8 +173,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 		tracker.k8s = k8s
+		slog.Debug("ADD: publishing BGP state", "containerID", args.ContainerID, "interfaceType", interfaceTypeTap)
 		return publishBGPStateK8s(args, pluginConf, nodeName, namespace, ipamResult, vpcHex, vrfID, k8s, tracker)
 	}
 
+	slog.Debug("ADD: publishing BGP state", "containerID", args.ContainerID, "interfaceType", pluginConf.InterfaceType)
 	return publishBGPState(args, pluginConf, nodeName, namespace, ipamResult, tracker)
 }

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -34,6 +35,8 @@ func cmdCheck(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	slog.Info("CHECK: starting", "containerID", args.ContainerID,
+		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment, "interfaceType", pluginConf.InterfaceType)
 
 	var errs []error
 
@@ -62,8 +65,13 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("CHECK failed: %w", errors.Join(errs...))
+		err := fmt.Errorf("CHECK failed: %w", errors.Join(errs...))
+		slog.Error("CHECK: failed", "err", err, "containerID", args.ContainerID,
+			"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
+		return err
 	}
+	slog.Info("CHECK: passed", "containerID", args.ContainerID,
+		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 	return nil
 }
 
@@ -105,10 +113,23 @@ func cmdStatus(args *skel.CmdArgs) error {
 	if logFile == "" {
 		logFile = DefaultLogFile
 	}
-	setupLogging(logFile)
+	logLevel := os.Getenv("GALACTIC_CNI_LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = hostConf.LogLevel
+	}
+	if logLevel == "" {
+		logLevel = DefaultLogLevel
+	}
+	setupLogging(logFile, logLevel)
 
 	// Config is parseable and API server is reachable.
-	return probeAPIServer()
+	slog.Info("STATUS: probing API server reachability")
+	if err := probeAPIServer(); err != nil {
+		slog.Error("STATUS: API server probe failed", "err", err)
+		return err
+	}
+	slog.Info("STATUS: ready")
+	return nil
 }
 
 // probeAPIServer performs a lightweight GET against the in-cluster API server

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -15,6 +15,7 @@ import (
 func cmdDel(args *skel.CmdArgs) error {
 	// DEL is idempotent per the CNI spec: always return success.
 	// Missing resources are not errors.
+	slog.Info("DEL: starting", "containerID", args.ContainerID, "netns", args.Netns)
 
 	// Parse config — if we can't parse it we still return success but
 	// won't be able to clean up any resources.
@@ -26,6 +27,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		_ = types.PrintResult(result, cniVersion100)
 		return nil
 	}
+	vpc, vpcAtt := pluginConf.VPC, pluginConf.VPCAttachment
 
 	// Deallocate the pod's IPAM subnet. This is pod-specific and safe to
 	// release immediately. Applies to both veth and tap modes.
@@ -33,6 +35,9 @@ func cmdDel(args *skel.CmdArgs) error {
 	if hasIPAM {
 		if k8s, err := newK8sClient(); err == nil {
 			deallocateIPAM(args, pluginConf, k8s)
+		} else {
+			slog.Warn("DEL: failed to create k8s client, skipping IPAM deallocation", "err", err,
+				"containerID", args.ContainerID)
 		}
 	}
 
@@ -44,11 +49,8 @@ func cmdDel(args *skel.CmdArgs) error {
 	// The GC runs periodically and removes orphaned resources safely by checking
 	// whether any live container still references them. See gc.CollectOrphanedCRDs
 	// and gc.CollectOrphanedVRFs.
-	vpc, vpcAtt := pluginConf.VPC, pluginConf.VPCAttachment
-	if parseErr == nil {
-		slog.Info("DEL: skipping shared resource cleanup (handled by GC)",
-			"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
-	}
+	slog.Info("DEL: skipping shared resource cleanup (handled by GC)",
+		"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 
 	result := &type100.Result{}
 	_ = types.PrintResult(result, cniVersion100)

--- a/internal/cni/resource.go
+++ b/internal/cni/resource.go
@@ -67,6 +67,8 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 		if err := rt.k8s.Delete(ctx, adv); client.IgnoreNotFound(err) != nil {
 			slog.Error("Rollback: failed to delete BGPAdvertisement", "err", err,
 				"name", adv.Name, "namespace", rt.namespace)
+		} else {
+			slog.Debug("Rollback: deleted BGPAdvertisement", "name", adv.Name, "namespace", rt.namespace)
 		}
 	}
 
@@ -81,6 +83,8 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 		if err := rt.k8s.Delete(ctx, vrfInst); client.IgnoreNotFound(err) != nil {
 			slog.Error("Rollback: failed to delete BGPVRFInstance", "err", err,
 				"name", vrfInst.Name, "namespace", rt.namespace)
+		} else {
+			slog.Debug("Rollback: deleted BGPVRFInstance", "name", vrfInst.Name, "namespace", rt.namespace)
 		}
 	}
 
@@ -89,6 +93,8 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 		if err := srv6.RouteIngressDel(rt.srv6SID, rt.vpc, rt.vpcAttachment); err != nil {
 			slog.Error("Rollback: failed to delete SRv6 ingress route", "err", err,
 				"sid", rt.srv6SID)
+		} else {
+			slog.Debug("Rollback: deleted SRv6 ingress route", "sid", rt.srv6SID)
 		}
 	}
 
@@ -97,6 +103,8 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 		if err := veth.Delete(rt.vpc, rt.vpcAttachment); err != nil {
 			slog.Error("Rollback: failed to delete veth", "err", err,
 				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+		} else {
+			slog.Debug("Rollback: deleted veth", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 		}
 	}
 
@@ -105,6 +113,8 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 		if err := tap.Delete(rt.vpc, rt.vpcAttachment); err != nil {
 			slog.Error("Rollback: failed to delete tap", "err", err,
 				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+		} else {
+			slog.Debug("Rollback: deleted tap", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 		}
 	}
 
@@ -112,5 +122,7 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 	if err := vrf.Delete(rt.vpc, rt.vpcAttachment); err != nil {
 		slog.Error("Rollback: failed to delete VRF", "err", err,
 			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
+	} else {
+		slog.Debug("Rollback: deleted VRF", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 	}
 }

--- a/internal/cni/route/route.go
+++ b/internal/cni/route/route.go
@@ -6,6 +6,7 @@ package route
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/vishvananda/netlink"
@@ -53,7 +54,11 @@ func Add(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
 	if err != nil {
 		return err
 	}
-	return netlink.RouteAdd(route)
+	if err := netlink.RouteAdd(route); err != nil {
+		return err
+	}
+	slog.Debug("route: termination route added", "prefix", prefix, "via", nextHop, "dev", dev, "vrfTable", vrfID)
+	return nil
 }
 
 func Delete(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
@@ -65,5 +70,9 @@ func Delete(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
 	if err != nil {
 		return err
 	}
-	return netlink.RouteDel(route)
+	if err := netlink.RouteDel(route); err != nil {
+		return err
+	}
+	slog.Debug("route: termination route deleted", "prefix", prefix, "via", nextHop, "dev", dev, "vrfTable", vrfID)
+	return nil
 }

--- a/internal/cni/tap/tap.go
+++ b/internal/cni/tap/tap.go
@@ -10,6 +10,7 @@ package tap
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -74,6 +75,7 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	// Check if tap already exists (crash-recovery or prior partial failure).
 	existingTap, err := netlink.LinkByName(tapName)
 	if err == nil {
+		slog.Warn("tap: found existing tap from a previous ADD attempt, repairing state", "tap", tapName)
 		return repairTap(existingTap, vrfLink, tapName)
 	}
 
@@ -88,6 +90,7 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	if err := netlink.LinkAdd(tap); err != nil {
 		return fmt.Errorf("create tap %q: %w", tapName, err)
 	}
+	slog.Debug("tap: created", "tap", tapName, "mtu", mtu)
 
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {
@@ -102,8 +105,11 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	}
 
 	// Allow forwarded traffic through the tap (bidirectional).
-	if err := updateForwardRule(tapName, "add"); err != nil && !errors.Is(err, errIptablesMissing) {
-		return err
+	if err := updateForwardRule(tapName, "add"); err != nil {
+		if !errors.Is(err, errIptablesMissing) {
+			return err
+		}
+		slog.Warn("tap: iptables binary not available, skipping FORWARD rules", "tap", tapName)
 	}
 
 	// Bring the interface up so the kernel populates sysctl entries.
@@ -116,6 +122,7 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 		return err
 	}
 
+	slog.Debug("tap: enslaved to VRF and up", "tap", tapName, "vrf", vrfName)
 	return nil
 }
 
@@ -131,16 +138,22 @@ func Delete(vpc, vpcAttachment string) error {
 
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {
+		slog.Debug("tap: already gone, nothing to delete", "tap", tapName)
 		return nil // interface already gone — idempotent
 	}
 
-	return netlink.LinkDel(tapLink)
+	if err := netlink.LinkDel(tapLink); err != nil {
+		return err
+	}
+	slog.Debug("tap: deleted", "tap", tapName)
+	return nil
 }
 
 // repairTap verifies and repairs a pre-existing tap interface's state.
 func repairTap(tapLink netlink.Link, vrfLink netlink.Link, tapName string) error {
 	// Verify VRF enslavement.
 	if tapLink.Attrs().MasterIndex != vrfLink.Attrs().Index {
+		slog.Warn("tap: re-enslaving tap to VRF during repair", "tap", tapName)
 		if err := netlink.LinkSetMaster(tapLink, vrfLink); err != nil {
 			return fmt.Errorf("re-enslave tap to VRF: %w", err)
 		}
@@ -153,6 +166,7 @@ func repairTap(tapLink netlink.Link, vrfLink netlink.Link, tapName string) error
 
 	// Bring up if down (ensures sysctl entries are populated).
 	if tapLink.Attrs().Flags&net.FlagUp == 0 {
+		slog.Warn("tap: bringing tap back up during repair", "tap", tapName)
 		if err := netlink.LinkSetUp(tapLink); err != nil {
 			return fmt.Errorf("bring up tap %q: %w", tapName, err)
 		}

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -57,6 +57,7 @@ type HostConf struct {
 	Kubeconfig string `json:"kubeconfig"`
 	Namespace  string `json:"namespace"`
 	LogFile    string `json:"log_file"`
+	LogLevel   string `json:"log_level,omitempty"`
 }
 
 // ipamResult holds the IPAM allocation details for building the CNI result.

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -7,6 +7,7 @@ package veth
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -87,6 +88,8 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	// with no corresponding cmdDel), clean up the stale guest end and recreate
 	// the pair so the guest side is in a known-good state.
 	if existing, err := netlink.LinkByName(hostName); err == nil {
+		slog.Warn("veth: removing stale host veth left behind by a previous ADD attempt",
+			"host", hostName, "guest", guestName)
 		// Remove any stale guest endpoint that may linger from a prior run.
 		if guest, guestErr := netlink.LinkByName(guestName); guestErr == nil {
 			netlink.LinkDel(guest) //nolint:errcheck // best-effort cleanup
@@ -105,13 +108,17 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	}
 
 	if err := netlink.LinkAdd(veth); err != nil {
-		return err
+		return fmt.Errorf("create veth pair %s/%s: %w", hostName, guestName, err)
 	}
+	slog.Debug("veth: pair created", "host", hostName, "guest", guestName, "mtu", mtu)
 
 	// iptables is not available in distroless images; skip forwarding rules
 	// gracefully so the CNI plugin can still produce a result in test environments.
-	if err := updateForwardRule(hostName, "add"); err != nil && !errors.Is(err, errIptablesMissing) {
-		return err
+	if err := updateForwardRule(hostName, "add"); err != nil {
+		if !errors.Is(err, errIptablesMissing) {
+			return err
+		}
+		slog.Warn("veth: iptables binary not available, skipping FORWARD rules", "host", hostName)
 	}
 
 	if err := sysctl.ConfigureInterfaceSysctls(hostName); err != nil {
@@ -138,7 +145,11 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 		return err
 	}
 
-	return netlink.LinkSetMaster(hostLink, vrfLink)
+	if err := netlink.LinkSetMaster(hostLink, vrfLink); err != nil {
+		return err
+	}
+	slog.Debug("veth: enslaved to VRF and up", "host", hostName, "vrf", vrfName)
+	return nil
 }
 
 func Delete(vpc, vpcAttachment string) error {
@@ -157,10 +168,15 @@ func Delete(vpc, vpcAttachment string) error {
 	hostLink, err := netlink.LinkByName(hostName)
 	if err != nil {
 		if isLinkNotFoundError(err) {
+			slog.Debug("veth: host veth already gone, nothing to delete", "host", hostName)
 			return nil // interface already gone — idempotent
 		}
 		return err
 	}
 
-	return netlink.LinkDel(hostLink)
+	if err := netlink.LinkDel(hostLink); err != nil {
+		return err
+	}
+	slog.Debug("veth: deleted", "host", hostName)
+	return nil
 }

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -51,6 +51,7 @@ type HostConf struct {
 	Kubeconfig string `json:"kubeconfig"`
 	Namespace  string `json:"namespace"`
 	LogFile    string `json:"log_file"`
+	LogLevel   string `json:"log_level,omitempty"`
 }
 
 type conflistEnvelope struct {
@@ -285,7 +286,8 @@ func Bootstrap(ctx context.Context, nodeName string) error {
       "node_name": %q,
       "kubeconfig": "/var/lib/galactic/kubeconfig",
       "namespace": "galactic-system",
-      "log_file": "/var/log/galactic/galactic-cni.log"
+      "log_file": "/var/log/galactic/galactic-cni.log",
+      "log_level": "info"
     }
   ]
 }

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -117,6 +117,18 @@ func TestBootstrap(t *testing.T) {
 		if conflist.NodeName != "test-node" {
 			t.Errorf("expected node_name test-node, got %s", conflist.NodeName)
 		}
+		if conflist.Kubeconfig != "/var/lib/galactic/kubeconfig" {
+			t.Errorf("expected kubeconfig /var/lib/galactic/kubeconfig, got %s", conflist.Kubeconfig)
+		}
+		if conflist.Namespace != "galactic-system" {
+			t.Errorf("expected namespace galactic-system, got %s", conflist.Namespace)
+		}
+		if conflist.LogFile != "/var/log/galactic/galactic-cni.log" {
+			t.Errorf("expected log_file /var/log/galactic/galactic-cni.log, got %s", conflist.LogFile)
+		}
+		if conflist.LogLevel != "info" {
+			t.Errorf("expected log_level info, got %s", conflist.LogLevel)
+		}
 
 		// Verify kubeconfig written
 		kubeconfig, err := os.ReadFile(filepath.Join(HostEtcDir, "kubeconfig"))


### PR DESCRIPTION
## Summary
- Adds `slog`-based logging across the CNI ADD/DEL/CHECK/STATUS paths and the `veth`/`tap`/`route` subpackages — start/outcome per operation at `info`, per-resource milestones (VRF/interface/route/IPAM ready, BGP CRDs applied, rollback confirmations) at `debug` — since each CNI invocation is a short-lived process with no persistent daemon to inspect.
- Adds a `log_level` config setting (new conflist field + `GALACTIC_CNI_LOG_LEVEL` env var, mirroring how `log_file` already resolves), defaulting to `info`, so verbosity is adjustable without a code change.
- Fixes a rollback bug found during review: `err` was shadowed inside nested `if`/`switch` blocks in `cmdAdd`, so the deferred selective-rollback silently skipped most failure paths (leaking VRF/veth/tap/route state on failures after `vrf.Add` succeeded). Fixed with a named return, since Go's `return expr` always assigns to a named result regardless of local shadowing.
- Updates `docs/cni/configuration.md` (new "Log verbosity" section, resolution table, removed a redundant `JSON Key` column across its tables) and the mirrored table in `docs/agents/ARCHITECTURE.md`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race` across all packages except `tests/e2e` (needs a disposable Kind cluster)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Added unit tests: `parseLogLevel` (valid/case-insensitive/whitespace/invalid-fallback), level-filtering behavior of `setupLogging`, `LogLevel` field coverage in `TestLoadHostConf`, and a conflist-shape assertion in the installer's `TestBootstrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)