### PR TITLE
feat(cni): add dual-stack config fields and validation

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -103,12 +104,13 @@ func assertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
 
 func TestParseConf(t *testing.T) {
 	tests := []struct {
-		name       string
-		input      string
-		wantVPC    string
-		wantIfType string
-		wantErr    string
-		wantCode   uint // CNI error code; 0 means "don't check"
+		name                string
+		input               string
+		wantVPC             string
+		wantIfType          string
+		wantAddressFamilies []string // nil means "don't check"
+		wantErr             string
+		wantCode            uint // CNI error code; 0 means "don't check"
 	}{
 		{
 			name: "valid config",
@@ -317,6 +319,137 @@ func TestParseConf(t *testing.T) {
 			wantVPC:    testVPC,
 			wantIfType: interfaceTypeVeth,
 		},
+
+		// ---- dual-stack addressing fields (ipv6_subnet, ipv4_subnet, address_families) ----
+
+		{
+			name: "dual-stack fields omitted parses successfully",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:             testVPC,
+			wantIfType:          interfaceTypeVeth,
+			wantAddressFamilies: []string{addressFamilyIPv6},
+		},
+		{
+			name: "valid ipv6_subnet accepted",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv6_subnet":"fd00:10:ff01::/48"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			name: "invalid ipv6_subnet CIDR rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv6_subnet":"not-a-cidr"}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  "invalid CIDR value for field 'ipv6_subnet'",
+			wantCode: 7,
+		},
+		{
+			name: "ipv4 CIDR given where ipv6_subnet expected rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv6_subnet":"10.0.0.0/24"}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  "ipv6_subnet must be an IPv6 CIDR, got IPv4",
+			wantCode: 7,
+		},
+		{
+			name: "ipv6_subnet prefix length over 96 rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv6_subnet":"fd00:10:ff01::/112"}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  "ipv6_subnet prefix length 112 exceeds maximum of 96",
+			wantCode: 7,
+		},
+		{
+			name: "valid ipv4_subnet accepted",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv4_subnet":"10.0.0.0/20"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:    testVPC,
+			wantIfType: interfaceTypeVeth,
+		},
+		{
+			// A standard dotted-decimal CIDR can never carry a mask longer
+			// than /32 (net.ParseCIDR itself rejects e.g. "10.0.0.0/33"), so
+			// this exercises the prefix-length guard via an IPv4-mapped IPv6
+			// literal, which Go parses with a 128-bit mask space.
+			name: "ipv4_subnet prefix length over 32 rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv4_subnet":"::ffff:10.0.0.0/40"}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  "ipv4_subnet prefix length 40 exceeds maximum of 32",
+			wantCode: 7,
+		},
+		{
+			name: "ipv6 CIDR given where ipv4_subnet expected rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","ipv4_subnet":"2001:db8::/64"}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  "ipv4_subnet must be an IPv4 CIDR, got IPv6",
+			wantCode: 7,
+		},
+		{
+			name: "address_families defaults to ipv6 when omitted",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s"}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:             testVPC,
+			wantIfType:          interfaceTypeVeth,
+			wantAddressFamilies: []string{addressFamilyIPv6},
+		},
+		{
+			name: "address_families explicit dual-stack accepted",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","address_families":["ipv6","ipv4"]}`,
+				testVPC, testAttachment,
+			),
+			wantVPC:             testVPC,
+			wantIfType:          interfaceTypeVeth,
+			wantAddressFamilies: []string{addressFamilyIPv6, addressFamilyIPv4},
+		},
+		{
+			name: "invalid address_families entry rejected",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s",`+
+					`"vpcattachment":"%s","address_families":["ipv6","bogus"]}`,
+				testVPC, testAttachment,
+			),
+			wantErr:  `invalid address_families entry "bogus": must be "ipv6" or "ipv4"`,
+			wantCode: 7,
+		},
 	}
 
 	for _, tt := range tests {
@@ -342,6 +475,9 @@ func TestParseConf(t *testing.T) {
 			}
 			if conf.InterfaceType != tt.wantIfType {
 				t.Errorf("InterfaceType = %q, want %q", conf.InterfaceType, tt.wantIfType)
+			}
+			if tt.wantAddressFamilies != nil && !reflect.DeepEqual(conf.AddressFamilies, tt.wantAddressFamilies) {
+				t.Errorf("AddressFamilies = %v, want %v", conf.AddressFamilies, tt.wantAddressFamilies)
 			}
 		})
 	}

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,26 @@ const errInvalidCNIConfig = "invalid CNI config"
 const (
 	errVPCRequired           = "vpc is required and must be a non-empty base62 string"
 	errVPCAttachmentRequired = "vpcattachment is required and must be a non-empty base62 string"
+)
+
+const (
+	// maxIPv6SubnetPrefixLen is the maximum (longest) prefix length allowed
+	// for ipv6_subnet. It matches ipam.PoolAllocator's constraint that the
+	// pool prefix must be no longer than the per-allocation subnet length;
+	// dual-stack tenant addressing allocates /96 endpoints from this subnet,
+	// so the subnet itself must be a /96 or shorter.
+	maxIPv6SubnetPrefixLen = 96
+
+	// maxIPv4SubnetPrefixLen is the maximum (longest) prefix length allowed
+	// for ipv4_subnet: a full IPv4 host route.
+	maxIPv4SubnetPrefixLen = 32
+)
+
+// addressFamilyIPv6 and addressFamilyIPv4 are the only valid entries for
+// the address_families config field.
+const (
+	addressFamilyIPv6 = "ipv6"
+	addressFamilyIPv4 = "ipv4"
 )
 
 // isValidBase62 reports whether s contains only valid base62 characters
@@ -395,6 +416,66 @@ func parseConf(data []byte) (*PluginConf, error) {
 	// Enforce required IPAM block if local IPAM is enabled
 	if enableLocalIPAM && conf.IPAM == nil {
 		return nil, &types.Error{Code: 7, Msg: "local IPAM is enabled, but no 'ipam' block is present in the configuration"}
+	}
+
+	// Validate dual-stack addressing fields (ipv6_subnet, ipv4_subnet,
+	// address_families). ipv6_subnet and ipv4_subnet are both optional: as of
+	// this change nothing downstream consumes them yet (allocateIPAM is not
+	// wired to read them until a later phase), so making either required now
+	// would reject every existing config, including local-IPAM dev configs and
+	// current e2e configs, none of which set them. When present, both are
+	// validated for CIDR shape so misconfigurations are caught early.
+	if conf.IPv6Subnet != "" {
+		ip, mask, err := net.ParseCIDR(conf.IPv6Subnet)
+		if err != nil {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"invalid CIDR value for field 'ipv6_subnet': %q", sanitizeForError(conf.IPv6Subnet)),
+			}
+		}
+		if ip.To4() != nil {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"ipv6_subnet must be an IPv6 CIDR, got IPv4: %q", sanitizeForError(conf.IPv6Subnet)),
+			}
+		}
+		if prefixLen, _ := mask.Mask.Size(); prefixLen > maxIPv6SubnetPrefixLen {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"ipv6_subnet prefix length %d exceeds maximum of %d: %q",
+				prefixLen, maxIPv6SubnetPrefixLen, sanitizeForError(conf.IPv6Subnet)),
+			}
+		}
+	}
+	if conf.IPv4Subnet != "" {
+		ip, mask, err := net.ParseCIDR(conf.IPv4Subnet)
+		if err != nil {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"invalid CIDR value for field 'ipv4_subnet': %q", sanitizeForError(conf.IPv4Subnet)),
+			}
+		}
+		if ip.To4() == nil {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"ipv4_subnet must be an IPv4 CIDR, got IPv6: %q", sanitizeForError(conf.IPv4Subnet)),
+			}
+		}
+		if prefixLen, _ := mask.Mask.Size(); prefixLen > maxIPv4SubnetPrefixLen {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"ipv4_subnet prefix length %d exceeds maximum of %d: %q",
+				prefixLen, maxIPv4SubnetPrefixLen, sanitizeForError(conf.IPv4Subnet)),
+			}
+		}
+	}
+	if len(conf.AddressFamilies) == 0 {
+		conf.AddressFamilies = []string{addressFamilyIPv6}
+	} else {
+		for _, af := range conf.AddressFamilies {
+			switch af {
+			case addressFamilyIPv6, addressFamilyIPv4:
+			default:
+				return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+					"invalid address_families entry %q: must be %q or %q",
+					sanitizeForError(af), addressFamilyIPv6, addressFamilyIPv4),
+				}
+			}
+		}
 	}
 
 	if conf.PrevResult != nil {

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -40,15 +40,23 @@ type Address struct {
 }
 
 // PluginConf is the CNI plugin configuration passed via stdin on each invocation.
+//
+// IPv6Subnet, IPv4Subnet, and AddressFamilies feed the dual-stack IPAM
+// allocators (internal/cni/ipam, IPv4PoolAllocator/DualStackAllocator); as of
+// this change allocateIPAM does not yet consume them, and format/requiredness
+// validation in parseConf lands in a later phase.
 type PluginConf struct {
 	types.PluginConf
-	VPC           string        `json:"vpc"`
-	VPCAttachment string        `json:"vpcattachment"`
-	MTU           int           `json:"mtu,omitempty"`
-	InterfaceType string        `json:"interface_type,omitempty"` // interfaceTypeVeth or interfaceTypeTap
-	Terminations  []Termination `json:"terminations,omitempty"`
-	IPAM          *IPAM         `json:"ipam"`
-	Namespace     string        `json:"namespace,omitempty"`
+	VPC             string        `json:"vpc"`
+	VPCAttachment   string        `json:"vpcattachment"`
+	MTU             int           `json:"mtu,omitempty"`
+	InterfaceType   string        `json:"interface_type,omitempty"` // interfaceTypeVeth or interfaceTypeTap
+	Terminations    []Termination `json:"terminations,omitempty"`
+	IPAM            *IPAM         `json:"ipam"`
+	Namespace       string        `json:"namespace,omitempty"`
+	IPv6Subnet      string        `json:"ipv6_subnet,omitempty"`      // region IPv6 pool CIDR; endpoints alloc /96
+	IPv4Subnet      string        `json:"ipv4_subnet,omitempty"`      // optional site IPv4 pool CIDR; endpoints alloc /32
+	AddressFamilies []string      `json:"address_families,omitempty"` // families to allocate; default ["ipv6"]
 }
 
 // HostConf holds node-local settings read from /etc/cni/net.d/10-galactic.conflist.


### PR DESCRIPTION
## Summary
- Adds three new `PluginConf` fields (`IPv6Subnet`, `IPv4Subnet`, `AddressFamilies`) to accept the region `/64`/site `/20` pool CIDRs carried by the NAD under PR datum-cloud/enhancements#740's dual-stack tenant addressing model.
- Adds `parseConf` validation for the new fields: format/CIDR checks (IPv6 prefix ≤ /96, IPv4 prefix ≤ /32 — matching what the existing pool allocators already enforce, not a hardcoded /64 or /20), and `address_families` defaulting to `["ipv6"]` with unknown-value rejection.
- `ipv6_subnet`/`ipv4_subnet` are intentionally left optional for now — nothing downstream reads them yet (`allocateIPAM` isn't rewritten until a follow-up change), so making them required today would reject every existing config.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1` (full module)
- [x] `golangci-lint run ./...`
- [x] 11 new `TestParseConf` subtests covering valid/invalid CIDRs, family mismatches, prefix-length boundaries, and `address_families` defaulting/validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)