### PR TITLE
fix: Merge BGPAdvertisement prefixes across shared containers

### DIFF
--- a/internal/cni/bgp.go
+++ b/internal/cni/bgp.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sort"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -317,6 +319,43 @@ func ipamAdvertisementPrefixes(ipamResult *ipamResult) (prefixes []string, ipv6S
 	return prefixes, ipv6Subnet, ipv4Addr
 }
 
+// allAdvertisedPrefixes derives the full set of BGP-advertised prefixes for
+// a BGPAdvertisement CRD from every subnet annotation currently present on
+// it, rather than from just the container currently being processed.
+//
+// A single BGPAdvertisement is keyed by (vpc, vpcAttachment) alone
+// (bgpAdvertisementName), so multiple containers attaching under the same
+// VPCAttachment on this node — a second pod, or a second interface with its
+// own vpcattachment reusing this one — all share one CRD. Each one's own
+// CNI ADD must not clobber another still-live container's already-published
+// prefix: annotations is the durable per-container record (subnetAnnotationKeyIPv6/IPv4),
+// so recomputing Spec.Prefixes from all of them on every ADD keeps every
+// live container's prefix present regardless of ADD order. cmdDel
+// deliberately leaves this annotation (and thus this prefix) in place even
+// after that container exits — see ops_del.go's "skipping shared resource
+// cleanup (handled by GC)" — so a stale entry for an exited container can
+// briefly outlive it until gc.CollectOrphanedCRDs removes the whole CRD
+// once every container sharing it is gone; that's a pre-existing tradeoff
+// this function doesn't change.
+func allAdvertisedPrefixes(annotations map[string]string) []string {
+	var prefixes []string
+	for key, value := range annotations {
+		switch {
+		case strings.HasPrefix(key, annotationAllocatedSubnetIPv6+"."):
+			prefixes = append(prefixes, value)
+		case strings.HasPrefix(key, annotationAllocatedSubnetIPv4+"."):
+			// Annotation stores the bare address (see ipamAdvertisementPrefixes);
+			// the advertised prefix needs the explicit /32 CIDR form.
+			prefixes = append(prefixes, value+"/32")
+		}
+	}
+	// Deterministic ordering: map iteration is randomized, and an
+	// unstable Spec.Prefixes order across otherwise-identical ADDs would
+	// look like a spurious spec change to anything diffing this CRD.
+	sort.Strings(prefixes)
+	return prefixes
+}
+
 // publishBGPStateK8s creates the BGPVRFInstance and BGPAdvertisement CRDs with
 // retry on transient k8s API errors. The host gateway must be configured before
 // calling this (via configureHostGateway). This is interface-agnostic and can be
@@ -382,8 +421,8 @@ func publishBGPStateK8s(
 			},
 		}
 		prefixes, ipv6Subnet, ipv4Addr := ipamAdvertisementPrefixes(ipamResult)
+		var mergedPrefixes []string
 		_, err = controllerutil.CreateOrUpdate(ctx, k8s, adv, func() error {
-			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, prefixes, vrfID)
 			if adv.Annotations == nil {
 				adv.Annotations = make(map[string]string)
 			}
@@ -401,6 +440,13 @@ func publishBGPStateK8s(
 			if ipv4Addr != "" {
 				adv.Annotations[subnetAnnotationKeyIPv4(args.ContainerID)] = ipv4Addr
 			}
+			// Recompute Spec.Prefixes from every container's annotations, not
+			// just this one's own — see allAdvertisedPrefixes. Must run after
+			// this container's own annotations are set above, and be read
+			// back into mergedPrefixes for the log line below since this
+			// closure may run more than once (RetryOnConflict).
+			mergedPrefixes = allAdvertisedPrefixes(adv.Annotations)
+			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, mergedPrefixes, vrfID)
 			return nil
 		})
 		if err != nil {
@@ -408,7 +454,7 @@ func publishBGPStateK8s(
 		}
 		tracker.advCreated = true
 		slog.Debug("BGP: BGPAdvertisement applied", "name", adv.Name, "namespace", namespace,
-			"prefixes", prefixes, "containerID", args.ContainerID)
+			"prefixes", mergedPrefixes, "addedPrefixes", prefixes, "containerID", args.ContainerID)
 
 		slog.Info("ADD: BGP state published", "containerID", args.ContainerID,
 			"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)

--- a/internal/cni/bgp_test.go
+++ b/internal/cni/bgp_test.go
@@ -6,6 +6,7 @@ package cni
 
 import (
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -333,6 +334,72 @@ func TestIPAMAdvertisementPrefixesDualStack(t *testing.T) {
 	}
 	if len(prefixes) != 2 || prefixes[0] != ipv6Subnet.String() || prefixes[1] != "10.128.0.5/32" {
 		t.Errorf("prefixes = %v, want [%q, \"10.128.0.5/32\"]", prefixes, ipv6Subnet.String())
+	}
+}
+
+// ---- allAdvertisedPrefixes ---------------------------------------------------
+
+func TestAllAdvertisedPrefixesEmpty(t *testing.T) {
+	if got := allAdvertisedPrefixes(nil); got != nil {
+		t.Errorf("prefixes = %v, want nil", got)
+	}
+	if got := allAdvertisedPrefixes(map[string]string{}); got != nil {
+		t.Errorf("prefixes = %v, want nil", got)
+	}
+}
+
+func TestAllAdvertisedPrefixesSingleContainer(t *testing.T) {
+	const v6, v4 = "fd00:20:ff01::1234/96", "172.20.1.5"
+	annotations := map[string]string{
+		netnsAnnotationKey("cid-a"):      testNetns,
+		subnetAnnotationKeyIPv6("cid-a"): v6,
+		subnetAnnotationKeyIPv4("cid-a"): v4,
+	}
+
+	got := allAdvertisedPrefixes(annotations)
+
+	want := []string{v4 + "/32", v6}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("prefixes = %v, want %v", got, want)
+	}
+}
+
+// TestAllAdvertisedPrefixesMultipleContainers is the regression test for the
+// bug this function fixes: a second container attaching under the same
+// (vpc, vpcAttachment) — and thus sharing this BGPAdvertisement CRD — must
+// not cause the first, still-live container's prefix to disappear from
+// Spec.Prefixes. See allAdvertisedPrefixes's doc comment.
+func TestAllAdvertisedPrefixesMultipleContainers(t *testing.T) {
+	const aV4, bV6, bV4 = "172.20.1.5", "fd00:20:ff01::1234/96", "172.21.1.2"
+	annotations := map[string]string{
+		netnsAnnotationKey("cid-a"):        testNetns,
+		subnetAnnotationKeyIPv4("cid-a"):   aV4,
+		netnsAnnotationKey("cid-b"):        testNetns,
+		subnetAnnotationKeyIPv6("cid-b"):   bV6,
+		subnetAnnotationKeyIPv4(("cid-b")): bV4,
+	}
+
+	got := allAdvertisedPrefixes(annotations)
+
+	want := []string{aV4 + "/32", bV4 + "/32", bV6}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("prefixes = %v, want %v (a second container's annotations must not drop the first's prefix)", got, want)
+	}
+}
+
+func TestAllAdvertisedPrefixesIgnoresOtherAnnotations(t *testing.T) {
+	const v4 = "172.20.1.5"
+	annotations := map[string]string{
+		netnsAnnotationKey("cid-a"):      testNetns,
+		subnetAnnotationKeyIPv4("cid-a"): v4,
+		"some.other/annotation":          "should be ignored",
+	}
+
+	got := allAdvertisedPrefixes(annotations)
+
+	want := []string{v4 + "/32"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("prefixes = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

A single BGPAdvertisement CRD is keyed by `(vpc, vpcAttachment)` alone, so multiple containers attaching under the same VPCAttachment on a node — a second pod, or a second interface reusing it — share one CRD. `publishBGPStateK8s` was building `Spec.Prefixes` from only the container currently being processed, so a second container's CNI ADD would silently drop the first still-live container's already-published prefix from the spec.

`allAdvertisedPrefixes` fixes this by recomputing `Spec.Prefixes` from every subnet annotation currently present on the CRD (each container's durable per-container record) instead of just the one being processed, so every live container's prefix stays present regardless of ADD order.

Independent of the eBPF uSID datapath work landing in a separate stack — no shared imports or call-site overlap beyond this file's existing `publishBGPStateK8s`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/cni/...`
- [x] `go test ./internal/cni/...` (new `TestAllAdvertisedPrefixes*` cases, including the multi-container regression case)
- [x] `task lint` (0 issues)