### PR TITLE
feat: Widen tap host gateway IPv4 address to /25

### DIFF
--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -297,6 +297,12 @@ calls `publishBGPStateK8s()` to create the SRv6 ingress route and
 only things tap mode skips are host-device delegation and guest-netns configuration, since
 there is no container network namespace to move an interface into.
 
+`configureHostGateway()` assigns the IPv4 gateway as a `/25` on the host tap (vs. `/32`
+everywhere else) so it looks like a real subnet to the VM guest, adding it with
+`IFA_F_NOPREFIXROUTE` to suppress the kernel's auto-created connected route for the wider
+mask — otherwise this would reintroduce the subnet-router-anycast hazard that `/32` avoids
+elsewhere. See [docs/cni/configuration.md](../cni/configuration.md) for details.
+
 The result is printed to Multus **before** SRv6 ingress setup and BGP CRD publish run
 (see [docs/cni-cmd-sequence.md](../cni-cmd-sequence.md)) — a successful ADD response does not
 guarantee the BGPAdvertisement/BGPVRFInstance CRDs exist yet.

--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -137,6 +137,16 @@ and then `publishBGPStateK8s` to create the SRv6 ingress route and
 VM still configures its own IP addresses independently (the CNI-allocated
 subnet/gateway describe only the host-side BGP-advertised state).
 
+The IPv4 gateway address on the host tap is a `/25`, not the `/32` used
+everywhere else (veth's host/guest gateways, and the pod's own address in both
+modes). VM guests expect the gateway to look like a real subnet rather than a
+bare host route. Because a wider mask would normally make the kernel
+auto-install a connected route for the whole `/25` in the VRF table — exactly
+the subnet-router-anycast hazard the `/32` choice exists to avoid elsewhere —
+the address is added with `IFA_F_NOPREFIXROUTE`, which suppresses that
+auto-created route. The explicit pod-subnet `/32` route `configureHostGateway`
+installs remains the only route governing delivery to the VM's address.
+
 > **Note:** Tap mode is intended for VM-based workloads (Kata, Firecracker,
 > QEMU) where the hypervisor opens the tap fd and handles guest networking.
 

--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -438,9 +439,10 @@ func routeConflicts(existing, desired *netlink.Route) bool {
 }
 
 // configureHostGateway assigns each configured family's gateway address as a
-// host address (/128 for IPv6, /32 for IPv4) on the host-side interface (veth
-// or tap) and installs an explicit pod-subnet route for that family into the
-// VRF table. IPv4 is skipped entirely when the attachment is IPv6-only.
+// host address (/128 for IPv6, /32 for IPv4 on veth) on the host-side
+// interface (veth or tap) and installs an explicit pod-subnet route for that
+// family into the VRF table. IPv4 is skipped entirely when the attachment is
+// IPv6-only.
 //
 // Using a full-length host address (not the pod subnet mask) prevents the
 // kernel from auto-creating a subnet-router anycast entry in the VRF local
@@ -448,6 +450,13 @@ func routeConflicts(existing, desired *netlink.Route) bool {
 // absorbs seg6local-decapped inner packets before they reach the guest
 // interface. The explicit subnet route replaces the one the kernel would
 // have created from the wider mask.
+//
+// For tap interfaces, the IPv4 gateway is instead assigned as a /25 so the
+// address reported on the interface reflects a real subnet (VM guests expect
+// this). That reintroduces the wider-mask hazard described above, so the
+// address is added with IFA_F_NOPREFIXROUTE: the kernel skips auto-creating
+// the connected /25 route entirely, leaving the explicit pod-subnet route
+// below as the only thing that governs delivery to this VM's address.
 func configureHostGateway(vpc, vpcAttachment string, res *ipamResult) error {
 	if res == nil {
 		return nil
@@ -464,27 +473,44 @@ func configureHostGateway(vpc, vpcAttachment string, res *ipamResult) error {
 
 	if res.ipv6Gateway != nil {
 		gwNet := &net.IPNet{IP: res.ipv6Gateway, Mask: net.CIDRMask(128, 128)}
-		if err := installGatewayRoute(hostLink, gwNet, res.ipv6Subnet, netlink.FAMILY_V6, int(tableID)); err != nil {
+		if err := installGatewayRoute(hostLink, gwNet, res.ipv6Subnet, netlink.FAMILY_V6, int(tableID), 0); err != nil {
 			return err
 		}
 	}
 	if res.ipv4Gateway != nil {
-		gwNet := &net.IPNet{IP: res.ipv4Gateway, Mask: net.CIDRMask(32, 32)}
+		ipv4Mask, addrFlags := ipv4GatewayAddrParams(hostLink)
+		gwNet := &net.IPNet{IP: res.ipv4Gateway, Mask: ipv4Mask}
 		ipv4Subnet := &net.IPNet{IP: res.ipv4Address, Mask: net.CIDRMask(32, 32)}
-		if err := installGatewayRoute(hostLink, gwNet, ipv4Subnet, netlink.FAMILY_V4, int(tableID)); err != nil {
+		if err := installGatewayRoute(hostLink, gwNet, ipv4Subnet, netlink.FAMILY_V4, int(tableID), addrFlags); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// ipv4GatewayAddrParams returns the IPv4 gateway mask and netlink address
+// flags to use for hostLink. Tap interfaces get a /25 (so the address
+// reported on the interface reflects a real subnet) with
+// IFA_F_NOPREFIXROUTE, which stops the kernel from auto-creating a connected
+// route for the wider mask — see the anycast-avoidance note on
+// configureHostGateway for why that route must not exist. Veth interfaces
+// keep the plain /32 host address with no flags.
+func ipv4GatewayAddrParams(hostLink netlink.Link) (net.IPMask, int) {
+	if _, isTap := hostLink.(*netlink.Tuntap); isTap {
+		return net.CIDRMask(25, 32), unix.IFA_F_NOPREFIXROUTE
+	}
+	return net.CIDRMask(32, 32), 0
+}
+
 // installGatewayRoute assigns gwNet as a host address on hostLink and
 // installs an explicit route to subnet into the given VRF table, for one
 // address family. Idempotent: existing matching routes/addresses are left
 // alone, and conflicting ones return an error rather than being overwritten.
-func installGatewayRoute(hostLink netlink.Link, gwNet, subnet *net.IPNet, family, tableID int) error {
+// addrFlags is passed through to the netlink address (e.g. IFA_F_NOPREFIXROUTE
+// to suppress the kernel's auto-created connected route for a wider mask).
+func installGatewayRoute(hostLink netlink.Link, gwNet, subnet *net.IPNet, family, tableID, addrFlags int) error {
 	hostName := hostLink.Attrs().Name
-	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet}); err != nil {
+	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet, Flags: addrFlags}); err != nil {
 		if !errors.Is(err, syscall.EEXIST) {
 			return fmt.Errorf("add gateway address %s to host interface %q: %w", gwNet, hostName, err)
 		}

--- a/internal/cni/bgp_test.go
+++ b/internal/cni/bgp_test.go
@@ -10,11 +10,48 @@ import (
 	"testing"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
+
+// ---- ipv4GatewayAddrParams ------------------------------------------------
+
+func TestIPv4GatewayAddrParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		hostLink  netlink.Link
+		wantMask  net.IPMask
+		wantFlags int
+	}{
+		{
+			name:      "tap gets /25 with NOPREFIXROUTE",
+			hostLink:  &netlink.Tuntap{LinkAttrs: netlink.LinkAttrs{Name: "tap0"}},
+			wantMask:  net.CIDRMask(25, 32),
+			wantFlags: unix.IFA_F_NOPREFIXROUTE,
+		},
+		{
+			name:      "veth gets /32 with no flags",
+			hostLink:  &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "veth0"}},
+			wantMask:  net.CIDRMask(32, 32),
+			wantFlags: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMask, gotFlags := ipv4GatewayAddrParams(tt.hostLink)
+			if gotMask.String() != tt.wantMask.String() {
+				t.Errorf("mask = %v, want %v", gotMask, tt.wantMask)
+			}
+			if gotFlags != tt.wantFlags {
+				t.Errorf("flags = %v, want %v", gotFlags, tt.wantFlags)
+			}
+		})
+	}
+}
 
 // ---- routeConflicts ------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Tap-mode workloads (Kata, Firecracker, QEMU) got an IPv4 gateway address that looked like a bare host route (`/32`), when VM guests generally expect a gateway that looks like a real subnet. This widens the gateway mask to `/25` for tap interfaces only — veth is unchanged.

A wider mask would normally make the kernel auto-install a connected route for the whole `/25` in the VRF table, reintroducing the subnet-router-anycast hazard the `/32` choice was originally meant to avoid (seg6local-decapped packets getting absorbed before reaching the guest). To avoid that, the address is added with `IFA_F_NOPREFIXROUTE`, which suppresses the auto-created route — the existing explicit pod-subnet `/32` route remains the only thing governing delivery to the VM's address.

## Test plan

- [x] `task build`, `task lint`, `task test:unit` pass
- [x] New unit test (`TestIPv4GatewayAddrParams`) covers both the tap (`/25` + `IFA_F_NOPREFIXROUTE`) and veth (`/32`, no flags) cases
- [ ] `task test:e2e` / manual verification against a real tap-mode deployment: confirm `ip addr show <tap>` reports `/25` and `ip route show table <vrf>` has no kernel-auto-created connected route for the block