### PR TITLE
feat(cni): report tap IPv4 address as /25 in CNI result

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -1153,6 +1153,43 @@ func TestBuildTapResult(t *testing.T) {
 	}
 }
 
+// TestBuildTapResultIPv4Mask verifies that buildTapResult reports the IPv4
+// address with a /25 mask (matching the host gateway mask
+// ipv4GatewayAddrParams installs on the tap interface), not the /32 used for
+// veth.
+func TestBuildTapResultIPv4Mask(t *testing.T) {
+	ipv4Address := net.ParseIP("172.20.1.5")
+	ipv4Gateway := net.ParseIP("172.20.1.1")
+	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+
+	conf := &PluginConf{
+		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
+		VPC:           testVPC,
+		VPCAttachment: testAttachment,
+	}
+	ipRes := &ipamResult{
+		ipv4Address: ipv4Address,
+		ipv4Gateway: ipv4Gateway,
+		routes:      []*net.IPNet{ipv4Route},
+	}
+
+	result := buildTapResult(conf, ipRes, "H0abc123", "aa:bb:cc:dd:ee:ff", 1500)
+
+	if len(result.IPs) != 1 {
+		t.Fatalf("IPs count = %d, want 1", len(result.IPs))
+	}
+	wantIPv4Mask := net.CIDRMask(25, 32).String()
+	if result.IPs[0].Address.IP.String() != ipv4Address.String() || result.IPs[0].Address.Mask.String() != wantIPv4Mask {
+		t.Errorf("IPs[0].Address = %v, want %s/25", result.IPs[0].Address, ipv4Address)
+	}
+	if !result.IPs[0].Gateway.Equal(ipv4Gateway) {
+		t.Errorf("IPs[0].Gateway = %v, want %v", result.IPs[0].Gateway, ipv4Gateway)
+	}
+	if result.IPs[0].Interface == nil || *result.IPs[0].Interface != 0 {
+		t.Errorf("IPs[0].Interface = %v, want 0 (host tap)", result.IPs[0].Interface)
+	}
+}
+
 // TestBuildTapResultHostNetns verifies that the tap path produces a valid
 // CNI result when args.Netns is the host network namespace. Kraftlet/unikraft
 // workloads pass the host netns because they don't have a Linux network

--- a/internal/cni/result.go
+++ b/internal/cni/result.go
@@ -40,14 +40,18 @@ func buildResult(
 			},
 		},
 	}
-	appendIPConfigs(result, ipRes, 1) // index into Interfaces (guest veth)
+	appendIPConfigs(result, ipRes, 1, net.CIDRMask(32, 32)) // index into Interfaces (guest veth)
 	return result
 }
 
 // appendIPConfigs adds one IPConfig per allocated address family in ipRes
 // (IPv6, and IPv4 when present) plus any default routes, all pointing at the
-// given Interfaces index. No-op when ipRes is nil.
-func appendIPConfigs(result *type100.Result, ipRes *ipamResult, ifaceIndex int) {
+// given Interfaces index. ipv4Mask sets the prefix length reported for the
+// IPv4 address — /32 for veth, /25 for tap (matching the host gateway mask
+// installed by ipv4GatewayAddrParams, so downstream consumers such as
+// kraftlet configure the guest with the same real subnet the host side
+// advertises). No-op when ipRes is nil.
+func appendIPConfigs(result *type100.Result, ipRes *ipamResult, ifaceIndex int, ipv4Mask net.IPMask) {
 	if ipRes == nil {
 		return
 	}
@@ -60,7 +64,7 @@ func appendIPConfigs(result *type100.Result, ipRes *ipamResult, ifaceIndex int) 
 	}
 	if ipRes.ipv4Address != nil {
 		result.IPs = append(result.IPs, &type100.IPConfig{
-			Address:   net.IPNet{IP: ipRes.ipv4Address, Mask: net.CIDRMask(32, 32)},
+			Address:   net.IPNet{IP: ipRes.ipv4Address, Mask: ipv4Mask},
 			Gateway:   ipRes.ipv4Gateway,
 			Interface: type100.Int(ifaceIndex),
 		})
@@ -125,7 +129,9 @@ func buildVethResult(
 
 // buildTapResult constructs the CNI result for tap mode: a single host
 // interface with optional IPAM data. The guest VM manages its own interface;
-// the IP here describes the allocated subnet for BGP advertisement.
+// the IP here describes the allocated subnet for BGP advertisement. The IPv4
+// address is reported with a /25 mask, matching the mask
+// ipv4GatewayAddrParams installs on the host side of the tap (see bgp.go).
 func buildTapResult(
 	pluginConf *PluginConf,
 	ipRes *ipamResult,
@@ -143,6 +149,6 @@ func buildTapResult(
 			},
 		},
 	}
-	appendIPConfigs(result, ipRes, 0) // index into Interfaces (host tap)
+	appendIPConfigs(result, ipRes, 0, net.CIDRMask(25, 32)) // index into Interfaces (host tap)
 	return result
 }


### PR DESCRIPTION
## Summary

`galactic-cni`'s CNI result always reports the pod's IPv4 address with a
`/32` mask, for both veth and tap interfaces. For tap this no longer matched
reality: #277 widened the *host-side* gateway address on the tap interface to
`/25` so it reflects a real subnet, but the CNI result handed back to the
runtime (and, for tap, to kraftlet — which reads it to configure the guest
VM) kept reporting `/32`. That told the guest it owned a single
point-to-point address rather than the wider on-link subnet the host side
advertises.

This widens the IPv4 mask in the CNI result to `/25` for tap only, mirroring
the existing veth/tap split already used for the host gateway mask
(`ipv4GatewayAddrParams` in `bgp.go`). veth keeps `/32`.

## Changes

- `appendIPConfigs` takes an `ipv4Mask` parameter instead of hardcoding `/32`
- `buildResult` (veth) passes `/32`; `buildTapResult` passes `/25`
- Added `TestBuildTapResultIPv4Mask` — no existing test exercised the tap
  IPv4 path at all (only IPv6 was covered)

## Test plan

- [x] `go test ./internal/cni/...` passes, including new and existing
      `buildResult`/`buildTapResult` coverage
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Verify against a live tap workload that kraftlet configures the guest
      interface with the `/25` mask as expected