### PR TITLE
feat: Harden fabric-router DaemonSet defaults

### DIFF
--- a/config/fabric/daemonset.yaml
+++ b/config/fabric/daemonset.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: fabric-router
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -75,12 +79,32 @@ spec:
       containers:
         - name: frr
           image: ghcr.io/datum-cloud/fabric-router:latest
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /usr/lib/frr/frrinit.sh
+                  - stop
           securityContext:
             capabilities:
               add:
                 - NET_ADMIN
                 - NET_RAW
                 - SYS_ADMIN
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pidof zebra bgpd
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
           volumeMounts:
             - name: frr-etc
               mountPath: /etc/frr

--- a/config/fabric/daemonset.yaml
+++ b/config/fabric/daemonset.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/name: fabric-router
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
       # FRR here establishes the underlay eBGP session to the physical fabric
       # and brings up the node's lo address, both of which galactic-router
       # depends on before it can start — so this must tolerate NotReady the
@@ -91,17 +93,27 @@ spec:
                 - NET_ADMIN
                 - NET_RAW
                 - SYS_ADMIN
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - vtysh -d zebra -c "show version" && vtysh -d bgpd -c "show version"
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             exec:
               command:
                 - sh
                 - -c
-                - pidof zebra bgpd
+                - vtysh -d zebra -c "show version" && vtysh -d bgpd -c "show version"
             initialDelaySeconds: 10
             periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 64Mi
             limits:
               memory: 256Mi


### PR DESCRIPTION
## Summary

The canonical `fabric-router` DaemonSet baseline had no liveness/startup probes, no resource requests/limits, no graceful shutdown hook, and no rolling update strategy — gaps that would otherwise cost every consumer (prod, staging, containerlab) real operational safety once they adopt this baseline.

- `updateStrategy.rollingUpdate.maxUnavailable: 1` so rollouts don't take down the underlay fleet-wide at once.
- A `preStop` hook and resource requests/limits sized for FRR's actual footprint at this scale (small peer/route count, not a full-table edge router).
- A liveness check using per-daemon `vtysh -d <daemon> -c "show version"` calls instead of `pidof zebra bgpd` — verified against FRR's source that a `pidof`-style or `vtysh -c "show daemons"` check can't reliably detect a single dead daemon, since it only needs one named process alive (or, for `show daemons`, silently omits unreachable daemons without affecting the exit code).
- A `startupProbe` so a slow config load (peer groups, route-maps, prefix-lists) isn't killed by liveness before it's up.
- `priorityClassName: system-node-critical` and `dnsPolicy: ClusterFirstWithHostNet`


