### PR TITLE
fix(cni): fix ContainerLab NAD manifests and BGPAdvertisement annotation overflow

### DIFF
--- a/deploy/containerlab/resources/vpc/dfw/nad-vpc10.yaml
+++ b/deploy/containerlab/resources/vpc/dfw/nad-vpc10.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:10:ff01::/48",
-        "gateway": "fd00:10:ff01::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:10:ff01::/48"
     }

--- a/deploy/containerlab/resources/vpc/dfw/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/dfw/nad-vpc20.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:20:ff01::/48",
-        "gateway": "fd00:20:ff01::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:20:ff01::/48"
     }

--- a/deploy/containerlab/resources/vpc/iad/nad-vpc10.yaml
+++ b/deploy/containerlab/resources/vpc/iad/nad-vpc10.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:10:ff03::/48",
-        "gateway": "fd00:10:ff03::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:10:ff03::/48"
     }

--- a/deploy/containerlab/resources/vpc/iad/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/iad/nad-vpc20.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:20:ff03::/48",
-        "gateway": "fd00:20:ff03::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:20:ff03::/48"
     }

--- a/deploy/containerlab/resources/vpc/sjc/nad-vpc10.yaml
+++ b/deploy/containerlab/resources/vpc/sjc/nad-vpc10.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:10:ff02::/48",
-        "gateway": "fd00:10:ff02::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:10:ff02::/48"
     }

--- a/deploy/containerlab/resources/vpc/sjc/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/sjc/nad-vpc20.yaml
@@ -12,10 +12,5 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipam": {
-        "type": "pool",
-        "pool": "fd00:20:ff02::/48",
-        "gateway": "fd00:20:ff02::1",
-        "subnet_len": 80
-      }
+      "ipv6_subnet": "fd00:20:ff02::/48"
     }

--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -50,9 +50,11 @@ const (
 
 	// annotationContainerIDLen is the number of characters used from a
 	// container ID in annotation keys. Kubernetes limits the name part of an
-	// annotation key to 63 bytes; "allocated-subnet." is 17 bytes, leaving 46
-	// bytes for the container ID prefix.
-	annotationContainerIDLen = 46
+	// annotation key to 63 bytes. The longest prefix sharing this constant is
+	// "allocated-subnet-ipv6." (or "-ipv4."), both 22 bytes, leaving 41 bytes
+	// for the container ID suffix — shorter prefixes ("netns.") just leave
+	// more room than they need.
+	annotationContainerIDLen = 41
 )
 
 const (

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -1849,6 +1849,45 @@ func TestEnableLocalIPAMRequired(t *testing.T) {
 	}
 }
 
+// ---- annotation key length -------------------------------------------------
+
+// TestAnnotationKeyNameLength verifies that every annotation key builder stays
+// within Kubernetes' 63-byte limit on the "name" part of an annotation key
+// (the segment after the last "/"), using a realistic 64-character container
+// ID (containerd/Docker use full SHA256 hex digests). This guards against a
+// real production incident: annotationContainerIDLen was sized for the old
+// "allocated-subnet." prefix (17 bytes) and wasn't updated when the prefix
+// grew by 5 bytes to "allocated-subnet-ipv6."/"-ipv4." — every BGPAdvertisement
+// apply failed with "name part must be no more than 63 bytes" until fixed.
+func TestAnnotationKeyNameLength(t *testing.T) {
+	const maxAnnotationNameLen = 63
+	// A realistic full-length container ID (64 hex chars, as containerd/Docker use).
+	fullContainerID := strings.Repeat("a", 64)
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"subnetAnnotationKeyIPv6", subnetAnnotationKeyIPv6(fullContainerID)},
+		{"subnetAnnotationKeyIPv4", subnetAnnotationKeyIPv4(fullContainerID)},
+		{"netnsAnnotationKey", netnsAnnotationKey(fullContainerID)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slash := strings.LastIndex(tt.key, "/")
+			namePart := tt.key
+			if slash != -1 {
+				namePart = tt.key[slash+1:]
+			}
+			if len(namePart) > maxAnnotationNameLen {
+				t.Errorf("%s(%d-char containerID) name part %q is %d bytes, want <= %d",
+					tt.name, len(fullContainerID), namePart, len(namePart), maxAnnotationNameLen)
+			}
+		})
+	}
+}
+
 // ---- logging setup ----------------------------------------------------------
 
 func TestLoggingSetup(t *testing.T) {


### PR DESCRIPTION
## Summary

After #261 merged, every ContainerLab VPC pod (all 3 sites, both VPCs) got stuck in `ContainerCreating` forever. Root cause was two related regressions from that dual-stack change:

- **ContainerLab NADs never allocated any address.** The six VPC `NetworkAttachmentDefinition` manifests still configured IPAM via the old `"ipam":{"type":"pool","pool":...,"gateway":...,"subnet_len":80}` block. `IPAM.Pool`/`Gateway`/`SubnetLen` no longer exist on the config struct, and the new `wantsIPAM` gate has no way to recognize this shape — so IPAM silently allocated nothing. Migrated all six to the new top-level `ipv6_subnet` field (same pool CIDR; the default gateway and subnet length it produces are unchanged).
- **Every BGPAdvertisement apply failed validation.** `annotationContainerIDLen` (46) was sized for the old single-family `"allocated-subnet."` annotation prefix (17 bytes). The new per-family prefixes (`"allocated-subnet-ipv6."`/`"-ipv4."`) are 5 bytes longer, pushing every built annotation key to 68 bytes — over Kubernetes' 63-byte limit on the name part of an annotation key. Every pod ADD failed with `apply BGPAdvertisement: ... name part must be no more than 63 bytes`, which is exactly what live cluster logs showed. Fixed the constant to 41.

## Test plan

- [x] `task lint` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./internal/cni/...` — clean
- [x] New `TestAnnotationKeyNameLength` builds each annotation key with a realistic 64-char container ID (containerd/Docker use full SHA256 hex digests) and asserts the name part stays ≤63 bytes; verified it fails against the pre-fix constant with the exact same 68-byte overflow observed live
- [x] All 6 fixed NAD manifests validated as parseable JSON, and the resulting config round-tripped through the real `parseConf`/`allocateIPAM` path in a throwaway test (removed before commit), confirming identical gateway/subnet-length output to the original explicit config
- [ ] Redeploy to the live ContainerLab lab and confirm the 6 stuck pods actually clear (not run as part of this PR — the lab environment is local to the reporter)

Related to datum-cloud/enhancements#740