### PR TITLE
fix: populate AdvertisedPrefixes in BGPAdvertisement status

### DIFF
--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -392,6 +392,14 @@ func (r *GoBGPRuntime) Status(ctx context.Context) (model.RuntimeStatus, error) 
 		return model.RuntimeStatus{Healthy: false}, fmt.Errorf("list peers: %w", listErr)
 	}
 
+	// Collect advertisement statuses from the applied advertisements map.
+	for name, adv := range r.appliedAdvertisements {
+		status.Advertisements = append(status.Advertisements, model.AdvertisementStatus{
+			Name:               name,
+			AdvertisedPrefixes: int32(len(adv.Prefixes)),
+		})
+	}
+
 	return status, nil
 }
 


### PR DESCRIPTION
## Problem

`kubectl get bgpadvertisements` shows an empty PREFIXES column. The `status.advertisedPrefixes` field is never populated.

## Root cause

`GoBGPRuntime.Status()` collects peer statuses but never populates the `Advertisements` slice. The controller's `updateAdvertisementStatuses()` builds a lookup map from this empty slice, so no `AdvertisedPrefixes` count is ever written to any BGPAdvertisement CRD status.

## Fix

Iterate `appliedAdvertisements` in `Status()` and emit `AdvertisementStatus` entries with the prefix count derived from `len(adv.Prefixes)`.


Generated with Qwen Code (1-shotted by Qwen-Coder)