### PR TITLE
fix(containerlab): fix fabric BGP prefix advertisements and add transit filter

### DIFF
--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -220,11 +220,11 @@ tasks:
       - docker exec iad-control-plane kubectl get bgppeers -n galactic-system
 
   "test:srv6":
-    desc: Verify each site's per-node SRv6 locator block on tr1
+    desc: Verify each site's SRv6 locator prefix on tr1
     cmds:
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff01:100::/56"
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff02:100::/56"
-      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff03:100::/56"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff01::/48"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff02::/48"
+      - docker exec clab-gvpc-tr1 vtysh -c "show bgp ipv6 unicast 2001:db8:ff03::/48"
 
   "test:evpn":
     desc: Verify EVPN BGP routes on iad, sjc, and dfw via BGPRouter status

--- a/deploy/containerlab/node_files/tr1/frr.conf
+++ b/deploy/containerlab/node_files/tr1/frr.conf
@@ -22,6 +22,12 @@ interface eth4
  ipv6 address 2001:db8:0:14::1/64
 !
 
+ipv6 prefix-list MIN48 seq 5 prefix ::/0 le 48 permit
+ipv6 prefix-list MIN48 seq 10 deny
+route-map FILTER_PREFIX deny 10
+ match ipv6 address prefix-list MIN48
+route-map FILTER_PREFIX permit 20
+
 router bgp 65100
  bgp router-id 10.255.255.100
  no bgp default ipv4-unicast
@@ -34,12 +40,16 @@ router bgp 65100
  !
  address-family ipv6 unicast
   neighbor 2001:db8:1:10::2 activate
+  neighbor 2001:db8:1:10::2 route-map FILTER_PREFIX in
   neighbor eth2 activate
   neighbor eth2 next-hop-self
+  neighbor eth2 route-map FILTER_PREFIX in
   neighbor eth3 activate
   neighbor eth3 next-hop-self
+  neighbor eth3 route-map FILTER_PREFIX in
   neighbor eth4 activate
   neighbor eth4 next-hop-self
+  neighbor eth4 route-map FILTER_PREFIX in
   network fc00:0:1::1/128
  exit-address-family
 !

--- a/deploy/containerlab/node_files/tr2/frr.conf
+++ b/deploy/containerlab/node_files/tr2/frr.conf
@@ -22,6 +22,12 @@ interface eth4
  ipv6 address 2001:db8:0:24::2/64
 !
 
+ipv6 prefix-list MIN48 seq 5 prefix ::/0 le 48 permit
+ipv6 prefix-list MIN48 seq 10 deny
+route-map FILTER_PREFIX deny 10
+ match ipv6 address prefix-list MIN48
+route-map FILTER_PREFIX permit 20
+
 router bgp 65100
  bgp router-id 10.255.255.101
  no bgp default ipv4-unicast
@@ -34,12 +40,16 @@ router bgp 65100
  !
  address-family ipv6 unicast
   neighbor 2001:db8:1:20::2 activate
+  neighbor 2001:db8:1:20::2 route-map FILTER_PREFIX in
   neighbor eth2 activate
   neighbor eth2 next-hop-self
+  neighbor eth2 route-map FILTER_PREFIX in
   neighbor eth3 activate
   neighbor eth3 next-hop-self
+  neighbor eth3 route-map FILTER_PREFIX in
   neighbor eth4 activate
   neighbor eth4 next-hop-self
+  neighbor eth4 route-map FILTER_PREFIX in
   network fc00:0:5::1/128
  exit-address-family
 !

--- a/deploy/containerlab/node_files/tr3/frr.conf
+++ b/deploy/containerlab/node_files/tr3/frr.conf
@@ -25,6 +25,13 @@ interface eth5
  description iad-worker-facing
  ipv6 address 2001:db8:1:30::1/64
 !
+
+ipv6 prefix-list MIN48 seq 5 prefix ::/0 le 48 permit
+ipv6 prefix-list MIN48 seq 10 deny
+route-map FILTER_PREFIX deny 10
+ match ipv6 address prefix-list MIN48
+route-map FILTER_PREFIX permit 20
+
 router bgp 65100
  bgp router-id 10.255.255.102
  no bgp default ipv4-unicast
@@ -38,13 +45,18 @@ router bgp 65100
  !
  address-family ipv6 unicast
   neighbor 2001:db8:1:30::2 activate
+  neighbor 2001:db8:1:30::2 route-map FILTER_PREFIX in
   neighbor 2001:db8:1:31::2 activate
+  neighbor 2001:db8:1:31::2 route-map FILTER_PREFIX in
   neighbor eth1 activate
   neighbor eth1 next-hop-self
+  neighbor eth1 route-map FILTER_PREFIX in
   neighbor eth2 activate
   neighbor eth2 next-hop-self
+  neighbor eth2 route-map FILTER_PREFIX in
   neighbor eth3 activate
   neighbor eth3 next-hop-self
+  neighbor eth3 route-map FILTER_PREFIX in
   network fc00:0:6::1/128
  exit-address-family
 !

--- a/deploy/containerlab/node_files/tr4/frr.conf
+++ b/deploy/containerlab/node_files/tr4/frr.conf
@@ -18,6 +18,12 @@ interface eth3
  ipv6 address 2001:db8:0:34::4/64
 !
 
+ipv6 prefix-list MIN48 seq 5 prefix ::/0 le 48 permit
+ipv6 prefix-list MIN48 seq 10 deny
+route-map FILTER_PREFIX deny 10
+ match ipv6 address prefix-list MIN48
+route-map FILTER_PREFIX permit 20
+
 router bgp 65100
  bgp router-id 10.255.255.103
  no bgp default ipv4-unicast
@@ -30,10 +36,13 @@ router bgp 65100
  address-family ipv6 unicast
   neighbor eth1 activate
   neighbor eth1 next-hop-self
+  neighbor eth1 route-map FILTER_PREFIX in
   neighbor eth2 activate
   neighbor eth2 next-hop-self
+  neighbor eth2 route-map FILTER_PREFIX in
   neighbor eth3 activate
   neighbor eth3 next-hop-self
+  neighbor eth3 route-map FILTER_PREFIX in
   network fc00:0:7::1/128
  exit-address-family
 !

--- a/deploy/containerlab/resources/fabric/dfw/frr.conf
+++ b/deploy/containerlab/resources/fabric/dfw/frr.conf
@@ -9,24 +9,22 @@ interface eth1
  description tr1-facing
  ipv6 address 2001:db8:1:10::2/64
 
-ipv6 route 2001:db8:ff01:100::/56 Null0
-
-route-map SET_SRC permit 10
- set src fc00:0:2::1
+ipv6 route 2001:db8:ff01::/48 Null0
+ipv6 route fc00:0:2::/48 Null0
 
 router bgp 65000
  bgp router-id 10.255.255.2
  no bgp default ipv4-unicast
  no bgp ebgp-requires-policy
  bgp log-neighbor-changes
+
  neighbor 2001:db8:1:10::1 remote-as 65100
 
  address-family ipv6 unicast
   neighbor 2001:db8:1:10::1 activate
   neighbor 2001:db8:1:10::1 allowas-in 1
-  neighbor 2001:db8:1:10::1 route-map SET_SRC in
-  network 2001:db8:ff01:100::/56
-  network fc00:0:2::1/128
+  network 2001:db8:ff01::/48
+  network fc00:0:2::/48
  exit-address-family
 
 ipv6 forwarding

--- a/deploy/containerlab/resources/fabric/iad/frr.conf
+++ b/deploy/containerlab/resources/fabric/iad/frr.conf
@@ -9,10 +9,8 @@ interface eth1
  description tr3-facing
  ipv6 address 2001:db8:1:30::2/64
 
-ipv6 route 2001:db8:ff03:100::/56 Null0
-
-route-map SET_SRC permit 10
- set src fc00:0:4::1
+ipv6 route 2001:db8:ff03::/48 Null0
+ipv6 route fc00:0:4::/48 Null0
 
 router bgp 65000
  bgp router-id 10.255.255.1
@@ -24,9 +22,8 @@ router bgp 65000
  address-family ipv6 unicast
   neighbor 2001:db8:1:30::1 activate
   neighbor 2001:db8:1:30::1 allowas-in 1
-  neighbor 2001:db8:1:30::1 route-map SET_SRC in
-  network 2001:db8:ff03:100::/56
-  network fc00:0:4::1/128
+  network 2001:db8:ff03::/48
+  network fc00:0:4::/48
  exit-address-family
 
 ipv6 forwarding

--- a/deploy/containerlab/resources/fabric/sjc/frr.conf
+++ b/deploy/containerlab/resources/fabric/sjc/frr.conf
@@ -10,10 +10,8 @@ interface eth1
  ipv6 address 2001:db8:1:20::2/64
 
 
-ipv6 route 2001:db8:ff02:100::/56 Null0
-
-route-map SET_SRC permit 10
- set src fc00:0:3::1
+ipv6 route 2001:db8:ff02::/48 Null0
+ipv6 route fc00:0:3::/48 Null0
 
 router bgp 65000
  bgp router-id 10.255.255.3
@@ -25,9 +23,8 @@ router bgp 65000
  address-family ipv6 unicast
   neighbor 2001:db8:1:20::1 activate
   neighbor 2001:db8:1:20::1 allowas-in 1
-  neighbor 2001:db8:1:20::1 route-map SET_SRC in
-  network 2001:db8:ff02:100::/56
-  network fc00:0:3::1/128
+  network 2001:db8:ff02::/48
+  network fc00:0:3::/48
  exit-address-family
 
 ipv6 forwarding


### PR DESCRIPTION
- Advertise /48 SID locator per site instead of /56 per-node block
- Advertise /48 loopback prefix per site instead of /128, with matching static route
- Remove invalid SET_SRC route-map (set src is not a valid FRR action)
- Add FILTER_PREFIX route-map on tr1-tr4 to reject prefixes more specific than /48
- Update test:srv6 verification commands for /48 prefixes
