### PR TITLE
fix: use negotiated CNIVersion in PrintResult instead of hardcoded constant

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -56,9 +56,6 @@ const (
 	interfaceTypeVeth = "veth"
 	// interfaceTypeTap is the tap interface type: L2 fd for VMs (Kata, Firecracker).
 	interfaceTypeTap = "tap"
-
-	// cniVersion100 is the CNI spec version this plugin reports.
-	cniVersion100 = "1.0.0"
 )
 
 // RunPlugin starts the CNI plugin, handling ADD, DEL, CHECK, and STATUS operations.

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -45,6 +45,7 @@ const (
 	testIfName        = "eth0"
 	testRouterName    = "overlay-router"
 	testSID128        = "2001:db8::1/128"
+	testCNIVersion    = "1.0.0"
 
 	// testPrevResult is a valid CNI v1.0.0 result used in prevResult tests.
 	testPrevResult = `{"cniVersion":"1.0.0",` +
@@ -378,7 +379,7 @@ func TestSanitizeForError(t *testing.T) {
 
 func TestValidatePrevResult(t *testing.T) {
 	validResult := &type100.Result{
-		CNIVersion: cniVersion100,
+		CNIVersion: testCNIVersion,
 		Interfaces: []*type100.Interface{
 			{Name: testIfName, Mac: testMac, Sandbox: testNetns},
 		},
@@ -414,7 +415,7 @@ func TestValidatePrevResult(t *testing.T) {
 
 func TestValidatePrevResultAdd(t *testing.T) {
 	validWithInterface := &type100.Result{
-		CNIVersion: cniVersion100,
+		CNIVersion: testCNIVersion,
 		Interfaces: []*type100.Interface{
 			{Name: testIfName, Mac: testMac, Sandbox: testNetns},
 		},
@@ -423,13 +424,13 @@ func TestValidatePrevResultAdd(t *testing.T) {
 		},
 	}
 	validWithIPsOnly := &type100.Result{
-		CNIVersion: cniVersion100,
+		CNIVersion: testCNIVersion,
 		IPs: []*type100.IPConfig{
 			{Address: *mustParseCIDR(t, "fd00:1::1/64")},
 		},
 	}
 	emptyResult := &type100.Result{
-		CNIVersion: cniVersion100,
+		CNIVersion: testCNIVersion,
 		// No interfaces, no IPs — should fail content validation.
 	}
 
@@ -699,7 +700,7 @@ func TestBuildResult(t *testing.T) {
 	netns := "/proc/1234/ns/net"
 
 	conf := &PluginConf{
-		PluginConf:    types.PluginConf{CNIVersion: cniVersion100},
+		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
 		VPC:           testVPC,
 		VPCAttachment: testAttachment,
 	}
@@ -740,8 +741,8 @@ func TestBuildResult(t *testing.T) {
 				netns,
 			)
 
-			if result.CNIVersion != cniVersion100 {
-				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, cniVersion100)
+			if result.CNIVersion != testCNIVersion {
+				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, testCNIVersion)
 			}
 
 			if len(result.Interfaces) != tt.wantInts {
@@ -816,7 +817,7 @@ func TestBuildTapResult(t *testing.T) {
 	route := mustParseCIDR(t, "::/0")
 
 	conf := &PluginConf{
-		PluginConf:    types.PluginConf{CNIVersion: cniVersion100},
+		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
 		VPC:           testVPC,
 		VPCAttachment: testAttachment,
 	}
@@ -845,8 +846,8 @@ func TestBuildTapResult(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildTapResult(conf, tt.ipRes, "H0abc123", "aa:bb:cc:dd:ee:ff", 1500)
 
-			if result.CNIVersion != cniVersion100 {
-				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, cniVersion100)
+			if result.CNIVersion != testCNIVersion {
+				t.Errorf("CNIVersion = %q, want %q", result.CNIVersion, testCNIVersion)
 			}
 
 			if len(result.Interfaces) != 1 {

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -153,7 +153,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 		// Print the CNI result with IP info.
 		result := buildTapResult(pluginConf, ipamResult, hostName, hostMac, hostMTU)
-		if err := types.PrintResult(result, cniVersion100); err != nil {
+		if err := types.PrintResult(result, pluginConf.CNIVersion); err != nil {
 			return fmt.Errorf("print CNI result: %w", err)
 		}
 

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -24,7 +24,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		slog.Error("DEL: failed to parse CNI config, skipping cleanup", "err", parseErr,
 			"containerID", args.ContainerID)
 		result := &type100.Result{}
-		_ = types.PrintResult(result, cniVersion100)
+		_ = types.PrintResult(result, "1.0.0")
 		return nil
 	}
 	vpc, vpcAtt := pluginConf.VPC, pluginConf.VPCAttachment
@@ -53,7 +53,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 
 	result := &type100.Result{}
-	_ = types.PrintResult(result, cniVersion100)
+	_ = types.PrintResult(result, pluginConf.CNIVersion)
 
 	return nil
 }

--- a/internal/cni/plan.md
+++ b/internal/cni/plan.md
@@ -45,7 +45,7 @@ Package-level godoc explaining the CNI plugin's purpose: wires containers into V
 - `RunPlugin()` — `skel.PluginMainFuncs` wiring
 - `init()` — scheme registration
 - `SetEnableLocalIPAM()` — CLI flag setter
-- Constants only: `cniTimeout`, `ipamTypePool`, `localIPAMDefaultPool`, `localIPAMDefaultSubnetLen`, `cniVersion100`, `interfaceTypeVeth`, `interfaceTypeTap`, `defaultNamespace`
+- Constants only: `cniTimeout`, `ipamTypePool`, `localIPAMDefaultPool`, `localIPAMDefaultSubnetLen`, `interfaceTypeVeth`, `interfaceTypeTap`, `defaultNamespace`
 
 **Move out:** All function bodies. Only type declarations that are referenced from other files stay (`PluginConf` → `types.go`).
 

--- a/internal/cni/result.go
+++ b/internal/cni/result.go
@@ -99,7 +99,7 @@ func buildVethResult(
 		return nil, fmt.Errorf("read guest interface: %w", err)
 	}
 	result := buildResult(pluginConf, ipamResult, hostName, args.IfName, hostMac, guestMac, hostMTU, guestMTU, args.Netns)
-	if err := types.PrintResult(result, cniVersion100); err != nil {
+	if err := types.PrintResult(result, pluginConf.CNIVersion); err != nil {
 		return nil, fmt.Errorf("print CNI result: %w", err)
 	}
 


### PR DESCRIPTION
## What

All calls to `types.PrintResult()` used a hardcoded `"1.0.0"` constant regardless of the CNI version negotiated by the runtime. If the runtime negotiates spec v1.1.0, the plugin still emitted v1.0.0 JSON, which would silently drop any v1.1.0-specific result fields.

## Why

The negotiated version is available as `pluginConf.CNIVersion` but was ignored. This is a latent version mismatch that will surface when newer result features are needed.

## Changes

- Remove `cniVersion100` constant from `cni.go`
- Pass `pluginConf.CNIVersion` to `PrintResult` in veth, tap, and DEL paths
- Use inline `"1.0.0"` fallback in DEL parse-error path where `pluginConf` is unavailable
- Add test-local `testCNIVersion` constant to satisfy goconst linter
- Update `plan.md` to reflect removed constant

## Verification

- `task ci` passes: lint (0 issues), build, unit tests, e2e tests

fixes #239

Generated with Qwen Code (1-shotted by Qwen-Coder)