### PR TITLE
feat(vmtap-cni): add chained CNI plugin for kraftlet/Cilium tap redirect

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -99,6 +99,7 @@ tasks:
     cmds:
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-cni ./cmd/galactic-cni
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-router ./cmd/galactic-router
+      - go build -ldflags "{{.LDFLAGS}}" -o bin/vmtap-cni ./cmd/vmtap-cni
       - GOBIN={{.LOCALBIN}} go install github.com/containernetworking/plugins/plugins/main/host-device@v1.9.1
 
   ##

--- a/cmd/vmtap-cni/main.go
+++ b/cmd/vmtap-cni/main.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"go.datum.net/galactic/internal/metadata"
+	"go.datum.net/galactic/internal/vmtap"
+)
+
+const (
+	appName = "vmtap-cni"
+
+	appDesc = `vmtap CNI Plugin
+
+ Chained CNI plugin giving a Unikraft/kraftlet microVM access to the pod's
+ real Cilium-assigned identity via a tap device and tc-redirect. Must be
+ chained after Cilium's own CNI plugin in the pod's primary conflist.
+
+ Find more information at: https://www.datum.net/docs`
+)
+
+func newRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   appName,
+		Short: strings.Split(appDesc, "\n")[0],
+		Long:  appDesc,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
+				fmt.Println(metadata.BuildInfo(appName))
+				return nil
+			}
+			if ok, _ := cmd.Flags().GetBool("version"); ok {
+				fmt.Printf("%s version %s\n", appName, metadata.Version)
+				return nil
+			}
+			if os.Getenv("CNI_COMMAND") == "VERSION" {
+				return version.All.Encode(os.Stdout)
+			}
+
+			// Real CNI runtimes always pipe the network config JSON on
+			// stdin and close it. If stdin is an interactive terminal
+			// instead, no config will ever arrive and skel's blocking
+			// stdin read would hang forever — print version info instead.
+			if term.IsTerminal(int(os.Stdin.Fd())) {
+				fmt.Printf("%s version %s\n", appName, metadata.Version)
+				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
+				return nil
+			}
+
+			vmtap.RunPlugin()
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("build-info", false, "Print build information and exit")
+	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
+	cmd.AddCommand(newPatchConflistCommand())
+	return cmd
+}
+
+// newPatchConflistCommand runs the conflist-chaining installer step: see
+// vmtap.RunPatchLoop for why this loops instead of running once. It is
+// meant to run as a long-lived container (not an init container) in the
+// vmtap-cni DaemonSet — see config/vmtap/daemonset.yaml.
+func newPatchConflistCommand() *cobra.Command {
+	var (
+		cniNetDir    string
+		ciliumGlob   string
+		pollInterval time.Duration
+	)
+
+	cmd := &cobra.Command{
+		Use:   "patch-conflist",
+		Short: "Chain vmtap-cni into Cilium's conflist and keep re-patching it",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			vmtap.RunPatchLoop(ctx, cniNetDir, ciliumGlob, pollInterval)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cniNetDir, "cni-net-dir", "/host/etc/cni/net.d", "Host CNI conflist directory to patch")
+	cmd.Flags().StringVar(&ciliumGlob, "cilium-glob", "*cilium*.conflist",
+		"Glob (within --cni-net-dir) matching Cilium's own conflist file")
+	cmd.Flags().DurationVar(&pollInterval, "poll-interval", 10*time.Second,
+		"How often to re-check the conflist for the vmtap-cni entry")
+	return cmd
+}
+
+func main() {
+	if err := newRootCommand().Execute(); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - system
   - cni
   - router
+  - vmtap

--- a/config/vmtap/daemonset.yaml
+++ b/config/vmtap/daemonset.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vmtap-cni
+  namespace: galactic-system
+  labels:
+    app.kubernetes.io/name: vmtap-cni
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vmtap-cni
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vmtap-cni
+    spec:
+      serviceAccountName: vmtap-cni
+      hostNetwork: true
+      tolerations:
+        - operator: Exists
+      # Placeholder node signal: only nodes actually running kraftlet-managed
+      # Unikraft workloads need this plugin chained into their conflist.
+      # "galactic.datumapis.com/node: kraftlet" is not an established label
+      # anywhere else in this repo — it stands in for whatever pod/node-level
+      # signal gets decided per the open item in
+      # .local/kraftlet-cilium-tap-plan.md section 7 ("Decide the pod-level
+      # signal (annotation vs. RuntimeClass)..."). Update or remove this
+      # affinity block once that decision is made.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.datumapis.com/node
+                    operator: In
+                    values:
+                      - kraftlet
+      initContainers:
+        - name: install-cni-bin
+          # ":latest" is a placeholder only, matching the convention in
+          # config/cni/daemonset.yaml — no such tag is ever pushed to GHCR.
+          image: ghcr.io/datum-cloud/vmtap-cni:latest
+          command: ["cp", "/vmtap-cni", "/host/opt/cni/bin/vmtap-cni"]
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          volumeMounts:
+            - name: cni-bin-dir
+              mountPath: /host/opt/cni/bin
+      containers:
+        # patch-conflist chains vmtap-cni into Cilium's conflist and keeps
+        # re-checking it — see internal/vmtap.RunPatchLoop and the
+        # conflist-chaining open item in
+        # .local/kraftlet-cilium-tap-plan.md section 7. This is a
+        # best-effort convergence loop, not a verified solution: nothing
+        # here guarantees the patch lands before Cilium starts servicing
+        # ADD calls on a freshly booted node.
+        - name: patch-conflist
+          image: ghcr.io/datum-cloud/vmtap-cni:latest
+          command: ["/vmtap-cni", "patch-conflist"]
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 5m
+              memory: 16Mi
+            limits:
+              memory: 32Mi
+          volumeMounts:
+            - name: cni-net-dir
+              mountPath: /host/etc/cni/net.d
+      volumes:
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+            type: DirectoryOrCreate

--- a/config/vmtap/kustomization.yaml
+++ b/config/vmtap/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - serviceaccount.yaml
+  - daemonset.yaml

--- a/config/vmtap/serviceaccount.yaml
+++ b/config/vmtap/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vmtap-cni
+  namespace: galactic-system

--- a/containers/vmtap-cni/Dockerfile
+++ b/containers/vmtap-cni/Dockerfile
@@ -1,0 +1,44 @@
+# Build the vmtap CNI plugin. Exists solely for `task test:e2e`, same as
+# containers/galactic-cni/Dockerfile — there is no production release image
+# build in this repo.
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
+ARG SPDX_LICENSE=AGPL-3.0-or-later
+ARG GIT_URL=https://github.com/datum-cloud/galactic
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY internal/ internal/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
+      -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
+      -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
+      -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE} \
+      -X go.datum.net/galactic/internal/metadata.SPDXLicense=${SPDX_LICENSE} \
+      -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
+    -o vmtap-cni cmd/vmtap-cni/main.go
+
+# Use distroless as minimal base image to package the binary
+FROM gcr.io/distroless/static:nonroot AS production
+COPY --from=builder /workspace/vmtap-cni /vmtap-cni
+
+# Final image: alpine (provides iproute2/tc, sh, cp) — the patch-conflist
+# container needs a shell-less `cp` for its init step, and the plugin's own
+# tc-redirect setup exercises iproute2/tc at runtime under e2e.
+FROM docker.io/library/alpine:latest
+COPY --from=production /vmtap-cni /vmtap-cni
+RUN apk add --no-cache iproute2
+
+USER 0:0
+ENTRYPOINT ["/vmtap-cni"]

--- a/docs/vmtap-cni/configuration.md
+++ b/docs/vmtap-cni/configuration.md
@@ -1,0 +1,141 @@
+# vmtap-cni Configuration
+
+`vmtap-cni` is a standalone CNI plugin, separate from `galactic-cni`, that gives a
+Unikraft microVM managed by `kraftlet` access to the pod's real Cilium-assigned
+identity. It has no VPC/VPCAttachment configuration and no Kubernetes API
+dependency — it never creates a `BGPAdvertisement`, never touches a VRF, and
+these pods have no `vpc`/`vpcattachment`. See
+[.local/kraftlet-cilium-tap-plan.md](../../.local/kraftlet-cilium-tap-plan.md)
+for the full design.
+
+> This plugin has not yet been validated against a real Cilium-managed cluster
+> — see [Open items / unvalidated caveats](#open-items--unvalidated-caveats) below
+> before relying on it in production.
+
+## How it works
+
+`vmtap-cni` must be **chained** after Cilium's own CNI plugin inside the pod's
+primary conflist (e.g. appended into whatever `/etc/cni/net.d/*cilium*.conflist`
+Cilium installs) — it is not delivered via a Multus `NetworkAttachmentDefinition`,
+and it does not run standalone. Because it runs as part of the same `cmdAdd`
+invocation that creates the pod's `eth0`, it receives Cilium's `prevResult`
+(interface name, MAC, MTU, IPs) directly.
+
+On `ADD`, inside the pod's network namespace:
+
+1. Reads `eth0`'s state from `prevResult` (MAC, link MTU) and the kernel's
+   routing table (route MTU) — see [MTU handling](#mtu-handling) below.
+   **`eth0` itself is never modified.**
+2. Creates a tap device (default name `tap0`) with its MTU set to the
+   resolved route MTU.
+3. Installs a `clsact`-equivalent `ingress` qdisc and a `tc-mirred` redirect
+   filter on both `eth0` and the tap in each direction, so every packet
+   arriving on one is stolen and re-injected as egress on the other.
+4. Returns a CNI result that copies `prevResult` forward (this plugin is the
+   last one in the chain, so its result is what the runtime hands back) and
+   appends the tap as a new interface entry, with `sandbox` set to
+   `CNI_CONTAINERID` instead of a netns path — see
+   [How kraftlet reads the result](#how-kraftlet-reads-the-result) below.
+
+`DEL` removes the redirect filters and the tap device; both `DEL` and `CHECK`
+are idempotent per the CNI spec. Opening the tap's fd, handing it to the VMM,
+and configuring the Unikraft guest's network stack (no runtime DHCP by
+default) are **not** this plugin's job — that is `kraftlet`'s responsibility
+once it reads this plugin's `ADD` result.
+
+## CNI Configuration JSON
+
+All fields are optional; the plugin runs against sane defaults when the
+config block is empty (`{"type": "vmtap-cni"}` is a valid entry).
+
+| Field             | Type     | Default    | Description                                                                                                               |
+| ----------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`         | `bool`   | `true`     | Set to `false` to no-op this conflist entry (passes `prevResult` through unchanged) without removing it from the chain.   |
+| `tap_name`        | `string` | `"tap0"`   | Name of the tap device created inside the pod netns.                                                                       |
+| `owner_uid`       | `int`    | `0` (root) | Tap device owner uid, so a non-root VMM process can open its fd without `CAP_NET_ADMIN`.                                  |
+| `owner_gid`       | `int`    | `0` (root) | Tap device owner gid.                                                                                                      |
+| `filter_priority` | `int`    | `1`        | tc filter priority for the mirred redirect filters. Override if it collides with Cilium's own hooks — see the caveat below. |
+
+Standard CNI fields (`cniVersion`, `name`, `prevResult`) are inherited from the
+conflist envelope, as for any chained plugin.
+
+### Example conflist entry
+
+```json
+{
+  "cniVersion": "1.0.0",
+  "name": "cilium",
+  "plugins": [
+    { "type": "cilium-cni" },
+    { "type": "vmtap-cni" }
+  ]
+}
+```
+
+## MTU handling
+
+Cilium adjusts the pod's *route* MTU for overlay/tunnel overhead, which can
+differ from `eth0`'s *link* MTU. `vmtap-cni` reads the actual route MTU from
+the kernel routing table (the route's `MTU` metric, via netlink `RouteList`)
+rather than copying the link MTU, and sets the tap's own MTU to that
+resolved value — so the tap's `mtu` field in the CNI result already carries
+the corrected number kraftlet needs, without a separate schema field. If no
+route carries an explicit MTU metric, it falls back to `eth0`'s link MTU.
+
+## How kraftlet reads the result
+
+`vmtap-cni`'s `cmdAdd` runs at pod-sandbox-creation time, invoked by whatever
+calls the chained conflist (typically containerd's CNI integration) — not by
+`kraftlet` directly. `kraftlet`'s own VM-start code runs later, as a separate
+step, and needs to read the same CNI result back out.
+
+This plugin's convention: the tap's interface entry in the CNI result sets
+`sandbox` to `CNI_CONTAINERID` (the CRI sandbox ID) rather than a netns path,
+since there is no netns for the VM the way there is for a container.
+**This convention has not been confirmed against the actual kraftlet/CRI
+integration** — see the open item below.
+
+## Cilium-specific caveats (unvalidated)
+
+These are called out explicitly because they are correctness risks this
+plugin's code cannot self-verify — they require a real Cilium-managed
+cluster to confirm:
+
+- **tc/bpf hook ordering**: the default `filter_priority` (`1`) has not been
+  checked against any specific Cilium version/datapath mode (veth vs.
+  netkit, tunnel vs. native routing) for a collision with Cilium's own
+  `clsact` bpf programs on `eth0`.
+- **socketLB / kube-proxy replacement**: Cilium's socket-level load balancing
+  intercepts `connect()`/`sendmsg()` in the *host* kernel, which the guest's
+  own kernel never reaches. This needs a **cluster-wide** Cilium config
+  change (`socketLB.hostNamespaceOnly=true`), not anything this plugin can
+  set per-pod.
+- **Envoy sidecar interaction**: unverified whether Envoy/Cilium's own
+  interception of traffic on `eth0` still works correctly once that traffic
+  is also being mirrored to/from the tap.
+- **NetworkPolicy, Service routing, Hubble attribution**: all assumed to
+  keep working because `eth0`'s identity is untouched, but not yet tested
+  end-to-end.
+
+## Open items
+
+- **Conflist chaining.** `vmtap-cni` ships with a `patch-conflist` subcommand
+  (`internal/vmtap.RunPatchLoop`, wired into
+  [`config/vmtap/daemonset.yaml`](../../config/vmtap/daemonset.yaml)) that
+  polls for a `*cilium*.conflist` file and appends a `{"type": "vmtap-cni"}`
+  entry to it if missing. This is a best-effort convergence loop, **not** a
+  verified solution — it does not guarantee the patch lands before Cilium
+  starts servicing `ADD` calls on a freshly booted node, and it does not
+  remove its own entry on uninstall (manually edit Cilium's conflist back
+  out if needed).
+- **Pod-level trigger signal.** Which pods get this conflist entry at all
+  (RuntimeClass vs. annotation) is not decided; `config/vmtap/daemonset.yaml`
+  currently gates the whole DaemonSet on a placeholder node label
+  (`galactic.datumapis.com/node: kraftlet`) that does not exist anywhere else
+  in this repo.
+- **kraftlet hand-off convention.** The `sandbox: CNI_CONTAINERID` convention
+  described above is this plugin's own choice, not something confirmed
+  against kraftlet's actual CRI/containerd integration.
+
+See [.local/kraftlet-cilium-tap-plan.md](../../.local/kraftlet-cilium-tap-plan.md)
+section 7 for the full list.

--- a/internal/vmtap/config.go
+++ b/internal/vmtap/config.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// defaultTapName is the tap device name used when PluginConf.TapName is unset.
+const defaultTapName = "tap0"
+
+// defaultFilterPriority is the tc filter priority used for the mirred
+// redirect filters when PluginConf.FilterPriority is unset. Priority 1 is
+// the highest (lowest-numbered) priority tc allows; this has not been
+// validated against Cilium's own clsact priority on any specific
+// version/datapath mode — see the tc/bpf hook ordering caveat in
+// docs/vmtap-cni/configuration.md. Override via filter_priority if it
+// collides.
+const defaultFilterPriority = 1
+
+// errNoPrevResult is returned when the plugin config carries no prevResult.
+// vmtap-cni only makes sense chained after a plugin (Cilium) that has
+// already configured the pod's primary interface — mirrors
+// awslabs/tc-redirect-tap's NoPreviousResultError.
+var errNoPrevResult = errors.New("vmtap-cni must be chained after a plugin that sets prevResult (e.g. cilium-cni)")
+
+// parseConf unmarshals the CNI configuration from stdin data, defaults
+// optional fields, and parses prevResult into conf.PrevResult. Returns
+// errNoPrevResult if no prevResult is present.
+func parseConf(data []byte) (*PluginConf, error) {
+	conf := &PluginConf{}
+	if err := json.Unmarshal(data, conf); err != nil {
+		return nil, &types.Error{Code: 7, Msg: "invalid CNI config", Details: err.Error()}
+	}
+
+	if conf.TapName == "" {
+		conf.TapName = defaultTapName
+	}
+	if conf.FilterPriority == 0 {
+		conf.FilterPriority = defaultFilterPriority
+	}
+
+	if conf.RawPrevResult == nil {
+		return nil, &types.Error{Code: 7, Msg: errNoPrevResult.Error()}
+	}
+	if err := version.ParsePrevResult(&conf.PluginConf); err != nil {
+		return nil, &types.Error{Code: 6, Msg: fmt.Sprintf("parse prevResult: %v", err)}
+	}
+	if conf.PrevResult == nil {
+		return nil, &types.Error{Code: 7, Msg: errNoPrevResult.Error()}
+	}
+
+	return conf, nil
+}

--- a/internal/vmtap/config_test.go
+++ b/internal/vmtap/config_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"strings"
+	"testing"
+)
+
+const validStdin = `{
+	"cniVersion": "1.0.0",
+	"name": "cilium",
+	"type": "vmtap-cni",
+	"prevResult": {
+		"cniVersion": "1.0.0",
+		"interfaces": [{"name": "eth0", "mac": "aa:bb:cc:dd:ee:ff", "mtu": 1500}],
+		"ips": [{"address": "10.0.0.5/24", "gateway": "10.0.0.1", "interface": 0}]
+	}
+}`
+
+func TestParseConfMissingPrevResult(t *testing.T) {
+	_, err := parseConf([]byte(`{"cniVersion": "1.0.0", "name": "cilium", "type": "vmtap-cni"}`))
+	if err == nil {
+		t.Fatal("expected error for missing prevResult, got nil")
+	}
+	if !strings.Contains(err.Error(), "chained") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseConfInvalidJSON(t *testing.T) {
+	_, err := parseConf([]byte(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParseConfDefaults(t *testing.T) {
+	conf, err := parseConf([]byte(validStdin))
+	if err != nil {
+		t.Fatalf("parseConf() = %v, want nil", err)
+	}
+	if conf.TapName != defaultTapName {
+		t.Errorf("TapName = %q, want %q", conf.TapName, defaultTapName)
+	}
+	if conf.FilterPriority != defaultFilterPriority {
+		t.Errorf("FilterPriority = %d, want %d", conf.FilterPriority, defaultFilterPriority)
+	}
+	if !conf.enabled() {
+		t.Error("enabled() = false, want true (default)")
+	}
+	if conf.PrevResult == nil {
+		t.Fatal("PrevResult = nil, want parsed result")
+	}
+}
+
+func TestParseConfExplicitFields(t *testing.T) {
+	stdin := `{
+		"cniVersion": "1.0.0",
+		"name": "cilium",
+		"type": "vmtap-cni",
+		"enabled": false,
+		"tap_name": "vmtap1",
+		"filter_priority": 42,
+		"prevResult": {
+			"cniVersion": "1.0.0",
+			"interfaces": [{"name": "eth0", "mac": "aa:bb:cc:dd:ee:ff", "mtu": 1500}]
+		}
+	}`
+
+	conf, err := parseConf([]byte(stdin))
+	if err != nil {
+		t.Fatalf("parseConf() = %v, want nil", err)
+	}
+	if conf.TapName != "vmtap1" {
+		t.Errorf("TapName = %q, want %q", conf.TapName, "vmtap1")
+	}
+	if conf.FilterPriority != 42 {
+		t.Errorf("FilterPriority = %d, want %d", conf.FilterPriority, 42)
+	}
+	if conf.enabled() {
+		t.Error("enabled() = true, want false (explicitly disabled)")
+	}
+}

--- a/internal/vmtap/conflist.go
+++ b/internal/vmtap/conflist.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PluginType is the "type" field vmtap-cni registers under in a conflist's
+// "plugins" array, and the value PatchConflistDir looks for to decide
+// whether a conflist has already been patched.
+const PluginType = "vmtap-cni"
+
+// conflistEnvelope is the standard CNI conflist JSON structure. Plugins is
+// kept as raw JSON so patching only ever appends a new element — existing
+// plugin entries (Cilium's own, and any others already chained) are never
+// re-marshaled and so cannot be reformatted or reordered by a patch.
+type conflistEnvelope struct {
+	CNIVersion string            `json:"cniVersion"`
+	Name       string            `json:"name"`
+	Plugins    []json.RawMessage `json:"plugins"`
+}
+
+// PatchConflistDir scans dir (non-recursively) for conflist files matching
+// glob and appends a {"type": vmtap.PluginType} entry to each one's
+// "plugins" array, unless already present. Returns the paths that were
+// newly patched this call.
+//
+// This is a best-effort installer step, not a verified solution to the
+// conflist-chaining problem flagged in
+// .local/kraftlet-cilium-tap-plan.md section 7: it assumes Cilium's
+// conflist already exists under dir by the time this runs (there is no
+// cross-DaemonSet ordering guarantee for that — see RunPatchLoop, which
+// polls specifically to tolerate arriving late) and it does not undo the
+// patch on uninstall, so removing vmtap-cni from a cluster currently
+// requires manually editing Cilium's conflist back out. Both are open
+// items, not solved problems.
+func PatchConflistDir(dir, glob string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, glob))
+	if err != nil {
+		return nil, fmt.Errorf("glob %q in %q: %w", glob, dir, err)
+	}
+
+	var patched []string
+	for _, path := range matches {
+		changed, err := patchConflistFile(path)
+		if err != nil {
+			return patched, fmt.Errorf("patch %q: %w", path, err)
+		}
+		if changed {
+			patched = append(patched, path)
+		}
+	}
+	return patched, nil
+}
+
+// patchConflistFile appends vmtap-cni's plugin entry to path's "plugins"
+// array if not already present. Returns true if the file was modified.
+func patchConflistFile(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read: %w", err)
+	}
+
+	var env conflistEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return false, fmt.Errorf("parse conflist: %w", err)
+	}
+
+	for _, raw := range env.Plugins {
+		var meta struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(raw, &meta); err != nil {
+			continue
+		}
+		if meta.Type == PluginType {
+			return false, nil // already patched
+		}
+	}
+
+	entry, err := json.Marshal(map[string]string{"type": PluginType})
+	if err != nil {
+		return false, fmt.Errorf("marshal plugin entry: %w", err)
+	}
+	env.Plugins = append(env.Plugins, entry)
+
+	out, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return false, fmt.Errorf("marshal patched conflist: %w", err)
+	}
+
+	return true, writeFileAtomic(path, out)
+}
+
+// writeFileAtomic writes data to path via a temp-file-plus-rename, so a
+// CNI runtime reading the conflist concurrently never observes a partially
+// written file — conflists are read on every pod ADD, including
+// potentially while this patch is in flight.
+func writeFileAtomic(path string, data []byte) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+
+	tmp := path + ".vmtap-cni.tmp"
+	if err := os.WriteFile(tmp, data, info.Mode()); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+	return nil
+}

--- a/internal/vmtap/conflist_run.go
+++ b/internal/vmtap/conflist_run.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RunPatchLoop periodically re-applies PatchConflistDir until ctx is
+// canceled. Running as a loop rather than a one-shot init container is a
+// deliberate hedge against two ordering problems neither Kubernetes nor
+// this plugin can otherwise guarantee: Cilium's own DaemonSet may not have
+// written its conflist yet the first time this container starts, and
+// Cilium can rewrite its conflist later (e.g. on an upgrade), which would
+// silently drop vmtap-cni back out of the chain until the next patch.
+//
+// It is still not a complete answer to the conflist-chaining problem in
+// .local/kraftlet-cilium-tap-plan.md section 7 — in particular, nothing
+// here guarantees this patch lands before Cilium's own CNI starts
+// servicing ADD calls on a freshly booted node, only that it eventually
+// converges.
+func RunPatchLoop(ctx context.Context, dir, glob string, interval time.Duration) {
+	patchOnce := func() {
+		patched, err := PatchConflistDir(dir, glob)
+		if err != nil {
+			slog.Error("conflist patch: failed", "dir", dir, "glob", glob, "err", err)
+			return
+		}
+		for _, path := range patched {
+			slog.Info("conflist patch: appended vmtap-cni to plugin chain", "path", path)
+		}
+	}
+
+	patchOnce()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			patchOnce()
+		}
+	}
+}

--- a/internal/vmtap/conflist_test.go
+++ b/internal/vmtap/conflist_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const ciliumConflist = `{
+	"cniVersion": "1.0.0",
+	"name": "cilium",
+	"plugins": [
+		{"type": "cilium-cni"}
+	]
+}`
+
+func TestPatchConflistDirAppendsEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "05-cilium.conflist")
+	if err := os.WriteFile(path, []byte(ciliumConflist), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	patched, err := PatchConflistDir(dir, "*cilium*.conflist")
+	if err != nil {
+		t.Fatalf("PatchConflistDir() = %v, want nil", err)
+	}
+	if len(patched) != 1 || patched[0] != path {
+		t.Fatalf("patched = %v, want [%s]", patched, path)
+	}
+
+	var env conflistEnvelope
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read patched file: %v", err)
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("unmarshal patched file: %v", err)
+	}
+	if len(env.Plugins) != 2 {
+		t.Fatalf("plugins count = %d, want 2", len(env.Plugins))
+	}
+	var last struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(env.Plugins[1], &last); err != nil {
+		t.Fatalf("unmarshal last plugin entry: %v", err)
+	}
+	if last.Type != PluginType {
+		t.Errorf("last plugin type = %q, want %q", last.Type, PluginType)
+	}
+}
+
+func TestPatchConflistDirIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "05-cilium.conflist")
+	if err := os.WriteFile(path, []byte(ciliumConflist), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	if _, err := PatchConflistDir(dir, "*cilium*.conflist"); err != nil {
+		t.Fatalf("first PatchConflistDir() = %v, want nil", err)
+	}
+	patched, err := PatchConflistDir(dir, "*cilium*.conflist")
+	if err != nil {
+		t.Fatalf("second PatchConflistDir() = %v, want nil", err)
+	}
+	if len(patched) != 0 {
+		t.Errorf("second call patched = %v, want empty (already patched)", patched)
+	}
+}
+
+func TestPatchConflistDirNoMatch(t *testing.T) {
+	dir := t.TempDir()
+
+	patched, err := PatchConflistDir(dir, "*cilium*.conflist")
+	if err != nil {
+		t.Fatalf("PatchConflistDir() = %v, want nil", err)
+	}
+	if len(patched) != 0 {
+		t.Errorf("patched = %v, want empty (no matching files)", patched)
+	}
+}

--- a/internal/vmtap/doc.go
+++ b/internal/vmtap/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package vmtap implements a chained CNI plugin that gives a Unikraft
+// microVM (managed by kraftlet) access to the pod's real Cilium-assigned
+// identity via a tap device, using the tc-redirect pattern Kata Containers
+// uses for its "tcfilter" endpoint type.
+//
+// vmtap-cni is unrelated to the VPC/SRv6 dataplane implemented by
+// internal/cni — it never touches a VRF, never creates a BGPAdvertisement,
+// and these pods have no vpc/vpcattachment. It must be chained after
+// Cilium's own CNI plugin in the pod's primary conflist and requires a
+// prevResult describing the interface Cilium already configured (typically
+// eth0). On ADD it creates a tap device in the same network namespace, adds
+// mirred redirect tc filters between the two links in both directions, and
+// reports the tap as a synthetic VM-facing interface in the CNI result —
+// eth0 itself is never modified. DEL removes the filters and the tap
+// device; both DEL and CHECK are idempotent per the CNI spec.
+//
+// See .local/kraftlet-cilium-tap-plan.md for the design this package
+// implements, including caveats around route-MTU, Cilium's socketLB, and
+// tc/bpf hook ordering that still require empirical validation on a real
+// cluster.
+package vmtap

--- a/internal/vmtap/ops_add.go
+++ b/internal/vmtap/ops_add.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	type100 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// cmdAdd creates a tap device in the pod's network namespace and installs
+// bidirectional tc-mirred redirects between it and the interface the
+// preceding plugin (Cilium) already configured, without ever modifying that
+// interface. See doc.go and .local/kraftlet-cilium-tap-plan.md section 3.
+func cmdAdd(args *skel.CmdArgs) error {
+	conf, err := parseConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("ADD: starting", "containerID", args.ContainerID, "netns", args.Netns, "ifName", args.IfName)
+
+	if !conf.enabled() {
+		slog.Info("ADD: plugin disabled via config, passing prevResult through unchanged",
+			"containerID", args.ContainerID)
+		return types.PrintResult(conf.PrevResult, conf.CNIVersion)
+	}
+
+	var result *type100.Result
+	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		info, err := resolveRedirectInterface(conf, args.IfName)
+		if err != nil {
+			return fmt.Errorf("resolve redirect interface %q: %w", args.IfName, err)
+		}
+
+		redirectLink, err := netlink.LinkByName(args.IfName)
+		if err != nil {
+			return fmt.Errorf("find redirect interface %q: %w", args.IfName, err)
+		}
+
+		// Tap MTU is the resolved route MTU, not eth0's link MTU — this is
+		// what fixes the Cilium/Kata MTU mismatch caveat (section 4 of the
+		// plan) without needing a dedicated schema field: the tap's own Mtu
+		// in the CNI result is already the corrected value.
+		tapLink, err := addTap(conf.TapName, info.routeMTU, conf.OwnerUID, conf.OwnerGID)
+		if err != nil {
+			return fmt.Errorf("create tap %q: %w", conf.TapName, err)
+		}
+
+		if err := addRedirect(redirectLink, tapLink, conf.FilterPriority); err != nil {
+			return fmt.Errorf("add redirect %s->%s: %w", args.IfName, conf.TapName, err)
+		}
+		if err := addRedirect(tapLink, redirectLink, conf.FilterPriority); err != nil {
+			return fmt.Errorf("add redirect %s->%s: %w", conf.TapName, args.IfName, err)
+		}
+		slog.Debug("ADD: redirect installed", "containerID", args.ContainerID,
+			"redirect", args.IfName, "tap", conf.TapName, "routeMTU", info.routeMTU)
+
+		result, err = buildResult(conf, tapLink, args.ContainerID)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("ADD in netns %q: %w", args.Netns, err)
+	}
+
+	slog.Info("ADD: tap and redirect ready", "containerID", args.ContainerID, "tap", conf.TapName)
+	return types.PrintResult(result, conf.CNIVersion)
+}

--- a/internal/vmtap/ops_check.go
+++ b/internal/vmtap/ops_check.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// cmdCheck validates that the tap device and both redirect filters are
+// still present, and that the redirect interface (eth0) has not drifted
+// from what prevResult recorded — the strongest guarantee this plugin can
+// give that it is still leaving Cilium's interface alone.
+func cmdCheck(args *skel.CmdArgs) error {
+	conf, err := parseConf(args.StdinData)
+	if err != nil {
+		return err
+	}
+	slog.Info("CHECK: starting", "containerID", args.ContainerID)
+
+	if !conf.enabled() {
+		slog.Info("CHECK: plugin disabled via config, nothing to check", "containerID", args.ContainerID)
+		return nil
+	}
+
+	var errs []error
+	if nsErr := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		checkInNetns(conf, args, &errs)
+		return nil
+	}); nsErr != nil {
+		errs = append(errs, fmt.Errorf("enter netns %q: %w", args.Netns, nsErr))
+	}
+
+	if len(errs) > 0 {
+		err := fmt.Errorf("CHECK failed: %w", errors.Join(errs...))
+		slog.Error("CHECK: failed", "err", err, "containerID", args.ContainerID)
+		return err
+	}
+	slog.Info("CHECK: passed", "containerID", args.ContainerID)
+	return nil
+}
+
+// checkInNetns runs the actual state checks once inside the pod netns,
+// appending any failures to errs so cmdCheck can report all of them at once
+// rather than stopping at the first.
+func checkInNetns(conf *PluginConf, args *skel.CmdArgs, errs *[]error) {
+	redirectLink, err := netlink.LinkByName(args.IfName)
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf("redirect interface %q: %w", args.IfName, err))
+		return
+	}
+
+	tapLink, err := netlink.LinkByName(conf.TapName)
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf("tap %q: %w", conf.TapName, err))
+		return
+	}
+
+	if ok, err := hasRedirectFilter(redirectLink, conf.FilterPriority); err != nil {
+		*errs = append(*errs, fmt.Errorf("check redirect filter on %q: %w", args.IfName, err))
+	} else if !ok {
+		*errs = append(*errs, fmt.Errorf("missing redirect filter on %q at priority %d", args.IfName, conf.FilterPriority))
+	}
+
+	if ok, err := hasRedirectFilter(tapLink, conf.FilterPriority); err != nil {
+		*errs = append(*errs, fmt.Errorf("check redirect filter on %q: %w", conf.TapName, err))
+	} else if !ok {
+		*errs = append(*errs, fmt.Errorf("missing redirect filter on %q at priority %d", conf.TapName, conf.FilterPriority))
+	}
+
+	info, err := resolveRedirectInterface(conf, args.IfName)
+	if err != nil {
+		*errs = append(*errs, fmt.Errorf("resolve prevResult interface %q: %w", args.IfName, err))
+		return
+	}
+	if info.mac != "" && redirectLink.Attrs().HardwareAddr.String() != info.mac {
+		*errs = append(*errs, fmt.Errorf("interface %q MAC changed: expected %q, got %q",
+			args.IfName, info.mac, redirectLink.Attrs().HardwareAddr.String()))
+	}
+	if info.mtu > 0 && redirectLink.Attrs().MTU != info.mtu {
+		*errs = append(*errs, fmt.Errorf("interface %q MTU changed: expected %d, got %d",
+			args.IfName, info.mtu, redirectLink.Attrs().MTU))
+	}
+}

--- a/internal/vmtap/ops_del.go
+++ b/internal/vmtap/ops_del.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	type100 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// cmdDel removes the redirect filter and tap device this plugin created.
+// DEL is idempotent per the CNI spec: a missing netns, tap, or filter is not
+// an error. The redirect interface (eth0) is never touched — it was never
+// modified by ADD, so there is nothing to restore on it.
+func cmdDel(args *skel.CmdArgs) error {
+	slog.Info("DEL: starting", "containerID", args.ContainerID, "netns", args.Netns)
+
+	conf, err := parseConf(args.StdinData)
+	if err != nil {
+		// Config didn't parse (or carries no prevResult) — nothing to
+		// identify which tap/priority to clean up. Still return success:
+		// DEL must be idempotent even against garbage state.
+		slog.Warn("DEL: failed to parse config, skipping cleanup", "err", err, "containerID", args.ContainerID)
+		return types.PrintResult(&type100.Result{}, "1.0.0")
+	}
+
+	if err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+		if link, linkErr := netlink.LinkByName(args.IfName); linkErr == nil {
+			if err := deleteRedirect(link, conf.FilterPriority); err != nil {
+				return fmt.Errorf("remove redirect on %q: %w", args.IfName, err)
+			}
+		}
+		return deleteTap(conf.TapName)
+	}); err != nil {
+		// Netns is commonly already gone by the time DEL runs (the runtime
+		// tears it down before or concurrently with calling DEL) — that is
+		// the expected, non-error case, not a real cleanup failure.
+		if _, statErr := ns.GetNS(args.Netns); statErr != nil {
+			slog.Debug("DEL: netns already gone, nothing to clean up", "containerID", args.ContainerID, "netns", args.Netns)
+			return types.PrintResult(&type100.Result{}, conf.CNIVersion)
+		}
+		return fmt.Errorf("DEL in netns %q: %w", args.Netns, err)
+	}
+
+	slog.Info("DEL: done", "containerID", args.ContainerID)
+	return types.PrintResult(&type100.Result{}, conf.CNIVersion)
+}

--- a/internal/vmtap/prevresult.go
+++ b/internal/vmtap/prevresult.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+
+	type100 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/vishvananda/netlink"
+)
+
+// resolveRedirectInterface reads ifName's state out of pluginConf's already-
+// parsed prevResult (MAC, link MTU) and, for the route MTU Cilium may have
+// adjusted independently of the link MTU, out of the kernel routing table.
+// Callers must already be running inside the target network namespace.
+//
+// Per .local/kraftlet-cilium-tap-plan.md section 1, this never mutates
+// ifName — it is read-only.
+func resolveRedirectInterface(conf *PluginConf, ifName string) (*redirectInterfaceInfo, error) {
+	prevResult, err := type100.GetResult(conf.PrevResult)
+	if err != nil {
+		return nil, fmt.Errorf("get prevResult: %w", err)
+	}
+
+	var iface *type100.Interface
+	for _, i := range prevResult.Interfaces {
+		if i.Name == ifName {
+			iface = i
+			break
+		}
+	}
+	if iface == nil {
+		return nil, fmt.Errorf("prevResult does not describe an interface named %q", ifName)
+	}
+
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return nil, fmt.Errorf("find interface %q: %w", ifName, err)
+	}
+
+	routeMTU, err := findRouteMTU(link)
+	if err != nil {
+		return nil, fmt.Errorf("resolve route MTU for %q: %w", ifName, err)
+	}
+	if routeMTU == 0 {
+		// No route carries an explicit MTU metric — fall back to the link
+		// MTU. This is the same fallback awslabs/tc-redirect-tap always
+		// takes (it never reads route MTU at all); see the MTU caveat in
+		// docs/vmtap-cni/configuration.md for when this fallback is wrong.
+		routeMTU = iface.Mtu
+	}
+
+	return &redirectInterfaceInfo{
+		name:     ifName,
+		mac:      iface.Mac,
+		mtu:      iface.Mtu,
+		routeMTU: routeMTU,
+	}, nil
+}
+
+// findRouteMTU returns the largest MTU metric set on any route bound to
+// link, across both address families. Returns 0 if no route carries an
+// explicit MTU (the common case when Cilium hasn't needed to shrink it for
+// overlay/tunnel overhead).
+func findRouteMTU(link netlink.Link) (int, error) {
+	var maxMTU int
+	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+		routes, err := netlink.RouteList(link, family)
+		if err != nil {
+			return 0, fmt.Errorf("list routes: %w", err)
+		}
+		for _, r := range routes {
+			if r.MTU > maxMTU {
+				maxMTU = r.MTU
+			}
+		}
+	}
+	return maxMTU, nil
+}

--- a/internal/vmtap/result.go
+++ b/internal/vmtap/result.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
+	type100 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/vishvananda/netlink"
+)
+
+// buildResult copies prevResult forward (interfaces, IPs, routes — vmtap-cni
+// is the last plugin in the chain, so its own result is what the CNI runtime
+// hands back to the caller) and appends the tap device as a new interface
+// entry.
+//
+// The tap's Sandbox field is set to containerID rather than a netns path —
+// there is no netns for the VM the way there is for a container, so this
+// plugin uses containerID (the CRI sandbox ID passed as CNI_CONTAINERID) as
+// the hand-off key kraftlet is expected to read the CNI ADD result back out
+// by. This convention is not yet confirmed against the actual kraftlet
+// integration — see the "how kraftlet reads this plugin's result" open item
+// in .local/kraftlet-cilium-tap-plan.md section 7.
+//
+// tapLink's MTU is expected to already equal the resolved route MTU (not
+// eth0's link MTU) — see resolveRedirectInterface and the MTU caveat in
+// docs/vmtap-cni/configuration.md — so no separate route-MTU field is
+// needed: the tap's own Mtu communicates the corrected value.
+func buildResult(conf *PluginConf, tapLink netlink.Link, containerID string) (*type100.Result, error) {
+	prevResult, err := type100.GetResult(conf.PrevResult)
+	if err != nil {
+		return nil, fmt.Errorf("get prevResult: %w", err)
+	}
+
+	result := &type100.Result{
+		CNIVersion: conf.CNIVersion,
+		Interfaces: append([]*type100.Interface{}, prevResult.Interfaces...),
+		IPs:        append([]*type100.IPConfig{}, prevResult.IPs...),
+		Routes:     append([]*types.Route{}, prevResult.Routes...),
+		DNS:        prevResult.DNS,
+	}
+
+	attrs := tapLink.Attrs()
+	result.Interfaces = append(result.Interfaces, &type100.Interface{
+		Name:    attrs.Name,
+		Mac:     attrs.HardwareAddr.String(),
+		Mtu:     attrs.MTU,
+		Sandbox: containerID,
+	})
+
+	return result, nil
+}

--- a/internal/vmtap/tap.go
+++ b/internal/vmtap/tap.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/vishvananda/netlink"
+)
+
+// addTap creates a tap device with the given name, MTU, and owner uid/gid.
+// Callers must already be running inside the target network namespace (see
+// ns.WithNetNSPath in ops_add.go) — addTap never enters a namespace itself.
+// Idempotent: if a tap device with this name already exists (crash-recovery
+// or a retried ADD), its attributes are left as-is rather than recreated,
+// mirroring internal/cni/tap.Add's repair behavior for a simpler case (no
+// VRF enslavement here).
+func addTap(name string, mtu int, ownerUID, ownerGID uint32) (netlink.Link, error) {
+	if existing, err := netlink.LinkByName(name); err == nil {
+		slog.Warn("vmtap: found existing tap from a previous ADD attempt, reusing", "tap", name)
+		return existing, nil
+	}
+
+	tap := &netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: name,
+			MTU:  mtu,
+		},
+		Mode:  netlink.TUNTAP_MODE_TAP,
+		Flags: netlink.TUNTAP_ONE_QUEUE | netlink.TUNTAP_VNET_HDR,
+		Owner: ownerUID,
+		Group: ownerGID,
+	}
+
+	if err := netlink.LinkAdd(tap); err != nil {
+		return nil, fmt.Errorf("create tap %q: %w", name, err)
+	}
+	slog.Debug("vmtap: tap created", "tap", name, "mtu", mtu, "ownerUID", ownerUID, "ownerGID", ownerGID)
+
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("find created tap %q: %w", name, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return nil, fmt.Errorf("bring up tap %q: %w", name, err)
+	}
+
+	return link, nil
+}
+
+// deleteTap removes the named tap device. Idempotent — a missing device is
+// not an error, per the CNI spec's DEL idempotency requirement.
+func deleteTap(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		slog.Debug("vmtap: tap already gone, nothing to delete", "tap", name)
+		return nil
+	}
+	if err := netlink.LinkDel(link); err != nil {
+		return fmt.Errorf("delete tap %q: %w", name, err)
+	}
+	slog.Debug("vmtap: tap deleted", "tap", name)
+	return nil
+}

--- a/internal/vmtap/tc.go
+++ b/internal/vmtap/tc.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// addRedirect wires bidirectional tc-mirred redirects between fromLink and
+// toLink: every packet ingressing on fromLink is stolen and re-injected as
+// an egress packet on toLink. Calling it twice, once with (eth0, tap0) and
+// once with (tap0, eth0), gives the full bidirectional pattern described in
+// .local/kraftlet-cilium-tap-plan.md section 3 — same mechanism
+// awslabs/tc-redirect-tap uses for Firecracker.
+//
+// Callers must already be running inside the target network namespace.
+// priority must not collide with Cilium's own clsact hooks on fromLink —
+// see the tc/bpf hook ordering caveat in docs/vmtap-cni/configuration.md;
+// this is unvalidated against any specific Cilium version/datapath mode.
+func addRedirect(fromLink, toLink netlink.Link, priority uint16) error {
+	if err := ensureIngressQdisc(fromLink); err != nil {
+		return fmt.Errorf("ensure ingress qdisc on %q: %w", fromLink.Attrs().Name, err)
+	}
+
+	if err := removeRedirectFilter(fromLink, priority); err != nil {
+		return fmt.Errorf("clear stale redirect filter on %q: %w", fromLink.Attrs().Name, err)
+	}
+
+	filter := &netlink.U32{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: fromLink.Attrs().Index,
+			Parent:    netlink.HANDLE_MIN_INGRESS,
+			Priority:  priority,
+			Protocol:  unix.ETH_P_ALL,
+		},
+		Actions: []netlink.Action{
+			&netlink.MirredAction{
+				ActionAttrs:  netlink.ActionAttrs{Action: netlink.TC_ACT_STOLEN},
+				MirredAction: netlink.TCA_EGRESS_REDIR,
+				Ifindex:      toLink.Attrs().Index,
+			},
+		},
+	}
+	if err := netlink.FilterAdd(filter); err != nil {
+		return fmt.Errorf("add redirect filter %s->%s: %w", fromLink.Attrs().Name, toLink.Attrs().Name, err)
+	}
+	slog.Debug("vmtap: redirect filter installed",
+		"from", fromLink.Attrs().Name, "to", toLink.Attrs().Name, "priority", priority)
+	return nil
+}
+
+// ensureIngressQdisc adds an ingress qdisc to link if one is not already
+// present. Idempotent, and tolerant of Cilium (or anything else) having
+// already attached its own qdisc — an ingress qdisc is shared per-link, so
+// finding one already there (of any recognized type) is not an error; only
+// a failed add when none exists is.
+func ensureIngressQdisc(link netlink.Link) error {
+	qdiscs, err := netlink.QdiscList(link)
+	if err != nil {
+		return fmt.Errorf("list qdiscs: %w", err)
+	}
+	for _, q := range qdiscs {
+		if q.Attrs().Parent == netlink.HANDLE_INGRESS {
+			return nil
+		}
+	}
+
+	qdisc := &netlink.Ingress{
+		QdiscAttrs: netlink.QdiscAttrs{
+			LinkIndex: link.Attrs().Index,
+			Parent:    netlink.HANDLE_INGRESS,
+		},
+	}
+	if err := netlink.QdiscAdd(qdisc); err != nil {
+		return fmt.Errorf("add ingress qdisc: %w", err)
+	}
+	return nil
+}
+
+// hasRedirectFilter reports whether a filter at the given priority exists on
+// link's ingress qdisc — used by cmdCheck to verify ADD's filters are still
+// in place.
+func hasRedirectFilter(link netlink.Link, priority uint16) (bool, error) {
+	filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_INGRESS)
+	if err != nil {
+		return false, fmt.Errorf("list filters: %w", err)
+	}
+	for _, f := range filters {
+		if f.Attrs().Priority == priority {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// removeRedirectFilter deletes the redirect filter this plugin owns at the
+// given priority on link's ingress qdisc, if present. Idempotent — a
+// missing filter is not an error.
+func removeRedirectFilter(link netlink.Link, priority uint16) error {
+	filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_INGRESS)
+	if err != nil {
+		return fmt.Errorf("list filters: %w", err)
+	}
+	for _, f := range filters {
+		if f.Attrs().Priority == priority {
+			if err := netlink.FilterDel(f); err != nil {
+				return fmt.Errorf("delete filter at priority %d: %w", priority, err)
+			}
+		}
+	}
+	return nil
+}
+
+// deleteRedirect removes the redirect filter this plugin installed on link.
+// It intentionally leaves the ingress qdisc itself in place — on eth0 that
+// qdisc may be shared with Cilium's own hooks, and deleting it out from
+// under a still-running pod interface would be far riskier than leaving an
+// unused qdisc behind. Idempotent.
+func deleteRedirect(link netlink.Link, priority uint16) error {
+	if err := removeRedirectFilter(link, priority); err != nil {
+		return fmt.Errorf("remove redirect filter on %q: %w", link.Attrs().Name, err)
+	}
+	return nil
+}

--- a/internal/vmtap/tc_test.go
+++ b/internal/vmtap/tc_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+)
+
+// requireRoot skips the test when not running as root. tap and tc
+// operations require CAP_NET_ADMIN/CAP_SYS_ADMIN — mirrors the pattern in
+// internal/cni/netns_test.go and internal/cni/tap/tap_test.go.
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Getuid() != 0 {
+		t.Skip("skipping: requires root (CAP_NET_ADMIN/CAP_SYS_ADMIN)")
+	}
+}
+
+// inTestNetns creates a fresh network namespace with a dummy "eth0" link
+// standing in for Cilium's real interface, runs fn inside it, and tears the
+// namespace down afterward. Isolating each test in its own netns keeps
+// tap/tc state from leaking onto the host running the test.
+func inTestNetns(t *testing.T, fn func()) {
+	t.Helper()
+	requireRoot(t)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer nsObj.Close() //nolint:errcheck // best-effort cleanup
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy eth0: %w", err)
+		}
+		link, err := netlink.LinkByName("eth0")
+		if err != nil {
+			return err
+		}
+		if err := netlink.LinkSetUp(link); err != nil {
+			return fmt.Errorf("set eth0 up: %w", err)
+		}
+		fn()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("in test netns: %v", err)
+	}
+}
+
+func TestAddTapCreatesLink(t *testing.T) {
+	inTestNetns(t, func() {
+		link, err := addTap("tap0", 1500, 0, 0)
+		if err != nil {
+			t.Fatalf("addTap() = %v, want nil", err)
+		}
+		if link.Type() != "tuntap" && link.Attrs().Name != "tap0" {
+			t.Errorf("addTap() link = %+v, want a tap0 link", link.Attrs())
+		}
+		if link.Attrs().MTU != 1500 {
+			t.Errorf("MTU = %d, want 1500", link.Attrs().MTU)
+		}
+	})
+}
+
+func TestAddTapIdempotent(t *testing.T) {
+	inTestNetns(t, func() {
+		if _, err := addTap("tap0", 1500, 0, 0); err != nil {
+			t.Fatalf("first addTap() = %v, want nil", err)
+		}
+		if _, err := addTap("tap0", 1500, 0, 0); err != nil {
+			t.Fatalf("second addTap() = %v, want nil (idempotent)", err)
+		}
+	})
+}
+
+func TestDeleteTapRemovesLink(t *testing.T) {
+	inTestNetns(t, func() {
+		if _, err := addTap("tap0", 1500, 0, 0); err != nil {
+			t.Fatalf("addTap() = %v, want nil", err)
+		}
+		if err := deleteTap("tap0"); err != nil {
+			t.Fatalf("deleteTap() = %v, want nil", err)
+		}
+		if _, err := netlink.LinkByName("tap0"); err == nil {
+			t.Error("tap0 still exists after deleteTap")
+		}
+	})
+}
+
+func TestDeleteTapNonExistentIsNoop(t *testing.T) {
+	inTestNetns(t, func() {
+		if err := deleteTap("zzz-nonexistent"); err != nil {
+			t.Errorf("deleteTap(nonexistent) = %v, want nil", err)
+		}
+	})
+}
+
+func TestAddRedirectAndCheck(t *testing.T) {
+	inTestNetns(t, func() {
+		tapLink, err := addTap("tap0", 1500, 0, 0)
+		if err != nil {
+			t.Fatalf("addTap() = %v, want nil", err)
+		}
+		eth0, err := netlink.LinkByName("eth0")
+		if err != nil {
+			t.Fatalf("find eth0: %v", err)
+		}
+
+		const priority = 7
+		if err := addRedirect(eth0, tapLink, priority); err != nil {
+			t.Fatalf("addRedirect(eth0->tap0) = %v, want nil", err)
+		}
+		if err := addRedirect(tapLink, eth0, priority); err != nil {
+			t.Fatalf("addRedirect(tap0->eth0) = %v, want nil", err)
+		}
+
+		if ok, err := hasRedirectFilter(eth0, priority); err != nil || !ok {
+			t.Errorf("hasRedirectFilter(eth0) = %v, %v, want true, nil", ok, err)
+		}
+		if ok, err := hasRedirectFilter(tapLink, priority); err != nil || !ok {
+			t.Errorf("hasRedirectFilter(tap0) = %v, %v, want true, nil", ok, err)
+		}
+
+		if err := deleteRedirect(eth0, priority); err != nil {
+			t.Fatalf("deleteRedirect(eth0) = %v, want nil", err)
+		}
+		if ok, err := hasRedirectFilter(eth0, priority); err != nil || ok {
+			t.Errorf("hasRedirectFilter(eth0) after delete = %v, %v, want false, nil", ok, err)
+		}
+	})
+}
+
+func TestAddRedirectIdempotent(t *testing.T) {
+	inTestNetns(t, func() {
+		tapLink, err := addTap("tap0", 1500, 0, 0)
+		if err != nil {
+			t.Fatalf("addTap() = %v, want nil", err)
+		}
+		eth0, err := netlink.LinkByName("eth0")
+		if err != nil {
+			t.Fatalf("find eth0: %v", err)
+		}
+
+		const priority = 3
+		if err := addRedirect(eth0, tapLink, priority); err != nil {
+			t.Fatalf("first addRedirect() = %v, want nil", err)
+		}
+		if err := addRedirect(eth0, tapLink, priority); err != nil {
+			t.Fatalf("second addRedirect() = %v, want nil (idempotent)", err)
+		}
+
+		filters, err := netlink.FilterList(eth0, netlink.HANDLE_MIN_INGRESS)
+		if err != nil {
+			t.Fatalf("FilterList() = %v, want nil", err)
+		}
+		count := 0
+		for _, f := range filters {
+			if f.Attrs().Priority == priority {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("filter count at priority %d = %d, want 1 (no duplicate)", priority, count)
+		}
+	})
+}

--- a/internal/vmtap/types.go
+++ b/internal/vmtap/types.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// PluginConf is the vmtap-cni configuration passed via stdin on each
+// invocation, as a chained entry inside the pod's primary conflist (e.g.
+// appended to whatever Cilium installs at /etc/cni/net.d/05-cilium.conflist).
+// It carries no VPC/VPCAttachment identifiers — those belong exclusively to
+// galactic-cni.
+type PluginConf struct {
+	types.PluginConf
+
+	// Enabled gates whether this invocation does anything. Defaults to true.
+	// Set to false to no-op the plugin for a given conflist entry without
+	// removing it from the chain — a cheap kill switch independent of
+	// whichever pod-level signal (annotation vs RuntimeClass) ultimately
+	// decides which pods get this conflist entry at all (see
+	// .local/kraftlet-cilium-tap-plan.md section 7).
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// TapName overrides the default tap interface name ("tap0").
+	TapName string `json:"tap_name,omitempty"`
+
+	// OwnerUID and OwnerGID set the tap device's owner so kraftlet can open
+	// its fd without running as root or holding CAP_NET_ADMIN. Zero (root)
+	// if unset.
+	OwnerUID uint32 `json:"owner_uid,omitempty"`
+	OwnerGID uint32 `json:"owner_gid,omitempty"`
+
+	// FilterPriority overrides the default tc filter priority used for the
+	// mirred redirect filters. Only needed if the default collides with
+	// Cilium's own bpf hooks on a given cluster/datapath mode — see the
+	// Cilium-specific caveats in docs/vmtap-cni/configuration.md.
+	FilterPriority uint16 `json:"filter_priority,omitempty"`
+}
+
+// enabled reports whether the plugin should act on this invocation.
+// Defaults to true when unset.
+func (c *PluginConf) enabled() bool {
+	return c.Enabled == nil || *c.Enabled
+}
+
+// redirectInterfaceInfo describes the interface Cilium already configured
+// (typically eth0), read from prevResult and netlink. It is never mutated —
+// only used to describe the tap's redirect target and to populate the CNI
+// result the guest-side consumer (kraftlet) reads.
+type redirectInterfaceInfo struct {
+	name string
+	mac  string
+	mtu  int // link MTU, from prevResult
+
+	// routeMTU is the pod's route MTU (accounting for overlay/tunnel
+	// overhead), read from the kernel's routing table rather than copied
+	// from the link MTU. See the MTU caveat in
+	// .local/kraftlet-cilium-tap-plan.md section 4 — Cilium adjusts the
+	// route MTU independently of the interface's link MTU.
+	routeMTU int
+}

--- a/internal/vmtap/vmtap.go
+++ b/internal/vmtap/vmtap.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vmtap
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+
+	"go.datum.net/galactic/internal/metadata"
+)
+
+// pluginName is used in the "about" string skel prints when invoked with no
+// CNI_COMMAND, and mirrors the "type" field this plugin is expected to be
+// registered under in the conflist chain.
+const pluginName = "vmtap-cni"
+
+// RunPlugin starts the CNI plugin, handling ADD, DEL, and CHECK operations.
+// STATUS is intentionally omitted (optional per the CNI spec): unlike
+// galactic-cni, vmtap-cni has no Kubernetes API dependency or node-level
+// bootstrap state to probe readiness against.
+func RunPlugin() {
+	skel.PluginMainFuncs(
+		skel.CNIFuncs{
+			Add:   cmdAdd,
+			Check: cmdCheck,
+			Del:   cmdDel,
+		},
+		version.All,
+		"CNI "+pluginName+" plugin "+metadata.Version,
+	)
+}


### PR DESCRIPTION
## Summary

- Adds `vmtap-cni`, a standalone CNI plugin chained after Cilium's own CNI plugin, giving a Unikraft microVM (managed by `kraftlet`) access to the pod's real Cilium-assigned identity via a tap device and bidirectional `tc-mirred` redirect — the same mechanism Kata's `tcfilter` endpoint type uses. Unrelated to `galactic-cni`'s VPC/SRv6 dataplane: no VRF/BGP involvement, no shared config surface.
- Tap MTU is set to the pod's resolved *route* MTU (read from the kernel routing table), not `eth0`'s link MTU, addressing the documented Cilium/Kata MTU mismatch. `eth0` itself is never modified.
- Adds a `config/vmtap` DaemonSet with a `patch-conflist` loop (`vmtap-cni patch-conflist`) that appends the plugin into Cilium's conflist and keeps re-checking it, since DaemonSet startup ordering across Cilium and vmtap-cni isn't guaranteed.
- Wires a third binary (`bin/vmtap-cni`) into `Taskfile.yaml`'s build task and adds `containers/vmtap-cni/Dockerfile` (e2e-only, mirroring the existing `galactic-cni` Dockerfile pattern — not yet wired into `scripts/ci.sh`, since real end-to-end validation needs a Cilium-enabled cluster).
- Adds `docs/vmtap-cni/configuration.md` covering config fields, MTU handling, the kraftlet hand-off convention, and the still-unvalidated Cilium caveats (tc/bpf hook ordering, socketLB, Envoy sidecar interaction).


### Explicitly out of scope / open items (see plan section 7 and the doc's "Open items" section)

- Verified tc/bpf filter priority against a real Cilium version/datapath mode (veth+tc vs. netkit vs. XDP native routing).
- The pod-level trigger signal (RuntimeClass vs. annotation) deciding which pods get this conflist entry — the DaemonSet currently gates on a placeholder node label.
- Confirmation of the `sandbox: CNI_CONTAINERID` convention against kraftlet's actual CRI/containerd integration.
- Cluster-wide `socketLB.hostNamespaceOnly=true` Cilium config (owned by whoever manages the Cilium install, not this plugin).

## Test plan

- [x] `task build` — all three binaries (`galactic-cni`, `galactic-router`, `vmtap-cni`) build
- [x] `go vet ./...`
- [x] `task lint` (golangci-lint + yamlfmt) — 0 issues
- [x] `bash scripts/ci.sh unittest` — full suite passes; new root-gated netns/tap/tc tests skip cleanly without CAP_NET_ADMIN (same convention as `internal/cni`)
- [x] `kubectl kustomize config/` and `kubectl kustomize config/vmtap` build cleanly
- [ ] End-to-end validation against a real Cilium-managed cluster (NetworkPolicy, Service routing, Hubble attribution, MTU, throughput) — deferred, tracked as an open item

🤖 Generated with [Claude Code](https://claude.com/claude-code)
