### PR TITLE
fix(cni,router): cross-process VRF locking, IPv4 onlink route, and EVPN prefix masking

### DIFF
--- a/deploy/containerlab/resources/vpc/base/vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/base/vpc20.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: vpc20
       annotations:
-        k8s.v1.cni.cncf.io/networks: vpc20
+        v1.multus-cni.io/default-network: vpc/vpc20
     spec:
       affinity:
         nodeAffinity:

--- a/deploy/containerlab/resources/vpc/dfw/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/dfw/nad-vpc20.yaml
@@ -12,5 +12,7 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipv6_subnet": "fd00:20:ff01::/48"
+      "ipv6_subnet": "fd00:20:ff01::/48",
+      "ipv4_subnet": "172.20.1.0/24",
+      "address_families": ["ipv6", "ipv4"]
     }

--- a/deploy/containerlab/resources/vpc/iad/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/iad/nad-vpc20.yaml
@@ -12,5 +12,7 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipv6_subnet": "fd00:20:ff03::/48"
+      "ipv6_subnet": "fd00:20:ff03::/48",
+      "ipv4_subnet": "172.20.3.0/24",
+      "address_families": ["ipv6", "ipv4"]
     }

--- a/deploy/containerlab/resources/vpc/sjc/nad-vpc20.yaml
+++ b/deploy/containerlab/resources/vpc/sjc/nad-vpc20.yaml
@@ -12,5 +12,7 @@ spec:
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
-      "ipv6_subnet": "fd00:20:ff02::/48"
+      "ipv6_subnet": "fd00:20:ff02::/48",
+      "ipv4_subnet": "172.20.2.0/24",
+      "address_families": ["ipv6", "ipv4"]
     }

--- a/internal/cni/netns.go
+++ b/internal/cni/netns.go
@@ -77,10 +77,16 @@ func addAddrAndDefaultRoute(
 	if gateway == nil {
 		return nil
 	}
+	// onlink: the IPv4 pool allocates a /32 host address (no on-link subnet
+	// route to the gateway), so the kernel refuses this route with
+	// ENETUNREACH unless told to treat the gateway as directly reachable.
+	// IPv6's /96 subnet allocation already covers the gateway, so the flag
+	// is a no-op there — safe to set unconditionally for both families.
 	defaultRoute := &netlink.Route{
 		Dst:       nil, // default route
 		Gw:        gateway,
 		LinkIndex: link.Attrs().Index,
+		Flags:     int(netlink.FLAG_ONLINK),
 	}
 	if err := handle.RouteAdd(defaultRoute); err != nil {
 		return fmt.Errorf("add default route via %s: %w", gateway, err)

--- a/internal/plumbing/vrf/lock.go
+++ b/internal/plumbing/vrf/lock.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vrf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockDir is the well-known parent directory for the node-local flock that
+// serializes VRF table ID allocation across separate CNI plugin invocations.
+// Each CNI ADD/DEL is its own OS process, so two pods attaching to different
+// VPCs concurrently on the same node construct independent calls into this
+// package against the same node-wide VRF table ID space; an in-process
+// sync.Mutex (vrfMu) does nothing to serialize across those process
+// boundaries, which lets both processes race in findNextAvailableVRFID and
+// netlink.LinkAdd, surfacing as "device or resource busy" from the kernel.
+const lockDir = "/var/lib/cni/galactic-vrf"
+
+const lockFileName = "lock"
+
+// fileLock is a cross-process advisory lock backed by flock(2), mirroring
+// internal/cni/ipam's fileLock: flock(2) locks are held per open file
+// description, so any number of processes opening the same path contend for
+// the same lock.
+type fileLock struct {
+	f *os.File
+}
+
+// acquireLock opens (creating if necessary) the well-known VRF lock file and
+// blocks until an exclusive flock on it is acquired.
+func acquireLock() (*fileLock, error) {
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create VRF lock dir %q: %w", lockDir, err)
+	}
+
+	path := filepath.Join(lockDir, lockFileName)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open VRF lock file %q: %w", path, err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock VRF lock file %q: %w", path, err)
+	}
+
+	return &fileLock{f: f}, nil
+}
+
+// close releases the flock and closes the underlying file.
+func (l *fileLock) close() error {
+	_ = unix.Flock(int(l.f.Fd()), unix.LOCK_UN)
+	return l.f.Close()
+}

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -23,18 +23,28 @@ import (
 const minVRFID = uint32(1)
 const maxVRFID = uint32(math.MaxUint32 - 1)
 
-// vrfMu serializes VRF creation to prevent two concurrent CNI ADD calls from
-// scanning the same free table ID and both attempting to create a VRF with it.
+// vrfMu serializes VRF creation/deletion within a single process (e.g.
+// concurrent goroutines in galactic-router's GC). It does not, by itself,
+// protect against two separate CNI ADD/DEL invocations racing on the same
+// node — each is its own OS process — so Add and Delete also take the
+// cross-process flock in lock.go.
 var vrfMu sync.Mutex
 
 // Add creates a Linux VRF interface for the given base62-encoded VPC and
 // VPCAttachment, allocating the next available routing table ID and applying
-// the required sysctl settings. Concurrent calls are serialized internally.
-// If a VRF with the same name already exists (e.g. left behind by a previous
-// failed cmdAdd with no corresponding cmdDel), Add returns nil.
+// the required sysctl settings. Concurrent calls, whether from goroutines in
+// this process or from separate CNI plugin processes on the same node, are
+// serialized. If a VRF with the same name already exists (e.g. left behind
+// by a previous failed cmdAdd with no corresponding cmdDel), Add returns nil.
 func Add(vpc, vpcAttachment string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
+
+	lock, err := acquireLock()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.close() }()
 
 	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
 
@@ -73,6 +83,15 @@ func Add(vpc, vpcAttachment string) error {
 // interface for the given base62-encoded VPC and VPCAttachment. Delete is
 // idempotent: if the VRF interface does not exist, it returns nil.
 func Delete(vpc, vpcAttachment string) error {
+	vrfMu.Lock()
+	defer vrfMu.Unlock()
+
+	lock, err := acquireLock()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = lock.close() }()
+
 	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
 
 	vrfID, err := getVRFIDForInterface(name)

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -175,8 +175,21 @@ func evpnMpReachNexthop(attrs []bgp.PathAttributeInterface) string {
 }
 
 // addrToIPNet converts a netip.Addr and prefix length to a masked *net.IPNet.
+// IPv4 addresses are kept in native 4-byte form: netip.Addr.As16() returns an
+// IPv4-mapped 16-byte address, but pairing that with net.CIDRMask(bits, 128)
+// sets the mask's leading bits — the wrong end for a 4-in-16 address, whose
+// meaningful octets sit in the last 4 bytes — so consumers that reduce the IP
+// to 4 bytes (net.IP.To4(), as net.IPNet.String() and vishvananda/netlink's
+// family detection both do) see the mask's trailing, unset bits and read the
+// prefix length as 0 regardless of bits.
 func addrToIPNet(addr netip.Addr, bits int) *net.IPNet {
 	masked := netip.PrefixFrom(addr, bits).Masked()
+	if masked.Addr().Is4() {
+		a := masked.Addr().As4()
+		ip := make(net.IP, 4)
+		copy(ip, a[:])
+		return &net.IPNet{IP: ip, Mask: net.CIDRMask(masked.Bits(), 32)}
+	}
 	a := masked.Addr().As16()
 	ip := make(net.IP, 16)
 	copy(ip, a[:])


### PR DESCRIPTION
## Summary
- `internal/plumbing/vrf/{vrf.go,lock.go}`: add a cross-process flock around VRF create/delete. Each CNI ADD/DEL is a separate OS process, so the existing in-process `sync.Mutex` didn't stop two pods in different VPCs from racing `netlink.LinkAdd` on the same node — seen live as intermittent `FailedCreatePodSandBox: ... add VRF: device or resource busy`, papered over by kubelet's automatic retry.
- `internal/cni/netns.go`: mark the guest default route `onlink`. The IPv4 pool allocates a `/32` host address with no on-link subnet route to the gateway, so the kernel refused the route with `ENETUNREACH` — this hard-blocked every pod using `ipv4_subnet`.
- `internal/runtime/gobgp/monitor.go`: fix `addrToIPNet` to keep IPv4 addresses in native 4-byte form. It previously always built a 128-bit mask against a 16-byte IPv4-mapped address; `net.IP.To4()`/vishvananda-netlink's family detection reduces that mask from the wrong end, so every IPv4 EVPN prefix installed as a `/0` default route in its VRF table instead of a `/32` host route.
- `deploy/containerlab/resources/vpc/**`: fix a NAD annotation typo (`v1.muluts-cni.io` → `v1.multus-cni.io`) that left `vpc20` silently falling back to the cluster's default CNI for `eth0`; drop the resulting duplicate network attachment (same NAD listed in both `default-network` and `k8s.v1.cni.cncf.io/networks`); wire an `ipv4_subnet` pool + `address_families` into `vpc20`'s NAD at each site (dfw/iad/sjc).

## Known follow-up (not fixed here)
Cross-site IPv4 reachability still doesn't work end-to-end. `internal/runtime/gobgp/paths.go` intentionally leaves the EVPN Gateway IP field at the IPv4 zero address for IPv4 prefixes (RFC 9136 requires the GW family to match the prefix family, and there's no IPv4-shaped SID to offer). The receiving side in `monitor.go` currently trusts that zero value as the SRv6 SID rather than reusing the sibling IPv6 path's SID for the same VRF/route-target. Fixing this touches shared BGP RIB-processing state and needs its own design pass.

## Test plan
- [x] `task build`
- [x] `task lint` (0 issues)
- [x] `task test:unit`
- [x] `task test:e2e`
- [x] Verified live on the dfw/iad/sjc containerlab topology: rebuilt `galactic-cni`/`galactic-router` images, rolled the DaemonSets, confirmed `vpc20` pods get valid dual-stack addresses with correct `onlink` default routes, and IPv6 cross-site ping (dfw → iad, dfw → sjc) succeeds at 0% loss. IPv4 cross-site ping still fails, as expected per the known follow-up above.