### PR TITLE
enh(cni): return proper CNI error codes instead of generic Go errors

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -79,6 +79,23 @@ func routerForNode(name, nodeName, namespace string, asn int64) *bgpv1alpha1.BGP
 	}
 }
 
+// assertCNIError verifies that err is a *types.Error with the expected Code
+// and that its Msg contains wantMsg (substring match). Pass wantMsg == "" to
+// skip the message check.
+func assertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
+	t.Helper()
+	var cniErr *types.Error
+	if !errors.As(err, &cniErr) {
+		t.Fatalf("expected *types.Error, got %T: %v", err, err)
+	}
+	if cniErr.Code != wantCode {
+		t.Fatalf("expected code %d, got %d (Msg: %q)", wantCode, cniErr.Code, cniErr.Msg)
+	}
+	if wantMsg != "" && !strings.Contains(cniErr.Msg, wantMsg) {
+		t.Fatalf("expected Msg to contain %q, got %q", wantMsg, cniErr.Msg)
+	}
+}
+
 // ---- parseConf -----------------------------------------------------------
 
 func TestParseConf(t *testing.T) {
@@ -88,6 +105,7 @@ func TestParseConf(t *testing.T) {
 		wantVPC    string
 		wantIfType string
 		wantErr    string
+		wantCode   uint // CNI error code; 0 means "don't check"
 	}{
 		{
 			name: "valid config",
@@ -101,14 +119,16 @@ func TestParseConf(t *testing.T) {
 			wantIfType: interfaceTypeVeth,
 		},
 		{
-			name:    "invalid JSON",
-			input:   "not json",
-			wantErr: "parse CNI config",
+			name:     "invalid JSON",
+			input:    "not json",
+			wantErr:  "invalid CNI config",
+			wantCode: 7,
 		},
 		{
-			name:    "empty input",
-			input:   "",
-			wantErr: "parse CNI config",
+			name:     "empty input",
+			input:    "",
+			wantErr:  "invalid CNI config",
+			wantCode: 7,
 		},
 		{
 			name: "interface_type=veth",
@@ -151,7 +171,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"%s","interface_type":"unknown"}`,
 				testVPC, testAttachment,
 			),
-			wantErr: `invalid interface_type "unknown": must be "veth" or "tap"`,
+			wantErr:  `invalid interface_type "unknown": must be "veth" or "tap"`,
+			wantCode: 7,
 		},
 		{
 			name: "missing vpc",
@@ -160,7 +181,8 @@ func TestParseConf(t *testing.T) {
 					`"type":"galactic-cni","vpcattachment":"%s"}`,
 				testAttachment,
 			),
-			wantErr: "vpc is required and must be a non-empty base62 string",
+			wantErr:  "vpc is required and must be a non-empty base62 string",
+			wantCode: 7,
 		},
 		{
 			name: "empty vpc",
@@ -170,7 +192,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"%s"}`,
 				testAttachment,
 			),
-			wantErr: "vpc is required and must be a non-empty base62 string",
+			wantErr:  "vpc is required and must be a non-empty base62 string",
+			wantCode: 7,
 		},
 		{
 			name: "vpc with invalid char hyphen",
@@ -180,7 +203,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"%s"}`,
 				testInvalidBase62, testAttachment,
 			),
-			wantErr: fmt.Sprintf("invalid base62 value for field 'vpc': %q", testInvalidBase62),
+			wantErr:  fmt.Sprintf("invalid base62 value for field 'vpc': %q", testInvalidBase62),
+			wantCode: 7,
 		},
 		{
 			name: "vpc with invalid char underscore",
@@ -190,7 +214,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"%s"}`,
 				testAttachment,
 			),
-			wantErr: `invalid base62 value for field 'vpc': "abc_def"`,
+			wantErr:  `invalid base62 value for field 'vpc': "abc_def"`,
+			wantCode: 7,
 		},
 		{
 			name: "missing vpcattachment",
@@ -199,7 +224,8 @@ func TestParseConf(t *testing.T) {
 					`"type":"galactic-cni","vpc":"%s"}`,
 				testVPC,
 			),
-			wantErr: "vpcattachment is required and must be a non-empty base62 string",
+			wantErr:  "vpcattachment is required and must be a non-empty base62 string",
+			wantCode: 7,
 		},
 		{
 			name: "empty vpcattachment",
@@ -209,7 +235,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":""}`,
 				testVPC,
 			),
-			wantErr: "vpcattachment is required and must be a non-empty base62 string",
+			wantErr:  "vpcattachment is required and must be a non-empty base62 string",
+			wantCode: 7,
 		},
 		{
 			name: "vpcattachment with invalid char space",
@@ -219,7 +246,8 @@ func TestParseConf(t *testing.T) {
 					`"vpcattachment":"def ghi"}`,
 				testVPC,
 			),
-			wantErr: `invalid base62 value for field 'vpcattachment': "def ghi"`,
+			wantErr:  `invalid base62 value for field 'vpcattachment': "def ghi"`,
+			wantCode: 7,
 		},
 		{
 			name: "valid vpc and vpcattachment with mixed case base62",
@@ -297,6 +325,9 @@ func TestParseConf(t *testing.T) {
 				}
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				if tt.wantCode > 0 {
+					assertCNIError(t, err, tt.wantCode, tt.wantErr)
 				}
 				return
 			}
@@ -950,8 +981,8 @@ func TestCmdCheckInvalidConfig(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for invalid JSON, got nil")
 	}
-	if !strings.Contains(err.Error(), "parse CNI config") {
-		t.Fatalf("error %q does not contain 'parse CNI config'", err.Error())
+	if !strings.Contains(err.Error(), "invalid CNI config") {
+		t.Fatalf("error %q does not contain 'invalid CNI config'", err.Error())
 	}
 }
 
@@ -1160,12 +1191,7 @@ func TestCmdStatusInvalidConfig(t *testing.T) {
 	}
 
 	err := cmdStatus(args)
-	if err == nil {
-		t.Fatalf("expected error for invalid JSON, got nil")
-	}
-	if !strings.Contains(err.Error(), "parse CNI config") {
-		t.Fatalf("error %q does not contain 'parse CNI config'", err.Error())
-	}
+	assertCNIError(t, err, 7, "invalid CNI config")
 }
 
 func TestCmdStatusInvalidInterfaceType(t *testing.T) {
@@ -1181,12 +1207,7 @@ func TestCmdStatusInvalidInterfaceType(t *testing.T) {
 	}
 
 	err := cmdStatus(args)
-	if err == nil {
-		t.Fatalf("expected error for invalid interface_type, got nil")
-	}
-	if !strings.Contains(err.Error(), `invalid interface_type "bogus"`) {
-		t.Fatalf("error %q does not contain expected message", err.Error())
-	}
+	assertCNIError(t, err, 7, `invalid interface_type "bogus"`)
 }
 
 func TestCmdStatusValidConfigMissingResources(t *testing.T) {
@@ -1258,6 +1279,27 @@ func TestCmdStatusMissingVPCAttachment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil (STATUS does not validate attachment fields), got: %v", err)
 	}
+}
+
+func TestCmdStatusAPIProbeFailure(t *testing.T) {
+	// STATUS should return CNI error code 50 when the API server probe fails.
+	original := probeAPIServer
+	probeAPIServer = func() error { return errors.New("connection refused") }
+	defer func() { probeAPIServer = original }()
+
+	conf := fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test",`+
+			`"type":"galactic-cni","vpc":"%s",`+
+			`"vpcattachment":"%s"}`,
+		testVPC, testAttachment,
+	)
+	args := &skel.CmdArgs{
+		ContainerID: testContainerID,
+		StdinData:   []byte(conf),
+	}
+
+	err := cmdStatus(args)
+	assertCNIError(t, err, 50, "API server health check failed")
 }
 
 // ---- isTransientError ----------------------------------------------------
@@ -1459,7 +1501,7 @@ func TestCmdAddPrevResultValid(t *testing.T) {
 	t.Setenv("NODE_NAME", "")
 	// prevResult that is a valid CNI result. cmdAdd should pass prevResult
 
-	// validation and fail later due to missing NODE_NAME env var.
+	// validation and fail later due to missing node name.
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
 			`"type":"galactic-cni","vpc":"%s",`+
@@ -1473,16 +1515,9 @@ func TestCmdAddPrevResultValid(t *testing.T) {
 	}
 
 	err := cmdAdd(args)
-	if err == nil {
-		t.Fatal("expected cmdAdd to fail for missing NODE_NAME, got nil")
-	}
-	// Should fail on NODE_NAME, not prevResult.
-	if strings.Contains(err.Error(), "prevResult validation in ADD") {
-		t.Fatalf("prevResult should not cause error when valid, got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "NODE_NAME") {
-		t.Fatalf("expected NODE_NAME error, got: %v", err)
-	}
+	// Should fail with code 4 (invalid env vars) for missing node name,
+	// not code 6 for prevResult.
+	assertCNIError(t, err, 4, "node name is required")
 }
 
 // ---- loadHostConf -----------------------------------------------------------

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -43,6 +43,16 @@ var ConfFile = DefaultConfFile
 
 const sanitizeForErrorBinary = "<binary>"
 
+// errInvalidCNIConfig is the message for CNI config parse errors (code 7).
+const errInvalidCNIConfig = "invalid CNI config"
+
+// errVPCRequired and errVPCAttachmentRequired are messages for missing
+// identifier fields (code 7).
+const (
+	errVPCRequired           = "vpc is required and must be a non-empty base62 string"
+	errVPCAttachmentRequired = "vpcattachment is required and must be a non-empty base62 string"
+)
+
 // isValidBase62 reports whether s contains only valid base62 characters
 // ([0-9a-zA-Z]) and is non-empty. VPC and VPCAttachment identifiers are
 // base62-encoded and used throughout the ADD path (interface naming,
@@ -238,23 +248,23 @@ type statusConf struct {
 func parseStatusConf(data []byte) error {
 	var sc statusConf
 	if err := json.Unmarshal(data, &sc); err != nil {
-		return fmt.Errorf("parse CNI config: %w", err)
+		return &types.Error{Code: 7, Msg: errInvalidCNIConfig, Details: err.Error()}
 	}
 	if sc.CNIVersion == "" {
-		return errors.New("cniVersion is required")
+		return &types.Error{Code: 7, Msg: "cniVersion is required"}
 	}
 	if sc.Type == "" {
-		return errors.New("type is required")
+		return &types.Error{Code: 7, Msg: "type is required"}
 	}
 	// Validate interface_type if present.
 	if sc.InterfaceType != "" {
 		switch sc.InterfaceType {
 		case interfaceTypeVeth, interfaceTypeTap:
 		default:
-			return fmt.Errorf(
+			return &types.Error{Code: 7, Msg: fmt.Sprintf(
 				"invalid interface_type %q: must be %q or %q",
 				sc.InterfaceType, interfaceTypeVeth, interfaceTypeTap,
-			)
+			)}
 		}
 	}
 	return nil
@@ -314,19 +324,25 @@ func validatePrevResultAdd(res types.Result) error {
 func parseConf(data []byte) (*PluginConf, error) {
 	conf := &PluginConf{}
 	if err := json.Unmarshal(data, &conf); err != nil {
-		return nil, fmt.Errorf("parse CNI config: %w", err)
+		return nil, &types.Error{Code: 7, Msg: errInvalidCNIConfig, Details: err.Error()}
 	}
 	if !isValidBase62(conf.VPC) {
 		if len(conf.VPC) == 0 {
-			return nil, errors.New("vpc is required and must be a non-empty base62 string")
+			return nil, &types.Error{Code: 7, Msg: errVPCRequired}
 		}
-		return nil, fmt.Errorf("invalid base62 value for field 'vpc': %q", sanitizeForError(conf.VPC))
+		return nil, &types.Error{
+			Code: 7,
+			Msg:  fmt.Sprintf("invalid base62 value for field 'vpc': %q", sanitizeForError(conf.VPC)),
+		}
 	}
 	if !isValidBase62(conf.VPCAttachment) {
 		if len(conf.VPCAttachment) == 0 {
-			return nil, errors.New("vpcattachment is required and must be a non-empty base62 string")
+			return nil, &types.Error{Code: 7, Msg: errVPCAttachmentRequired}
 		}
-		return nil, fmt.Errorf("invalid base62 value for field 'vpcattachment': %q", sanitizeForError(conf.VPCAttachment))
+		return nil, &types.Error{
+			Code: 7,
+			Msg:  fmt.Sprintf("invalid base62 value for field 'vpcattachment': %q", sanitizeForError(conf.VPCAttachment)),
+		}
 	}
 
 	// Load host CNI config
@@ -355,7 +371,7 @@ func parseConf(data []byte) (*PluginConf, error) {
 		nodeName = detected
 	}
 	if nodeName == "" {
-		return nil, errors.New("node name is required (or set GALACTIC_CNI_NODE_NAME)")
+		return nil, &types.Error{Code: 4, Msg: "node name is required (or set GALACTIC_CNI_NODE_NAME)"}
 	}
 	_ = os.Setenv("NODE_NAME", nodeName)
 
@@ -406,12 +422,12 @@ func parseConf(data []byte) (*PluginConf, error) {
 
 	// Enforce required IPAM block if local IPAM is enabled
 	if enableLocalIPAM && conf.IPAM == nil {
-		return nil, errors.New("local IPAM is enabled, but no 'ipam' block is present in the configuration")
+		return nil, &types.Error{Code: 7, Msg: "local IPAM is enabled, but no 'ipam' block is present in the configuration"}
 	}
 
 	if conf.PrevResult != nil {
 		if err := validatePrevResult(conf.PrevResult); err != nil {
-			return nil, fmt.Errorf("invalid prevResult: %w", err)
+			return nil, &types.Error{Code: 6, Msg: fmt.Sprintf("invalid prevResult: %v", err)}
 		}
 	}
 	if conf.InterfaceType == "" {
@@ -420,10 +436,10 @@ func parseConf(data []byte) (*PluginConf, error) {
 	switch conf.InterfaceType {
 	case interfaceTypeVeth, interfaceTypeTap:
 	default:
-		return nil, fmt.Errorf(
+		return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
 			"invalid interface_type %q: must be %q or %q",
 			conf.InterfaceType, interfaceTypeVeth, interfaceTypeTap,
-		)
+		)}
 
 	}
 	return conf, nil

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -6,7 +6,6 @@ package cni
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -42,13 +41,13 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	// configured chain that galactic-cni should not silently ignore.
 	if pluginConf.PrevResult != nil {
 		if err := validatePrevResultAdd(pluginConf.PrevResult); err != nil {
-			return fmt.Errorf("prevResult validation in ADD: %w", err)
+			return &types.Error{Code: 6, Msg: fmt.Sprintf("prevResult validation in ADD: %v", err)}
 		}
 	}
 
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName == "" {
-		return errors.New("NODE_NAME environment variable is not set")
+		return &types.Error{Code: 4, Msg: "NODE_NAME environment variable is not set"}
 	}
 
 	namespace := pluginConf.Namespace

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -92,7 +93,7 @@ func cmdStatus(args *skel.CmdArgs) error {
 	// Load host CNI config to resolve Kubeconfig and LogFile
 	hostConf, err := loadHostConf(ConfFile)
 	if err != nil {
-		return fmt.Errorf("load host CNI config: %w", err)
+		return &types.Error{Code: 7, Msg: fmt.Sprintf("load host CNI config: %v", err)}
 	}
 
 	// Resolve and propagate Kubeconfig
@@ -126,7 +127,7 @@ func cmdStatus(args *skel.CmdArgs) error {
 	slog.Info("STATUS: probing API server reachability")
 	if err := probeAPIServer(); err != nil {
 		slog.Error("STATUS: API server probe failed", "err", err)
-		return err
+		return &types.Error{Code: 50, Msg: fmt.Sprintf("API server health check failed: %v", err)}
 	}
 	slog.Info("STATUS: ready")
 	return nil


### PR DESCRIPTION
## Problem

The plugin returned plain Go `error` values from all CNI command handlers. The CNI framework serializes these as code `100` (generic), losing semantic meaning for the runtime — which relies on codes like 50/51 for STATUS readiness and 4 for invalid environment variables.

## Solution

Replace targeted `fmt.Errorf`/`errors.New` returns with `types.Error` carrying semantic CNI error codes:

| Code | Meaning | Where |
|---|---|---|
| 4 | Invalid environment variables | Missing NODE_NAME, missing node name in parseConf |
| 6 | Failed to decode content | prevResult validation in parseConf and cmdAdd |
| 7 | Invalid network config | Config parse errors in parseConf and parseStatusConf |
| 50 | Plugin not available | API server probe failure in cmdStatus |

## Changes

- Replace 13 error returns in \`parseConf\` with \`types.Error\` (codes 4, 6, 7)
- Replace 4 error returns in \`parseStatusConf\` with \`types.Error\` (code 7)
- Return code 4 for missing NODE_NAME in cmdAdd
- Return code 6 for prevResult validation failure in cmdAdd
- Return code 50 for API server probe failure in cmdStatus
- Return code 7 for loadHostConf failure in cmdStatus
- Add \`assertCNIError\` test helper with \`errors.As\` for code assertions
- Add \`wantCode\` field to TestParseConf table and assert on error codes
- Add TestCmdStatusAPIProbeFailure for code 50 coverage
- Extract error message constants to satisfy goconst linter

## Verification

\`task ci\` passes: lint → build → test:unit → test:e2e

---

fixes #240

Generated with Qwen Code (1-shotted by Qwen-Coder)