### PR TITLE
fix(cni): forward DEL to host-device delegated plugin

### DIFF
--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -41,6 +41,13 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
+	// Forward DEL to host-device delegated plugin (CNI spec §4).
+	// host-device DEL is idempotent — missing devices are not errors.
+	// Only applies to veth mode; tap mode has no host-device delegation.
+	if pluginConf.InterfaceType == interfaceTypeVeth {
+		_ = hostDevice("DEL", args, pluginConf)
+	}
+
 	// Shared resources (VRF, veth/tap, routes, SRv6 ingress, BGPAdvertisement,
 	// BGPVRFInstance) are keyed by (vpc, vpcAttachment) and may still be in use
 	// by another pod. Deleting them here races with cmdAdd during pod restarts —


### PR DESCRIPTION
## Problem

`cmdDel` never forwards the DEL command to the `host-device` delegated plugin, even though ADD invokes it. The CNI spec §4 (Plugin Delegation) requires:

> Main plugin must forward CHECK, DEL, and GC to delegated plugins.

Currently `internal/cni/ops_del.go` deallocates IPAM and returns without calling `hostDevice("DEL", ...)`.

## Impact

If `host-device` maintains any state (reference counting, device tracking, future extensions), it will leak on pod deletion. Even if the current host-device binary is a no-op on DEL, this is a latent spec violation that any contributor extending host-device would inherit.

## Fix

Add `hostDevice("DEL", args, pluginConf)` to `cmdDel` in `internal/cni/ops_del.go`, after IPAM deallocation and before the final result print. The error is intentionally ignored per CNI spec — DEL must be idempotent and return success even if resources are already gone.

Only applies to veth mode; tap mode has no host-device delegation.

## Verification

- `task ci` passes: lint (0 issues), build, unit tests, e2e tests
- Matches ADD path: `hostDevice("ADD", ...)` in `buildVethResult()` now has a symmetric DEL

Closes #238

Generated with Qwen Code (1-shotted by Qwen-Coder)