### PR TITLE
refactor: consolidate configuration into centralized config package

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	grpchealth "google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -24,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/controller"
 	"go.datum.net/galactic/internal/hash"
 	"go.datum.net/galactic/internal/metadata"
@@ -43,132 +43,6 @@ const (
  Find more information at: https://www.datum.net/docs`
 )
 
-// newViper returns a configured viper instance with defaults, env var
-// bindings, and automatic fallback for keys not explicitly bound.
-func newViper() *viper.Viper {
-	v := viper.New()
-	v.SetDefault("galactic_router.bgp_listen_port", 179)
-	v.SetDefault("galactic_router.metrics_port", 8080)
-	v.SetDefault("galactic_router.grpc_health_port", 5000)
-	v.SetDefault("galactic_router.gc_namespace", "galactic-system")
-	v.SetDefault("galactic_router.gc_interval", 5*time.Minute)
-
-	v.AutomaticEnv()
-
-	// Explicit bindings — AutomaticEnv uses the snake_case key derived from
-	// the viper key path (e.g. galactic_router.node_name ->
-	// GALACTIC_ROUTER_NODE_NAME), but some keys need explicit mapping.
-	//nolint:errcheck // keys are controlled, BindEnv cannot fail here
-	v.BindEnv("galactic_router.node_name", "GALACTIC_ROUTER_NODE_NAME")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.router_mode", "GALACTIC_ROUTER_ROUTER_MODE")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.bgp_listen_port", "GALACTIC_ROUTER_BGP_LISTEN_PORT")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.bgp_local_address", "GALACTIC_ROUTER_BGP_LOCAL_ADDRESS")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.metrics_port", "GALACTIC_ROUTER_METRICS_PORT")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.grpc_health_port", "GALACTIC_ROUTER_GRPC_HEALTH_PORT")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.gc_namespace", "GALACTIC_ROUTER_GC_NAMESPACE")
-	//nolint:errcheck
-	v.BindEnv("galactic_router.gc_interval", "GALACTIC_ROUTER_GC_INTERVAL")
-	//nolint:errcheck
-	v.BindEnv("reflector", "GALACTIC_ROUTER_REFLECTOR")
-
-	return v
-}
-
-const (
-	modeTransit = "transit"
-	modeFabric  = "fabric"
-	modeTenant  = "tenant"
-)
-
-// bindFlags registers each viper-configured flag on the command so that
-// `viper.BindPFlags` can resolve flag values at runtime.
-func bindFlags(cmd *cobra.Command, v *viper.Viper) { //nolint:lll // cobra flag defs are inherently long
-	cmd.Flags().StringP("node-name", "n", "", "Kubernetes node name (required)")
-	cmd.Flags().StringP("mode", "m", "",
-		"Operating mode: 'transit', 'fabric', or 'tenant' (required)")
-	cmd.Flags().Bool("reflector", false,
-		"Enable route reflector mode (requires --mode=fabric or --mode=tenant)")
-	cmd.Flags().IntP("bgp-listen-port", "p", v.GetInt("galactic_router.bgp_listen_port"),
-		"BGP listen port")
-	cmd.Flags().StringP("bgp-local-address", "",
-		v.GetString("galactic_router.bgp_local_address"),
-		"Source address for outgoing BGP connections; auto-detected from lo if unset")
-	cmd.Flags().IntP("metrics-port", "",
-		v.GetInt("galactic_router.metrics_port"),
-		"Metrics listen port")
-	cmd.Flags().IntP("grpc-health-port", "",
-		v.GetInt("galactic_router.grpc_health_port"),
-		"gRPC health check port")
-	cmd.Flags().StringP("gc-namespace", "",
-		v.GetString("galactic_router.gc_namespace"),
-		"Namespace for orphaned CRD cleanup")
-	cmd.Flags().DurationP("gc-interval", "",
-		v.GetDuration("galactic_router.gc_interval"),
-		"Cleanup interval")
-
-	// v.BindPFlags binds each flag under its own flag name (e.g.
-	// "grpc-health-port") as the viper key, but validateConfig/runCmd only
-	// ever read the "galactic_router.*"-prefixed keys set up by newViper —
-	// so a blanket BindPFlags leaves every flag here disconnected from the
-	// config it's meant to override. Bind each flag explicitly to the key
-	// it actually needs to reach.
-	flagKeys := map[string]string{
-		"node-name":         "galactic_router.node_name",
-		"mode":              "galactic_router.router_mode",
-		"reflector":         "reflector",
-		"bgp-listen-port":   "galactic_router.bgp_listen_port",
-		"bgp-local-address": "galactic_router.bgp_local_address",
-		"metrics-port":      "galactic_router.metrics_port",
-		"grpc-health-port":  "galactic_router.grpc_health_port",
-		"gc-namespace":      "galactic_router.gc_namespace",
-		"gc-interval":       "galactic_router.gc_interval",
-	}
-	for flagName, key := range flagKeys {
-		if err := v.BindPFlag(key, cmd.Flags().Lookup(flagName)); err != nil {
-			log.Fatalf("bind flag %s: %v", flagName, err)
-		}
-	}
-}
-
-// validateConfig checks that the configuration values are valid.
-func validateConfig(v *viper.Viper) error {
-	nodeName := v.GetString("galactic_router.node_name")
-	mode := v.GetString("galactic_router.router_mode")
-	reflector := v.GetBool("reflector")
-	bgpListenPort := v.GetInt("galactic_router.bgp_listen_port")
-	metricsPort := v.GetInt("galactic_router.metrics_port")
-	grpcHealthPort := v.GetInt("galactic_router.grpc_health_port")
-
-	if nodeName == "" {
-		return errors.New("--node-name is required")
-	}
-	if mode == "" {
-		return errors.New("--mode is required (valid values: 'transit', 'fabric', 'tenant')")
-	}
-	if mode != modeTransit && mode != modeFabric && mode != modeTenant {
-		return fmt.Errorf("GALACTIC_ROUTER_ROUTER_MODE must be 'transit', 'fabric', or 'tenant', got %q", mode)
-	}
-	if reflector && mode != modeFabric && mode != modeTenant {
-		return errors.New("--reflector is only valid when --mode=fabric or --mode=tenant")
-	}
-	if bgpListenPort < -1 || bgpListenPort > 65535 {
-		return fmt.Errorf("GALACTIC_ROUTER_BGP_LISTEN_PORT must be -1 or a valid port number, got %d", bgpListenPort)
-	}
-	if metricsPort < 1 || metricsPort > 65535 {
-		return fmt.Errorf("GALACTIC_ROUTER_METRICS_PORT must be a valid port number (1-65535), got %d", metricsPort)
-	}
-	if grpcHealthPort < 1 || grpcHealthPort > 65535 {
-		return fmt.Errorf("GALACTIC_ROUTER_GRPC_HEALTH_PORT must be a valid port number (1-65535), got %d", grpcHealthPort)
-	}
-	return nil
-}
-
 // resolveBGPLocalAddress returns explicit if non-empty. Otherwise it calls
 // detect to read the BGP local address from the host's lo interface,
 // returning an error if detection fails — there is no silent fallback to an
@@ -186,30 +60,26 @@ func resolveBGPLocalAddress(explicit string, detect func() (string, error)) (str
 }
 
 // runCmd contains the application startup logic. It reads configuration from
-// the provided viper instance and initializes the BGP runtime.
-func runCmd(v *viper.Viper) error {
-	if err := validateConfig(v); err != nil {
-		return err
-	}
+// the provided config and initializes the BGP runtime.
+func runCmd(cfg *config.RouterConfig) error {
+	nodeName := cfg.NodeName
+	mode := cfg.Mode
+	bgpListenPort := cfg.BGPListenPort
+	metricsPort := cfg.MetricsPort
+	grpcHealthPort := cfg.GRPCHealthPort
 
-	nodeName := v.GetString("galactic_router.node_name")
-	mode := v.GetString("galactic_router.router_mode")
-	bgpListenPort := v.GetInt("galactic_router.bgp_listen_port")
-	metricsPort := v.GetInt("galactic_router.metrics_port")
-	grpcHealthPort := v.GetInt("galactic_router.grpc_health_port")
-
-	bgpLocalAddr, err := resolveBGPLocalAddress(v.GetString("galactic_router.bgp_local_address"), loaddr.Detect)
+	bgpLocalAddr, err := resolveBGPLocalAddress(cfg.BGPLocalAddr, loaddr.Detect)
 	if err != nil {
 		return err
 	}
 
 	var factory galacticruntime.RuntimeFactory
 	switch mode {
-	case modeTenant:
+	case config.ModeTenant:
 		factory = gobgp.NewRuntimeFactory(int32(bgpListenPort), bgpLocalAddr)
-	case modeFabric:
+	case config.ModeFabric:
 		factory = frr.NewRuntimeFactory()
-	case modeTransit:
+	case config.ModeTransit:
 		return errors.New("mode=transit is not yet supported")
 	}
 
@@ -327,14 +197,12 @@ func runCmd(v *viper.Viper) error {
 	}
 
 	// Register GC controller for cleaning up orphaned BGP CRDs and VRFs.
-	gcNamespace := v.GetString("galactic_router.gc_namespace")
-	gcInterval := v.GetDuration("galactic_router.gc_interval")
 	gcRec := &controller.GCReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
-		Namespace: gcNamespace,
+		Namespace: cfg.GCNamespace,
 		NodeName:  nodeName,
-		Interval:  gcInterval,
+		Interval:  cfg.GCInterval,
 	}
 	if err := gcRec.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup GC controller: %w", err)
@@ -344,7 +212,7 @@ func runCmd(v *viper.Viper) error {
 	// is cancelled. The initial GC pass waits for informer caches to sync
 	// so it doesn't see an empty BGPAdvertisement list and delete live VRFs.
 	go func() {
-		ticker := time.NewTicker(gcInterval)
+		ticker := time.NewTicker(cfg.GCInterval)
 		defer ticker.Stop()
 
 		if !mgr.GetCache().WaitForCacheSync(ctx) {
@@ -373,8 +241,6 @@ func runCmd(v *viper.Viper) error {
 // newRootCommand builds the root cobra command with all flags and the
 // application startup logic.
 func newRootCommand() *cobra.Command {
-	v := newViper()
-
 	cmd := &cobra.Command{
 		Use:   appName,
 		Short: strings.Split(appDesc, "\n")[0],
@@ -388,11 +254,38 @@ func newRootCommand() *cobra.Command {
 				fmt.Printf("galactic-router version %s\n", metadata.Version)
 				return nil
 			}
-			return runCmd(v)
+
+			cfg := config.NewRouterConfig()
+			cfg.BindFlags(cmd.Flags())
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+			return runCmd(cfg)
 		},
 	}
 
-	bindFlags(cmd, v)
+	cmd.Flags().StringP("node-name", "n", "", "Kubernetes node name (required)")
+	cmd.Flags().StringP("mode", "m", "",
+		"Operating mode: '"+config.ModeTransit+"', '"+config.ModeFabric+"', or '"+config.ModeTenant+"' (required)")
+	cmd.Flags().Bool("reflector", false,
+		"Enable route reflector mode (requires --mode="+config.ModeFabric+" or --mode="+config.ModeTenant+")")
+	cmd.Flags().IntP("bgp-listen-port", "p", config.DefaultRouterBGPListenPort,
+		"BGP listen port")
+	cmd.Flags().StringP("bgp-local-address", "",
+		"",
+		"Source address for outgoing BGP connections; auto-detected from lo if unset")
+	cmd.Flags().IntP("metrics-port", "",
+		config.DefaultRouterMetricsPort,
+		"Metrics listen port")
+	cmd.Flags().IntP("grpc-health-port", "",
+		config.DefaultRouterGRPCHealthPort,
+		"gRPC health check port")
+	cmd.Flags().StringP("gc-namespace", "",
+		config.DefaultRouterGCNamespace,
+		"Namespace for orphaned CRD cleanup")
+	cmd.Flags().DurationP("gc-interval", "",
+		config.DefaultRouterGCInterval,
+		"Cleanup interval")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
 	return cmd

--- a/cmd/galactic-router/root_test.go
+++ b/cmd/galactic-router/root_test.go
@@ -6,238 +6,225 @@ package main
 
 import (
 	"errors"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
+	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/metadata"
 )
 
 const testCmdUse = "test"
 
-// cmdWithViper creates a cobra command with a fresh viper instance and
-// binds all flags. This is used to test flag defaults and cobra integration.
-func cmdWithViper(t *testing.T) *viper.Viper {
+// testCmd creates a cobra command with the same flags as newRootCommand.
+func testCmd(t *testing.T) *cobra.Command {
 	t.Helper()
-	v := newViper()
-	cmd := &cobra.Command{
-		Use: testCmdUse,
-	}
-	bindFlags(cmd, v)
-	return v
+	cmd := &cobra.Command{Use: testCmdUse}
+	cmd.Flags().StringP("node-name", "n", "", "Kubernetes node name (required)")
+	cmd.Flags().StringP("mode", "m", "", "Operating mode")
+	cmd.Flags().Bool("reflector", false, "Enable route reflector mode")
+	cmd.Flags().IntP("bgp-listen-port", "p", config.DefaultRouterBGPListenPort, "BGP listen port")
+	cmd.Flags().StringP("bgp-local-address", "", "", "BGP local address")
+	cmd.Flags().IntP("metrics-port", "", config.DefaultRouterMetricsPort, "Metrics listen port")
+	cmd.Flags().IntP("grpc-health-port", "", config.DefaultRouterGRPCHealthPort, "gRPC health check port")
+	cmd.Flags().StringP("gc-namespace", "", config.DefaultRouterGCNamespace, "Namespace for orphaned CRD cleanup")
+	cmd.Flags().DurationP("gc-interval", "", config.DefaultRouterGCInterval, "Cleanup interval")
+	return cmd
 }
 
 func TestFlagDefaults(t *testing.T) {
-	v := cmdWithViper(t)
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
 
-	if v.GetInt("galactic_router.bgp_listen_port") != 179 {
-		t.Errorf("bgp_listen_port default = %d, want 179", v.GetInt("galactic_router.bgp_listen_port"))
+	if cfg.BGPListenPort != config.DefaultRouterBGPListenPort {
+		t.Errorf("BGPListenPort = %d, want %d", cfg.BGPListenPort, config.DefaultRouterBGPListenPort)
 	}
-	if v.GetInt("galactic_router.metrics_port") != 8080 {
-		t.Errorf("metrics_port default = %d, want 8080", v.GetInt("galactic_router.metrics_port"))
+	if cfg.MetricsPort != config.DefaultRouterMetricsPort {
+		t.Errorf("MetricsPort = %d, want %d", cfg.MetricsPort, config.DefaultRouterMetricsPort)
 	}
-	if v.GetInt("galactic_router.grpc_health_port") != 5000 {
-		t.Errorf("grpc_health_port default = %d, want 5000", v.GetInt("galactic_router.grpc_health_port"))
+	if cfg.GRPCHealthPort != config.DefaultRouterGRPCHealthPort {
+		t.Errorf("GRPCHealthPort = %d, want %d", cfg.GRPCHealthPort, config.DefaultRouterGRPCHealthPort)
 	}
 }
 
 func TestRequiredFlags(t *testing.T) {
-	v := cmdWithViper(t)
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with empty node-name and router-role returned nil error")
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with empty node-name and mode returned nil error")
 	}
 }
 
 func TestEnvVarDefaults(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
 
-	v := cmdWithViper(t)
-	if err := validateConfig(v); err != nil {
-		t.Errorf("validateConfig with valid env vars: %v", err)
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() with valid env vars: %v", err)
 	}
 }
 
 func TestInvalidMode(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "invalid")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, "invalid")
 
-	v := cmdWithViper(t)
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with invalid mode returned nil error")
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with invalid mode returned nil error")
 	}
 }
 
 func TestBGPListenPortMinusOne(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
-	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "-1")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
+	t.Setenv(config.EnvRouterBGPListenPort, "-1")
 
-	v := cmdWithViper(t)
-	if err := validateConfig(v); err != nil {
-		t.Errorf("validateConfig with GALACTIC_ROUTER_BGP_LISTEN_PORT=-1: %v", err)
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() with BGP listen port -1: %v", err)
 	}
 }
 
 func TestBGPListenPortOverflow(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
-	t.Setenv("GALACTIC_ROUTER_BGP_LISTEN_PORT", "70000")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
+	t.Setenv(config.EnvRouterBGPListenPort, "70000")
 
-	v := cmdWithViper(t)
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with GALACTIC_ROUTER_BGP_LISTEN_PORT=70000 returned nil error")
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with BGP listen port 70000 returned nil error")
 	}
 }
 
 func TestNodeNameRequired(t *testing.T) {
-	v := cmdWithViper(t)
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with empty node-name returned nil error")
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with empty node-name returned nil error")
 	}
 }
 
 func TestModeRequired(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	// GALACTIC_ROUTER_ROUTER_MODE unset
+	t.Setenv(config.EnvRouterNodeName, "test-node")
 
-	v := cmdWithViper(t)
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with empty mode returned nil error")
-	}
-	if err != nil && !strings.Contains(err.Error(), "--mode is required") {
-		t.Errorf("expected --mode required error, got: %v", err)
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with empty mode returned nil error")
 	}
 }
 
 func TestValidModes(t *testing.T) {
-	for _, mode := range []string{"transit", "fabric", "tenant"} {
+	for _, mode := range []string{config.ModeTransit, config.ModeFabric, config.ModeTenant} {
 		t.Run(mode, func(t *testing.T) {
-			t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-			t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", mode)
+			t.Setenv(config.EnvRouterNodeName, "test-node")
+			t.Setenv(config.EnvRouterMode, mode)
 
-			v := cmdWithViper(t)
-			// Verify the mode is read correctly.
-			if v.GetString("galactic_router.router_mode") != mode {
-				t.Errorf("router_mode = %q, want %q", v.GetString("galactic_router.router_mode"), mode)
+			cfg := config.NewRouterConfig()
+			cmd := testCmd(t)
+			cfg.BindFlags(cmd.Flags())
+
+			if cfg.Mode != mode {
+				t.Errorf("Mode = %q, want %q", cfg.Mode, mode)
 			}
-			// Verify validation passes.
-			if err := validateConfig(v); err != nil {
-				t.Errorf("validateConfig with mode %q: %v", mode, err)
+			if err := cfg.Validate(); err != nil {
+				t.Errorf("Validate() with mode %q: %v", mode, err)
 			}
 		})
 	}
 }
 
 func TestReflectorInvalidMode(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "transit")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTransit)
 
-	v := cmdWithViper(t)
-	// Simulate --reflector being set via flag.
-	cmd := &cobra.Command{Use: testCmdUse}
-	bindFlags(cmd, v)
-	//nolint:errcheck // flag exists, setting it is safe
-	cmd.Flags().Set("reflector", "true")
-	_ = v.BindPFlags(cmd.Flags())
-
-	err := validateConfig(v)
-	if err == nil {
-		t.Error("validateConfig with --reflector and --mode=transit returned nil error")
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	if err := cmd.Flags().Set("reflector", "true"); err != nil {
+		t.Fatalf("set --reflector flag: %v", err)
 	}
-	if err != nil && !strings.Contains(err.Error(), "--reflector is only valid") {
-		t.Errorf("expected --reflector validation error, got: %v", err)
+	cfg.BindFlags(cmd.Flags())
+
+	if err := cfg.Validate(); err == nil {
+		t.Error("Validate() with --reflector and --mode=transit returned nil error")
 	}
 }
 
 func TestMetricsPortOverride(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
-	t.Setenv("GALACTIC_ROUTER_METRICS_PORT", "9090")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
+	t.Setenv(config.EnvRouterMetricsPort, "9090")
 
-	v := cmdWithViper(t)
-	if v.GetInt("galactic_router.metrics_port") != 9090 {
-		t.Errorf("metrics_port = %d, want 9090", v.GetInt("galactic_router.metrics_port"))
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if cfg.MetricsPort != 9090 {
+		t.Errorf("MetricsPort = %d, want 9090", cfg.MetricsPort)
 	}
 }
 
 func TestGRPCHealthPortOverride(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
-	t.Setenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT", "9091")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
+	t.Setenv(config.EnvRouterGRPCHealthPort, "9091")
 
-	v := cmdWithViper(t)
-	if v.GetInt("galactic_router.grpc_health_port") != 9091 {
-		t.Errorf("grpc_health_port = %d, want 9091", v.GetInt("galactic_router.grpc_health_port"))
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	cfg.BindFlags(cmd.Flags())
+	if cfg.GRPCHealthPort != 9091 {
+		t.Errorf("GRPCHealthPort = %d, want 9091", cfg.GRPCHealthPort)
 	}
 }
 
 func TestModeFlagOverridesEnv(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "fabric")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeFabric)
 
-	v := newViper()
-	cmd := &cobra.Command{Use: testCmdUse}
-	bindFlags(cmd, v)
-	if err := cmd.Flags().Set("mode", "tenant"); err != nil {
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
+	if err := cmd.Flags().Set("mode", config.ModeTenant); err != nil {
 		t.Fatalf("set --mode flag: %v", err)
 	}
+	cfg.BindFlags(cmd.Flags())
 
-	if got := v.GetString("galactic_router.router_mode"); got != "tenant" {
-		t.Errorf("router_mode = %q, want %q (flag should override env var)", got, "tenant")
+	if cfg.Mode != config.ModeTenant {
+		t.Errorf("Mode = %q, want %q (flag should override env var)", cfg.Mode, config.ModeTenant)
 	}
 }
 
 func TestGRPCHealthPortFlagOverridesEnv(t *testing.T) {
-	t.Setenv("GALACTIC_ROUTER_NODE_NAME", "test-node")
-	t.Setenv("GALACTIC_ROUTER_ROUTER_MODE", "tenant")
-	t.Setenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT", "9091")
+	t.Setenv(config.EnvRouterNodeName, "test-node")
+	t.Setenv(config.EnvRouterMode, config.ModeTenant)
+	t.Setenv(config.EnvRouterGRPCHealthPort, "9091")
 
-	v := newViper()
-	cmd := &cobra.Command{Use: testCmdUse}
-	bindFlags(cmd, v)
+	cfg := config.NewRouterConfig()
+	cmd := testCmd(t)
 	if err := cmd.Flags().Set("grpc-health-port", "9092"); err != nil {
 		t.Fatalf("set --grpc-health-port flag: %v", err)
 	}
+	cfg.BindFlags(cmd.Flags())
 
-	if got := v.GetInt("galactic_router.grpc_health_port"); got != 9092 {
-		t.Errorf("grpc_health_port = %d, want %d (flag should override env var)", got, 9092)
+	if cfg.GRPCHealthPort != 9092 {
+		t.Errorf("GRPCHealthPort = %d, want %d (flag should override env var)", cfg.GRPCHealthPort, 9092)
 	}
 }
 
 func TestVersionFlag(t *testing.T) {
 	if metadata.Version == "" {
 		t.Error("metadata.Version should not be empty")
-	}
-}
-
-func TestDefaults(t *testing.T) {
-	// Clear all relevant env vars.
-	_ = os.Unsetenv("GALACTIC_ROUTER_NODE_NAME")
-	_ = os.Unsetenv("GALACTIC_ROUTER_ROUTER_MODE")
-	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LISTEN_PORT")
-	_ = os.Unsetenv("GALACTIC_ROUTER_BGP_LOCAL_ADDRESS")
-	_ = os.Unsetenv("GALACTIC_ROUTER_METRICS_PORT")
-	_ = os.Unsetenv("GALACTIC_ROUTER_GRPC_HEALTH_PORT")
-
-	v := cmdWithViper(t)
-
-	if v.GetInt("galactic_router.bgp_listen_port") != 179 {
-		t.Errorf("bgp_listen_port = %d, want 179", v.GetInt("galactic_router.bgp_listen_port"))
-	}
-	if v.GetInt("galactic_router.metrics_port") != 8080 {
-		t.Errorf("metrics_port = %d, want 8080", v.GetInt("galactic_router.metrics_port"))
-	}
-	if v.GetInt("galactic_router.grpc_health_port") != 5000 {
-		t.Errorf("grpc_health_port = %d, want 5000", v.GetInt("galactic_router.grpc_health_port"))
 	}
 }
 

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -3,14 +3,17 @@
 `galactic-router` supports configuration via environment variables, CLI flags,
 or a combination of both. CLI flags take precedence over environment variables.
 
+All configuration is managed centrally by the `internal/config` package. The
+`RouterConfig` struct and its constants (`EnvRouterNodeName`, `ModeTenant`,
+etc.) are the single source of truth.
+
 ## Quick Reference
 
 Environment variable names are not a naive uppercased guess from the CLI
-flag name — every flag is bound to its own explicit `GALACTIC_ROUTER_*`
-variable (see `newViper()` in `cmd/galactic-router/root.go`), and several
-don't match what `AutomaticEnv` alone would produce from the flag name. The
-most common trip-up: `--mode` is `GALACTIC_ROUTER_ROUTER_MODE`, not
-`GALACTIC_ROUTER_MODE`. Always use the exact name from the table below.
+flag name — the mapping is defined in `internal/config` (see `RouterConfig`
+and the `EnvRouter*` constants). The most common trip-up: `--mode` is
+`GALACTIC_ROUTER_ROUTER_MODE`, not `GALACTIC_ROUTER_MODE`. Always use the
+exact name from the table below.
 
 | Option | Environment Variable | CLI Flag | Default |
 |---|---|---|---|

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -27,15 +27,15 @@ import (
 
 var ConfFile = config.DefaultConfFile
 
-// cniViper is the shared Viper instance for env var resolution.
+// cniConfig is the shared config resolver for env var resolution.
 // Initialized by InitCNIConfig() (called from cmd/galactic-cni/main.go).
-var cniViper *config.CNIViper
+var cniConfig *config.CNIConfig
 
-// InitCNIConfig initializes the shared Viper instance for CNI env var
+// InitCNIConfig initializes the shared config resolver for CNI env var
 // resolution. Callers should invoke this once at process startup before any
 // config lookups.
 func InitCNIConfig() {
-	cniViper = config.NewCNI()
+	cniConfig = config.NewCNIConfig()
 }
 
 const sanitizeForErrorBinary = "<binary>"
@@ -350,42 +350,46 @@ func parseConf(data []byte) (*PluginConf, error) {
 		return nil, fmt.Errorf("load host CNI config: %w", err)
 	}
 
-	// Resolve and propagate NodeName
-	nodeName := cniViper.NodeName(hostConf.NodeName)
-	if nodeName == "" {
-		// Fallback: auto-detect from the Kubernetes API by matching local
-		// interface addresses against node InternalIPs. This handles cases
-		// where the conflist file is missing (e.g. hostPath mount issues
-		// in container-based environments like Kind).
+	// Resolve config: env var > conflist > default.
+	cniConfig.Resolve(&config.ConflistValues{
+		NodeName:   hostConf.NodeName,
+		Kubeconfig: hostConf.Kubeconfig,
+		Namespace:  hostConf.Namespace,
+		LogFile:    hostConf.LogFile,
+		LogLevel:   hostConf.LogLevel,
+	})
+
+	// NodeName fallback: auto-detect from the Kubernetes API by matching local
+	// interface addresses against node InternalIPs. This handles cases where
+	// the conflist file is missing (e.g. hostPath mount issues in container-
+	// based environments like Kind).
+	if cniConfig.NodeName == "" {
 		detected, detectErr := detectNodeNameFromAPI()
 		if detectErr != nil {
 			slog.Warn("Node name auto-detection failed", "err", detectErr)
 		}
-		nodeName = detected
+		cniConfig.NodeName = detected
 	}
-	if nodeName == "" {
+	if cniConfig.NodeName == "" {
 		return nil, &types.Error{Code: 4, Msg: "node name is required (or set GALACTIC_CNI_NODE_NAME)"}
 	}
-	_ = os.Setenv("NODE_NAME", nodeName)
+	_ = os.Setenv("NODE_NAME", cniConfig.NodeName)
 
-	// Resolve and propagate Kubeconfig
-	kubeconfig := cniViper.Kubeconfig(hostConf.Kubeconfig)
-	_ = os.Setenv("KUBECONFIG", kubeconfig)
+	// Propagate Kubeconfig
+	_ = os.Setenv("KUBECONFIG", cniConfig.Kubeconfig)
 
 	// Resolve and propagate Namespace fallback
 	namespace := conf.Namespace
 	if namespace == "" {
-		namespace = cniViper.Namespace(hostConf.Namespace)
+		namespace = cniConfig.Namespace
 	}
 	conf.Namespace = namespace
 
-	// Resolve and setup Logging
-	logFile := cniViper.LogFile(hostConf.LogFile)
-	logLevel := cniViper.LogLevel(hostConf.LogLevel)
-	setupLogging(logFile, logLevel)
+	// Setup Logging
+	setupLogging(cniConfig.LogFile, cniConfig.LogLevel)
 
 	// Resolve local IPAM flag
-	enableLocalIPAM = cniViper.EnableLocalIPAM()
+	enableLocalIPAM = config.CNIGetEnableLocalIPAM()
 
 	// Enforce required IPAM block if local IPAM is enabled
 	if enableLocalIPAM && conf.IPAM == nil {

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
@@ -96,14 +97,19 @@ func cmdStatus(args *skel.CmdArgs) error {
 		return &types.Error{Code: 7, Msg: fmt.Sprintf("load host CNI config: %v", err)}
 	}
 
-	// Resolve and propagate Kubeconfig
-	kubeconfig := cniViper.Kubeconfig(hostConf.Kubeconfig)
-	_ = os.Setenv("KUBECONFIG", kubeconfig)
+	// Resolve config: env var > conflist > default.
+	cniConfig.Resolve(&config.ConflistValues{
+		Kubeconfig: hostConf.Kubeconfig,
+		Namespace:  hostConf.Namespace,
+		LogFile:    hostConf.LogFile,
+		LogLevel:   hostConf.LogLevel,
+	})
 
-	// Resolve and setup Logging
-	logFile := cniViper.LogFile(hostConf.LogFile)
-	logLevel := cniViper.LogLevel(hostConf.LogLevel)
-	setupLogging(logFile, logLevel)
+	// Propagate Kubeconfig
+	_ = os.Setenv("KUBECONFIG", cniConfig.Kubeconfig)
+
+	// Setup Logging
+	setupLogging(cniConfig.LogFile, cniConfig.LogLevel)
 
 	// Config is parseable and API server is reachable.
 	slog.Info("STATUS: probing API server reachability")

--- a/internal/config/cni.go
+++ b/internal/config/cni.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// --- CNI environment variable keys -----------------------------------------
+
+const (
+	EnvCNINodeName         = "GALACTIC_CNI_NODE_NAME"
+	EnvCNIKubeconfig       = "GALACTIC_CNI_KUBECONFIG"
+	EnvCNIKubernetesConfig = "GALACTIC_CNI_KUBERNETES_CONFIG"
+	EnvCNIEnableLocalIPAM  = "GALACTIC_CNI_ENABLE_LOCAL_IPAM"
+	EnvLogLevel            = "GALACTIC_CNI_LOG_LEVEL"
+	EnvLogFile             = "GALACTIC_CNI_LOG_FILE"
+	EnvNamespace           = "GALACTIC_CNI_NAMESPACE"
+	EnvNodeNameLegacy      = "NODE_NAME"
+)
+
+// --- CNIConfig -------------------------------------------------------------
+
+// CNIConfig resolves CNI configuration with three-tier precedence: env var >
+// conflist field > compiled-in default. Create once via NewCNIConfig() and
+// call Resolve() with conflist values to populate the exported fields.
+type CNIConfig struct {
+	// Resolved fields (populated by Resolve).
+	NodeName   string
+	Kubeconfig string
+	Namespace  string
+	LogFile    string
+	LogLevel   string
+}
+
+// NewCNIConfig creates a new CNI config resolver. Callers should invoke this
+// once at process startup.
+func NewCNIConfig() *CNIConfig {
+	return &CNIConfig{}
+}
+
+// Resolve populates the exported fields from the conflist values, overridden
+// by any matching environment variables. The conflist values act as the
+// "middle tier" between env vars and compiled-in defaults.
+func (c *CNIConfig) Resolve(conflist *ConflistValues) {
+	var cnflistNode, cnflistKube, cnflistNS, cnflistLog, cnflistLevel string
+	if conflist != nil {
+		cnflistNode = conflist.NodeName
+		cnflistKube = conflist.Kubeconfig
+		cnflistNS = conflist.Namespace
+		cnflistLog = conflist.LogFile
+		cnflistLevel = conflist.LogLevel
+	}
+
+	// NodeName: env > conflist > legacy fallback > (no default)
+	c.NodeName = resolveEnv(EnvCNINodeName, cnflistNode, "")
+	if c.NodeName == "" {
+		c.NodeName = os.Getenv(EnvNodeNameLegacy)
+	}
+
+	// Kubeconfig: env > conflist > default
+	c.Kubeconfig = resolveEnv(EnvCNIKubeconfig, cnflistKube, DefaultKubeconfig)
+	if c.Kubeconfig == DefaultKubeconfig {
+		c.Kubeconfig = resolveEnv(EnvCNIKubernetesConfig, cnflistKube, DefaultKubeconfig)
+	}
+
+	// Namespace: env > conflist > default
+	c.Namespace = resolveEnv(EnvNamespace, cnflistNS, DefaultNamespace)
+
+	// LogFile: env > conflist > default
+	c.LogFile = resolveEnv(EnvLogFile, cnflistLog, DefaultLogFile)
+
+	// LogLevel: env > conflist > default
+	c.LogLevel = resolveEnv(EnvLogLevel, cnflistLevel, DefaultLogLevel)
+}
+
+// ConflistValues holds the raw values read from the CNI conflist file.
+// Passed to CNIConfig.Resolve() as the middle tier between env vars and defaults.
+type ConflistValues struct {
+	NodeName   string
+	Kubeconfig string
+	Namespace  string
+	LogFile    string
+	LogLevel   string
+}
+
+// CNIGetEnableLocalIPAM reports whether local (in-memory) IPAM is enabled via
+// environment variable. Returns false if the variable is unset or not "true".
+func CNIGetEnableLocalIPAM() bool {
+	val := os.Getenv(EnvCNIEnableLocalIPAM)
+	return strings.EqualFold(val, "true")
+}

--- a/internal/config/cni_test.go
+++ b/internal/config/cni_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import "testing"
+
+const (
+	testConflistNode = "conflist-node"
+	testConflistKube = "/conflist/kubeconfig"
+	testConflistNS   = "conflist-ns"
+	testConflistLog  = "/conflist/log.txt"
+	testEnvLog       = "/env/log.txt"
+	testEnvKube      = "/env/kubeconfig"
+	testEnvNS        = "env-ns"
+	testEnvNode      = "env-node"
+)
+
+func TestCNIConfigDefaults(t *testing.T) {
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{})
+
+	if cfg.Kubeconfig != DefaultKubeconfig {
+		t.Errorf("Kubeconfig = %q, want %q", cfg.Kubeconfig, DefaultKubeconfig)
+	}
+	if cfg.Namespace != DefaultNamespace {
+		t.Errorf("Namespace = %q, want %q", cfg.Namespace, DefaultNamespace)
+	}
+	if cfg.LogFile != DefaultLogFile {
+		t.Errorf("LogFile = %q, want %q", cfg.LogFile, DefaultLogFile)
+	}
+	if cfg.LogLevel != DefaultLogLevel {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, DefaultLogLevel)
+	}
+}
+
+func TestCNIConfigConflistValues(t *testing.T) {
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{
+		NodeName:   testConflistNode,
+		Kubeconfig: testConflistKube,
+		Namespace:  testConflistNS,
+		LogFile:    testConflistLog,
+		LogLevel:   LogLevelDebug,
+	})
+
+	if cfg.NodeName != testConflistNode {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, testConflistNode)
+	}
+	if cfg.Kubeconfig != testConflistKube {
+		t.Errorf("Kubeconfig = %q, want %q", cfg.Kubeconfig, testConflistKube)
+	}
+	if cfg.Namespace != testConflistNS {
+		t.Errorf("Namespace = %q, want %q", cfg.Namespace, testConflistNS)
+	}
+	if cfg.LogFile != testConflistLog {
+		t.Errorf("LogFile = %q, want %q", cfg.LogFile, testConflistLog)
+	}
+	if cfg.LogLevel != LogLevelDebug {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, LogLevelDebug)
+	}
+}
+
+func TestCNIConfigEnvOverride(t *testing.T) {
+	t.Setenv(EnvLogLevel, LogLevelDebug)
+	t.Setenv(EnvLogFile, testEnvLog)
+	t.Setenv(EnvCNIKubeconfig, testEnvKube)
+	t.Setenv(EnvNamespace, testEnvNS)
+	t.Setenv(EnvCNINodeName, testEnvNode)
+
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{
+		NodeName:   testConflistNode,
+		Kubeconfig: testConflistKube,
+		Namespace:  testConflistNS,
+		LogFile:    testConflistLog,
+		LogLevel:   DefaultLogLevel,
+	})
+
+	// Env var takes precedence over conflist value
+	if cfg.LogLevel != LogLevelDebug {
+		t.Errorf("LogLevel = %q, want %q (env override)", cfg.LogLevel, LogLevelDebug)
+	}
+	if cfg.LogFile != testEnvLog {
+		t.Errorf("LogFile = %q, want %q (env override)", cfg.LogFile, testEnvLog)
+	}
+	if cfg.Kubeconfig != testEnvKube {
+		t.Errorf("Kubeconfig = %q, want %q (env override)", cfg.Kubeconfig, testEnvKube)
+	}
+	if cfg.Namespace != testEnvNS {
+		t.Errorf("Namespace = %q, want %q (env override)", cfg.Namespace, testEnvNS)
+	}
+	if cfg.NodeName != testEnvNode {
+		t.Errorf("NodeName = %q, want %q (env override)", cfg.NodeName, testEnvNode)
+	}
+}
+
+func TestCNIConfigNodeNameLegacyFallback(t *testing.T) {
+	t.Setenv(EnvNodeNameLegacy, "legacy-node")
+
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{})
+
+	if cfg.NodeName != "legacy-node" {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, "legacy-node")
+	}
+}
+
+func TestCNIGetEnableLocalIPAM(t *testing.T) {
+	t.Setenv(EnvCNIEnableLocalIPAM, "true")
+	if got := CNIGetEnableLocalIPAM(); !got {
+		t.Error("CNIGetEnableLocalIPAM() = false, want true")
+	}
+}
+
+func TestCNIGetEnableLocalIPAMFalse(t *testing.T) {
+	if got := CNIGetEnableLocalIPAM(); got {
+		t.Error("CNIGetEnableLocalIPAM() = true, want false (env unset)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,154 +2,58 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package config holds shared defaults and Viper-based configuration
-// resolution for galactic-cni. Both the CNI plugin (internal/cni) and the
-// installer (internal/installer) import these constants and helpers to avoid
-// duplicated defaults and env-var resolution logic.
+// Package config provides shared configuration defaults, environment variable
+// keys, and typed resolvers for both galactic-cni and galactic-router.
+//
+// Each component gets its own resolver (CNIConfig, RouterConfig).
+// Precedence: env var > conflist/flag > compiled-in default.
 package config
 
 import (
-	"log/slog"
 	"os"
 	"strings"
-
-	"github.com/spf13/viper"
 )
 
-// Default settings for galactic-cni. Defined once here so the CNI plugin and
-// the installer always agree on the same values.
+// --- Shared defaults -------------------------------------------------------
+
 const (
 	DefaultConfFile   = "/etc/cni/net.d/10-galactic.conflist"
 	DefaultKubeconfig = "/var/lib/galactic/kubeconfig"
 	DefaultNamespace  = "galactic-system"
 	DefaultLogFile    = "/var/log/galactic/galactic-cni.log"
 	DefaultLogLevel   = "info"
-)
 
-// Recognized log_level values.
-const (
 	LogLevelDebug   = "debug"
 	LogLevelWarn    = "warn"
 	LogLevelWarning = "warning"
 	LogLevelError   = "error"
 )
 
-// Env var keys.
-const (
-	EnvNodeName        = "GALACTIC_CNI_NODE_NAME"
-	EnvKubeconfig      = "GALACTIC_CNI_KUBECONFIG"
-	EnvNamespace       = "GALACTIC_CNI_NAMESPACE"
-	EnvLogFile         = "GALACTIC_CNI_LOG_FILE"
-	EnvLogLevel        = "GALACTIC_CNI_LOG_LEVEL"
-	EnvEnableLocalIPAM = "GALACTIC_CNI_ENABLE_LOCAL_IPAM"
-	// Legacy fallback for node name (set by the DaemonSet).
-	EnvNodeNameLegacy = "NODE_NAME"
-)
+// --- Shared helpers --------------------------------------------------------
 
-// CNIViper wraps a viper instance pre-configured with AutomaticEnv and the
-// GALACTIC_CNI prefix. Callers should obtain it once via NewCNI() and reuse
-// it across the process lifetime.
-type CNIViper struct {
-	v        *viper.Viper
-	prefix   string
-	defaults map[string]string
-}
-
-// NewCNI returns a CNIViper with AutomaticEnv and the GALACTIC_CNI prefix.
-// The returned instance is safe for concurrent reads.
-func NewCNI() *CNIViper {
-	v := viper.New()
-	v.SetEnvPrefix("GALACTIC_CNI")
-	v.AutomaticEnv()
-
-	return &CNIViper{
-		v:      v,
-		prefix: "GALACTIC_CNI",
-		defaults: map[string]string{
-			"log_file":   DefaultLogFile,
-			"log_level":  DefaultLogLevel,
-			"kubeconfig": DefaultKubeconfig,
-			"namespace":  DefaultNamespace,
-		},
-	}
-}
-
-// resolveEnv returns the env var value for a given Viper key.
-// Keys use _ as separator (e.g. "log_file" → "GALACTIC_CNI_LOG_FILE").
-// The special "node_name" key also checks the legacy "NODE_NAME" fallback.
-func (c *CNIViper) resolveEnv(key string) string {
-	if key == "node_name" {
-		if val := os.Getenv(EnvNodeName); val != "" {
-			return val
-		}
-		return os.Getenv(EnvNodeNameLegacy)
-	}
-	return os.Getenv(c.prefix + "_" + strings.ToUpper(key))
-}
-
-// Resolve returns the value for the given key, falling back to the provided
-// conflist value when the env var is unset. This implements the standard
-// precedence: env var > conflist field > default.
-func (c *CNIViper) Resolve(key, conflistValue string) string {
-	if val := c.resolveEnv(key); val != "" {
-		return val
-	}
-	if conflistValue != "" {
-		return conflistValue
-	}
-	return c.defaults[key]
-}
-
-// LogLevel returns the resolved log level string, with NormalizeLogLevel
-// applied so that "warning" becomes "warn" and unrecognized values fall back
-// to DefaultLogLevel.
-func (c *CNIViper) LogLevel(conflistValue string) string {
-	return NormalizeLogLevel(c.Resolve("log_level", conflistValue))
-}
-
-// Kubeconfig returns the resolved kubeconfig path.
-func (c *CNIViper) Kubeconfig(conflistValue string) string {
-	return c.Resolve("kubeconfig", conflistValue)
-}
-
-// Namespace returns the resolved namespace.
-func (c *CNIViper) Namespace(conflistValue string) string {
-	return c.Resolve("namespace", conflistValue)
-}
-
-// NodeName returns the resolved node name (env var or conflist, no default).
-func (c *CNIViper) NodeName(conflistValue string) string {
-	return c.Resolve("node_name", conflistValue)
-}
-
-// LogFile returns the resolved log file path.
-func (c *CNIViper) LogFile(conflistValue string) string {
-	return c.Resolve("log_file", conflistValue)
-}
-
-// EnableLocalIPAM returns whether the local IPAM allocator is enabled.
-func (c *CNIViper) EnableLocalIPAM() bool {
-	val := os.Getenv(EnvEnableLocalIPAM)
-	return val == "true" || val == "1"
-}
-
-// NormalizeLogLevel validates and normalizes a log level string.
-// "warning" is normalized to "warn". Unrecognized values return
-// DefaultLogLevel and log a warning.
-func NormalizeLogLevel(s string) string {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "", DefaultLogLevel:
-		return DefaultLogLevel
+// NormalizeLogLevel maps common log level aliases to canonical values.
+// "warning" is normalized to "warn"; unrecognized values fall back to "info".
+func NormalizeLogLevel(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
 	case LogLevelDebug:
 		return LogLevelDebug
-	case LogLevelWarn:
-		return LogLevelWarn
-	case LogLevelWarning:
+	case LogLevelWarn, LogLevelWarning:
 		return LogLevelWarn
 	case LogLevelError:
 		return LogLevelError
 	default:
-		slog.Warn("Unrecognized log level, falling back to info", "value", s)
 		return DefaultLogLevel
 	}
+}
+
+// resolveEnv checks an environment variable, then falls back to a conflist
+// value, then to a default. Returns the first non-empty value.
+func resolveEnv(envKey, conflistVal, defaultValue string) string {
+	if val := os.Getenv(envKey); val != "" {
+		return val
+	}
+	if conflistVal != "" {
+		return conflistVal
+	}
+	return defaultValue
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,9 +4,7 @@
 
 package config
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestNormalizeLogLevel(t *testing.T) {
 	tests := []struct {
@@ -34,89 +32,5 @@ func TestNormalizeLogLevel(t *testing.T) {
 				t.Errorf("NormalizeLogLevel(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestCNIViperResolve(t *testing.T) {
-	v := NewCNI()
-
-	// Default values
-	if got := v.Resolve("log_file", ""); got != DefaultLogFile {
-		t.Errorf("Resolve(log_file, \"\") = %q, want %q", got, DefaultLogFile)
-	}
-	if got := v.Resolve("log_level", ""); got != DefaultLogLevel {
-		t.Errorf("Resolve(log_level, \"\") = %q, want %q", got, DefaultLogLevel)
-	}
-	if got := v.Resolve("kubeconfig", ""); got != DefaultKubeconfig {
-		t.Errorf("Resolve(kubeconfig, \"\") = %q, want %q", got, DefaultKubeconfig)
-	}
-	if got := v.Resolve("namespace", ""); got != DefaultNamespace {
-		t.Errorf("Resolve(namespace, \"\") = %q, want %q", got, DefaultNamespace)
-	}
-
-	// Conflist value used when env var is empty
-	if got := v.Resolve("log_file", "/custom/path.log"); got != "/custom/path.log" {
-		t.Errorf("Resolve(log_file, \"/custom/path.log\") = %q, want %q", got, "/custom/path.log")
-	}
-}
-
-func TestCNIViperEnvOverride(t *testing.T) {
-	t.Setenv(EnvLogLevel, "debug")
-	t.Setenv(EnvLogFile, "/env/log.txt")
-	t.Setenv(EnvKubeconfig, "/env/kubeconfig")
-	t.Setenv(EnvNamespace, "env-ns")
-	t.Setenv(EnvNodeName, "env-node")
-
-	v := NewCNI()
-
-	// Env var takes precedence over conflist value
-	if got := v.Resolve("log_level", "info"); got != "debug" {
-		t.Errorf("Resolve(log_level) = %q, want %q (env override)", got, "debug")
-	}
-	if got := v.Resolve("log_file", "/conflist/path.log"); got != "/env/log.txt" {
-		t.Errorf("Resolve(log_file) = %q, want %q (env override)", got, "/env/log.txt")
-	}
-	if got := v.Resolve("kubeconfig", "/conflist/kubeconfig"); got != "/env/kubeconfig" {
-		t.Errorf("Resolve(kubeconfig) = %q, want %q (env override)", got, "/env/kubeconfig")
-	}
-	if got := v.Resolve("namespace", "conflist-ns"); got != "env-ns" {
-		t.Errorf("Resolve(namespace) = %q, want %q (env override)", got, "env-ns")
-	}
-	if got := v.Resolve("node_name", "conflist-node"); got != "env-node" {
-		t.Errorf("Resolve(node_name) = %q, want %q (env override)", got, "env-node")
-	}
-}
-
-func TestCNIViperTypedGetters(t *testing.T) {
-	t.Setenv(EnvLogLevel, LogLevelWarning)
-	t.Setenv(EnvEnableLocalIPAM, "true")
-
-	v := NewCNI()
-
-	// LogLevel normalizes "warning" → "warn"
-	if got := v.LogLevel("info"); got != LogLevelWarn {
-		t.Errorf("LogLevel() = %q, want %q", got, LogLevelWarn)
-	}
-
-	// EnableLocalIPAM reads env var
-	if got := v.EnableLocalIPAM(); !got {
-		t.Error("EnableLocalIPAM() = false, want true")
-	}
-}
-
-func TestCNIViperEnableLocalIPAMFalse(t *testing.T) {
-	v := NewCNI()
-	if got := v.EnableLocalIPAM(); got {
-		t.Error("EnableLocalIPAM() = true, want false (env unset)")
-	}
-}
-
-func TestCNIViperNodeNameLegacyFallback(t *testing.T) {
-	// Set only the legacy NODE_NAME env var, not GALACTIC_CNI_NODE_NAME
-	t.Setenv(EnvNodeNameLegacy, "legacy-node")
-
-	v := NewCNI()
-	if got := v.Resolve("node_name", ""); got != "legacy-node" {
-		t.Errorf("Resolve(node_name) with NODE_NAME = %q, want %q", got, "legacy-node")
 	}
 }

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// --- Router defaults -------------------------------------------------------
+
+const (
+	DefaultRouterBGPListenPort  = 179
+	DefaultRouterMetricsPort    = 8080
+	DefaultRouterGRPCHealthPort = 5000
+	DefaultRouterGCNamespace    = "galactic-system"
+	DefaultRouterGCInterval     = 5 * time.Minute
+)
+
+// --- Router environment variable keys --------------------------------------
+
+const (
+	EnvRouterNodeName       = "GALACTIC_ROUTER_NODE_NAME"
+	EnvRouterMode           = "GALACTIC_ROUTER_ROUTER_MODE"
+	EnvRouterReflector      = "GALACTIC_ROUTER_REFLECTOR"
+	EnvRouterBGPListenPort  = "GALACTIC_ROUTER_BGP_LISTEN_PORT"
+	EnvRouterBGPLocalAddr   = "GALACTIC_ROUTER_BGP_LOCAL_ADDRESS"
+	EnvRouterMetricsPort    = "GALACTIC_ROUTER_METRICS_PORT"
+	EnvRouterGRPCHealthPort = "GALACTIC_ROUTER_GRPC_HEALTH_PORT"
+	EnvRouterGCNamespace    = "GALACTIC_ROUTER_GC_NAMESPACE"
+	EnvRouterGCInterval     = "GALACTIC_ROUTER_GC_INTERVAL"
+)
+
+// --- Router mode constants -------------------------------------------------
+
+const (
+	ModeTransit = "transit"
+	ModeFabric  = "fabric"
+	ModeTenant  = "tenant"
+)
+
+// --- RouterConfig ----------------------------------------------------------
+
+// RouterConfig resolves router configuration with three-tier precedence: CLI
+// flag > env var > compiled-in default. Create once via NewRouterConfig(),
+// call BindFlags() to layer CLI flags, then read the exported fields.
+type RouterConfig struct {
+	v      *viper.Viper
+	prefix string
+
+	// Resolved fields.
+	NodeName       string
+	Mode           string
+	Reflector      bool
+	BGPListenPort  int
+	BGPLocalAddr   string
+	MetricsPort    int
+	GRPCHealthPort int
+	GCNamespace    string
+	GCInterval     time.Duration
+}
+
+// NewRouterConfig creates a router config resolver with the GALACTIC_ROUTER
+// env prefix and AutomaticEnv enabled. Exported fields are populated from env
+// vars and defaults; call BindFlags() to layer CLI overrides.
+func NewRouterConfig() *RouterConfig {
+	v := viper.New()
+	v.SetEnvPrefix("GALACTIC_ROUTER")
+	v.AutomaticEnv()
+
+	v.SetDefault("node_name", "")
+	v.SetDefault("router_mode", "")
+	v.SetDefault("reflector", false)
+	v.SetDefault("bgp_listen_port", DefaultRouterBGPListenPort)
+	v.SetDefault("bgp_local_address", "")
+	v.SetDefault("metrics_port", DefaultRouterMetricsPort)
+	v.SetDefault("grpc_health_port", DefaultRouterGRPCHealthPort)
+	v.SetDefault("gc_namespace", DefaultRouterGCNamespace)
+	v.SetDefault("gc_interval", DefaultRouterGCInterval.String())
+
+	cfg := &RouterConfig{
+		v:      v,
+		prefix: "GALACTIC_ROUTER",
+	}
+	cfg.readFields()
+	return cfg
+}
+
+// BindFlags binds Cobra/pflag flags to the config resolver and re-reads the
+// exported fields. Each flag is bound to a Viper key using the key argument.
+func (c *RouterConfig) BindFlags(flags *pflag.FlagSet) {
+	bindings := []struct {
+		flag string
+		key  string
+	}{
+		{"node-name", "node_name"},
+		{"mode", "router_mode"},
+		{"reflector", "reflector"},
+		{"bgp-listen-port", "bgp_listen_port"},
+		{"bgp-local-address", "bgp_local_address"},
+		{"metrics-port", "metrics_port"},
+		{"grpc-health-port", "grpc_health_port"},
+		{"gc-namespace", "gc_namespace"},
+		{"gc-interval", "gc_interval"},
+	}
+	for _, b := range bindings {
+		if flags.Changed(b.flag) {
+			c.v.Set(b.key, flags.Lookup(b.flag).Value.String())
+		} else {
+			//nolint:errcheck // controlled keys, BindPFlag cannot fail here
+			c.v.BindPFlag(b.key, flags.Lookup(b.flag))
+		}
+	}
+	c.readFields()
+}
+
+// readFields populates the exported fields from the current Viper state.
+func (c *RouterConfig) readFields() {
+	c.NodeName = c.v.GetString("node_name")
+	c.Mode = c.v.GetString("router_mode")
+	c.Reflector = c.v.GetBool("reflector")
+	c.BGPListenPort = c.v.GetInt("bgp_listen_port")
+	c.BGPLocalAddr = c.v.GetString("bgp_local_address")
+	c.MetricsPort = c.v.GetInt("metrics_port")
+	c.GRPCHealthPort = c.v.GetInt("grpc_health_port")
+	c.GCNamespace = c.v.GetString("gc_namespace")
+	c.GCInterval = c.v.GetDuration("gc_interval")
+}
+
+// Validate checks that the required configuration fields are set and that
+// mode/reflector constraints are satisfied.
+func (c *RouterConfig) Validate() error {
+	if c.NodeName == "" {
+		return fmt.Errorf("node name is required (use --node-name flag or %s env var)", EnvRouterNodeName)
+	}
+	if c.Mode == "" {
+		return fmt.Errorf("router mode is required (use --mode flag or %s env var)", EnvRouterMode)
+	}
+	switch c.Mode {
+	case ModeTransit, ModeFabric, ModeTenant:
+	default:
+		return fmt.Errorf("invalid router mode %q: must be %s, %s, or %s",
+			c.Mode, ModeTransit, ModeFabric, ModeTenant)
+	}
+	if c.Reflector && c.Mode != ModeFabric && c.Mode != ModeTenant {
+		return fmt.Errorf("route reflector mode requires --mode=%s or --mode=%s", ModeFabric, ModeTenant)
+	}
+	if c.BGPListenPort != -1 && (c.BGPListenPort < 1 || c.BGPListenPort > 65535) {
+		return errors.New("bgp listen port must be between 1 and 65535, or -1 for outbound-only mode")
+	}
+	if c.MetricsPort < 1 || c.MetricsPort > 65535 {
+		return errors.New("metrics port must be between 1 and 65535")
+	}
+	if c.GRPCHealthPort < 1 || c.GRPCHealthPort > 65535 {
+		return errors.New("grpc health port must be between 1 and 65535")
+	}
+	return nil
+}

--- a/internal/config/router_test.go
+++ b/internal/config/router_test.go
@@ -1,0 +1,199 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testRouterNodeName = "test-node"
+	testBoolTrue       = "true"
+)
+
+func TestRouterConfigDefaults(t *testing.T) {
+	cfg := NewRouterConfig()
+
+	if cfg.BGPListenPort != DefaultRouterBGPListenPort {
+		t.Errorf("BGPListenPort = %d, want %d", cfg.BGPListenPort, DefaultRouterBGPListenPort)
+	}
+	if cfg.MetricsPort != DefaultRouterMetricsPort {
+		t.Errorf("MetricsPort = %d, want %d", cfg.MetricsPort, DefaultRouterMetricsPort)
+	}
+	if cfg.GRPCHealthPort != DefaultRouterGRPCHealthPort {
+		t.Errorf("GRPCHealthPort = %d, want %d", cfg.GRPCHealthPort, DefaultRouterGRPCHealthPort)
+	}
+	if cfg.GCNamespace != DefaultRouterGCNamespace {
+		t.Errorf("GCNamespace = %q, want %q", cfg.GCNamespace, DefaultRouterGCNamespace)
+	}
+	if cfg.GCInterval != DefaultRouterGCInterval {
+		t.Errorf("GCInterval = %v, want %v", cfg.GCInterval, DefaultRouterGCInterval)
+	}
+	if cfg.Reflector {
+		t.Error("Reflector = true, want false")
+	}
+}
+
+func TestRouterConfigEnvOverride(t *testing.T) {
+	t.Setenv(EnvRouterNodeName, "env-node")
+	t.Setenv(EnvRouterMode, ModeTenant)
+	t.Setenv(EnvRouterReflector, testBoolTrue)
+	t.Setenv(EnvRouterBGPListenPort, "1790")
+	t.Setenv(EnvRouterBGPLocalAddr, "2001:db8::1")
+	t.Setenv(EnvRouterMetricsPort, "9090")
+	t.Setenv(EnvRouterGRPCHealthPort, "5179")
+	t.Setenv(EnvRouterGCNamespace, "custom-ns")
+	t.Setenv(EnvRouterGCInterval, "10m")
+
+	cfg := NewRouterConfig()
+
+	if cfg.NodeName != "env-node" {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, "env-node")
+	}
+	if cfg.Mode != ModeTenant {
+		t.Errorf("Mode = %q, want %q", cfg.Mode, ModeTenant)
+	}
+	if !cfg.Reflector {
+		t.Error("Reflector = false, want true")
+	}
+	if cfg.BGPListenPort != 1790 {
+		t.Errorf("BGPListenPort = %d, want 1790", cfg.BGPListenPort)
+	}
+	if cfg.BGPLocalAddr != "2001:db8::1" {
+		t.Errorf("BGPLocalAddr = %q, want %q", cfg.BGPLocalAddr, "2001:db8::1")
+	}
+	if cfg.MetricsPort != 9090 {
+		t.Errorf("MetricsPort = %d, want 9090", cfg.MetricsPort)
+	}
+	if cfg.GRPCHealthPort != 5179 {
+		t.Errorf("GRPCHealthPort = %d, want 5179", cfg.GRPCHealthPort)
+	}
+	if cfg.GCNamespace != "custom-ns" {
+		t.Errorf("GCNamespace = %q, want %q", cfg.GCNamespace, "custom-ns")
+	}
+	if cfg.GCInterval != 10*time.Minute {
+		t.Errorf("GCInterval = %v, want 10m", cfg.GCInterval)
+	}
+}
+
+func TestRouterConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		wantErr string
+	}{
+		{
+			name:    "missing node name",
+			envVars: map[string]string{EnvRouterMode: ModeTenant},
+			wantErr: "node name is required",
+		},
+		{
+			name:    "missing mode",
+			envVars: map[string]string{EnvRouterNodeName: testRouterNodeName},
+			wantErr: "router mode is required",
+		},
+		{
+			name:    "invalid mode",
+			envVars: map[string]string{EnvRouterNodeName: testRouterNodeName, EnvRouterMode: "invalid"},
+			wantErr: "invalid router mode",
+		},
+		{
+			name: "reflector without valid mode",
+			envVars: map[string]string{
+				EnvRouterNodeName:  testRouterNodeName,
+				EnvRouterMode:      ModeTransit,
+				EnvRouterReflector: testBoolTrue,
+			},
+			wantErr: "route reflector mode requires",
+		},
+		{
+			name: "valid tenant mode",
+			envVars: map[string]string{
+				EnvRouterNodeName: testRouterNodeName,
+				EnvRouterMode:     ModeTenant,
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid fabric mode with reflector",
+			envVars: map[string]string{
+				EnvRouterNodeName:  testRouterNodeName,
+				EnvRouterMode:      ModeFabric,
+				EnvRouterReflector: testBoolTrue,
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid tenant mode with reflector",
+			envVars: map[string]string{
+				EnvRouterNodeName:  testRouterNodeName,
+				EnvRouterMode:      ModeTenant,
+				EnvRouterReflector: testBoolTrue,
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid bgp listen port",
+			envVars: map[string]string{
+				EnvRouterNodeName:      testRouterNodeName,
+				EnvRouterMode:          ModeTenant,
+				EnvRouterBGPListenPort: "0",
+			},
+			wantErr: "bgp listen port must be between",
+		},
+		{
+			name: "outbound-only bgp listen port",
+			envVars: map[string]string{
+				EnvRouterNodeName:      testRouterNodeName,
+				EnvRouterMode:          ModeTenant,
+				EnvRouterBGPListenPort: "-1",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid metrics port",
+			envVars: map[string]string{
+				EnvRouterNodeName:    testRouterNodeName,
+				EnvRouterMode:        ModeTenant,
+				EnvRouterMetricsPort: "0",
+			},
+			wantErr: "metrics port must be between",
+		},
+		{
+			name: "invalid grpc health port",
+			envVars: map[string]string{
+				EnvRouterNodeName:       testRouterNodeName,
+				EnvRouterMode:           ModeTenant,
+				EnvRouterGRPCHealthPort: "0",
+			},
+			wantErr: "grpc health port must be between",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+			cfg := NewRouterConfig()
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("Validate() = nil, want error containing %q", tc.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() = %q, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace scattered viper reads in galactic-router with a centralized
RouterConfig in internal/config, matching the existing CNIConfig pattern.
Rename CNIViper to CNIConfig with field-based access and split the monolithic
config.go into separate files per component for clearer ownership.

- Rename CNIViper to CNIConfig with exported fields and Resolve() method
- Add RouterConfig with NewRouterConfig(), BindFlags(), and Validate()
- Split internal/config into config.go, cni.go, and router.go
- Remove inline newViper(), bindFlags(), and validateConfig() from root.go
- Update root.go to accept *RouterConfig instead of *viper.Viper
- Rewrite config, CNI, and router test suites for the new APIs
- Update router configuration docs to reference the config package
