### PR TITLE
feat(cni): complete dual-stack tenant endpoint allocation

### DIFF
--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -216,17 +216,27 @@ func buildVRFInstanceSpec(routerName, rtValue string, vrfID int32) bgpv1alpha1.B
 }
 
 // buildAdvertisementSpec constructs the BGPAdvertisementSpec for a VPC
-// attachment's pod subnet. VRFID and Function record structurally what used
-// to live in the legacy galactic.datum.net/srv6-sid annotation: which VRF
-// this advertisement belongs to, and which SRv6 endpoint behavior the CNI
-// kernel ingress route installs (always End.DT46, regardless of pod-subnet
-// address family — see setupSRv6Ingress/srv6.RouteIngressAdd).
-func buildAdvertisementSpec(routerName, rtValue, podSubnet string, vrfID int32) bgpv1alpha1.BGPAdvertisementSpec {
+// attachment's pod subnet(s) — one IPv6 prefix, plus an IPv4 prefix when the
+// attachment is dual-stack. RFC 9136's Type-5 route is self-describing per
+// NLRI, so a single BGPAdvertisement carrying both families is valid; see
+// galactic-router's buildEVPNPaths for the corresponding per-family gateway
+// handling. VRFID and Function record structurally what used to live in the
+// legacy galactic.datum.net/srv6-sid annotation: which VRF this advertisement
+// belongs to, and which SRv6 endpoint behavior the CNI kernel ingress route
+// installs (always End.DT46, regardless of pod-subnet address family — see
+// setupSRv6Ingress/srv6.RouteIngressAdd).
+func buildAdvertisementSpec(
+	routerName, rtValue string, prefixes []string, vrfID int32,
+) bgpv1alpha1.BGPAdvertisementSpec {
 	function := bgpv1alpha1.SRv6FunctionEndDT46
+	bgpPrefixes := make([]bgpv1alpha1.Prefix, len(prefixes))
+	for i, p := range prefixes {
+		bgpPrefixes[i] = bgpv1alpha1.Prefix(p)
+	}
 	return bgpv1alpha1.BGPAdvertisementSpec{
 		RouterRef:     bgpv1alpha1.RouterRef{Name: routerName},
 		AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
-		Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(podSubnet)},
+		Prefixes:      bgpPrefixes,
 		Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community(rtValue)},
 		VRFID:         &vrfID,
 		Function:      &function,
@@ -338,19 +348,29 @@ func publishBGPStateK8s(
 		slog.Debug("BGP: BGPVRFInstance applied", "name", vrfName, "namespace", namespace,
 			"vrfID", vrfID, "routeTarget", rtValue, "router", bgp.routerName)
 
-		// Create the BGPAdvertisement to originate the pod's subnet prefix.
+		// Create the BGPAdvertisement to originate the pod's subnet prefix(es).
 		adv := &bgpv1alpha1.BGPAdvertisement{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
 				Namespace: namespace,
 			},
 		}
-		podSubnet := ""
+		var prefixes []string
+		var ipv6Subnet, ipv4Addr string
 		if ipamResult != nil {
-			podSubnet = ipamResult.subnet.String()
+			ipv6Subnet = ipamResult.ipv6Subnet.String()
+			prefixes = append(prefixes, ipv6Subnet)
+			if ipamResult.ipv4Address != nil {
+				// The annotation stores the bare address (matching
+				// IPv4PoolAllocator's marker-file naming, so cmdDel's
+				// Deallocate call finds it — see ipam_ops.go); the
+				// advertised prefix needs the explicit /32 CIDR form.
+				ipv4Addr = ipamResult.ipv4Address.String()
+				prefixes = append(prefixes, ipv4Addr+"/32")
+			}
 		}
 		_, err = controllerutil.CreateOrUpdate(ctx, k8s, adv, func() error {
-			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, podSubnet, vrfID)
+			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, prefixes, vrfID)
 			if adv.Annotations == nil {
 				adv.Annotations = make(map[string]string)
 			}
@@ -359,9 +379,14 @@ func publishBGPStateK8s(
 			// guessing a name from the container ID (see
 			// gc.ContainerNetNSExistsByPath).
 			adv.Annotations[netnsAnnotationKey(args.ContainerID)] = args.Netns
-			// Store the allocated subnet keyed by container ID so cmdDel can look it up.
-			if ipamResult != nil {
-				adv.Annotations[subnetAnnotationKey(args.ContainerID)] = podSubnet
+			// Store the allocated addresses keyed by container ID so cmdDel can
+			// look them up, one annotation per family so DEL can deallocate
+			// each independently.
+			if ipv6Subnet != "" {
+				adv.Annotations[subnetAnnotationKeyIPv6(args.ContainerID)] = ipv6Subnet
+			}
+			if ipv4Addr != "" {
+				adv.Annotations[subnetAnnotationKeyIPv4(args.ContainerID)] = ipv4Addr
 			}
 			return nil
 		})
@@ -370,7 +395,7 @@ func publishBGPStateK8s(
 		}
 		tracker.advCreated = true
 		slog.Debug("BGP: BGPAdvertisement applied", "name", adv.Name, "namespace", namespace,
-			"podSubnet", podSubnet, "containerID", args.ContainerID)
+			"prefixes", prefixes, "containerID", args.ContainerID)
 
 		slog.Info("ADD: BGP state published", "containerID", args.ContainerID,
 			"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
@@ -400,17 +425,19 @@ func routeConflicts(existing, desired *netlink.Route) bool {
 	return false
 }
 
-// configureHostGateway assigns the gateway address as a /128 host address on
-// the host-side interface (veth or tap) and installs an explicit pod-subnet
-// route into the VRF table.
+// configureHostGateway assigns each configured family's gateway address as a
+// host address (/128 for IPv6, /32 for IPv4) on the host-side interface (veth
+// or tap) and installs an explicit pod-subnet route for that family into the
+// VRF table. IPv4 is skipped entirely when the attachment is IPv6-only.
 //
-// Using /128 (not the pod subnet mask) prevents the kernel from auto-creating a
-// subnet-router anycast entry in the VRF local table. When the pod address equals
-// the subnet network address the anycast absorbs seg6local-decapped inner packets
-// before they reach the guest interface. The explicit subnet route replaces the
-// one the kernel would have created from the wider mask.
+// Using a full-length host address (not the pod subnet mask) prevents the
+// kernel from auto-creating a subnet-router anycast entry in the VRF local
+// table. When the pod address equals the subnet network address the anycast
+// absorbs seg6local-decapped inner packets before they reach the guest
+// interface. The explicit subnet route replaces the one the kernel would
+// have created from the wider mask.
 func configureHostGateway(vpc, vpcAttachment string, res *ipamResult) error {
-	if res == nil || res.gateway == nil {
+	if res == nil {
 		return nil
 	}
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
@@ -418,26 +445,49 @@ func configureHostGateway(vpc, vpcAttachment string, res *ipamResult) error {
 	if err != nil {
 		return fmt.Errorf("get host interface %q: %w", hostName, err)
 	}
-	gwNet := &net.IPNet{IP: res.gateway, Mask: net.CIDRMask(128, 128)}
-	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); err != nil {
-		if !errors.Is(err, syscall.EEXIST) {
-			return fmt.Errorf("add gateway address to host interface %q: %w", hostName, err)
-		}
-	}
 	tableID, err := vrf.TableID(vpc, vpcAttachment)
 	if err != nil {
 		return fmt.Errorf("get VRF table ID for pod subnet route: %w", err)
 	}
+
+	if res.ipv6Gateway != nil {
+		gwNet := &net.IPNet{IP: res.ipv6Gateway, Mask: net.CIDRMask(128, 128)}
+		if err := installGatewayRoute(hostLink, gwNet, res.ipv6Subnet, netlink.FAMILY_V6, int(tableID)); err != nil {
+			return err
+		}
+	}
+	if res.ipv4Gateway != nil {
+		gwNet := &net.IPNet{IP: res.ipv4Gateway, Mask: net.CIDRMask(32, 32)}
+		ipv4Subnet := &net.IPNet{IP: res.ipv4Address, Mask: net.CIDRMask(32, 32)}
+		if err := installGatewayRoute(hostLink, gwNet, ipv4Subnet, netlink.FAMILY_V4, int(tableID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// installGatewayRoute assigns gwNet as a host address on hostLink and
+// installs an explicit route to subnet into the given VRF table, for one
+// address family. Idempotent: existing matching routes/addresses are left
+// alone, and conflicting ones return an error rather than being overwritten.
+func installGatewayRoute(hostLink netlink.Link, gwNet, subnet *net.IPNet, family, tableID int) error {
+	hostName := hostLink.Attrs().Name
+	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); err != nil {
+		if !errors.Is(err, syscall.EEXIST) {
+			return fmt.Errorf("add gateway address %s to host interface %q: %w", gwNet, hostName, err)
+		}
+	}
+
 	desiredRoute := &netlink.Route{
-		Dst:       res.subnet,
+		Dst:       subnet,
 		LinkIndex: hostLink.Attrs().Index,
-		Table:     int(tableID),
+		Table:     tableID,
 	}
 
 	// Check for existing routes with the same destination before installing.
 	existingRoutes, err := netlink.RouteListFiltered(
-		netlink.FAMILY_V6,
-		&netlink.Route{Table: int(tableID)},
+		family,
+		&netlink.Route{Table: tableID},
 		netlink.RT_FILTER_TABLE,
 	)
 	if err != nil {

--- a/internal/cni/bgp_test.go
+++ b/internal/cni/bgp_test.go
@@ -258,7 +258,7 @@ func TestBuildVRFInstanceSpec(t *testing.T) {
 
 func TestBuildAdvertisementSpec(t *testing.T) {
 	const podSubnet = "fd00:10:ff01::1234/80"
-	spec := buildAdvertisementSpec(testRouterName, testRD65000_1, podSubnet, 1234)
+	spec := buildAdvertisementSpec(testRouterName, testRD65000_1, []string{podSubnet}, 1234)
 
 	if spec.RouterRef.Name != testRouterName {
 		t.Errorf("RouterRef.Name = %q, want %q", spec.RouterRef.Name, testRouterName)
@@ -277,5 +277,21 @@ func TestBuildAdvertisementSpec(t *testing.T) {
 	}
 	if spec.Function == nil || *spec.Function != bgpv1alpha1.SRv6FunctionEndDT46 {
 		t.Errorf("Function = %v, want pointer to %q", spec.Function, bgpv1alpha1.SRv6FunctionEndDT46)
+	}
+}
+
+func TestBuildAdvertisementSpecDualStack(t *testing.T) {
+	const ipv6Prefix = "fd00:10:ff01::1234/96"
+	const ipv4Prefix = "10.128.0.5/32"
+	spec := buildAdvertisementSpec(testRouterName, testRD65000_1, []string{ipv6Prefix, ipv4Prefix}, 1234)
+
+	if len(spec.Prefixes) != 2 {
+		t.Fatalf("Prefixes = %+v, want 2 entries", spec.Prefixes)
+	}
+	if string(spec.Prefixes[0]) != ipv6Prefix {
+		t.Errorf("Prefixes[0] = %q, want %q", spec.Prefixes[0], ipv6Prefix)
+	}
+	if string(spec.Prefixes[1]) != ipv4Prefix {
+		t.Errorf("Prefixes[1] = %q, want %q", spec.Prefixes[1], ipv4Prefix)
 	}
 }

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -15,24 +15,28 @@ import (
 
 const cniTimeout = 10 * time.Second
 
-// ipamTypePool is the ipam type for the built-in local IPAM pool allocator.
-const ipamTypePool = "pool"
+// ipamTypeStatic is the ipam type for a single pre-assigned static address.
+// Any other (or empty) IPAM.Type value takes the pool-based dual-stack path
+// — see wantsIPAM/allocateIPAM in ipam_ops.go.
+const ipamTypeStatic = "static"
+
+// localIPAMDefaultPool is the IPv6 CIDR pool used when local IPAM is enabled
+// but IPv6Subnet is unset in the CNI config. Allocations from it use
+// ipam.DefaultSubnetLen (/96).
+const localIPAMDefaultPool = "fd00:10:ff01::/64"
 
 const (
-	// localIPAMDefaultPool is the IPv6 CIDR pool used when local IPAM is
-	// enabled but no explicit ipam block is present in the CNI config.
-	localIPAMDefaultPool = "fd00:10:ff01::/64"
+	// annotationAllocatedSubnetIPv6 is the BGPAdvertisement annotation key
+	// prefix holding the allocated IPv6 pod subnet CIDR (the /96) for a
+	// container ID. The full key appends a truncated container ID; see
+	// subnetAnnotationKeyIPv6.
+	annotationAllocatedSubnetIPv6 = "galactic.datum.net/allocated-subnet-ipv6"
 
-	// localIPAMDefaultSubnetLen is the default prefix length for local IPAM
-	// allocations (default /96, giving 2^32 addresses per pod subnet).
-	localIPAMDefaultSubnetLen = 96
-)
-
-const (
-	// annotationAllocatedSubnet is the BGPAdvertisement annotation key prefix
-	// holding the allocated pod subnet CIDR for a container ID. The full key
-	// appends a truncated container ID; see subnetAnnotationKey.
-	annotationAllocatedSubnet = "galactic.datum.net/allocated-subnet"
+	// annotationAllocatedSubnetIPv4 is the BGPAdvertisement annotation key
+	// prefix holding the allocated IPv4 pod address (the /32) for a
+	// container ID, when the attachment is dual-stack. The full key appends
+	// a truncated container ID; see subnetAnnotationKeyIPv4.
+	annotationAllocatedSubnetIPv4 = "galactic.datum.net/allocated-subnet-ipv4"
 
 	// annotationNetNS is the BGPAdvertisement annotation key prefix holding
 	// the CNI-provided network namespace path for a container ID. The GC

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -884,7 +884,7 @@ func TestBuildResult(t *testing.T) {
 	}{
 		{
 			name:       "with IPAM config",
-			ipRes:      &ipamResult{subnet: subnet, gateway: gateway, routes: []*net.IPNet{route}},
+			ipRes:      &ipamResult{ipv6Subnet: subnet, ipv6Gateway: gateway, routes: []*net.IPNet{route}},
 			wantInts:   2,
 			wantIPs:    1,
 			wantRoutes: 1,
@@ -978,6 +978,59 @@ func TestBuildResult(t *testing.T) {
 	}
 }
 
+// TestBuildResultDualStack verifies that buildResult emits both an IPv6 and
+// an IPv4 IPConfig, both pointing at the guest interface, plus both default
+// routes, when ipamResult carries an IPv4 allocation.
+func TestBuildResultDualStack(t *testing.T) {
+	ipv6Subnet := mustParseCIDR(t, "fd00:10:ff01::1234/96")
+	ipv6Gateway := net.ParseIP("fd00:10:ff01::1")
+	ipv4Address := net.ParseIP("10.128.0.5")
+	ipv4Gateway := net.ParseIP("10.128.0.1")
+	ipv6Route := mustParseCIDR(t, "::/0")
+	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+
+	conf := &PluginConf{
+		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
+		VPC:           testVPC,
+		VPCAttachment: testAttachment,
+	}
+	ipRes := &ipamResult{
+		ipv6Subnet:  ipv6Subnet,
+		ipv6Gateway: ipv6Gateway,
+		ipv4Address: ipv4Address,
+		ipv4Gateway: ipv4Gateway,
+		routes:      []*net.IPNet{ipv6Route, ipv4Route},
+	}
+
+	result := buildResult(conf, ipRes, "G09-vpc03-vpcAttH", "eth0",
+		"aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:11", 1500, 1500, "/proc/1234/ns/net")
+
+	if len(result.IPs) != 2 {
+		t.Fatalf("IPs count = %d, want 2", len(result.IPs))
+	}
+	if result.IPs[0].Address.String() != ipv6Subnet.String() {
+		t.Errorf("IPs[0].Address = %v, want %v", result.IPs[0].Address, ipv6Subnet)
+	}
+	if !result.IPs[0].Gateway.Equal(ipv6Gateway) {
+		t.Errorf("IPs[0].Gateway = %v, want %v", result.IPs[0].Gateway, ipv6Gateway)
+	}
+	wantIPv4Mask := net.CIDRMask(32, 32).String()
+	if result.IPs[1].Address.IP.String() != ipv4Address.String() || result.IPs[1].Address.Mask.String() != wantIPv4Mask {
+		t.Errorf("IPs[1].Address = %v, want %s/32", result.IPs[1].Address, ipv4Address)
+	}
+	if !result.IPs[1].Gateway.Equal(ipv4Gateway) {
+		t.Errorf("IPs[1].Gateway = %v, want %v", result.IPs[1].Gateway, ipv4Gateway)
+	}
+	for i, r := range result.IPs {
+		if r.Interface == nil || *r.Interface != 1 {
+			t.Errorf("IPs[%d].Interface = %v, want 1 (guest)", i, r.Interface)
+		}
+	}
+	if len(result.Routes) != 2 {
+		t.Errorf("Routes count = %d, want 2", len(result.Routes))
+	}
+}
+
 // ---- buildTapResult ------------------------------------------------------
 
 func TestBuildTapResult(t *testing.T) {
@@ -999,7 +1052,7 @@ func TestBuildTapResult(t *testing.T) {
 	}{
 		{
 			name:       "with IPAM config",
-			ipRes:      &ipamResult{subnet: subnet, gateway: gateway, routes: []*net.IPNet{route}},
+			ipRes:      &ipamResult{ipv6Subnet: subnet, ipv6Gateway: gateway, routes: []*net.IPNet{route}},
 			wantIPs:    1,
 			wantRoutes: 1,
 		},
@@ -1074,7 +1127,7 @@ func TestBuildTapResultHostNetns(t *testing.T) {
 		VPC:           testVPC,
 		VPCAttachment: testAttachment,
 	}
-	ipRes := &ipamResult{subnet: subnet, gateway: gateway, routes: []*net.IPNet{route}}
+	ipRes := &ipamResult{ipv6Subnet: subnet, ipv6Gateway: gateway, routes: []*net.IPNet{route}}
 
 	result := buildTapResult(conf, ipRes, "H0abc123", "aa:bb:cc:dd:ee:ff", 1500)
 

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -419,12 +419,12 @@ func parseConf(data []byte) (*PluginConf, error) {
 	}
 
 	// Validate dual-stack addressing fields (ipv6_subnet, ipv4_subnet,
-	// address_families). ipv6_subnet and ipv4_subnet are both optional: as of
-	// this change nothing downstream consumes them yet (allocateIPAM is not
-	// wired to read them until a later phase), so making either required now
-	// would reject every existing config, including local-IPAM dev configs and
-	// current e2e configs, none of which set them. When present, both are
-	// validated for CIDR shape so misconfigurations are caught early.
+	// address_families). Both subnet fields stay optional at the parseConf
+	// level: whether one is actually required depends on which IPAM path a
+	// given ADD takes (static, local-IPAM fallback, or pool), which is
+	// resolved in allocateIPAM — see wantsIPAM/allocateIPAM in ipam_ops.go.
+	// When present, both are validated for CIDR shape so misconfigurations
+	// are caught early regardless of which path runs.
 	if conf.IPv6Subnet != "" {
 		ip, mask, err := net.ParseCIDR(conf.IPv6Subnet)
 		if err != nil {
@@ -509,20 +509,31 @@ func sanitizeForError(s string) string {
 	return s
 }
 
-// subnetAnnotationKey returns the annotation key for storing the allocated
-// subnet for the given container ID. Kubernetes limits the name part of an
-// annotation key to 63 bytes; "allocated-subnet." is 17 bytes, leaving 46
-// bytes for the container ID prefix.
-func subnetAnnotationKey(containerID string) string {
+// subnetAnnotationKeyIPv6 returns the annotation key for storing the
+// allocated IPv6 subnet for the given container ID. Kubernetes limits the
+// name part of an annotation key to 63 bytes; "allocated-subnet-ipv6." is 22
+// bytes, leaving 41 bytes for the container ID prefix.
+func subnetAnnotationKeyIPv6(containerID string) string {
 	id := containerID
 	if len(id) > annotationContainerIDLen {
 		id = id[:annotationContainerIDLen]
 	}
-	return fmt.Sprintf("%s.%s", annotationAllocatedSubnet, id)
+	return fmt.Sprintf("%s.%s", annotationAllocatedSubnetIPv6, id)
+}
+
+// subnetAnnotationKeyIPv4 returns the annotation key for storing the
+// allocated IPv4 address for the given container ID. Mirrors
+// subnetAnnotationKeyIPv6.
+func subnetAnnotationKeyIPv4(containerID string) string {
+	id := containerID
+	if len(id) > annotationContainerIDLen {
+		id = id[:annotationContainerIDLen]
+	}
+	return fmt.Sprintf("%s.%s", annotationAllocatedSubnetIPv4, id)
 }
 
 // netnsAnnotationKey returns the annotation key for storing the network
-// namespace path used by the given container ID. Mirrors subnetAnnotationKey.
+// namespace path used by the given container ID. Mirrors subnetAnnotationKeyIPv6.
 func netnsAnnotationKey(containerID string) string {
 	id := containerID
 	if len(id) > annotationContainerIDLen {

--- a/internal/cni/ipam_ops.go
+++ b/internal/cni/ipam_ops.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -18,98 +19,123 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// allocateIPAM allocates a subnet and gateway for the given container. This is
-// interface-agnostic — it does not touch any kernel state or network namespaces.
-// When enableLocalIPAM is true and no explicit ipam block is configured, falls
-// back to a built-in pool allocator using default pool CIDR and subnet length.
+// ipv4LockDir is the IPv4PoolAllocator lock/state directory used by
+// allocatePoolIPAM/deallocateIPAM. Overridable in tests (mirrors the
+// ConfFile pattern in config.go) so unit tests never touch the real
+// production path.
+var ipv4LockDir = ipam.DefaultIPv4LockDir
+
+// wantsIPAM reports whether the given config should trigger IPAM allocation
+// at all. Three independent signals opt in: an explicit "static" IPAM type,
+// a configured IPv6Subnet (the NAD-driven dual-stack path), or the
+// --enable-local-ipam dev fallback. A config with none of these (e.g. a tap
+// workload that manages its own addressing) allocates nothing, matching
+// today's behavior of skipping IPAM entirely rather than erroring.
+func wantsIPAM(pluginConf *PluginConf) bool {
+	if pluginConf.IPAM != nil && pluginConf.IPAM.Type == ipamTypeStatic {
+		return true
+	}
+	return pluginConf.IPv6Subnet != "" || enableLocalIPAM
+}
+
+// allocateIPAM allocates addresses for the given container. This is
+// interface-agnostic — it does not touch any kernel state or network
+// namespaces. Returns (nil, nil) when wantsIPAM reports no allocation is
+// requested. When enableLocalIPAM is true and IPv6Subnet is unset, falls back
+// to a built-in default IPv6 pool CIDR.
 func allocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf) (*ipamResult, error) {
-	var pool *ipam.PoolAllocator
-	var subnet *net.IPNet
-	var err error
-
-	// pluginConf.IPAM is nil whenever the CNI config omits the "ipam" block
-	// entirely (e.g. tap mode relying solely on --enable-local-ipam); fall
-	// back to a zero-value IPAM so field access below is nil-safe.
-	var ipamConf IPAM
-	if pluginConf.IPAM != nil {
-		ipamConf = *pluginConf.IPAM
+	if !wantsIPAM(pluginConf) {
+		return nil, nil
 	}
 
-	// When local IPAM is enabled but no explicit ipam type is configured,
-	// use the built-in pool allocator with defaults.
-	poolType := ipamConf.Type
-	if poolType == "" && enableLocalIPAM {
-		poolType = ipamTypePool
+	if pluginConf.IPAM != nil && pluginConf.IPAM.Type == ipamTypeStatic {
+		return allocateStaticIPAM(args, pluginConf.IPAM)
 	}
 
-	switch poolType {
-	case "static":
-		alloc := ipam.NewStaticAllocator()
-		allocIP, err := alloc.Allocate(args.ContainerID, ipamConf.StaticIP)
-		if err != nil {
-			return nil, fmt.Errorf("allocate static IP: %w", err)
+	return allocatePoolIPAM(args, pluginConf)
+}
+
+// allocateStaticIPAM validates and returns the pre-assigned static IPv6
+// address from the "static" IPAM block. No IPv4 address is ever allocated
+// for static IPAM — it is a single fixed address, not a dual-stack pool.
+func allocateStaticIPAM(args *skel.CmdArgs, ipamConf *IPAM) (*ipamResult, error) {
+	alloc := ipam.NewStaticAllocator()
+	allocIP, err := alloc.Allocate(args.ContainerID, ipamConf.StaticIP)
+	if err != nil {
+		return nil, fmt.Errorf("allocate static IP: %w", err)
+	}
+	subnet := &net.IPNet{
+		IP:   allocIP,
+		Mask: net.CIDRMask(64, 128),
+	}
+	slog.Debug("IPAM: allocated static", "containerID", args.ContainerID, "subnet", subnet)
+	return &ipamResult{ipv6Subnet: subnet}, nil
+}
+
+// allocatePoolIPAM allocates a dual-stack (or IPv6-only) pool-based
+// endpoint address for the given container, via ipam.DualStackAllocator.
+// IPv6Subnet supplies the region pool CIDR (falling back to
+// localIPAMDefaultPool when enableLocalIPAM and unset); IPv4Subnet, when
+// present, additionally allocates a site-pool IPv4 address.
+func allocatePoolIPAM(args *skel.CmdArgs, pluginConf *PluginConf) (*ipamResult, error) {
+	ipv6Pool := pluginConf.IPv6Subnet
+	if ipv6Pool == "" {
+		if !enableLocalIPAM {
+			return nil, errors.New("ipv6_subnet is required (or enable local IPAM)")
 		}
-		subnet = &net.IPNet{
-			IP:   allocIP,
-			Mask: net.CIDRMask(64, 128),
-		}
-	case ipamTypePool:
-		poolCIDR := ipamConf.Pool
-		gateway := ipamConf.Gateway
-		subnetLen := ipamConf.SubnetLen
-		if poolCIDR == "" && enableLocalIPAM {
-			poolCIDR = localIPAMDefaultPool
-		}
-		if subnetLen == 0 && enableLocalIPAM {
-			subnetLen = localIPAMDefaultSubnetLen
-		}
-		pool, err = ipam.NewPoolAllocator(poolCIDR, gateway, subnetLen)
-		if err != nil {
-			return nil, fmt.Errorf("create pool allocator: %w", err)
-		}
-		subnet, err = pool.Allocate(args.ContainerID)
-		if err != nil {
-			return nil, fmt.Errorf("allocate from pool: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("unknown IPAM type: %s", ipamConf.Type)
+		ipv6Pool = localIPAMDefaultPool
 	}
 
-	var gateway net.IP
-	if pool != nil {
-		gateway = pool.Gateway()
+	alloc, err := ipam.NewDualStackAllocator(ipv6Pool, "", pluginConf.IPv4Subnet, "", ipv4LockDir)
+	if err != nil {
+		return nil, fmt.Errorf("create dual-stack allocator: %w", err)
 	}
 
-	var routes []*net.IPNet
-	if gateway != nil {
-		defaultRoute := &net.IPNet{
-			IP:   net.IPv6zero,
-			Mask: net.CIDRMask(0, 128),
-		}
-		routes = append(routes, defaultRoute)
+	res, err := alloc.Allocate(args.ContainerID)
+	if err != nil {
+		return nil, fmt.Errorf("allocate dual-stack addresses: %w", err)
 	}
 
-	slog.Debug("IPAM: allocated", "containerID", args.ContainerID, "type", poolType, "subnet", subnet, "gateway", gateway)
+	routes := []*net.IPNet{{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}}
+	if res.IPv4Address != nil {
+		routes = append(routes, &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)})
+	}
+
+	slog.Debug("IPAM: allocated", "containerID", args.ContainerID,
+		"ipv6Subnet", res.IPv6Subnet, "ipv6Gateway", res.IPv6Gateway,
+		"ipv4Address", res.IPv4Address, "ipv4Gateway", res.IPv4Gateway)
 
 	return &ipamResult{
-		subnet:  subnet,
-		gateway: gateway,
-		routes:  routes,
+		ipv6Subnet:  res.IPv6Subnet,
+		ipv6Gateway: res.IPv6Gateway,
+		ipv4Address: res.IPv4Address,
+		ipv4Gateway: res.IPv4Gateway,
+		routes:      routes,
 	}, nil
 }
 
-// configureIPAM allocates a subnet and configures the guest interface inside the
-// container network namespace. This is veth-only; for tap mode, use allocateIPAM
-// directly (the VM manages its own guest interface). When enableLocalIPAM is
-// true and no explicit ipam block is configured, falls back to a built-in pool
-// allocator using default pool CIDR and subnet length.
+// configureIPAM allocates addresses and configures the guest interface inside
+// the container network namespace with both families (when dual-stack). This
+// is veth-only; for tap mode, use allocateIPAM directly (the VM manages its
+// own guest interface).
 func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string) (*ipamResult, error) {
 	ipamResult, err := allocateIPAM(args, pluginConf)
 	if err != nil {
 		return nil, err
 	}
+	if ipamResult == nil {
+		return nil, nil
+	}
 
-	if err := configureInterfaceInNetns(args.Netns, guestName, ipamResult.subnet, ipamResult.gateway); err != nil {
+	var ipv4Net *net.IPNet
+	if ipamResult.ipv4Address != nil {
+		ipv4Net = &net.IPNet{IP: ipamResult.ipv4Address, Mask: net.CIDRMask(32, 32)}
+	}
+	if err := configureInterfaceInNetns(
+		args.Netns, guestName,
+		ipamResult.ipv6Subnet, ipamResult.ipv6Gateway,
+		ipv4Net, ipamResult.ipv4Gateway,
+	); err != nil {
 		return nil, err
 	}
 
@@ -117,52 +143,60 @@ func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string)
 }
 
 // deallocateIPAM releases the IPAM allocation for the given container.
-// Reads the allocated subnet from the BGPAdvertisement CRD annotation, then
-// deallocates it from the in-memory pool. When enableLocalIPAM is true and
-// no explicit ipam block is configured, uses the default pool CIDR.
+// Reads the allocated IPv6 subnet and (if present) IPv4 address from the
+// BGPAdvertisement CRD annotations, then deallocates each independently and
+// non-fatally: a missing annotation for one family (e.g. a pre-existing
+// v6-only pod, or a partial ADD failure that never reached IPv4 allocation)
+// must not prevent cleanup of the other.
 func deallocateIPAM(args *skel.CmdArgs, pluginConf *PluginConf, k8s client.Client) {
-	// Look up the allocated subnet from the BGPAdvertisement annotation.
-	subnetCIDR := getAllocatedSubnetFromCRD(args.ContainerID, pluginConf, k8s)
-	if subnetCIDR == "" {
+	if pluginConf.IPAM != nil && pluginConf.IPAM.Type == ipamTypeStatic {
+		// Static allocations don't need deallocation.
+		return
+	}
+
+	ipv6Subnet, ipv4Addr := getAllocatedSubnetsFromCRD(args.ContainerID, pluginConf, k8s)
+	if ipv6Subnet == "" && ipv4Addr == "" {
 		// No allocation found — either allocation was never completed,
 		// or the advertisement was already deleted. Nothing to clean up.
 		slog.Debug("IPAM: no allocation found to deallocate", "containerID", args.ContainerID)
 		return
 	}
 
-	var ipamConf IPAM
-	if pluginConf.IPAM != nil {
-		ipamConf = *pluginConf.IPAM
-	}
-
-	ipamType := ipamConf.Type
-	if ipamType == "" && enableLocalIPAM {
-		ipamType = ipamTypePool
-	}
-
-	switch ipamType {
-	case ipamTypePool:
-		poolCIDR := ipamConf.Pool
-		if poolCIDR == "" && enableLocalIPAM {
-			poolCIDR = localIPAMDefaultPool
+	if ipv6Subnet != "" {
+		ipv6Pool := pluginConf.IPv6Subnet
+		if ipv6Pool == "" && enableLocalIPAM {
+			ipv6Pool = localIPAMDefaultPool
 		}
-		pa, err := ipam.NewPoolAllocator(poolCIDR, ipamConf.Gateway, ipamConf.SubnetLen)
+		pa, err := ipam.NewPoolAllocator(ipv6Pool, "", 0)
 		if err != nil {
-			// Pool creation failed — allocation was never completed, nothing to clean up.
-			slog.Warn("IPAM: failed to build pool allocator for deallocation, skipping", "err", err,
-				"containerID", args.ContainerID, "subnet", subnetCIDR)
-			return
+			slog.Warn("IPAM: failed to build IPv6 pool allocator for deallocation, skipping", "err", err,
+				"containerID", args.ContainerID, "subnet", ipv6Subnet)
+		} else {
+			pa.Deallocate(ipv6Subnet)
+			slog.Debug("IPAM: deallocated IPv6", "containerID", args.ContainerID, "subnet", ipv6Subnet)
 		}
-		pa.Deallocate(subnetCIDR)
-		slog.Debug("IPAM: deallocated", "containerID", args.ContainerID, "subnet", subnetCIDR)
-	case "static":
-		// Static allocations don't need deallocation.
+	}
+
+	if ipv4Addr != "" {
+		if pluginConf.IPv4Subnet == "" {
+			slog.Warn("IPAM: found allocated IPv4 address but no ipv4_subnet in config, skipping deallocation",
+				"containerID", args.ContainerID, "address", ipv4Addr)
+		} else if pa, err := ipam.NewIPv4PoolAllocator(pluginConf.IPv4Subnet, "", ipv4LockDir); err != nil {
+			slog.Warn("IPAM: failed to build IPv4 pool allocator for deallocation, skipping", "err", err,
+				"containerID", args.ContainerID, "address", ipv4Addr)
+		} else {
+			pa.Deallocate(ipv4Addr)
+			slog.Debug("IPAM: deallocated IPv4", "containerID", args.ContainerID, "address", ipv4Addr)
+		}
 	}
 }
 
-// getAllocatedSubnetFromCRD reads the allocated subnet for the given container
-// from the BGPAdvertisement CRD annotation. Returns empty string if not found.
-func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf, k8s client.Client) string {
+// getAllocatedSubnetsFromCRD reads the allocated IPv6 subnet and (if present)
+// IPv4 address for the given container from the BGPAdvertisement CRD
+// annotations. Either return value is empty when not found.
+func getAllocatedSubnetsFromCRD(
+	containerID string, pluginConf *PluginConf, k8s client.Client,
+) (ipv6Subnet, ipv4Addr string) {
 	namespace := pluginConf.Namespace
 
 	ctx, cancel := context.WithTimeout(context.Background(), cniTimeout)
@@ -175,8 +209,8 @@ func getAllocatedSubnetFromCRD(containerID string, pluginConf *PluginConf, k8s c
 		},
 	}
 	if err := k8s.Get(ctx, client.ObjectKeyFromObject(adv), adv); err != nil {
-		return ""
+		return "", ""
 	}
 
-	return adv.Annotations[subnetAnnotationKey(containerID)]
+	return adv.Annotations[subnetAnnotationKeyIPv6(containerID)], adv.Annotations[subnetAnnotationKeyIPv4(containerID)]
 }

--- a/internal/cni/ipam_ops_test.go
+++ b/internal/cni/ipam_ops_test.go
@@ -1,0 +1,281 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cni
+
+import (
+	"net"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.datum.net/galactic/internal/cni/ipam"
+	"go.datum.net/galactic/internal/config"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// ---- wantsIPAM ------------------------------------------------------------
+
+func TestWantsIPAM(t *testing.T) {
+	original := enableLocalIPAM
+	defer func() { enableLocalIPAM = original }()
+
+	tests := []struct {
+		name           string
+		pluginConf     *PluginConf
+		enableLocalIPA bool
+		want           bool
+	}{
+		{
+			name:       "no ipam block, no ipv6_subnet, local IPAM disabled",
+			pluginConf: &PluginConf{},
+			want:       false,
+		},
+		{
+			name:       "static ipam type opts in regardless of other fields",
+			pluginConf: &PluginConf{IPAM: &IPAM{Type: ipamTypeStatic}},
+			want:       true,
+		},
+		{
+			name:       "ipv6_subnet set opts in",
+			pluginConf: &PluginConf{IPv6Subnet: localIPAMDefaultPool},
+			want:       true,
+		},
+		{
+			name:           "local IPAM enabled opts in even without ipv6_subnet",
+			pluginConf:     &PluginConf{},
+			enableLocalIPA: true,
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enableLocalIPAM = tt.enableLocalIPA
+			if got := wantsIPAM(tt.pluginConf); got != tt.want {
+				t.Errorf("wantsIPAM(%+v) = %v, want %v", tt.pluginConf, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---- allocateIPAM ----------------------------------------------------------
+
+func TestAllocateIPAMNoAllocation(t *testing.T) {
+	original := enableLocalIPAM
+	defer func() { enableLocalIPAM = original }()
+	enableLocalIPAM = false
+
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	res, err := allocateIPAM(args, &PluginConf{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != nil {
+		t.Errorf("allocateIPAM() = %+v, want nil (wantsIPAM should have been false)", res)
+	}
+}
+
+func TestAllocateIPAMStatic(t *testing.T) {
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	pluginConf := &PluginConf{
+		IPAM: &IPAM{Type: ipamTypeStatic, StaticIP: "fd00:10:ff01::1234"},
+	}
+
+	res, err := allocateIPAM(args, pluginConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("allocateIPAM() = nil, want a result")
+	}
+	if res.ipv6Subnet == nil || !res.ipv6Subnet.IP.Equal(net.ParseIP("fd00:10:ff01::1234")) {
+		t.Errorf("ipv6Subnet = %v, want fd00:10:ff01::1234", res.ipv6Subnet)
+	}
+	if res.ipv4Address != nil {
+		t.Errorf("ipv4Address = %v, want nil for static IPAM", res.ipv4Address)
+	}
+}
+
+func TestAllocateIPAMPoolIPv6Only(t *testing.T) {
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	pluginConf := &PluginConf{IPv6Subnet: localIPAMDefaultPool}
+
+	res, err := allocateIPAM(args, pluginConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("allocateIPAM() = nil, want a result")
+	}
+	if res.ipv6Subnet == nil {
+		t.Fatal("ipv6Subnet = nil, want an allocated /96")
+	}
+	if ones, bits := res.ipv6Subnet.Mask.Size(); ones != 96 || bits != 128 {
+		t.Errorf("ipv6Subnet mask = /%d, want /96", ones)
+	}
+	if res.ipv6Gateway == nil {
+		t.Error("ipv6Gateway = nil, want the pool's default gateway (::1 of the /64)")
+	}
+	if res.ipv4Address != nil {
+		t.Errorf("ipv4Address = %v, want nil (no ipv4_subnet configured)", res.ipv4Address)
+	}
+	if len(res.routes) != 1 {
+		t.Errorf("routes = %v, want exactly one default IPv6 route", res.routes)
+	}
+}
+
+func TestAllocateIPAMPoolDualStack(t *testing.T) {
+	origLockDir := ipv4LockDir
+	ipv4LockDir = t.TempDir()
+	defer func() { ipv4LockDir = origLockDir }()
+
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	pluginConf := &PluginConf{
+		IPv6Subnet: localIPAMDefaultPool,
+		IPv4Subnet: "10.128.0.0/20",
+	}
+
+	res, err := allocateIPAM(args, pluginConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("allocateIPAM() = nil, want a result")
+	}
+	if res.ipv6Subnet == nil {
+		t.Error("ipv6Subnet = nil, want an allocated /96")
+	}
+	if res.ipv4Address == nil {
+		t.Fatal("ipv4Address = nil, want an allocated /32")
+	}
+	if res.ipv4Gateway == nil {
+		t.Error("ipv4Gateway = nil, want the pool's default gateway")
+	}
+	if len(res.routes) != 2 {
+		t.Errorf("routes = %v, want one default route per family", res.routes)
+	}
+}
+
+func TestAllocateIPAMPoolMissingIPv6SubnetErrors(t *testing.T) {
+	original := enableLocalIPAM
+	defer func() { enableLocalIPAM = original }()
+	enableLocalIPAM = false
+
+	// wantsIPAM only opts in here via the static/ipv6_subnet/local-IPAM
+	// signals, so force the pool path directly to exercise the "no source
+	// for an IPv6 pool CIDR" error without relying on wantsIPAM's gating.
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	_, err := allocatePoolIPAM(args, &PluginConf{})
+	if err == nil {
+		t.Fatal("expected error when ipv6_subnet is unset and local IPAM is disabled, got nil")
+	}
+}
+
+// ---- deallocateIPAM ---------------------------------------------------------
+
+func TestDeallocateIPAMStaticNoop(t *testing.T) {
+	// Static IPAM never wrote a CRD annotation for cmdDel to look up, and
+	// deallocateIPAM must return immediately without attempting a k8s lookup.
+	pluginConf := &PluginConf{
+		VPC: testVPC, VPCAttachment: testAttachment,
+		IPAM: &IPAM{Type: ipamTypeStatic},
+	}
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	// A nil client would panic if deallocateIPAM tried to use it; passing nil
+	// here asserts the static-type early return happens first.
+	deallocateIPAM(args, pluginConf, nil)
+}
+
+func TestDeallocateIPAMDualStack(t *testing.T) {
+	origLockDir := ipv4LockDir
+	ipv4LockDir = t.TempDir()
+	defer func() { ipv4LockDir = origLockDir }()
+
+	pluginConf := &PluginConf{
+		VPC: testVPC, VPCAttachment: testAttachment,
+		IPv6Subnet: localIPAMDefaultPool,
+		IPv4Subnet: "10.128.0.0/20",
+	}
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+
+	// Allocate an IPv4 address the same way ADD would, so there's a real
+	// marker file for Deallocate to remove.
+	alloc, err := ipam.NewDualStackAllocator(pluginConf.IPv6Subnet, "", pluginConf.IPv4Subnet, "", ipv4LockDir)
+	if err != nil {
+		t.Fatalf("NewDualStackAllocator: %v", err)
+	}
+	dsRes, err := alloc.Allocate(args.ContainerID)
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+
+	ipv4Pool, err := ipam.NewIPv4PoolAllocator(pluginConf.IPv4Subnet, "", ipv4LockDir)
+	if err != nil {
+		t.Fatalf("NewIPv4PoolAllocator: %v", err)
+	}
+	if !ipv4Pool.IsAllocated(dsRes.IPv4Address.String()) {
+		t.Fatalf("setup: IPv4 address %s not marked allocated", dsRes.IPv4Address)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
+			Namespace: config.DefaultNamespace,
+			Annotations: map[string]string{
+				subnetAnnotationKeyIPv6(args.ContainerID): dsRes.IPv6Subnet.String(),
+				subnetAnnotationKeyIPv4(args.ContainerID): dsRes.IPv4Address.String(),
+			},
+		},
+	}
+	pluginConf.Namespace = config.DefaultNamespace
+	k8s := fakeClient(adv)
+
+	deallocateIPAM(args, pluginConf, k8s)
+
+	if ipv4Pool.IsAllocated(dsRes.IPv4Address.String()) {
+		t.Errorf("IPv4 address %s still marked allocated after deallocateIPAM", dsRes.IPv4Address)
+	}
+}
+
+func TestDeallocateIPAMPartialAllocationNonFatal(t *testing.T) {
+	// A v6-only pod (no IPv4 annotation, e.g. pre-existing or a partial ADD
+	// failure) must still have its IPv6 side cleaned up without erroring,
+	// and must not attempt to touch a nonexistent IPv4 pool.
+	pluginConf := &PluginConf{
+		VPC: testVPC, VPCAttachment: testAttachment,
+		Namespace:  config.DefaultNamespace,
+		IPv6Subnet: localIPAMDefaultPool,
+		// IPv4Subnet intentionally unset.
+	}
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
+			Namespace: config.DefaultNamespace,
+			Annotations: map[string]string{
+				subnetAnnotationKeyIPv6(args.ContainerID): "fd00:10:ff01::1234/96",
+			},
+		},
+	}
+	k8s := fakeClient(adv)
+
+	// Must not panic despite no ipv4_subnet in config.
+	deallocateIPAM(args, pluginConf, k8s)
+}
+
+func TestDeallocateIPAMNoAllocationFound(t *testing.T) {
+	pluginConf := &PluginConf{
+		VPC: testVPC, VPCAttachment: testAttachment,
+		Namespace: config.DefaultNamespace,
+	}
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	// No BGPAdvertisement exists at all.
+	k8s := fakeClient()
+
+	// Must return cleanly with nothing to deallocate.
+	deallocateIPAM(args, pluginConf, k8s)
+}

--- a/internal/cni/netns.go
+++ b/internal/cni/netns.go
@@ -13,9 +13,14 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// configureInterfaceInNetns applies an IP address and routes to the guest
-// interface inside the container network namespace.
-func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gateway net.IP) error {
+// configureInterfaceInNetns applies IP addresses and default routes to the
+// guest interface inside the container network namespace. ipv4Net/ipv4GW are
+// nil for an IPv6-only attachment.
+func configureInterfaceInNetns(
+	netnsPath, ifName string,
+	ipv6Net *net.IPNet, ipv6GW net.IP,
+	ipv4Net *net.IPNet, ipv4GW net.IP,
+) error {
 	containerNS, err := ns.GetNS(netnsPath)
 	if err != nil {
 		return fmt.Errorf("get container netns %q: %w", netnsPath, err)
@@ -34,24 +39,15 @@ func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gatew
 			return fmt.Errorf("find guest interface %q: %w", ifName, err)
 		}
 
-		if err := handle.AddrAdd(link, &netlink.Addr{IPNet: ipNet}); err != nil {
-			return fmt.Errorf("add IP %s to %q: %w", ipNet, ifName, err)
+		if err := addAddrAndDefaultRoute(handle, link, ifName, ipv6Net, ipv6GW); err != nil {
+			return err
+		}
+		if err := addAddrAndDefaultRoute(handle, link, ifName, ipv4Net, ipv4GW); err != nil {
+			return err
 		}
 
 		if err := handle.LinkSetUp(link); err != nil {
 			return fmt.Errorf("set interface %q up: %w", ifName, err)
-		}
-
-		// Install default route via gateway.
-		if gateway != nil {
-			defaultRoute := &netlink.Route{
-				Dst:       nil, // default route
-				Gw:        gateway,
-				LinkIndex: link.Attrs().Index,
-			}
-			if err := handle.RouteAdd(defaultRoute); err != nil {
-				return fmt.Errorf("add default route via %s: %w", gateway, err)
-			}
 		}
 
 		return nil
@@ -60,7 +56,35 @@ func configureInterfaceInNetns(netnsPath, ifName string, ipNet *net.IPNet, gatew
 	}
 
 	slog.Debug("netns: guest interface configured", "ifName", ifName, "netns", netnsPath,
-		"address", ipNet, "gateway", gateway)
+		"ipv6Address", ipv6Net, "ipv6Gateway", ipv6GW, "ipv4Address", ipv4Net, "ipv4Gateway", ipv4GW)
+	return nil
+}
+
+// addAddrAndDefaultRoute assigns ipNet to link and, if gateway is set,
+// installs a default route via it. No-op when ipNet is nil (family not in
+// use for this attachment).
+func addAddrAndDefaultRoute(
+	handle *netlink.Handle, link netlink.Link, ifName string, ipNet *net.IPNet, gateway net.IP,
+) error {
+	if ipNet == nil {
+		return nil
+	}
+
+	if err := handle.AddrAdd(link, &netlink.Addr{IPNet: ipNet}); err != nil {
+		return fmt.Errorf("add IP %s to %q: %w", ipNet, ifName, err)
+	}
+
+	if gateway == nil {
+		return nil
+	}
+	defaultRoute := &netlink.Route{
+		Dst:       nil, // default route
+		Gw:        gateway,
+		LinkIndex: link.Attrs().Index,
+	}
+	if err := handle.RouteAdd(defaultRoute); err != nil {
+		return fmt.Errorf("add default route via %s: %w", gateway, err)
+	}
 	return nil
 }
 

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -142,7 +142,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 		if ipamResult != nil {
 			slog.Debug("ADD: IPAM allocated", "containerID", args.ContainerID,
-				"subnet", ipamResult.subnet, "gateway", ipamResult.gateway)
+				"ipv6Subnet", ipamResult.ipv6Subnet, "ipv6Gateway", ipamResult.ipv6Gateway,
+				"ipv4Address", ipamResult.ipv4Address, "ipv4Gateway", ipamResult.ipv4Gateway)
 		}
 	case interfaceTypeTap:
 		// Allocate IPAM for the tap interface (same as veth).
@@ -153,15 +154,16 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 		if ipamResult != nil {
 			slog.Debug("ADD: IPAM allocated", "containerID", args.ContainerID,
-				"subnet", ipamResult.subnet, "gateway", ipamResult.gateway)
+				"ipv6Subnet", ipamResult.ipv6Subnet, "ipv6Gateway", ipamResult.ipv6Gateway,
+				"ipv4Address", ipamResult.ipv4Address, "ipv4Gateway", ipamResult.ipv4Gateway)
 		}
 
 		// Configure the gateway address on the host tap and install the VRF route.
 		if err := configureHostGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult); err != nil {
 			return err
 		}
-		if ipamResult != nil && ipamResult.gateway != nil {
-			slog.Debug("ADD: host gateway configured", "name", hostName, "gateway", ipamResult.gateway)
+		if ipamResult != nil && ipamResult.ipv6Gateway != nil {
+			slog.Debug("ADD: host gateway configured", "name", hostName, "gateway", ipamResult.ipv6Gateway)
 		}
 
 		// Print the CNI result with IP info.

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -31,8 +31,7 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	// Deallocate the pod's IPAM subnet. This is pod-specific and safe to
 	// release immediately. Applies to both veth and tap modes.
-	hasIPAM := (pluginConf.IPAM != nil && pluginConf.IPAM.Type != "") || enableLocalIPAM
-	if hasIPAM {
+	if wantsIPAM(pluginConf) {
 		if k8s, err := newK8sClient(); err == nil {
 			deallocateIPAM(args, pluginConf, k8s)
 		} else {

--- a/internal/cni/result.go
+++ b/internal/cni/result.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
@@ -39,23 +40,39 @@ func buildResult(
 			},
 		},
 	}
-	if ipRes != nil {
-		ipConfig := &type100.IPConfig{
-			Address:   *ipRes.subnet,
-			Gateway:   ipRes.gateway,
-			Interface: type100.Int(1), // index into Interfaces (guest veth)
-		}
-		result.IPs = []*type100.IPConfig{ipConfig}
-		if len(ipRes.routes) > 0 {
-			result.Routes = make([]*types.Route, 0, len(ipRes.routes))
-			for _, dst := range ipRes.routes {
-				result.Routes = append(result.Routes, &types.Route{
-					Dst: *dst,
-				})
-			}
+	appendIPConfigs(result, ipRes, 1) // index into Interfaces (guest veth)
+	return result
+}
+
+// appendIPConfigs adds one IPConfig per allocated address family in ipRes
+// (IPv6, and IPv4 when present) plus any default routes, all pointing at the
+// given Interfaces index. No-op when ipRes is nil.
+func appendIPConfigs(result *type100.Result, ipRes *ipamResult, ifaceIndex int) {
+	if ipRes == nil {
+		return
+	}
+	if ipRes.ipv6Subnet != nil {
+		result.IPs = append(result.IPs, &type100.IPConfig{
+			Address:   *ipRes.ipv6Subnet,
+			Gateway:   ipRes.ipv6Gateway,
+			Interface: type100.Int(ifaceIndex),
+		})
+	}
+	if ipRes.ipv4Address != nil {
+		result.IPs = append(result.IPs, &type100.IPConfig{
+			Address:   net.IPNet{IP: ipRes.ipv4Address, Mask: net.CIDRMask(32, 32)},
+			Gateway:   ipRes.ipv4Gateway,
+			Interface: type100.Int(ifaceIndex),
+		})
+	}
+	if len(ipRes.routes) > 0 {
+		result.Routes = make([]*types.Route, 0, len(ipRes.routes))
+		for _, dst := range ipRes.routes {
+			result.Routes = append(result.Routes, &types.Route{
+				Dst: *dst,
+			})
 		}
 	}
-	return result
 }
 
 // buildVethResult handles veth-specific result building: host-device
@@ -85,7 +102,7 @@ func buildVethResult(
 
 	// Configure IP address on the guest interface inside the container netns.
 	var ipamResult *ipamResult
-	if (pluginConf.IPAM != nil && pluginConf.IPAM.Type != "") || enableLocalIPAM {
+	if wantsIPAM(pluginConf) {
 		result, err := configureIPAM(args, pluginConf, args.IfName)
 		if err != nil {
 			return nil, fmt.Errorf("configure IPAM: %w", err)
@@ -126,21 +143,6 @@ func buildTapResult(
 			},
 		},
 	}
-	if ipRes != nil {
-		ipConfig := &type100.IPConfig{
-			Address:   *ipRes.subnet,
-			Gateway:   ipRes.gateway,
-			Interface: type100.Int(0), // index into Interfaces (host tap)
-		}
-		result.IPs = []*type100.IPConfig{ipConfig}
-		if len(ipRes.routes) > 0 {
-			result.Routes = make([]*types.Route, 0, len(ipRes.routes))
-			for _, dst := range ipRes.routes {
-				result.Routes = append(result.Routes, &types.Route{
-					Dst: *dst,
-				})
-			}
-		}
-	}
+	appendIPConfigs(result, ipRes, 0) // index into Interfaces (host tap)
 	return result
 }

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -18,12 +18,11 @@ type Termination struct {
 }
 
 // IPAM holds IP address management configuration passed in the CNI config.
+// Pool CIDR fields (formerly Pool/Gateway/SubnetLen) have been retired in
+// favor of PluginConf.IPv6Subnet/IPv4Subnet — see allocateIPAM.
 type IPAM struct {
-	Type      string    `json:"type"`                 // "pool" (default) or "static"
-	Pool      string    `json:"pool,omitempty"`       // IPv6 CIDR pool, e.g. "fd00:10:ff01::/48"
-	Gateway   string    `json:"gateway,omitempty"`    // IPv6 gateway address
-	SubnetLen int       `json:"subnet_len,omitempty"` // prefix length per allocation (default 80)
-	StaticIP  string    `json:"static_ip,omitempty"`  // used when type="static"
+	Type      string    `json:"type"`                // "pool" (default) or "static"
+	StaticIP  string    `json:"static_ip,omitempty"` // used when type="static"
 	Routes    []Route   `json:"routes,omitempty"`
 	Addresses []Address `json:"addresses,omitempty"`
 }
@@ -69,10 +68,13 @@ type HostConf struct {
 }
 
 // ipamResult holds the IPAM allocation details for building the CNI result.
+// ipv4Address/ipv4Gateway are nil when the attachment is IPv6-only.
 type ipamResult struct {
-	subnet  *net.IPNet
-	gateway net.IP
-	routes  []*net.IPNet
+	ipv6Subnet  *net.IPNet
+	ipv6Gateway net.IP
+	ipv4Address net.IP
+	ipv4Gateway net.IP
+	routes      []*net.IPNet
 }
 
 // HostDevicePluginConf is the configuration for the host-device CNI plugin

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -37,6 +37,26 @@ func parseSIDAddr(sid string) (netip.Addr, error) {
 	return netip.ParseAddr(sid)
 }
 
+// gatewayForPrefix returns the EVPN Type 5 Gateway IP Address to pair with
+// prefix. RFC 9136 requires the Prefix and Gateway IP Address fields to share
+// an address family, and GoBGP's wire encoding for this NLRI only recognizes
+// an all-IPv4 or an all-IPv6 layout (see EVPNIPPrefixRoute.Len/Serialize) —
+// mixing families produces a route whose declared length doesn't match its
+// serialized bytes. ipv6GW (the SRv6 SID, or the plain next-hop as a
+// fallback) is always an IPv6 address in this architecture, since SRv6 SIDs
+// and the transit next-hop are both IPv6-only, so it can only serve as the
+// gateway for an IPv6 prefix. An IPv4 prefix has no IPv4-shaped equivalent to
+// offer here, so its Gateway is left at the IPv4 zero address — RFC-compliant
+// per draft-ietf-bess-evpn-prefix-advertisement ("the GW IP field SHOULD be
+// zero if it is not used as an Overlay Index") rather than fabricating a
+// value nothing in this design actually produces.
+func gatewayForPrefix(prefix netip.Prefix, ipv6GW netip.Addr) netip.Addr {
+	if prefix.Addr().Is4() {
+		return netip.IPv4Unspecified()
+	}
+	return ipv6GW
+}
+
 // buildEVPNPaths adds or withdraws EVPN Type 5 IP Prefix paths for each prefix
 // in adv into the local GoBGP RIB.
 //
@@ -44,22 +64,23 @@ func parseSIDAddr(sid string) (netip.Addr, error) {
 // per-VRF route distinguisher (Type 1 IP-address: routerID:vrfID) when adv.VRFID
 // is set, matching the RD used by applyVRF during VRF registration. adv.NextHop
 // is the transit-reachable BGP peering address placed in MpReachNLRI. adv.SRv6SID,
-// when set, is the End.DT46 SID placed in the EVPN GWIPAddress field — this is
-// the SRv6 segment that remote nodes install in their seg6 encap kernel routes.
-// When adv.SRv6SID is empty the next-hop is used for both (non-SRv6 fallback).
+// when set, is the End.DT46 SID placed in the EVPN GWIPAddress field for IPv6
+// prefixes — this is the SRv6 segment that remote nodes install in their seg6
+// encap kernel routes. When adv.SRv6SID is empty the next-hop is used instead
+// (non-SRv6 fallback). See gatewayForPrefix for the IPv4-prefix case.
 func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, routerID string, withdraw bool) error {
 	nextHop, err := netip.ParseAddr(adv.NextHop)
 	if err != nil {
 		return fmt.Errorf("invalid EVPN next-hop %q: %w", adv.NextHop, err)
 	}
 
-	gwIP := nextHop
+	ipv6GW := nextHop
 	if adv.SRv6SID != "" {
 		sid, err := parseSIDAddr(adv.SRv6SID)
 		if err != nil {
 			return fmt.Errorf("invalid SRv6 SID %q: %w", adv.SRv6SID, err)
 		}
-		gwIP = sid
+		ipv6GW = sid
 	}
 
 	// Type 1 (IP-address:local-admin) RD, unique per VRF.
@@ -86,8 +107,10 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 
 		// EVPN Type 5 IP Prefix route. ESI all-zeros (Type 0 = not multihomed),
 		// ETag 0, label 0 (SRv6 — MPLS label unused).
-		// gwIP is the End.DT46 SRv6 SID when adv.SRv6SID is set; otherwise falls
-		// back to nextHop. Remote nodes use this as the seg6 encap segment.
+		// gwIP is the End.DT46 SRv6 SID (or nextHop fallback) for an IPv6
+		// prefix, matching its family; see gatewayForPrefix for the IPv4 case.
+		// Remote nodes use this as the seg6 encap segment.
+		gwIP := gatewayForPrefix(prefix, ipv6GW)
 		nlri, err := bgp.NewEVPNIPPrefixRoute(
 			rd,
 			bgp.EthernetSegmentIdentifier{},

--- a/internal/runtime/gobgp/paths_test.go
+++ b/internal/runtime/gobgp/paths_test.go
@@ -6,6 +6,7 @@ package gobgp
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -188,6 +189,108 @@ func TestBuildEVPNPathsWithdraw(t *testing.T) {
 	}
 	if err := buildEVPNPaths(b, adv, testRouterID1, true); err != nil {
 		t.Fatalf("buildEVPNPaths(withdraw) error = %v", err)
+	}
+}
+
+// TestGatewayForPrefix verifies that gatewayForPrefix selects a Gateway IP
+// matching each prefix's own address family: the IPv6 gateway (SRv6 SID or
+// next-hop) for an IPv6 prefix, and the IPv4 zero address for an IPv4
+// prefix — never the IPv6 gateway reused for an IPv4 prefix, which is the
+// bug this fixes (see buildEVPNPaths doc comment).
+func TestGatewayForPrefix(t *testing.T) {
+	ipv6GW := netip.MustParseAddr(testSID1)
+
+	tests := []struct {
+		name   string
+		prefix string
+		want   netip.Addr
+	}{
+		{
+			name:   "IPv6 prefix uses the IPv6 gateway",
+			prefix: testPrefix,
+			want:   ipv6GW,
+		},
+		{
+			name:   "IPv4 prefix uses the IPv4 zero address, not the IPv6 gateway",
+			prefix: "10.128.0.5/32",
+			want:   netip.IPv4Unspecified(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix, err := netip.ParsePrefix(tt.prefix)
+			if err != nil {
+				t.Fatalf("ParsePrefix(%q): %v", tt.prefix, err)
+			}
+			got := gatewayForPrefix(prefix, ipv6GW)
+			if got != tt.want {
+				t.Errorf("gatewayForPrefix(%q, %v) = %v, want %v", tt.prefix, ipv6GW, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildEVPNPathsMixedFamily verifies that a dual-stack DesiredAdvertisement
+// (one IPv6 prefix, one IPv4 prefix, sharing a single SRv6 SID next-hop)
+// produces two well-formed EVPN Type 5 NLRIs instead of a malformed one.
+// Before the gatewayForPrefix fix, the IPv4 prefix's NLRI paired a 4-byte
+// IPv4 prefix with the shared 16-byte IPv6 gateway: EVPNIPPrefixRoute.Len()
+// (computed from the prefix's family alone) would declare 34 bytes while
+// Serialize() actually emitted more, corrupting the wire encoding. This test
+// re-derives each prefix's NLRI the same way buildEVPNPaths does and checks
+// the serialized length always matches the declared Len().
+func TestBuildEVPNPathsMixedFamily(t *testing.T) {
+	b := newTestBgpServer(t)
+
+	const ipv6Prefix = "fd00:10:ff01::/96"
+	const ipv4Prefix = "10.128.0.5/32"
+
+	adv := model.DesiredAdvertisement{
+		Name: "adv-dual-stack",
+		AddressFamily: model.AddressFamily{
+			AFI:  afiL2VPN,
+			SAFI: safiEVPN,
+		},
+		Prefixes:    []string{ipv6Prefix, ipv4Prefix},
+		NextHop:     testNextHop,
+		SRv6SID:     testSID1,
+		VRFID:       ptrInt32Test(1),
+		Communities: []string{testRT100},
+	}
+
+	if err := buildEVPNPaths(b, adv, testRouterID1, false); err != nil {
+		t.Fatalf("buildEVPNPaths(dual-stack) error = %v", err)
+	}
+
+	rd, err := bgp.ParseRouteDistinguisher(deriveRD(testRouterID1, adv.VRFID))
+	if err != nil {
+		t.Fatalf("ParseRouteDistinguisher: %v", err)
+	}
+	ipv6GW := netip.MustParseAddr(testSID1)
+
+	for _, prefixStr := range adv.Prefixes {
+		prefix, err := netip.ParsePrefix(prefixStr)
+		if err != nil {
+			t.Fatalf("ParsePrefix(%q): %v", prefixStr, err)
+		}
+		gwIP := gatewayForPrefix(prefix, ipv6GW)
+
+		nlri, err := bgp.NewEVPNIPPrefixRoute(
+			rd, bgp.EthernetSegmentIdentifier{}, 0, uint8(prefix.Bits()), prefix.Addr(), gwIP, 0,
+		)
+		if err != nil {
+			t.Fatalf("NewEVPNIPPrefixRoute(%q) error = %v", prefixStr, err)
+		}
+
+		serialized, err := nlri.Serialize()
+		if err != nil {
+			t.Fatalf("Serialize(%q) error = %v", prefixStr, err)
+		}
+		if len(serialized) != nlri.Len() {
+			t.Errorf("prefix %q: serialized NLRI length %d != declared Len() %d — malformed wire encoding",
+				prefixStr, len(serialized), nlri.Len())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Building on the dual-stack IPAM allocators and config fields already merged (#257, #258), this wires endpoint allocation all the way through to BGP advertisement and the CNI result, so a dual-stack attachment actually gets both an IPv6 and an IPv4 address end to end.

- **IPAM ops (`galactic-cni`):** `allocateIPAM`/`deallocateIPAM` are rebuilt around the dual-stack allocator, and the legacy `IPAM.Pool`/`Gateway`/`SubnetLen` config fields are retired now that `ipv6_subnet`/`ipv4_subnet` are the only way to name a pool. DEL cleans up each address family independently, so a partial or v6-only allocation never blocks cleanup of the other.
- **BGP advertisement (`galactic-cni` + `galactic-router`):** a dual-stack attachment now advertises both its IPv6 `/96` and IPv4 `/32` prefixes, tracked under separate per-family annotations. This also fixes a real bug in `galactic-router`'s EVPN path builder: a dual-stack advertisement's IPv4 prefix was being paired with the shared IPv6 SRv6-SID gateway, producing a Type 5 NLRI whose declared length didn't match its actual encoded bytes on the wire. Each prefix now gets a gateway matching its own address family.
- **CNI result (`galactic-cni`):** the result handed back to the container runtime now includes an IP config and default route for each allocated family, for both veth and tap interface modes.

## Test plan

- [x] `task lint` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `task test:unit` (race detector) — all packages pass
- [x] New `internal/runtime/gobgp/paths_test.go` case reproduces the EVPN wire-encoding bug directly (verified it fails against the pre-fix code, not just "no error returned")
- [x] New `internal/cni/ipam_ops_test.go` covers static/IPv6-only/dual-stack allocation and per-family deallocation, including the partial-allocation non-fatal DEL path
- [ ] Manual dual-stack ADD/DEL against a live ContainerLab cluster (not run as part of this PR)

Related to datum-cloud/enhancements#740