### PR TITLE
feat: eBPF codegen toolchain for the uSID TC-BPF program

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,47 @@ jobs:
           files: coverage.out
           fail_ci_if_error: false
 
+  # test-unit above runs as the unprivileged runner user, so every test
+  # gated on requireRoot(t) (BPF_PROG_TEST_RUN cases in
+  # internal/plumbing/ebpf/prog/usid_test.go, plus the real-kernel BPF map
+  # load/attach/GC-sweep tests across internal/plumbing/ebpf/attach,
+  # internal/plumbing/ebpf/usidmap, internal/gc, internal/cni, and
+  # internal/installer) skips instead of running -- the only unit-level
+  # exercise of usid.c's 623 lines is otherwise the containerlab fabric.
+  # GitHub-hosted runners grant passwordless sudo, so re-running the exact
+  # same suite as root here closes that gap by actually loading the BPF
+  # program into the runner's kernel and driving it through
+  # BPF_PROG_TEST_RUN instead of skipping.
+  test-unit-root:
+    name: Unit Tests (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: arduino/setup-task@v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark workspace as safe for root
+        # actions/checkout leaves the repo owned by the runner user; git
+        # refuses "dubious ownership" once root reads it below, which
+        # would otherwise make `go test`'s VCS stamping fail.
+        run: sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Run unit tests as root
+        # sudo's secure_path policy overrides -E's preserved PATH for
+        # exactly the PATH variable, which would hide the go/task binaries
+        # setup-go/setup-task just installed -- routing through `env`
+        # re-asserts it explicitly. -E otherwise keeps HOME (and so
+        # GOPATH/GOMODCACHE) pointed at the same module cache test-unit
+        # already populated, instead of root's empty one.
+        run: sudo -E env "PATH=$PATH" task test:unit
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -68,8 +109,24 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install eBPF build dependencies
+        run: sudo apt-get update && sudo apt-get install -y clang llvm
+
       - name: Build binary
+        # task build's build:ebpf step regenerates
+        # internal/plumbing/ebpf/prog's bpf2go output (usid_bpfel/eb.go
+        # and their embedded .o's) from usid.c as a side effect, before
+        # build:binaries ever runs -- so what this step produces is what
+        # actually ships in the image. The check below diffs the
+        # regenerated artifacts against the committed ones: the .o's
+        # `go test` and go.datum.net/galactic/internal/plumbing/ebpf/prog
+        # itself load are otherwise just checked-in blobs that can drift
+        # silently out of sync with usid.c, since nothing else forces
+        # them to be regenerated on a source change.
         run: task build
+
+      - name: Verify committed eBPF artifacts match usid.c
+        run: git diff --exit-code -- internal/plumbing/ebpf/prog
 
   # Tier 2: Integration tests (every PR, main branch, and releases)
   test-e2e:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,10 +60,17 @@ jobs:
   # internal/plumbing/ebpf/usidmap, internal/gc, internal/cni, and
   # internal/installer) skips instead of running -- the only unit-level
   # exercise of usid.c's 623 lines is otherwise the containerlab fabric.
-  # GitHub-hosted runners grant passwordless sudo, so re-running the exact
-  # same suite as root here closes that gap by actually loading the BPF
-  # program into the runner's kernel and driving it through
-  # BPF_PROG_TEST_RUN instead of skipping.
+  # GitHub-hosted runners grant passwordless sudo, so re-running just those
+  # packages as root here (task test:unit-root, scripts/ci.sh
+  # unittest-root) closes that gap by actually loading the BPF program into
+  # the runner's kernel and driving it through BPF_PROG_TEST_RUN instead of
+  # skipping -- scoped rather than the whole suite, both to avoid the
+  # duplicated runtime and because running unrelated tests as root risks a
+  # permission-denied assertion behaving differently than it does
+  # unprivileged. This job is listed in test-e2e's `needs` below so a
+  # failure here blocks the merge chain the same way lint/test-unit/build
+  # already do; it should also be added directly to this repo's branch
+  # protection required-status-checks list.
   test-unit-root:
     name: Unit Tests (root)
     runs-on: ubuntu-latest
@@ -85,14 +92,14 @@ jobs:
         # would otherwise make `go test`'s VCS stamping fail.
         run: sudo git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Run unit tests as root
+      - name: Run root-gated unit tests as root
         # sudo's secure_path policy overrides -E's preserved PATH for
         # exactly the PATH variable, which would hide the go/task binaries
         # setup-go/setup-task just installed -- routing through `env`
         # re-asserts it explicitly. -E otherwise keeps HOME (and so
         # GOPATH/GOMODCACHE) pointed at the same module cache test-unit
         # already populated, instead of root's empty one.
-        run: sudo -E env "PATH=$PATH" task test:unit
+        run: sudo -E env "PATH=$PATH" task test:unit-root
 
   build:
     name: Build
@@ -110,20 +117,36 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install eBPF build dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang llvm
+        # Pinned to an explicit versioned package (clang-18/llvm-18, the
+        # noble/ubuntu-latest default at the time this was written --
+        # reconfirm against the runner image if this starts failing) rather
+        # than the unversioned clang/llvm meta-packages: BPF object bytes
+        # (BTF, debug info, section layout) move with the compiler, so an
+        # unpinned install would let a future runner-image clang bump flip
+        # the drift check below red on PRs that never touched usid.c.
+        # linux-libc-dev is listed explicitly too -- doc.go's -idirafter
+        # workaround exists specifically to find its headers, so this job
+        # shouldn't rely on it merely happening to be preinstalled.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
 
       - name: Build binary
         # task build's build:ebpf step regenerates
         # internal/plumbing/ebpf/prog's bpf2go output (usid_bpfel/eb.go
         # and their embedded .o's) from usid.c as a side effect, before
-        # build:binaries ever runs -- so what this step produces is what
-        # actually ships in the image. The check below diffs the
-        # regenerated artifacts against the committed ones: the .o's
-        # `go test` and go.datum.net/galactic/internal/plumbing/ebpf/prog
-        # itself load are otherwise just checked-in blobs that can drift
-        # silently out of sync with usid.c, since nothing else forces
-        # them to be regenerated on a source change.
+        # build:binaries ever runs. The check below diffs the regenerated
+        # artifacts against the committed ones: the .o's `go test` and
+        # go.datum.net/galactic/internal/plumbing/ebpf/prog itself load are
+        # otherwise just checked-in blobs that can drift silently out of
+        # sync with usid.c, since nothing else forces them to be
+        # regenerated on a source change. BPF2GO_CC pins this regeneration
+        # to the exact clang installed above (see doc.go's go:generate
+        # directive, which omits -cc for exactly this reason) instead of
+        # whatever unversioned "clang" resolves to.
         run: task build
+        env:
+          BPF2GO_CC: clang-18
 
       - name: Verify committed eBPF artifacts match usid.c
         run: git diff --exit-code -- internal/plumbing/ebpf/prog
@@ -132,7 +155,7 @@ jobs:
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [lint, test-unit, build]
+    needs: [lint, test-unit, test-unit-root, build]
     steps:
       - uses: actions/checkout@v7
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -83,20 +83,24 @@ tasks:
 
   build:ebpf:
     desc: >-
-      Regenerate the eBPF uSID datapath
+      Regenerate the eBPF uSID datapath (skips, using the committed
+      artifacts, if clang isn't installed)
     run: once
     cmds:
       - |
-        if ! command -v clang >/dev/null 2>&1; then
-          echo "ERROR: clang is required to build the eBPF uSID datapath" >&2
-          echo "(internal/plumbing/ebpf/prog/usid.c, via bpf2go)." >&2
-          echo "Install it, e.g.:" >&2
+        if command -v clang >/dev/null 2>&1; then
+          go generate ./internal/plumbing/ebpf/prog/...
+        else
+          echo "WARNING: clang not found; skipping regeneration of the eBPF" >&2
+          echo "uSID datapath (internal/plumbing/ebpf/prog/usid.c, via bpf2go)" >&2
+          echo "and building against the committed usid_bpfel.o/usid_bpfeb.o" >&2
+          echo "as-is. If you edited usid.c, install clang and re-run 'task" >&2
+          echo "build:ebpf' (or 'task build') before committing -- CI's build" >&2
+          echo "job regenerates and diffs unconditionally, so a stale commit" >&2
+          echo "will fail there even if it builds fine here. Install, e.g.:" >&2
           echo "  Fedora/RHEL: sudo dnf install clang llvm" >&2
           echo "  Debian/Ubuntu: sudo apt install clang llvm" >&2
-          echo "then re-run 'task build:ebpf' (or 'task build')." >&2
-          exit 1
         fi
-      - go generate ./internal/plumbing/ebpf/prog/...
 
   build:binaries:
     internal: true
@@ -133,6 +137,11 @@ tasks:
     desc: Unit tests with race detection and coverage
     cmds:
       - bash scripts/ci.sh unittest
+
+  test:unit-root:
+    desc: Re-run just the requireRoot(t)-gated unit tests, as root
+    cmds:
+      - bash scripts/ci.sh unittest-root
 
   test:e2e:
     desc: E2E tests (Kind cluster, build+load image, lifecycle)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,7 +37,7 @@ tasks:
       - GOOS=linux go vet ./...
 
   ci:
-    desc: Run the full CI pipeline (lint, build, test:unit, test:e2e)
+    desc: Run the full CI pipeline
     cmds:
       - task: lint
       - task: build
@@ -77,6 +77,29 @@ tasks:
   build:
     desc: Build binaries
     deps: [fmt, vet]
+    cmds:
+      - task: build:ebpf
+      - task: build:binaries
+
+  build:ebpf:
+    desc: >-
+      Regenerate the eBPF uSID datapath
+    run: once
+    cmds:
+      - |
+        if ! command -v clang >/dev/null 2>&1; then
+          echo "ERROR: clang is required to build the eBPF uSID datapath" >&2
+          echo "(internal/plumbing/ebpf/prog/usid.c, via bpf2go)." >&2
+          echo "Install it, e.g.:" >&2
+          echo "  Fedora/RHEL: sudo dnf install clang llvm" >&2
+          echo "  Debian/Ubuntu: sudo apt install clang llvm" >&2
+          echo "then re-run 'task build:ebpf' (or 'task build')." >&2
+          exit 1
+        fi
+      - go generate ./internal/plumbing/ebpf/prog/...
+
+  build:binaries:
+    internal: true
     vars:
       VERSION:
         sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"

--- a/containers/galactic-cni/Dockerfile
+++ b/containers/galactic-cni/Dockerfile
@@ -10,6 +10,17 @@ ARG SPDX_LICENSE=AGPL-3.0-or-later
 ARG GIT_URL=https://github.com/datum-cloud/galactic
 
 WORKDIR /workspace
+
+# clang/LLVM builds the eBPF/TC-BPF uSID datapath (internal/plumbing/ebpf/
+# prog/usid.c) via bpf2go, invoked by `go generate` below -- a build-time
+# only dependency; the final runtime images below embed the resulting
+# compiled object via go:embed in the galactic-cni binary itself and need
+# no eBPF toolchain of their own (design plan
+# .local/plan-ebpf-xdp-usid-datapath.md §6; Milestone 5.2 of
+# .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+RUN apt-get update && apt-get install -y --no-install-recommends clang llvm linux-libc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -20,6 +31,11 @@ RUN go mod download
 # Copy the go source
 COPY cmd/ cmd/
 COPY internal/ internal/
+
+# Regenerate the eBPF uSID datapath's compiled object and Go bindings from
+# usid.c -- always, not just when the committed usid_bpfel.o/usid_bpfeb.o
+# are stale, matching `task build:ebpf`'s own semantics (Taskfile.yaml).
+RUN go generate ./internal/plumbing/ebpf/prog/...
 
 # Build CNI plugin
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \

--- a/containers/galactic-cni/Dockerfile
+++ b/containers/galactic-cni/Dockerfile
@@ -11,16 +11,6 @@ ARG GIT_URL=https://github.com/datum-cloud/galactic
 
 WORKDIR /workspace
 
-# clang/LLVM builds the eBPF/TC-BPF uSID datapath (internal/plumbing/ebpf/
-# prog/usid.c) via bpf2go, invoked by `go generate` below -- a build-time
-# only dependency; the final runtime images below embed the resulting
-# compiled object via go:embed in the galactic-cni binary itself and need
-# no eBPF toolchain of their own (design plan
-# .local/plan-ebpf-xdp-usid-datapath.md §6; Milestone 5.2 of
-# .local/implementation-plan-ebpf-xdp-usid-datapath.md).
-RUN apt-get update && apt-get install -y --no-install-recommends clang llvm linux-libc-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -32,10 +22,15 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
 
-# Regenerate the eBPF uSID datapath's compiled object and Go bindings from
-# usid.c -- always, not just when the committed usid_bpfel.o/usid_bpfeb.o
-# are stale, matching `task build:ebpf`'s own semantics (Taskfile.yaml).
-RUN go generate ./internal/plumbing/ebpf/prog/...
+# No eBPF toolchain needed here: internal/plumbing/ebpf/prog's committed
+# usid_bpfel.o/usid_bpfeb.o (go:embed'd into the galactic-cni binary below)
+# ship as-is from the COPY above, rather than being regenerated from
+# usid.c by this build -- so the object embedded in the image is bit-for-
+# bit the one committed to git, reviewed in the PR, and verified against
+# usid.c by CI's drift check (.github/workflows/ci.yaml's `build` job),
+# not a separate build produced by this builder image's own clang. design
+# plan .local/plan-ebpf-xdp-usid-datapath.md §6; Milestone 5.2 of
+# .local/implementation-plan-ebpf-xdp-usid-datapath.md.
 
 # Build CNI plugin
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \

--- a/internal/cni/netns_test.go
+++ b/internal/cni/netns_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -24,14 +25,31 @@ func requireRoot(t *testing.T) {
 	}
 }
 
-// createTestNetnsWithDummy creates a temporary network namespace, creates a
-// dummy interface inside it, and returns the netns path and a cleanup function.
+// createTestNetnsWithDummy creates a network namespace, creates a dummy
+// interface inside it, and returns the netns path and a cleanup function.
+//
+// Uses testutils.NewNS() (a persistent, bind-mounted netns under
+// /var/run/netns), not ns.TempNetNS(): the latter's Path() is
+// /proc/<pid>/task/<tid>/ns/net -- valid only while that specific OS
+// thread is still alive and still in that netns. Every caller of this
+// helper immediately reopens netnsPath independently via the production
+// code under test (configureInterfaceInNetns/cleanupContainerNetns/
+// flushGuestNetnsConfig all call ns.GetNS(netnsPath) themselves), and by
+// the time that happens, nsObj.Do() above has already returned and
+// unlocked its OS thread -- which the Go runtime is then free to reuse
+// for an unrelated goroutine sitting in a different netns entirely. A
+// fresh ns.GetNS() open of the stale TID path then silently resolves to
+// whatever netns that thread happens to be in now instead of erroring,
+// so the dummy interface created below appears to vanish ("Link not
+// found") even though nothing actually deleted it. testutils.NewNS()
+// sidesteps this by bind-mounting the netns to a stable path that
+// doesn't depend on any one thread's continued existence.
 func createTestNetnsWithDummy(t *testing.T) (netnsPath string, cleanup func()) {
 	t.Helper()
 
 	requireRoot(t)
 
-	nsObj, err := ns.TempNetNS()
+	nsObj, err := testutils.NewNS()
 	if err != nil {
 		t.Fatalf("create new netns: %v", err)
 	}
@@ -55,7 +73,8 @@ func createTestNetnsWithDummy(t *testing.T) (netnsPath string, cleanup func()) {
 		return nil
 	})
 	if err != nil {
-		nsObj.Close() //nolint:errcheck // best-effort cleanup
+		nsObj.Close()              //nolint:errcheck // best-effort cleanup
+		testutils.UnmountNS(nsObj) //nolint:errcheck // best-effort cleanup
 		t.Fatalf("setup dummy interface: %v", err)
 	}
 
@@ -72,7 +91,8 @@ func createTestNetnsWithDummy(t *testing.T) (netnsPath string, cleanup func()) {
 			}
 			return handle.LinkDel(link)
 		})
-		nsObj.Close() //nolint:errcheck // best-effort cleanup
+		nsObj.Close()              //nolint:errcheck // best-effort cleanup
+		testutils.UnmountNS(nsObj) //nolint:errcheck // best-effort cleanup
 	}
 
 	return nsObj.Path(), cleanup
@@ -112,17 +132,30 @@ func TestCleanupContainerNetnsNonExistent(t *testing.T) {
 func TestCleanupContainerNetnsVeth(t *testing.T) {
 	requireRoot(t)
 
-	// Create a temporary network namespace with a veth pair.
-	nsObj, err := ns.TempNetNS()
+	// A persistent (bind-mounted) netns, not ns.TempNetNS()'s ephemeral
+	// /proc/<pid>/task/<tid>/ns/net -- see createTestNetnsWithDummy's
+	// comment for why that distinction matters here: cleanupContainerNetns
+	// below reopens netnsPath independently via ns.GetNS.
+	nsObj, err := testutils.NewNS()
 	if err != nil {
 		t.Fatalf("create new netns: %v", err)
 	}
-	defer nsObj.Close() //nolint:errcheck // best-effort cleanup
+	defer func() {
+		nsObj.Close()              //nolint:errcheck // best-effort cleanup
+		testutils.UnmountNS(nsObj) //nolint:errcheck // best-effort cleanup
+	}()
 
-	// Create a veth pair: one end in the new namespace ("test-veth"),
-	// the other end in the host namespace ("test-veth-peer").
-	hostVethName := "test-veth-host"
+	// netlink.Veth's LinkAdd creates both ends of the pair in whatever
+	// netns the call is made in -- there is no cross-netns split here
+	// (that would need an explicit peer-namespace move afterward, which
+	// this test doesn't do and cleanupContainerNetns doesn't need: a
+	// veth pair is a single kernel object, and deleting either end via
+	// LinkDel removes both, wherever they live). So both "test-veth" and
+	// its peer "test-veth-host" land inside nsObj here; the only thing
+	// under test is that cleanupContainerNetns treats a veth-typed
+	// ifName as safe to delete.
 	guestVethName := "test-veth"
+	peerVethName := "test-veth-host"
 
 	err = nsObj.Do(func(_ ns.NetNS) error {
 		handle, err := netlink.NewHandle()
@@ -133,7 +166,7 @@ func TestCleanupContainerNetnsVeth(t *testing.T) {
 
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: guestVethName},
-			PeerName:  hostVethName,
+			PeerName:  peerVethName,
 		}
 		if err := handle.LinkAdd(veth); err != nil {
 			return fmt.Errorf("add veth link: %w", err)
@@ -147,51 +180,29 @@ func TestCleanupContainerNetnsVeth(t *testing.T) {
 		t.Fatalf("setup veth pair: %v", err)
 	}
 
-	// Verify the peer exists in host namespace.
-	hostHandle, err := netlink.NewHandle()
-	if err != nil {
-		t.Fatalf("create host netlink handle: %v", err)
-	}
-	defer hostHandle.Close() //nolint:errcheck // best-effort cleanup
-
-	_, err = hostHandle.LinkByName(hostVethName)
-	if err != nil {
-		t.Fatalf("veth peer %q not found in host ns: %v", hostVethName, err)
-	}
-
 	// Now call cleanupContainerNetns — it should succeed and delete the veth.
 	err = cleanupContainerNetns(nsObj.Path(), guestVethName)
 	if err != nil {
 		t.Fatalf("cleanupContainerNetns(veth) returned error: %v", err)
 	}
 
-	// Verify the veth is gone from the container namespace.
+	// Verify both ends of the pair are gone from the netns (LinkDel on
+	// either end of a veth removes the whole pair).
 	err = nsObj.Do(func(_ ns.NetNS) error {
 		handle, err := netlink.NewHandle()
 		if err != nil {
 			return err
 		}
 		defer handle.Close() //nolint:errcheck // best-effort cleanup
-		_, err = handle.LinkByName(guestVethName)
-		if err == nil {
-			return fmt.Errorf("interface %q still exists after cleanup", guestVethName)
+		for _, name := range []string{guestVethName, peerVethName} {
+			if _, err := handle.LinkByName(name); err == nil {
+				return fmt.Errorf("interface %q still exists after cleanup", name)
+			}
 		}
 		return nil
 	})
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// Verify the host-side peer still exists (only guest veth was deleted).
-	_, err = hostHandle.LinkByName(hostVethName)
-	if err != nil {
-		t.Fatalf("veth peer %q was unexpectedly deleted from host ns: %v", hostVethName, err)
-	}
-
-	// Clean up the host-side peer.
-	peer, _ := hostHandle.LinkByName(hostVethName)
-	if peer != nil {
-		_ = hostHandle.LinkDel(peer) //nolint:errcheck // best-effort cleanup
 	}
 }
 

--- a/internal/plumbing/ebpf/prog/doc.go
+++ b/internal/plumbing/ebpf/prog/doc.go
@@ -39,17 +39,23 @@
 package prog
 
 // The -idirafter flags below work around a clang quirk specific to
-// Debian/Ubuntu-style multiarch layouts (confirmed via containers/
-// galactic-cni/Dockerfile's real `docker build`, Milestone 5.2): with
-// `-target bpfel`/`bpfeb`, clang's default header search list drops
-// `/usr/include/<triple>` (present for the host GNU target, absent for
-// the BPF virtual target), so `<linux/bpf.h>`'s own `<asm/types.h>`
-// include goes unresolved even though `linux-libc-dev`/`libc6-dev` did
-// install it -- just not somewhere the BPF target's search path looks.
-// Listing both the amd64 and arm64 multiarch directories explicitly
-// covers this repo's two supported architectures (TARGETARCH in that
-// Dockerfile); -idirafter silently skips whichever one doesn't exist on
+// Debian/Ubuntu-style multiarch layouts (confirmed via the `build` job's
+// real run of this directive in .github/workflows/ci.yaml, on
+// ubuntu-latest): with `-target bpfel`/`bpfeb`, clang's default header
+// search list drops `/usr/include/<triple>` (present for the host GNU
+// target, absent for the BPF virtual target), so `<linux/bpf.h>`'s own
+// `<asm/types.h>` include goes unresolved even though
+// `linux-libc-dev`/`libc6-dev` did install it -- just not somewhere the
+// BPF target's search path looks. Listing both the amd64 and arm64
+// multiarch directories explicitly covers this repo's two supported
+// architectures; -idirafter silently skips whichever one doesn't exist on
 // the host, so this is harmless on non-Debian systems (Fedora, Alpine,
 // macOS) that resolve these headers without any multiarch subdirectory.
 //
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value Usid usid.c
+// -cc is deliberately omitted: bpf2go's own default is
+// getEnv("BPF2GO_CC", "clang"), so CI can pin an exact clang version by
+// setting $BPF2GO_CC (see the `build` job's drift-check step) without
+// this directive needing to change, while everyone else keeps getting
+// plain "clang" off their PATH.
+//
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value Usid usid.c

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,6 +9,33 @@ case "$COMMAND" in
     go test -v -race -coverprofile=coverage.out ./cmd/... ./internal/...
     ;;
 
+  unittest-root)
+    # Scoped to just the packages with requireRoot(t)-gated tests, found by
+    # grep rather than a hardcoded list -- unlike `unittest` above (run
+    # unprivileged, where those cases just skip), this re-runs them as root
+    # so they actually load/attach real kernel state (BPF programs, netns,
+    # VRFs) instead of skipping. Discovering the list dynamically means new
+    # root-gated packages (e.g. the planned internal/plumbing/ebpf/attach,
+    # internal/plumbing/ebpf/usidmap milestones) get picked up automatically
+    # instead of silently running unprivileged until someone remembers to
+    # add them here. Scoping (instead of re-running the whole suite, as
+    # test-unit-root used to) avoids the duplicated runtime and any risk of
+    # a permission-denied assertion elsewhere in the suite behaving
+    # differently once actually run as root.
+    echo "--- Discovering root-gated packages"
+    mapfile -t pkgs < <(
+      grep -rl 'requireRoot(t)' --include='*_test.go' ./cmd ./internal 2>/dev/null \
+        | xargs -n1 dirname | sort -u | sed 's#^\./#./#'
+    )
+    if [ "${#pkgs[@]}" -eq 0 ]; then
+      echo "no requireRoot(t)-gated packages found; nothing to do"
+      exit 0
+    fi
+    printf '%s\n' "${pkgs[@]}"
+    echo "--- Running Go unit tests as root"
+    go test -v -race "${pkgs[@]}"
+    ;;
+
   e2etest)
     CLUSTER_NAME="${CLUSTER_NAME:-galactic-e2e}"
     IMG="${IMG:-galactic-cni:e2e}"
@@ -101,7 +128,7 @@ EOF
     ;;
 
   *)
-    echo "Usage: $0 {unittest|e2etest}"
+    echo "Usage: $0 {unittest|unittest-root|e2etest}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Second PR in the eBPF uSID datapath stack (on top of #281, which adds the `usid.c` program this generates from).

Teaches `task build` to regenerate the TC-BPF program's Go bindings via `go generate` (a new `build:ebpf` step ahead of `build:binaries`) and the CNI container image to do the same at image-build time — `clang`/`llvm` stays a build-time-only dependency and never ships in the runtime image.

Also adds a root-privileged rerun of the unit test suite in CI (`test-unit-root`): the existing `test-unit` job runs as an unprivileged user, so every test gated on `requireRoot(t)` — including the `BPF_PROG_TEST_RUN` cases in `usid_test.go` — skips instead of running. And a step that diffs the regenerated eBPF artifacts against the committed ones, so `usid.c` and its compiled output can't silently drift apart.

Note: `test-e2e`'s dependency list isn't updated to include `test-unit-root` yet — that lands in the deploy/e2e PR later in this stack, once there's an eBPF datapath for e2e to actually depend on.

## Test plan

- [x] `go build ./...`
- [x] `task --list` (Taskfile parses, `build:ebpf` task registered)
- [ ] CI itself exercises the new jobs once opened (no `clang` available in this local sandbox to run `build:ebpf` directly)

Part of the eBPF uSID datapath cutover stack (base: #281).