### PR TITLE
fix(cni): allocate IPv4-only IPAM instead of failing ADD

### DIFF
--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -4,8 +4,8 @@
 (or any CNI manager), plus node-local settings resolved at runtime from the
 conflist, environment variables, and (as a last resort) the Kubernetes API.
 
-> Last verified: 2026-07-24 against the current working tree of `internal/cni/config.go`
-> and `internal/installer/installer.go`.
+> Last verified: 2026-07-28 against the current working tree of `internal/cni/config.go`,
+> `internal/cni/ipam_ops.go`, and `internal/installer/installer.go`.
 
 ## Runtime Configuration
 
@@ -99,7 +99,10 @@ the standard CNI `PluginConf` with Galactic-specific fields.
 | `mtu`            | No       | `int`           | MTU for the host-side interface. For `veth` mode this applies to both veth endpoints; for `tap` mode it applies to the tap interface.                                                                                                                                                                                                                                                                                                                                                                     |
 | `terminations`   | No       | `[]Termination` | Array of static routes to add on the host side (see Termination sub-fields below).                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `namespace`      | No       | `string`        | Kubernetes namespace used to look up the `BGPRouter` CRD. Resolution order: this field → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace` (conflist) → `galactic-system`. See [Runtime Configuration](#runtime-configuration) above.                                                                                                                                                                                                                                                                   |
-| `ipam`           | No*      | `IPAM`          | IP address management configuration (see IPAM sub-fields below). *Required unless `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — applies identically in `veth` and `tap` mode. In `tap` mode `cmdAdd` (`internal/cni/ops_add.go`) calls `allocateIPAM` unconditionally (unlike `veth` mode, which checks first), so omitting both `ipam` and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` currently produces a nil-pointer panic in `tap` mode rather than a clean validation error — always set one or the other for tap. |
+| `ipam`           | No*      | `IPAM`          | Legacy static-IP / local-IPAM configuration block (see IPAM sub-fields below). Only `type: "static"` still drives its own allocation path; `type: "pool"` is otherwise superseded by `ipv6_subnet`/`ipv4_subnet` below. *Required unless `GALACTIC_CNI_ENABLE_LOCAL_IPAM`, `ipv6_subnet`, or `ipv4_subnet` is set — applies identically in `veth` and `tap` mode. In `tap` mode `cmdAdd` (`internal/cni/ops_add.go`) calls `allocateIPAM` unconditionally (unlike `veth` mode, which checks first), so a config satisfying none of those currently produces a nil-pointer panic in `tap` mode rather than a clean validation error — always set one of them for tap. |
+| `ipv6_subnet`    | No*      | `string`        | Region IPv6 pool CIDR for the NAD-driven pool-IPAM path; endpoints allocate a `/96` from it by default. Setting this field or `ipv4_subnet` (or both) opts a config into pool IPAM directly — no `ipam` block needed. See [Pool IPAM via `ipv6_subnet`/`ipv4_subnet`](#pool-ipam-via-ipv6_subnetipv4_subnet) below. |
+| `ipv4_subnet`    | No       | `string`        | Optional site IPv4 pool CIDR; endpoints allocate a `/32` host address from it. May be set alone (IPv4-only), alongside `ipv6_subnet` (dual-stack), or omitted entirely (IPv6-only, given `ipv6_subnet` is set).                                                                                                                                                                                                                                                                                          |
+| `address_families` | No     | `[]string`      | Families to record as in-use: any of `"ipv6"`, `"ipv4"`. Defaults to `["ipv6"]` when omitted. Validated at parse time, but the families actually allocated are driven by which of `ipv6_subnet`/`ipv4_subnet` are set — keep this field consistent with those.                                                                                                                                                                                                                                            |
 
 Standard CNI fields (`cniVersion`, `name`, `dns`, `runtimeConfig`) are also
 supported via the embedded `types.PluginConf`. `galactic-cni` declares support
@@ -141,26 +144,40 @@ subnet/gateway describe only the host-side BGP-advertised state).
 
 | Field        | Required               | Type     | Description                                                                                                                                                                                                                                                                    |
 | ------------ | ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `type`       | Conditionally required | `string` | `"pool"` or `"static"`. Determines IP allocation strategy. Required whenever an `ipam` block is present; only defaults to `"pool"` when the entire `ipam` block is omitted and `GALACTIC_CNI_ENABLE_LOCAL_IPAM` is set — an `ipam` block with an empty `type` is a hard error. |
-| `pool`       | Conditionally required | `string` | IPv6 CIDR pool (e.g. `"fd00:10:ff01::/48"`) from which subnets are allocated. Required when `type` is `"pool"`.                                                                                                                                                                |
-| `gateway`    | No                     | `string` | IPv6 gateway address. If omitted, uses the first usable address in the pool (host bits = 1). Must be within the pool CIDR.                                                                                                                                                     |
-| `subnet_len` | No                     | `int`    | Prefix length per allocation. Default is `96` (giving 2^32 addresses per pod subnet). Pool prefix must be <= this value.                                                                                                                                                       |
+| `type`       | Conditionally required | `string` | `"pool"` or `"static"`. Required whenever an `ipam` block is present — an `ipam` block with an empty `type` is a hard error. `"static"` drives its own allocation path (below); `"pool"` is otherwise vestigial now that pool allocation is driven by `ipv6_subnet`/`ipv4_subnet` (see below) — its former `pool`/`gateway`/`subnet_len` sub-fields have been retired. |
 | `static_ip`  | Conditionally required | `string` | A single IPv6 address to assign when `type` is `"static"`.                                                                                                                                                                                                                     |
-
-#### IPAM `type=pool`
-
-Allocates a `/subnet_len` subnet (default `/96`) from the pool CIDR. Thread-safe
-in-memory allocation. Allocations are ephemeral (lost on process restart);
-deallocation during `cmdDel` looks up the subnet from a `BGPAdvertisement` CRD
-annotation on the host.
 
 #### IPAM `type=static`
 
 Validates and assigns a single IPv6 address with a `/64` mask. No deallocation
-needed.
+needed, and no IPv4 address is ever allocated alongside it — static IPAM is a
+single fixed address, not a dual-stack pool.
 
-> **Note:** The plugin uses IPv6 only — both the pool allocator and static
-> allocator explicitly reject IPv4 addresses.
+### Pool IPAM via `ipv6_subnet`/`ipv4_subnet`
+
+This is the NAD-driven path most VPC attachments use (`wantsIPAM`/`allocatePoolIPAM`
+in `internal/cni/ipam_ops.go`). Either `ipv6_subnet` or `ipv4_subnet` alone is
+sufficient to opt a config into pool IPAM — an `ipam` block is not required, and
+neither field depends on the other being set:
+
+- **IPv6-only:** set `ipv6_subnet`, omit `ipv4_subnet`. Allocates a `/96` subnet
+  from the region pool; no IPv4 address is allocated.
+- **IPv4-only:** set `ipv4_subnet`, omit `ipv6_subnet`. Allocates a `/32` host
+  address from the site pool; no IPv6 subnet is allocated, and the resulting
+  `BGPAdvertisement` carries only the IPv4 `/32` prefix.
+- **Dual-stack:** set both. Allocates from each pool independently; the
+  `BGPAdvertisement` carries both prefixes and the CNI result carries both
+  `IPConfig`/route entries.
+
+Allocation is in-memory and thread-safe per pool; allocations are ephemeral
+(lost on process restart). `cmdDel` looks up each family's allocated address
+independently from its own `BGPAdvertisement` CRD annotation, so cleanup of
+one family never depends on the other having been allocated.
+
+When neither `ipv6_subnet` nor `ipv4_subnet` is set and `GALACTIC_CNI_ENABLE_LOCAL_IPAM`
+is enabled, allocation falls back to the built-in default IPv6 pool CIDR (see
+[`GALACTIC_CNI_ENABLE_LOCAL_IPAM`](#galactic_cni_enable_local_ipam) above) —
+this fallback is IPv6-only; there is no default IPv4 pool.
 
 ### Termination Fields
 
@@ -193,7 +210,7 @@ Without `GALACTIC_CNI_ENABLE_LOCAL_IPAM` set, no IP address is assigned to the
 guest interface. With `GALACTIC_CNI_ENABLE_LOCAL_IPAM` set, a subnet is allocated
 from the built-in pool.
 
-### Full pool-based configuration (testvpc)
+### Pool IPAM, IPv6-only (testvpc)
 
 ```json
 {
@@ -203,14 +220,51 @@ from the built-in pool.
   "vpc": "10",
   "vpcattachment": "10",
   "namespace": "galactic-system",
-  "ipam": {
-    "type": "pool",
-    "pool": "fd00:10:ff02::/48",
-    "gateway": "fd00:10:ff02::1",
-    "subnet_len": 96
-  }
+  "ipv6_subnet": "fd00:10:ff02::/48",
+  "address_families": ["ipv6"]
 }
 ```
+
+No `ipam` block needed — `ipv6_subnet` alone opts the config into pool IPAM.
+
+### Pool IPAM, dual-stack
+
+```json
+{
+  "cniVersion": "1.0.0",
+  "name": "vpc21",
+  "type": "galactic-cni",
+  "vpc": "21",
+  "vpcattachment": "21",
+  "namespace": "galactic-system",
+  "ipv6_subnet": "fd00:10:ff03::/48",
+  "ipv4_subnet": "172.21.1.0/24",
+  "address_families": ["ipv6", "ipv4"]
+}
+```
+
+Allocates from both pools independently; the `BGPAdvertisement` carries both
+the IPv6 `/96` and IPv4 `/32` prefixes.
+
+### Pool IPAM, IPv4-only
+
+```json
+{
+  "cniVersion": "1.0.0",
+  "name": "vpc20",
+  "type": "galactic-cni",
+  "vpc": "20",
+  "vpcattachment": "20",
+  "interface_type": "tap",
+  "namespace": "galactic-system",
+  "ipv4_subnet": "172.20.1.0/24",
+  "address_families": ["ipv4"]
+}
+```
+
+`ipv4_subnet` alone opts the config into pool IPAM with no IPv6 allocation at
+all — no `ipv6_subnet` is required, and the resulting `BGPAdvertisement`
+carries only the IPv4 `/32` prefix.
 
 ### Static IP configuration
 

--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -291,6 +291,31 @@ func publishBGPState(
 	return publishBGPStateK8s(args, pluginConf, nodeName, namespace, ipamResult, vpcHex, vrfID, tracker.k8s, tracker)
 }
 
+// ipamAdvertisementPrefixes derives the BGPAdvertisement prefixes to
+// originate, plus the per-family values to record in the annotations, from
+// ipamResult. ipamResult is nil when the attachment has no IPAM allocation
+// (e.g. a tap workload that manages its own addressing), in which case
+// prefixes is empty. Either family alone yields a single-entry prefixes
+// slice; ipv6Subnet/ipv4Addr are empty when that family wasn't allocated.
+func ipamAdvertisementPrefixes(ipamResult *ipamResult) (prefixes []string, ipv6Subnet, ipv4Addr string) {
+	if ipamResult == nil {
+		return nil, "", ""
+	}
+	if ipamResult.ipv6Subnet != nil {
+		ipv6Subnet = ipamResult.ipv6Subnet.String()
+		prefixes = append(prefixes, ipv6Subnet)
+	}
+	if ipamResult.ipv4Address != nil {
+		// The annotation stores the bare address (matching
+		// IPv4PoolAllocator's marker-file naming, so cmdDel's Deallocate
+		// call finds it — see ipam_ops.go); the advertised prefix needs the
+		// explicit /32 CIDR form.
+		ipv4Addr = ipamResult.ipv4Address.String()
+		prefixes = append(prefixes, ipv4Addr+"/32")
+	}
+	return prefixes, ipv6Subnet, ipv4Addr
+}
+
 // publishBGPStateK8s creates the BGPVRFInstance and BGPAdvertisement CRDs with
 // retry on transient k8s API errors. The host gateway must be configured before
 // calling this (via configureHostGateway). This is interface-agnostic and can be
@@ -355,20 +380,7 @@ func publishBGPStateK8s(
 				Namespace: namespace,
 			},
 		}
-		var prefixes []string
-		var ipv6Subnet, ipv4Addr string
-		if ipamResult != nil {
-			ipv6Subnet = ipamResult.ipv6Subnet.String()
-			prefixes = append(prefixes, ipv6Subnet)
-			if ipamResult.ipv4Address != nil {
-				// The annotation stores the bare address (matching
-				// IPv4PoolAllocator's marker-file naming, so cmdDel's
-				// Deallocate call finds it — see ipam_ops.go); the
-				// advertised prefix needs the explicit /32 CIDR form.
-				ipv4Addr = ipamResult.ipv4Address.String()
-				prefixes = append(prefixes, ipv4Addr+"/32")
-			}
-		}
+		prefixes, ipv6Subnet, ipv4Addr := ipamAdvertisementPrefixes(ipamResult)
 		_, err = controllerutil.CreateOrUpdate(ctx, k8s, adv, func() error {
 			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, prefixes, vrfID)
 			if adv.Annotations == nil {

--- a/internal/cni/bgp_test.go
+++ b/internal/cni/bgp_test.go
@@ -254,6 +254,51 @@ func TestBuildVRFInstanceSpec(t *testing.T) {
 	}
 }
 
+// ---- ipamAdvertisementPrefixes ----------------------------------------------
+
+func TestIPAMAdvertisementPrefixesNil(t *testing.T) {
+	prefixes, ipv6Subnet, ipv4Addr := ipamAdvertisementPrefixes(nil)
+	if prefixes != nil {
+		t.Errorf("prefixes = %v, want nil", prefixes)
+	}
+	if ipv6Subnet != "" || ipv4Addr != "" {
+		t.Errorf("ipv6Subnet, ipv4Addr = %q, %q, want empty strings", ipv6Subnet, ipv4Addr)
+	}
+}
+
+func TestIPAMAdvertisementPrefixesIPv4Only(t *testing.T) {
+	res := &ipamResult{ipv4Address: net.ParseIP("10.128.0.5")}
+
+	prefixes, ipv6Subnet, ipv4Addr := ipamAdvertisementPrefixes(res)
+
+	if ipv6Subnet != "" {
+		t.Errorf("ipv6Subnet = %q, want empty", ipv6Subnet)
+	}
+	if ipv4Addr != "10.128.0.5" {
+		t.Errorf("ipv4Addr = %q, want 10.128.0.5", ipv4Addr)
+	}
+	if len(prefixes) != 1 || prefixes[0] != "10.128.0.5/32" {
+		t.Errorf("prefixes = %v, want exactly [\"10.128.0.5/32\"] (no panic, no empty-prefixes case)", prefixes)
+	}
+}
+
+func TestIPAMAdvertisementPrefixesDualStack(t *testing.T) {
+	ipv6Subnet := mustParseCIDR(t, "fd00:10:ff01::1234/96")
+	res := &ipamResult{ipv6Subnet: ipv6Subnet, ipv4Address: net.ParseIP("10.128.0.5")}
+
+	prefixes, gotIPv6Subnet, gotIPv4Addr := ipamAdvertisementPrefixes(res)
+
+	if gotIPv6Subnet != ipv6Subnet.String() {
+		t.Errorf("ipv6Subnet = %q, want %q", gotIPv6Subnet, ipv6Subnet.String())
+	}
+	if gotIPv4Addr != "10.128.0.5" {
+		t.Errorf("ipv4Addr = %q, want 10.128.0.5", gotIPv4Addr)
+	}
+	if len(prefixes) != 2 || prefixes[0] != ipv6Subnet.String() || prefixes[1] != "10.128.0.5/32" {
+		t.Errorf("prefixes = %v, want [%q, \"10.128.0.5/32\"]", prefixes, ipv6Subnet.String())
+	}
+}
+
 // ---- buildAdvertisementSpec -------------------------------------------------
 
 func TestBuildAdvertisementSpec(t *testing.T) {

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -49,6 +49,7 @@ const (
 	testRouterName    = "overlay-router"
 	testSID128        = "2001:db8::1/128"
 	testCNIVersion    = "1.0.0"
+	testIPv4Subnet    = "10.128.0.0/20"
 
 	// testPrevResult is a valid CNI v1.0.0 result used in prevResult tests.
 	testPrevResult = `{"cniVersion":"1.0.0",` +
@@ -1028,6 +1029,47 @@ func TestBuildResultDualStack(t *testing.T) {
 	}
 	if len(result.Routes) != 2 {
 		t.Errorf("Routes count = %d, want 2", len(result.Routes))
+	}
+}
+
+// TestBuildResultIPv4Only verifies that buildResult emits a single IPv4
+// IPConfig (no IPv6 entry, no panic) when ipamResult carries an IPv4-only
+// allocation — the NAD config from the reported bug (ipv4_subnet set, no
+// ipv6_subnet).
+func TestBuildResultIPv4Only(t *testing.T) {
+	ipv4Address := net.ParseIP("172.20.1.5")
+	ipv4Gateway := net.ParseIP("172.20.1.1")
+	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+
+	conf := &PluginConf{
+		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
+		VPC:           testVPC,
+		VPCAttachment: testAttachment,
+	}
+	ipRes := &ipamResult{
+		ipv4Address: ipv4Address,
+		ipv4Gateway: ipv4Gateway,
+		routes:      []*net.IPNet{ipv4Route},
+	}
+
+	result := buildResult(conf, ipRes, "G09-vpc03-vpcAttH", "eth0",
+		"aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:11", 1500, 1500, "/proc/1234/ns/net")
+
+	if len(result.IPs) != 1 {
+		t.Fatalf("IPs count = %d, want 1", len(result.IPs))
+	}
+	wantIPv4Mask := net.CIDRMask(32, 32).String()
+	if result.IPs[0].Address.IP.String() != ipv4Address.String() || result.IPs[0].Address.Mask.String() != wantIPv4Mask {
+		t.Errorf("IPs[0].Address = %v, want %s/32", result.IPs[0].Address, ipv4Address)
+	}
+	if !result.IPs[0].Gateway.Equal(ipv4Gateway) {
+		t.Errorf("IPs[0].Gateway = %v, want %v", result.IPs[0].Gateway, ipv4Gateway)
+	}
+	if result.IPs[0].Interface == nil || *result.IPs[0].Interface != 1 {
+		t.Errorf("IPs[0].Interface = %v, want 1 (guest)", result.IPs[0].Interface)
+	}
+	if len(result.Routes) != 1 {
+		t.Errorf("Routes count = %d, want 1", len(result.Routes))
 	}
 }
 

--- a/internal/cni/ipam/dualstack.go
+++ b/internal/cni/ipam/dualstack.go
@@ -6,18 +6,20 @@ package ipam
 
 import "net"
 
-// DualStackAllocator wraps an IPv6 PoolAllocator and an optional IPv4
-// IPv4PoolAllocator, allocating from both in a single call. The IPv4
-// allocator is optional: when the CNI config does not carry an IPv4 pool,
-// DualStackAllocator behaves as IPv6-only.
+// DualStackAllocator wraps an optional IPv6 PoolAllocator and an optional
+// IPv4 IPv4PoolAllocator, allocating from whichever are configured in a
+// single call. Both families are optional: when the CNI config does not
+// carry an IPv6 pool, DualStackAllocator behaves as IPv4-only, and vice
+// versa.
 type DualStackAllocator struct {
 	ipv6 *PoolAllocator
 	ipv4 *IPv4PoolAllocator
 }
 
 // DualStackResult carries the addresses allocated for a single container.
-// IPv4Address and IPv4Gateway are nil when the allocator was constructed
-// without an IPv4 pool.
+// IPv6Subnet/IPv6Gateway are nil when the allocator was constructed without
+// an IPv6 pool; IPv4Address/IPv4Gateway are nil when constructed without an
+// IPv4 pool.
 type DualStackResult struct {
 	IPv6Subnet  *net.IPNet
 	IPv6Gateway net.IP
@@ -25,20 +27,25 @@ type DualStackResult struct {
 	IPv4Gateway net.IP
 }
 
-// NewDualStackAllocator creates a DualStackAllocator. The IPv6 pool is
-// always required. If ipv4Pool is empty, the resulting allocator only
-// allocates IPv6 addresses (IPv4 fields in DualStackResult are left nil) and
-// ipv4LockDir is ignored. ipv4LockDir is passed straight through to
-// NewIPv4PoolAllocator (see DefaultIPv4LockDir for the production path).
+// NewDualStackAllocator creates a DualStackAllocator. If ipv6Pool is empty,
+// the resulting allocator only allocates IPv4 addresses (IPv6 fields in
+// DualStackResult are left nil). If ipv4Pool is empty, the resulting
+// allocator only allocates IPv6 addresses (IPv4 fields in DualStackResult
+// are left nil) and ipv4LockDir is ignored. ipv4LockDir is passed straight
+// through to NewIPv4PoolAllocator (see DefaultIPv4LockDir for the production
+// path).
 func NewDualStackAllocator(
 	ipv6Pool, ipv6Gateway, ipv4Pool, ipv4Gateway, ipv4LockDir string,
 ) (*DualStackAllocator, error) {
-	ipv6, err := NewPoolAllocator(ipv6Pool, ipv6Gateway, DefaultSubnetLen)
-	if err != nil {
-		return nil, err
-	}
+	a := &DualStackAllocator{}
 
-	a := &DualStackAllocator{ipv6: ipv6}
+	if ipv6Pool != "" {
+		ipv6, err := NewPoolAllocator(ipv6Pool, ipv6Gateway, DefaultSubnetLen)
+		if err != nil {
+			return nil, err
+		}
+		a.ipv6 = ipv6
+	}
 
 	if ipv4Pool != "" {
 		ipv4, err := NewIPv4PoolAllocator(ipv4Pool, ipv4Gateway, ipv4LockDir)
@@ -51,18 +58,19 @@ func NewDualStackAllocator(
 	return a, nil
 }
 
-// Allocate allocates an IPv6 subnet and, if an IPv4 pool was configured, an
-// IPv4 address for the given container ID. Thread-safe (delegates to the
-// underlying allocators' own locking).
+// Allocate allocates an IPv6 subnet (if an IPv6 pool was configured) and an
+// IPv4 address (if an IPv4 pool was configured) for the given container ID.
+// Thread-safe (delegates to the underlying allocators' own locking).
 func (a *DualStackAllocator) Allocate(containerID string) (*DualStackResult, error) {
-	ipv6Subnet, err := a.ipv6.Allocate(containerID)
-	if err != nil {
-		return nil, err
-	}
+	result := &DualStackResult{}
 
-	result := &DualStackResult{
-		IPv6Subnet:  ipv6Subnet,
-		IPv6Gateway: a.ipv6.Gateway(),
+	if a.ipv6 != nil {
+		ipv6Subnet, err := a.ipv6.Allocate(containerID)
+		if err != nil {
+			return nil, err
+		}
+		result.IPv6Subnet = ipv6Subnet
+		result.IPv6Gateway = a.ipv6.Gateway()
 	}
 
 	if a.ipv4 != nil {

--- a/internal/cni/ipam/dualstack_test.go
+++ b/internal/cni/ipam/dualstack_test.go
@@ -15,6 +15,7 @@ func TestNewDualStackAllocator(t *testing.T) {
 		ipv4Gateway string
 		wantErr     bool
 		wantIPv4Nil bool
+		wantIPv6Nil bool
 	}{
 		{
 			name:        "dual-stack pool builds both allocators",
@@ -29,6 +30,13 @@ func TestNewDualStackAllocator(t *testing.T) {
 			ipv6Gateway: testPoolGw,
 			ipv4Pool:    "",
 			wantIPv4Nil: true,
+		},
+		{
+			name:        "empty ipv6 pool leaves ipv6 allocator nil",
+			ipv6Pool:    "",
+			ipv4Pool:    testIPv4PoolCIDR,
+			ipv4Gateway: testIPv4Gw,
+			wantIPv6Nil: true,
 		},
 		{
 			name:     "propagates ipv6 pool error",
@@ -60,6 +68,12 @@ func TestNewDualStackAllocator(t *testing.T) {
 			}
 			if !tt.wantIPv4Nil && a.ipv4 == nil {
 				t.Error("expected non-nil ipv4 allocator")
+			}
+			if tt.wantIPv6Nil && a.ipv6 != nil {
+				t.Error("expected nil ipv6 allocator")
+			}
+			if !tt.wantIPv6Nil && a.ipv6 == nil {
+				t.Error("expected non-nil ipv6 allocator")
 			}
 		})
 	}
@@ -116,6 +130,31 @@ func TestDualStackAllocatorAllocate(t *testing.T) {
 		}
 		if res.IPv4Gateway != nil {
 			t.Errorf("expected nil IPv4Gateway, got %q", res.IPv4Gateway.String())
+		}
+	})
+
+	t.Run("ipv6-omitted case returns ipv4 only with nil ipv6 fields", func(t *testing.T) {
+		a, err := NewDualStackAllocator("", "", testIPv4PoolCIDR, testIPv4Gw, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		res, err := a.Allocate("container-3")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if res.IPv6Subnet != nil {
+			t.Errorf("expected nil IPv6Subnet, got %q", res.IPv6Subnet.String())
+		}
+		if res.IPv6Gateway != nil {
+			t.Errorf("expected nil IPv6Gateway, got %q", res.IPv6Gateway.String())
+		}
+		if res.IPv4Address == nil {
+			t.Fatal("expected non-nil IPv4Address")
+		}
+		if res.IPv4Gateway == nil {
+			t.Error("expected non-nil IPv4Gateway")
 		}
 	})
 

--- a/internal/cni/ipam_ops.go
+++ b/internal/cni/ipam_ops.go
@@ -26,16 +26,17 @@ import (
 var ipv4LockDir = ipam.DefaultIPv4LockDir
 
 // wantsIPAM reports whether the given config should trigger IPAM allocation
-// at all. Three independent signals opt in: an explicit "static" IPAM type,
-// a configured IPv6Subnet (the NAD-driven dual-stack path), or the
-// --enable-local-ipam dev fallback. A config with none of these (e.g. a tap
-// workload that manages its own addressing) allocates nothing, matching
-// today's behavior of skipping IPAM entirely rather than erroring.
+// at all. Four independent signals opt in: an explicit "static" IPAM type, a
+// configured IPv6Subnet or IPv4Subnet (the NAD-driven pool-IPAM path, either
+// family alone or both), or the --enable-local-ipam dev fallback. A config
+// with none of these (e.g. a tap workload that manages its own addressing)
+// allocates nothing, matching today's behavior of skipping IPAM entirely
+// rather than erroring.
 func wantsIPAM(pluginConf *PluginConf) bool {
 	if pluginConf.IPAM != nil && pluginConf.IPAM.Type == ipamTypeStatic {
 		return true
 	}
-	return pluginConf.IPv6Subnet != "" || enableLocalIPAM
+	return pluginConf.IPv6Subnet != "" || pluginConf.IPv4Subnet != "" || enableLocalIPAM
 }
 
 // allocateIPAM allocates addresses for the given container. This is
@@ -72,16 +73,16 @@ func allocateStaticIPAM(args *skel.CmdArgs, ipamConf *IPAM) (*ipamResult, error)
 	return &ipamResult{ipv6Subnet: subnet}, nil
 }
 
-// allocatePoolIPAM allocates a dual-stack (or IPv6-only) pool-based
+// allocatePoolIPAM allocates a dual-stack, IPv6-only, or IPv4-only pool-based
 // endpoint address for the given container, via ipam.DualStackAllocator.
-// IPv6Subnet supplies the region pool CIDR (falling back to
-// localIPAMDefaultPool when enableLocalIPAM and unset); IPv4Subnet, when
-// present, additionally allocates a site-pool IPv4 address.
+// IPv6Subnet and IPv4Subnet each independently supply a pool CIDR for their
+// family; at least one must be set (falling back to localIPAMDefaultPool for
+// IPv6 when enableLocalIPAM and both are unset).
 func allocatePoolIPAM(args *skel.CmdArgs, pluginConf *PluginConf) (*ipamResult, error) {
 	ipv6Pool := pluginConf.IPv6Subnet
-	if ipv6Pool == "" {
+	if ipv6Pool == "" && pluginConf.IPv4Subnet == "" {
 		if !enableLocalIPAM {
-			return nil, errors.New("ipv6_subnet is required (or enable local IPAM)")
+			return nil, errors.New("ipv6_subnet or ipv4_subnet is required (or enable local IPAM)")
 		}
 		ipv6Pool = localIPAMDefaultPool
 	}
@@ -96,7 +97,10 @@ func allocatePoolIPAM(args *skel.CmdArgs, pluginConf *PluginConf) (*ipamResult, 
 		return nil, fmt.Errorf("allocate dual-stack addresses: %w", err)
 	}
 
-	routes := []*net.IPNet{{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}}
+	var routes []*net.IPNet
+	if res.IPv6Subnet != nil {
+		routes = append(routes, &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)})
+	}
 	if res.IPv4Address != nil {
 		routes = append(routes, &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)})
 	}

--- a/internal/cni/ipam_ops_test.go
+++ b/internal/cni/ipam_ops_test.go
@@ -44,6 +44,11 @@ func TestWantsIPAM(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "ipv4_subnet set opts in",
+			pluginConf: &PluginConf{IPv4Subnet: testIPv4Subnet},
+			want:       true,
+		},
+		{
 			name:           "local IPAM enabled opts in even without ipv6_subnet",
 			pluginConf:     &PluginConf{},
 			enableLocalIPA: true,
@@ -127,6 +132,35 @@ func TestAllocateIPAMPoolIPv6Only(t *testing.T) {
 	}
 }
 
+func TestAllocateIPAMPoolIPv4Only(t *testing.T) {
+	origLockDir := ipv4LockDir
+	ipv4LockDir = t.TempDir()
+	defer func() { ipv4LockDir = origLockDir }()
+
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	pluginConf := &PluginConf{IPv4Subnet: testIPv4Subnet}
+
+	res, err := allocateIPAM(args, pluginConf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("allocateIPAM() = nil, want a result")
+	}
+	if res.ipv6Subnet != nil {
+		t.Errorf("ipv6Subnet = %v, want nil (no ipv6_subnet configured)", res.ipv6Subnet)
+	}
+	if res.ipv4Address == nil {
+		t.Fatal("ipv4Address = nil, want an allocated /32")
+	}
+	if res.ipv4Gateway == nil {
+		t.Error("ipv4Gateway = nil, want the pool's default gateway")
+	}
+	if len(res.routes) != 1 {
+		t.Errorf("routes = %v, want exactly one default IPv4 route", res.routes)
+	}
+}
+
 func TestAllocateIPAMPoolDualStack(t *testing.T) {
 	origLockDir := ipv4LockDir
 	ipv4LockDir = t.TempDir()
@@ -135,7 +169,7 @@ func TestAllocateIPAMPoolDualStack(t *testing.T) {
 	args := &skel.CmdArgs{ContainerID: testContainerID}
 	pluginConf := &PluginConf{
 		IPv6Subnet: localIPAMDefaultPool,
-		IPv4Subnet: "10.128.0.0/20",
+		IPv4Subnet: testIPv4Subnet,
 	}
 
 	res, err := allocateIPAM(args, pluginConf)
@@ -159,18 +193,19 @@ func TestAllocateIPAMPoolDualStack(t *testing.T) {
 	}
 }
 
-func TestAllocateIPAMPoolMissingIPv6SubnetErrors(t *testing.T) {
+func TestAllocateIPAMPoolMissingBothSubnetsErrors(t *testing.T) {
 	original := enableLocalIPAM
 	defer func() { enableLocalIPAM = original }()
 	enableLocalIPAM = false
 
-	// wantsIPAM only opts in here via the static/ipv6_subnet/local-IPAM
-	// signals, so force the pool path directly to exercise the "no source
-	// for an IPv6 pool CIDR" error without relying on wantsIPAM's gating.
+	// wantsIPAM only opts in here via the static/ipv6_subnet/ipv4_subnet/
+	// local-IPAM signals, so force the pool path directly to exercise the
+	// "no source for any pool CIDR" error without relying on wantsIPAM's
+	// gating.
 	args := &skel.CmdArgs{ContainerID: testContainerID}
 	_, err := allocatePoolIPAM(args, &PluginConf{})
 	if err == nil {
-		t.Fatal("expected error when ipv6_subnet is unset and local IPAM is disabled, got nil")
+		t.Fatal("expected error when both ipv6_subnet and ipv4_subnet are unset and local IPAM is disabled, got nil")
 	}
 }
 
@@ -197,7 +232,7 @@ func TestDeallocateIPAMDualStack(t *testing.T) {
 	pluginConf := &PluginConf{
 		VPC: testVPC, VPCAttachment: testAttachment,
 		IPv6Subnet: localIPAMDefaultPool,
-		IPv4Subnet: "10.128.0.0/20",
+		IPv4Subnet: testIPv4Subnet,
 	}
 	args := &skel.CmdArgs{ContainerID: testContainerID}
 
@@ -237,6 +272,51 @@ func TestDeallocateIPAMDualStack(t *testing.T) {
 
 	if ipv4Pool.IsAllocated(dsRes.IPv4Address.String()) {
 		t.Errorf("IPv4 address %s still marked allocated after deallocateIPAM", dsRes.IPv4Address)
+	}
+}
+
+func TestDeallocateIPAMIPv4Only(t *testing.T) {
+	origLockDir := ipv4LockDir
+	ipv4LockDir = t.TempDir()
+	defer func() { ipv4LockDir = origLockDir }()
+
+	pluginConf := &PluginConf{
+		VPC: testVPC, VPCAttachment: testAttachment,
+		Namespace:  config.DefaultNamespace,
+		IPv4Subnet: testIPv4Subnet,
+	}
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+
+	ipv4Pool, err := ipam.NewIPv4PoolAllocator(pluginConf.IPv4Subnet, "", ipv4LockDir)
+	if err != nil {
+		t.Fatalf("NewIPv4PoolAllocator: %v", err)
+	}
+	ipv4Addr, err := ipv4Pool.Allocate(args.ContainerID)
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if !ipv4Pool.IsAllocated(ipv4Addr.String()) {
+		t.Fatalf("setup: IPv4 address %s not marked allocated", ipv4Addr)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bgpAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment),
+			Namespace: config.DefaultNamespace,
+			Annotations: map[string]string{
+				// No IPv6 annotation — this is an IPv4-only allocation.
+				subnetAnnotationKeyIPv4(args.ContainerID): ipv4Addr.String(),
+			},
+		},
+	}
+	k8s := fakeClient(adv)
+
+	// Must not panic despite no ipv6_subnet in config, and must deallocate
+	// the IPv4 address.
+	deallocateIPAM(args, pluginConf, k8s)
+
+	if ipv4Pool.IsAllocated(ipv4Addr.String()) {
+		t.Errorf("IPv4 address %s still marked allocated after deallocateIPAM", ipv4Addr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `wantsIPAM`/`allocatePoolIPAM` (`internal/cni/ipam_ops.go`) treated IPv6 as mandatory, so an `ipv4_subnet`-only NAD config (e.g. `vpc20`, live cluster repro on `us-central-1-lab`) skipped IPAM entirely, producing a nil `ipamResult` and a `BGPAdvertisement` with no prefixes — rejected by the CRD's own validation with a confusing, unrelated error.
- `DualStackAllocator` (`internal/cni/ipam/dualstack.go`) now treats IPv6 as optional, mirroring the existing optional IPv4, so `NewDualStackAllocator("", "", ipv4Pool, ...)` produces a working IPv4-only allocator.
- `publishBGPStateK8s` (`internal/cni/bgp.go`) now guards the IPv6 prefix append on `ipamResult.ipv6Subnet != nil` instead of calling `.String()` unconditionally, since `ipamResult` can now be non-nil with a nil `ipv6Subnet` in the IPv4-only case.
- `docs/cni/configuration.md` updated: documents `ipv6_subnet`/`ipv4_subnet`/`address_families` (previously undocumented), and replaces a stale example that used retired `ipam.pool`/`gateway`/`subnet_len` sub-fields with IPv6-only/dual-stack/IPv4-only examples.

## Test plan
- [x] `task lint`
- [x] `task build`
- [x] `task test:unit` — all tests touched by this change pass (one pre-existing, unrelated failure in `internal/cni/tap` requiring an `iptables` binary not present in this sandbox; confirmed it also fails on unmodified `main`)
- [ ] `task test:e2e` — not run in this environment (no configured container runtime for Kind); recommend running before merge
- [x] New/updated unit tests cover: `wantsIPAM`/`allocatePoolIPAM`/`deallocateIPAM` IPv4-only, `DualStackAllocator` IPv4-only construction/allocation, `ipamAdvertisementPrefixes` IPv4-only/dual-stack, `buildResult` IPv4-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)