### PR TITLE
fix(router): derive RD Type 2 (localASN:vrfID) instead of Type 1

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -66,8 +66,8 @@ type DesiredPeer struct {
 type DesiredVRFInstance struct {
 	Name string
 	// VRFID is the 16-bit PoP-local VRF identifier (BGPVRFInstanceSpec.VRFID).
-	// The runtime derives the RFC 4364 Type 1 route distinguisher from it as
-	// "routerID:vrfID".
+	// The runtime derives the RFC 4364 Type 2 route distinguisher from it as
+	// "localASN:vrfID".
 	VRFID              int32
 	ImportRouteTargets []string
 	ExportRouteTargets []string
@@ -88,9 +88,9 @@ type DesiredAdvertisement struct {
 	// a seg6 encap route targeting the correct SRv6 decap instruction.
 	SRv6SID string
 	// VRFID is the 16-bit PoP-local VRF identifier carried from the BGPAdvertisement
-	// spec. The runtime derives the per-VRF route distinguisher as "routerID:vrfID" so
+	// spec. The runtime derives the per-VRF route distinguisher as "localASN:vrfID" so
 	// that advertisements from different VRFs on the same router produce distinct NLRIs.
-	// When nil, the legacy "routerID:0" fallback is used.
+	// When nil, the legacy "localASN:0" fallback is used.
 	VRFID *int32
 }
 

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -17,15 +17,19 @@ import (
 	"go.datum.net/galactic/internal/model"
 )
 
-// deriveRD builds an RFC 4364 Type 1 route distinguisher from the router ID
-// and the advertisement's VRFID. When VRFID is set, the RD is "routerID:vrfID"
-// matching the per-VRF RD used by applyVRF during VRF registration. When VRFID
-// is nil (legacy advertisements without a VRFID), falls back to "routerID:0".
-func deriveRD(routerID string, vrfID *int32) string {
+// deriveRD builds an RFC 4364 Type 2 route distinguisher from the platform AS
+// number and the advertisement's VRFID. When VRFID is set, the RD is
+// "localASN:vrfID" matching the per-VRF RD used by applyVRF during VRF
+// registration. When VRFID is nil (legacy advertisements without a VRFID),
+// falls back to "localASN:0". Per RFC 7432 §7.9 / RFC 9136 §3.1, RD uniqueness
+// is required only per-PE, not across PEs, so every node in a PoP deriving the
+// same RD for the same VRFID (since localASN is the platform-wide AS number)
+// is RFC-compliant; disambiguation across nodes is handled by Route Targets.
+func deriveRD(localASN int64, vrfID *int32) string {
 	if vrfID != nil {
-		return fmt.Sprintf("%s:%d", routerID, *vrfID)
+		return fmt.Sprintf("%d:%d", localASN, *vrfID)
 	}
-	return routerID + ":0"
+	return fmt.Sprintf("%d:0", localASN)
 }
 
 // parseSIDAddr parses an SRv6 SID string that may be a bare IPv6 address or a
@@ -40,14 +44,15 @@ func parseSIDAddr(sid string) (netip.Addr, error) {
 // buildEVPNPaths adds or withdraws EVPN Type 5 IP Prefix paths for each prefix
 // in adv into the local GoBGP RIB.
 //
-// routerID is the BGP router-ID (IPv4 dotted-decimal) and is used to derive the
-// per-VRF route distinguisher (Type 1 IP-address: routerID:vrfID) when adv.VRFID
-// is set, matching the RD used by applyVRF during VRF registration. adv.NextHop
-// is the transit-reachable BGP peering address placed in MpReachNLRI. adv.SRv6SID,
-// when set, is the End.DT46 SID placed in the EVPN GWIPAddress field — this is
-// the SRv6 segment that remote nodes install in their seg6 encap kernel routes.
-// When adv.SRv6SID is empty the next-hop is used for both (non-SRv6 fallback).
-func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, routerID string, withdraw bool) error {
+// localASN is the platform's 4-byte BGP AS number and is used to derive the
+// per-VRF route distinguisher (Type 2 ASN:local-admin — "localASN:vrfID") when
+// adv.VRFID is set, matching the RD used by applyVRF during VRF registration.
+// adv.NextHop is the transit-reachable BGP peering address placed in
+// MpReachNLRI. adv.SRv6SID, when set, is the End.DT46 SID placed in the EVPN
+// GWIPAddress field — this is the SRv6 segment that remote nodes install in
+// their seg6 encap kernel routes. When adv.SRv6SID is empty the next-hop is
+// used for both (non-SRv6 fallback).
+func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, localASN int64, withdraw bool) error {
 	nextHop, err := netip.ParseAddr(adv.NextHop)
 	if err != nil {
 		return fmt.Errorf("invalid EVPN next-hop %q: %w", adv.NextHop, err)
@@ -62,11 +67,11 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 		gwIP = sid
 	}
 
-	// Type 1 (IP-address:local-admin) RD, unique per VRF.
+	// Type 2 (ASN:local-admin) RD, unique per VRF.
 	// When adv.VRFID is set, the RD matches the one used by applyVRF during
-	// VRF registration ("routerID:vrfID"), ensuring two VRFs on the same
+	// VRF registration ("localASN:vrfID"), ensuring two VRFs on the same
 	// router never produce colliding NLRIs even for identical prefixes.
-	rdStr := deriveRD(routerID, adv.VRFID)
+	rdStr := deriveRD(localASN, adv.VRFID)
 	rd, err := bgp.ParseRouteDistinguisher(rdStr)
 	if err != nil {
 		return fmt.Errorf("derive route distinguisher %q: %w", rdStr, err)

--- a/internal/runtime/gobgp/paths_test.go
+++ b/internal/runtime/gobgp/paths_test.go
@@ -14,19 +14,19 @@ import (
 )
 
 const (
-	testRouterID1 = "1.2.3.4"
-	testRouterID2 = "10.0.0.1"
-	testNextHop   = "fc00::1"
-	testPrefix    = "fd00:10:ff01::/80"
-	testSID1      = "2001:db8:ff01::1"
-	testSID2      = "2001:db8:ff01::2"
-	testRT100     = "65000:100"
-	testRT200     = "65000:200"
-	testRT99      = "65000:99"
-	testLegacyRD  = "1.2.3.4:0"
-	testRD100     = "1.2.3.4:100"
-	testRD200     = "1.2.3.4:200"
-	testRD99      = "10.0.0.1:99"
+	testASN1     = int64(65001)
+	testASN2     = int64(65002)
+	testNextHop  = "fc00::1"
+	testPrefix   = "fd00:10:ff01::/80"
+	testSID1     = "2001:db8:ff01::1"
+	testSID2     = "2001:db8:ff01::2"
+	testRT100    = "65000:100"
+	testRT200    = "65000:200"
+	testRT99     = "65000:99"
+	testLegacyRD = "65001:0"
+	testRD100    = "65001:100"
+	testRD200    = "65001:200"
+	testRD99     = "65002:99"
 )
 
 func ptrInt32Test(v int32) *int32 { return &v }
@@ -34,35 +34,35 @@ func ptrInt32Test(v int32) *int32 { return &v }
 func TestDeriveRD(t *testing.T) {
 	tests := []struct {
 		name  string
-		id    string
+		asn   int64
 		vrfID *int32
 		want  string
 	}{
 		{
 			name:  "with VRFID derives per-VRF RD",
-			id:    testRouterID1,
+			asn:   testASN1,
 			vrfID: ptrInt32Test(42),
-			want:  "1.2.3.4:42",
+			want:  "65001:42",
 		},
 		{
-			name:  "nil VRFID falls back to routerID:0",
-			id:    testRouterID1,
+			name:  "nil VRFID falls back to localASN:0",
+			asn:   testASN1,
 			vrfID: nil,
 			want:  testLegacyRD,
 		},
 		{
 			name:  "max VRFID",
-			id:    testRouterID2,
+			asn:   testASN2,
 			vrfID: ptrInt32Test(65535),
-			want:  "10.0.0.1:65535",
+			want:  "65002:65535",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := deriveRD(tt.id, tt.vrfID)
+			got := deriveRD(tt.asn, tt.vrfID)
 			if got != tt.want {
-				t.Errorf("deriveRD(%q, %v) = %q, want %q", tt.id, tt.vrfID, got, tt.want)
+				t.Errorf("deriveRD(%d, %v) = %q, want %q", tt.asn, tt.vrfID, got, tt.want)
 			}
 		})
 	}
@@ -103,16 +103,16 @@ func TestBuildEVPNPathsPerVRFRD(t *testing.T) {
 	}
 
 	// Both should succeed without error.
-	if err := buildEVPNPaths(b, adv1, testRouterID1, false); err != nil {
+	if err := buildEVPNPaths(b, adv1, testASN1, false); err != nil {
 		t.Fatalf("buildEVPNPaths(adv1) error = %v", err)
 	}
-	if err := buildEVPNPaths(b, adv2, testRouterID1, false); err != nil {
+	if err := buildEVPNPaths(b, adv2, testASN1, false); err != nil {
 		t.Fatalf("buildEVPNPaths(adv2) error = %v", err)
 	}
 
 	// Verify the derived RDs are distinct.
-	rd1 := deriveRD(testRouterID1, adv1.VRFID)
-	rd2 := deriveRD(testRouterID1, adv2.VRFID)
+	rd1 := deriveRD(testASN1, adv1.VRFID)
+	rd2 := deriveRD(testASN1, adv2.VRFID)
 
 	if rd1 == rd2 {
 		t.Fatalf("RD collision: both advertisements derived RD %q — two VRFs with identical prefix would collide", rd1)
@@ -138,7 +138,7 @@ func TestBuildEVPNPathsPerVRFRD(t *testing.T) {
 }
 
 // TestBuildEVPNPathsWithoutVRFID verifies that an advertisement without a
-// VRFID falls back to the legacy "routerID:0" route distinguisher.
+// VRFID falls back to the legacy "localASN:0" route distinguisher.
 func TestBuildEVPNPathsWithoutVRFID(t *testing.T) {
 	b := newTestBgpServer(t)
 
@@ -155,11 +155,11 @@ func TestBuildEVPNPathsWithoutVRFID(t *testing.T) {
 		Communities: []string{testRT100},
 	}
 
-	if err := buildEVPNPaths(b, adv, testRouterID1, false); err != nil {
+	if err := buildEVPNPaths(b, adv, testASN1, false); err != nil {
 		t.Fatalf("buildEVPNPaths(legacy) error = %v", err)
 	}
 
-	rdStr := deriveRD(testRouterID1, adv.VRFID)
+	rdStr := deriveRD(testASN1, adv.VRFID)
 	if rdStr != testLegacyRD {
 		t.Errorf("legacy RD = %q, want %q", rdStr, testLegacyRD)
 	}
@@ -183,10 +183,10 @@ func TestBuildEVPNPathsWithdraw(t *testing.T) {
 		Communities: []string{testRT100},
 	}
 
-	if err := buildEVPNPaths(b, adv, testRouterID1, false); err != nil {
+	if err := buildEVPNPaths(b, adv, testASN1, false); err != nil {
 		t.Fatalf("buildEVPNPaths(add) error = %v", err)
 	}
-	if err := buildEVPNPaths(b, adv, testRouterID1, true); err != nil {
+	if err := buildEVPNPaths(b, adv, testASN1, true); err != nil {
 		t.Fatalf("buildEVPNPaths(withdraw) error = %v", err)
 	}
 }
@@ -207,16 +207,16 @@ func TestBuildEVPNPathsMatchesApplyVRFRD(t *testing.T) {
 	}
 
 	// Apply the VRF.
-	if err := applyVRF(ctx, b, &vrf, testRouterID2); err != nil {
+	if err := applyVRF(ctx, b, &vrf, testASN2); err != nil {
 		t.Fatalf("applyVRF() error = %v", err)
 	}
 
 	// Derive the RD that buildEVPNPaths would use for an advertisement
 	// with the same VRFID.
 	advVRFID := &vrfID
-	advRD := deriveRD(testRouterID2, advVRFID)
+	advRD := deriveRD(testASN2, advVRFID)
 
-	// The applyVRF function derives the RD as "routerID:vrfID".
+	// The applyVRF function derives the RD as "localASN:vrfID".
 	if advRD != testRD99 {
 		t.Errorf("buildEVPNPaths RD = %q, want %q (should match applyVRF derivation)", advRD, testRD99)
 	}

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -109,13 +109,13 @@ func (r *GoBGPRuntime) Apply(ctx context.Context, desired model.DesiredRouter) e
 		return err
 	}
 
-	if err := r.applyVRFs(ctx, b, desired.VRFInstances, desired.RouterID); err != nil {
+	if err := r.applyVRFs(ctx, b, desired.VRFInstances, desired.LocalASN); err != nil {
 		return err
 	}
 
 	r.startRIBMonitor(b)
 
-	if err := r.applyEVPN(b, desired.Advertisements, desired.RouterID); err != nil {
+	if err := r.applyEVPN(b, desired.Advertisements, desired.LocalASN); err != nil {
 		return err
 	}
 
@@ -223,7 +223,7 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 // node can host thousands of VRFs (one per VPC attachment), so this — unlike
 // the single-VRF code it replaces — must handle the full set, not just one.
 func (r *GoBGPRuntime) applyVRFs(
-	ctx context.Context, b *gobgpserver.BgpServer, vrfs []model.DesiredVRFInstance, routerID string,
+	ctx context.Context, b *gobgpserver.BgpServer, vrfs []model.DesiredVRFInstance, localASN int64,
 ) error {
 	desired := make(map[string]model.DesiredVRFInstance, len(vrfs))
 	for _, v := range vrfs {
@@ -239,7 +239,7 @@ func (r *GoBGPRuntime) applyVRFs(
 	rtIndex := make(map[string]uint32, len(vrfs))
 	newlyRegistered := false
 	for _, v := range vrfs {
-		if err := applyVRF(ctx, b, &v, routerID); err != nil {
+		if err := applyVRF(ctx, b, &v, localASN); err != nil {
 			return fmt.Errorf("apply VRF %s: %w", v.Name, err)
 		}
 
@@ -284,7 +284,7 @@ func (r *GoBGPRuntime) applyVRFs(
 
 // applyEVPN advertises EVPN paths for all relevant advertisements, withdrawing
 // each advertisement's previous paths first when its content has changed.
-func (r *GoBGPRuntime) applyEVPN(b *gobgpserver.BgpServer, advs []model.DesiredAdvertisement, routerID string) error {
+func (r *GoBGPRuntime) applyEVPN(b *gobgpserver.BgpServer, advs []model.DesiredAdvertisement, localASN int64) error {
 	desiredNames := make(map[string]struct{}, len(advs))
 	for _, adv := range advs {
 		if adv.AddressFamily.AFI != afiL2VPN {
@@ -296,12 +296,12 @@ func (r *GoBGPRuntime) applyEVPN(b *gobgpserver.BgpServer, advs []model.DesiredA
 			if reflect.DeepEqual(oldAdv, adv) {
 				continue
 			}
-			if err := buildEVPNPaths(b, oldAdv, routerID, true); err != nil {
+			if err := buildEVPNPaths(b, oldAdv, localASN, true); err != nil {
 				return fmt.Errorf("withdraw stale EVPN paths for %s: %w", adv.Name, err)
 			}
 		}
 
-		if err := buildEVPNPaths(b, adv, routerID, false); err != nil {
+		if err := buildEVPNPaths(b, adv, localASN, false); err != nil {
 			return fmt.Errorf("advertise EVPN paths for %s: %w", adv.Name, err)
 		}
 		r.appliedAdvertisements[adv.Name] = adv
@@ -312,7 +312,7 @@ func (r *GoBGPRuntime) applyEVPN(b *gobgpserver.BgpServer, advs []model.DesiredA
 		if _, ok := desiredNames[name]; ok {
 			continue
 		}
-		if err := buildEVPNPaths(b, oldAdv, routerID, true); err != nil {
+		if err := buildEVPNPaths(b, oldAdv, localASN, true); err != nil {
 			return fmt.Errorf("withdraw removed EVPN advertisement %s: %w", name, err)
 		}
 		delete(r.appliedAdvertisements, name)
@@ -436,13 +436,13 @@ func fsmStateToModel(state api.PeerState_SessionState) model.BGPPeerState {
 }
 
 // applyVRF configures a VRF in GoBGP via AddVrf. The route distinguisher is
-// derived as the RFC 4364 Type 1 (IP-address:local-admin) format
-// "routerID:vrfID", matching the convention buildEVPNPaths uses for the
-// per-VRF RD so that EVPN paths and VRF registration share the same distinguisher.
+// derived as the RFC 4364 Type 2 (ASN:local-admin) format "localASN:vrfID",
+// matching the convention buildEVPNPaths uses for the per-VRF RD so that EVPN
+// paths and VRF registration share the same distinguisher.
 // If the VRF already exists, the call is treated as idempotent (no-op).
-func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredVRFInstance, routerID string) error {
+func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredVRFInstance, localASN int64) error {
 	// Derive and parse the route distinguisher.
-	rdStr := fmt.Sprintf("%s:%d", routerID, vrf.VRFID)
+	rdStr := deriveRD(localASN, &vrf.VRFID)
 	rd, err := bgp.ParseRouteDistinguisher(rdStr)
 	if err != nil {
 		return fmt.Errorf("parse route distinguisher %q: %w", rdStr, err)

--- a/internal/runtime/gobgp/runtime_test.go
+++ b/internal/runtime/gobgp/runtime_test.go
@@ -36,37 +36,37 @@ func newTestBgpServer(t *testing.T) *gobgpserver.BgpServer {
 }
 
 // TestApplyVRFDerivesRouteDistinguisher verifies applyVRF derives the RFC 4364
-// Type 1 route distinguisher as "routerID:vrfID" from the routerID parameter
+// Type 2 route distinguisher as "localASN:vrfID" from the localASN parameter
 // and vrf.VRFID, rather than reading a RouteDistinguisher field off the model
 // (which no longer exists after the BGPVRFInstanceSpec.VRFID API change).
 func TestApplyVRFDerivesRouteDistinguisher(t *testing.T) {
 	tests := []struct {
-		name     string
-		routerID string
-		vrf      model.DesiredVRFInstance
-		wantRD   string
+		name   string
+		asn    int64
+		vrf    model.DesiredVRFInstance
+		wantRD string
 	}{
 		{
-			name:     "basic vrfID",
-			routerID: "1.2.3.4",
+			name: "basic vrfID",
+			asn:  65001,
 			vrf: model.DesiredVRFInstance{
 				Name:               "vrf-a",
 				VRFID:              42,
 				ImportRouteTargets: []string{"65000:100"},
 				ExportRouteTargets: []string{"65000:100"},
 			},
-			wantRD: "1.2.3.4:42",
+			wantRD: "65001:42",
 		},
 		{
-			name:     "different routerID and vrfID",
-			routerID: "10.0.0.1",
+			name: "different asn and vrfID",
+			asn:  65002,
 			vrf: model.DesiredVRFInstance{
 				Name:               "vrf-b",
 				VRFID:              65535,
 				ImportRouteTargets: []string{"65000:200"},
 				ExportRouteTargets: []string{"65000:200"},
 			},
-			wantRD: "10.0.0.1:65535",
+			wantRD: "65002:65535",
 		},
 	}
 
@@ -76,7 +76,7 @@ func TestApplyVRFDerivesRouteDistinguisher(t *testing.T) {
 			ctx := context.Background()
 
 			vrf := tt.vrf
-			if err := applyVRF(ctx, b, &vrf, tt.routerID); err != nil {
+			if err := applyVRF(ctx, b, &vrf, tt.asn); err != nil {
 				t.Fatalf("applyVRF() error = %v", err)
 			}
 


### PR DESCRIPTION
## Summary

- PR [datum-cloud/enhancements#740](https://github.com/datum-cloud/enhancements/pull/740) revised its route-distinguisher model from per-node uniqueness to per-instance uniqueness shared across every node in a PoP, requiring an RFC 4364 Type 2 RD (platform AS number + VRF ID) instead of the Type 1 RD (router-ID + VRF ID) `deriveRD` currently computes in `internal/runtime/gobgp/paths.go`.
- RFC 7432 §7.9 / RFC 9136 §3.1 scope RD uniqueness to per-PE, not cross-PE, so a shared `localASN:vrfID` RD across nodes for the same tenant instance is compliant — Route Targets (not the RD) handle cross-node route disambiguation.
- `LocalASN` was already flowing into `model.DesiredRouter` and already used for GoBGP's own iBGP config (`applyGlobal`) — it just wasn't threaded down into `applyVRFs`/`applyVRF`/`applyEVPN`/`buildEVPNPaths`, all of which took a `routerID string` parameter used for nothing except this RD string.
- `applyVRF`'s previously-independent inline RD construction (`fmt.Sprintf("%s:%d", routerID, vrf.VRFID)`) now calls `deriveRD` directly instead of duplicating the format string — closes a second "two places build the same RD independently" risk.

Scope is limited to `galactic-router`'s BGP runtime — no `galactic-cni` changes, no CRD/schema changes, since the RD is derived at apply-time in Go and never stored on any CRD field.

**Operational note:** this changes the wire-visible RD for every currently-running `BGPVRFInstance`/`BGPAdvertisement`. On the next reconcile after this deploys, existing EVPN paths get withdrawn under the old Type 1 RD and re-advertised under the new Type 2 RD — RFC-compliant, but real live-traffic churn on a rolling upgrade, not a no-op refactor.

## Test plan

- [x] `task lint` — 0 issues
- [x] `task build` — clean
- [x] `task test:unit` (race detection) — all packages pass, including `internal/runtime/gobgp`'s `TestDeriveRD`, `TestBuildEVPNPaths*`, `TestApplyVRFDerivesRouteDistinguisher`
- [ ] `task test:e2e` — not run in this environment (no purpose-built e2e Kind cluster available here); nothing in this change touches the CNI attach path or e2e-covered surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)