### PR TITLE
feat: eBPF vrf_table GC sweep and control-daemon startup

### DIFF
--- a/cmd/galactic-cni/main.go
+++ b/cmd/galactic-cni/main.go
@@ -55,15 +55,17 @@ func newInitCommand() *cobra.Command {
 
 func newRunCommand() *cobra.Command {
 	var grpcHealthPort int
+	var metricsPort int
 
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Lightweight run loop to refresh credentials and run gRPC health server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return installer.Run(cmd.Context(), grpcHealthPort)
+			return installer.Run(cmd.Context(), grpcHealthPort, metricsPort)
 		},
 	}
 	runCmd.Flags().IntVar(&grpcHealthPort, "grpc-health-port", 5180, "gRPC health check port")
+	runCmd.Flags().IntVar(&metricsPort, "metrics-port", 9091, "Prometheus metrics HTTP port")
 	return runCmd
 }
 

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
+	"os"
 	"regexp"
 	"strings"
 
@@ -15,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -37,7 +41,12 @@ type OrphanedCRD struct {
 type CleanupResult struct {
 	OrphanedCRDsRemoved int
 	OrphanedVRFsRemoved int
-	Errors              int
+	// EBPFVRFEntriesRemoved counts stale eBPF uSID datapath vrf_table map
+	// entries removed by SweepEBPFVRFTable -- a distinct kind of resource
+	// from OrphanedVRFsRemoved's kernel VRF *interfaces* above (Milestone
+	// 7.3).
+	EBPFVRFEntriesRemoved int
+	Errors                int
 }
 
 // vrfNameRegex matches the deterministic VRF interface name pattern used by
@@ -57,18 +66,37 @@ var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})([A-Za-z0-9]{3})V$`)
 func routerNamesForNode(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) (map[string]struct{}, error) {
+	routers, err := routersForNode(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(routers))
+	for name := range routers {
+		names[name] = struct{}{}
+	}
+	return names, nil
+}
+
+// routersForNode is routerNamesForNode's fuller sibling: it keeps the full
+// BGPRouter object (keyed by name) rather than just membership, for
+// callers that need more than the name -- SweepEBPFVRFTable (Milestone
+// 7.3) needs each router's Spec.SRv6Locator to derive the eBPF uSID Block
+// its BGPVRFInstances resolve into.
+func routersForNode(
+	ctx context.Context, k8s client.Client, namespace, nodeName string,
+) (map[string]bgpv1alpha1.BGPRouter, error) {
 	routerList := &bgpv1alpha1.BGPRouterList{}
 	if err := k8s.List(ctx, routerList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPRouters: %w", err)
 	}
 
-	names := make(map[string]struct{})
+	routers := make(map[string]bgpv1alpha1.BGPRouter)
 	for _, r := range routerList.Items {
 		if r.Spec.TargetRef.Name == nodeName {
-			names[r.Name] = struct{}{}
+			routers[r.Name] = r
 		}
 	}
-	return names, nil
+	return routers, nil
 }
 
 // CollectOrphanedCRDs scans BGPAdvertisement and BGPVRFInstance CRDs owned by
@@ -290,6 +318,131 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 		slog.Info("GC: removed orphaned VRF",
 			"name", name, "vpc", vpc, "vpcAttachment", vpcAtt)
 		result.OrphanedVRFsRemoved++
+	}
+
+	return result
+}
+
+// SweepEBPFVRFTable removes eBPF uSID datapath vrf_table map entries whose
+// (Block, Argument) key no longer corresponds to a live BGPVRFInstance CRD
+// owned by nodeName's BGPRouter(s) (design plan §5.3; Milestone 7.3).
+// Unlike RunGC's CRD/kernel-VRF sweep above, this deliberately does NOT run
+// from galactic-router's existing GC controller (internal/controller/
+// gc_controller.go): the pinned vrf_table map only exists inside
+// galactic-cni's "run" container, which has the /sys/fs/bpf hostPath mount
+// and CAP_BPF (Milestone 3.1) that galactic-router's own DaemonSet does
+// not and, for this alone, should not need. internal/installer.Run calls
+// this directly on its own ticker instead -- see that package's doc
+// comment for the full reasoning. The RBAC galactic-cni's ServiceAccount
+// already has (get/list bgprouters; get/list/...  bgpvrfinstances, see
+// config/cni/rbac.yaml) is exactly what this function needs, so no
+// permission change was required to place it there.
+//
+// A pin directory this process can't confirm exists -- either genuinely
+// absent (the "run" container's eBPF datapath hasn't finished loading yet)
+// or inaccessible (e.g. /sys/fs/bpf's own restrictive mode denying a
+// non-root stat, which the production "run" container never hits since it
+// runs as root, design plan §9) -- is treated as "nothing to do this
+// tick," not an error; any stat failure here means there's no pinned
+// datapath this process can reach right now, and it isn't this function's
+// job to diagnose why.
+func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeName, pinDir string) CleanupResult {
+	result := CleanupResult{}
+
+	if _, statErr := os.Stat(pinDir); statErr != nil {
+		return result
+	}
+
+	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
+	if err != nil {
+		slog.Error("GC: failed to open pinned eBPF vrf_table for sweep", "pinDir", pinDir, "err", err)
+		result.Errors++
+		return result
+	}
+	defer func() { _ = closer.Close() }()
+
+	// Capture the cutoff *before* listing BGPVRFInstance CRDs below --
+	// VRFTable.Generation's own doc comment and doc.go's
+	// "plugin-binary-vs-run-container race" section explain why the
+	// ordering matters: a Register landing between this line and the List
+	// call below must survive this sweep.
+	cutoff := reg.VRF.Generation()
+
+	routers, err := routersForNode(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		slog.Error("GC: failed to list BGPRouters for eBPF vrf_table sweep", "err", err)
+		result.Errors++
+		return result
+	}
+	if len(routers) == 0 {
+		// A node with any live eBPF-registered attachment at all necessarily
+		// has a BGPRouter targeting it -- registerEBPFDatapath requires one
+		// to run at all (internal/cni/bgp.go). Finding none here is
+		// indistinguishable from a transient listing/cache hiccup or the
+		// router having just been renamed/recreated, so it must not be
+		// treated the same as "genuinely zero live attachments": doing so
+		// would fold every entry into the below-cutoff, absent-from-live
+		// case and wipe the entire vrf_table -- every pod on this node --
+		// on what may just be one bad tick. Skip this sweep instead; the
+		// next tick tries again once router listing is reliable again.
+		slog.Warn("GC: no BGPRouter found for node during eBPF vrf_table sweep, skipping reconcile this tick",
+			"nodeName", nodeName)
+		return result
+	}
+
+	vrfInstList := &bgpv1alpha1.BGPVRFInstanceList{}
+	if err := k8s.List(ctx, vrfInstList, client.InNamespace(namespace)); err != nil {
+		slog.Error("GC: failed to list BGPVRFInstances for eBPF vrf_table sweep", "err", err)
+		result.Errors++
+		return result
+	}
+
+	live := make(map[usidmap.VRFKey]struct{}, len(vrfInstList.Items))
+	for _, inst := range vrfInstList.Items {
+		if inst.Spec.RouterRef == nil {
+			continue
+		}
+		router, ok := routers[inst.Spec.RouterRef.Name]
+		if !ok {
+			continue // not one of this node's routers
+		}
+		if router.Spec.SRv6Locator == "" {
+			continue // this router has no eBPF-relevant locator configured
+		}
+		prefix, err := netip.ParsePrefix(router.Spec.SRv6Locator)
+		if err != nil {
+			slog.Warn("GC: skipping BGPVRFInstance with unparseable router locator during eBPF sweep",
+				"vrfInstance", inst.Name, "router", router.Name, "locator", router.Spec.SRv6Locator, "err", err)
+			continue
+		}
+		block, err := uformat.Block(prefix.Addr())
+		if err != nil {
+			slog.Warn("GC: skipping BGPVRFInstance with invalid router locator during eBPF sweep",
+				"vrfInstance", inst.Name, "router", router.Name, "locator", router.Spec.SRv6Locator, "err", err)
+			continue
+		}
+		// inst.Spec.VRFID is the real, allocated Argument value directly
+		// (Milestone 6.1) -- no derivation needed. Guard the int32->uint16
+		// narrowing explicitly rather than trusting an external CRD value
+		// (a boundary this GC sweep does not otherwise validate) to
+		// already be in range.
+		if inst.Spec.VRFID < int32(uformat.ArgumentMin) || inst.Spec.VRFID > int32(uformat.ArgumentMax) {
+			slog.Warn("GC: skipping BGPVRFInstance with out-of-range VRFID during eBPF sweep",
+				"vrfInstance", inst.Name, "vrfID", inst.Spec.VRFID)
+			continue
+		}
+		argument := uint16(inst.Spec.VRFID)
+		live[usidmap.VRFKey{Block: block, Argument: argument}] = struct{}{}
+	}
+
+	removed, err := reg.VRF.Reconcile(live, cutoff)
+	for _, e := range removed {
+		slog.Info("GC: removed stale eBPF vrf_table entry", "block", e.Block, "argument", e.Argument)
+	}
+	result.EBPFVRFEntriesRemoved = len(removed)
+	if err != nil {
+		slog.Error("GC: errors while reconciling eBPF vrf_table", "err", err)
+		result.Errors++
 	}
 
 	return result

--- a/internal/gc/gc_ebpf_test.go
+++ b/internal/gc/gc_ebpf_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gc
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// testRouteTarget is the import/export route target value shared by every
+// test fixture's BGPVRFInstance in this file; its exact value has no
+// bearing on the eBPF vrf_table sweep logic under test.
+const testRouteTarget = "65000:1"
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN) to load real BPF maps; re-run via sudo")
+	}
+}
+
+func gcTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme (client-go): %v", err)
+	}
+	if err := bgpv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme (bgpv1alpha1): %v", err)
+	}
+	return s
+}
+
+// TestSweepEBPFVRFTable_MissingPinDirIsNoOp covers the startup-ordering
+// case: the sweep ticker can fire before the "run" container has finished
+// loading/pinning the eBPF datapath, so /sys/fs/bpf/galactic (or wherever
+// pinDir points) may not exist yet -- SweepEBPFVRFTable must not treat
+// that as an error.
+func TestSweepEBPFVRFTable_MissingPinDirIsNoOp(t *testing.T) {
+	k8s := fake.NewClientBuilder().WithScheme(gcTestScheme(t)).Build()
+	result := SweepEBPFVRFTable(context.Background(), k8s, "default", "node-a", "/sys/fs/bpf/galactic-does-not-exist")
+	if result.Errors != 0 || result.EBPFVRFEntriesRemoved != 0 {
+		t.Errorf("result = %+v, want a zero-value result (no-op)", result)
+	}
+}
+
+// TestSweepEBPFVRFTable_RemovesStaleKeepsLive is Milestone 7.3's exit
+// criterion. It seeds two vrf_table entries against a real, pinned map:
+// one whose BGPVRFInstance/BGPRouter CRD pair is present in the fake k8s
+// client (must survive), and one whose BGPVRFInstance CRD is absent (must
+// be removed) -- both keyed by the same (Block, Argument) pair
+// registerEBPFDatapath (Milestone 7.1) would register: uformat.Block
+// (locator) and inst.Spec.VRFID directly as the Argument (Milestone 6.1).
+func TestSweepEBPFVRFTable_RemovesStaleKeepsLive(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		namespace  = "default"
+		nodeName   = "node-a"
+		routerName = "router-a"
+		locator    = "2001:db8:1::/48"
+		liveVRFID  = int32(10)
+		staleVRFID = int32(20)
+	)
+
+	router := &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: routerName, Namespace: namespace},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Kind: "Node", Name: nodeName},
+			LocalASN:    65000,
+			SRv6Locator: locator,
+			NodeID:      5,
+		},
+	}
+	liveInst := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-vrf", Namespace: namespace},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: routerName}},
+			VRFID:              liveVRFID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+		},
+	}
+	// staleVRFID's BGPVRFInstance is deliberately NOT created -- only
+	// live-vrf exists in the fake client.
+	k8s := fake.NewClientBuilder().WithScheme(gcTestScheme(t)).WithObjects(router, liveInst).Build()
+
+	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-gcsweep-test-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+	loaderObjs, err := attach.Load(pinDir)
+	if err != nil {
+		t.Fatalf("attach.Load: %v", err)
+	}
+	t.Cleanup(func() { _ = loaderObjs.Close() })
+
+	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
+	if err != nil {
+		t.Fatalf("OpenPinnedRegistry: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	block, err := blockFromLocator(t, locator)
+	if err != nil {
+		t.Fatalf("derive block: %v", err)
+	}
+	// inst.Spec.VRFID is the real Argument value directly (Milestone 6.1) --
+	// liveVRFID/staleVRFID are chosen small enough to already be valid
+	// Arguments, no fold needed.
+	liveArgument := uint16(liveVRFID)
+	staleArgument := uint16(staleVRFID)
+
+	if err := reg.VRF.Register(block, liveArgument, 0x111111, usidmap.EgressKindVeth); err != nil {
+		t.Fatalf("seed live entry: %v", err)
+	}
+	if err := reg.VRF.Register(block, staleArgument, 0x222222, usidmap.EgressKindVeth); err != nil {
+		t.Fatalf("seed stale entry: %v", err)
+	}
+
+	result := SweepEBPFVRFTable(context.Background(), k8s, namespace, nodeName, pinDir)
+	if result.Errors != 0 {
+		t.Errorf("result.Errors = %d, want 0", result.Errors)
+	}
+	if result.EBPFVRFEntriesRemoved != 1 {
+		t.Errorf("result.EBPFVRFEntriesRemoved = %d, want 1", result.EBPFVRFEntriesRemoved)
+	}
+
+	if _, ok, err := reg.VRF.Get(block, liveArgument); err != nil || !ok {
+		t.Errorf("live entry after sweep: ok=%v err=%v, want ok=true (must survive)", ok, err)
+	}
+	if _, ok, err := reg.VRF.Get(block, staleArgument); err != nil || ok {
+		t.Errorf("stale entry after sweep: ok=%v err=%v, want ok=false (must be removed)", ok, err)
+	}
+}
+
+// TestSweepEBPFVRFTable_NoRoutersForNodeSkipsSweep guards against a
+// regression of the fix where routersForNode returning zero routers (e.g. a
+// transient BGPRouter listing/cache hiccup, or the router being
+// renamed/recreated between ticks) was indistinguishable from "genuinely
+// nothing is live" -- causing every vrf_table entry on the node, including
+// ones with a perfectly live BGPVRFInstance, to be reconciled away with no
+// repair path. A tick that finds no router for this node at all must leave
+// vrf_table untouched.
+func TestSweepEBPFVRFTable_NoRoutersForNodeSkipsSweep(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		namespace = "default"
+		nodeName  = "node-a"
+		locator   = "2001:db8:1::/48"
+		vrfID     = int32(10)
+	)
+
+	// Deliberately no BGPRouter object at all for nodeName -- only the
+	// BGPVRFInstance exists, referencing a router name that isn't present.
+	inst := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphaned-router-ref", Namespace: namespace},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: "router-a"}},
+			VRFID:              vrfID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+		},
+	}
+	k8s := fake.NewClientBuilder().WithScheme(gcTestScheme(t)).WithObjects(inst).Build()
+
+	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-gcsweep-norouter-test-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+	loaderObjs, err := attach.Load(pinDir)
+	if err != nil {
+		t.Fatalf("attach.Load: %v", err)
+	}
+	t.Cleanup(func() { _ = loaderObjs.Close() })
+
+	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
+	if err != nil {
+		t.Fatalf("OpenPinnedRegistry: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	block, err := blockFromLocator(t, locator)
+	if err != nil {
+		t.Fatalf("derive block: %v", err)
+	}
+	argument := uint16(vrfID)
+	if err := reg.VRF.Register(block, argument, 0x333333, usidmap.EgressKindVeth); err != nil {
+		t.Fatalf("seed entry: %v", err)
+	}
+
+	result := SweepEBPFVRFTable(context.Background(), k8s, namespace, nodeName, pinDir)
+	if result.Errors != 0 {
+		t.Errorf("result.Errors = %d, want 0 (no-router is a skip, not an error)", result.Errors)
+	}
+	if result.EBPFVRFEntriesRemoved != 0 {
+		t.Errorf("result.EBPFVRFEntriesRemoved = %d, want 0 (must not reconcile against an empty live set)",
+			result.EBPFVRFEntriesRemoved)
+	}
+	if _, ok, err := reg.VRF.Get(block, argument); err != nil || !ok {
+		t.Errorf("entry after no-router sweep: ok=%v err=%v, want ok=true (must survive)", ok, err)
+	}
+}
+
+// blockFromLocator mirrors registerEBPFDatapath's/SweepEBPFVRFTable's own
+// locator-to-Block derivation, kept local to this test file to avoid
+// importing internal/cni (which would be a layering inversion) just for
+// one helper.
+func blockFromLocator(t *testing.T, locator string) (uint64, error) {
+	t.Helper()
+	prefix, err := netip.ParsePrefix(locator)
+	if err != nil {
+		return 0, err
+	}
+	return uformat.Block(prefix.Addr())
+}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +29,35 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/gc"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/metrics"
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
+
+// ebpfHealthCheckInterval controls how often Run polls
+// internal/plumbing/ebpf/attach.Health once the eBPF datapath is running.
+// A package-level var (not a const) so tests can shrink it, the same
+// override pattern internal/plumbing/ebpf/attach/watch.go's
+// debounceInterval already uses.
+var ebpfHealthCheckInterval = 10 * time.Second
+
+// ebpfGCSweepInterval controls how often Run calls gc.SweepEBPFVRFTable
+// once the eBPF datapath is running. A package-level var, same override
+// pattern as ebpfHealthCheckInterval above -- matches galactic-router's
+// own GC controller's documented default period (docs/agents/
+// ARCHITECTURE.md: "ticker-driven, default every 5m").
+var ebpfGCSweepInterval = 5 * time.Minute
+
+// ebpfHealthServiceName is the gRPC health service name (see
+// grpc_health_v1.HealthServer) reporting the live status of the eBPF uSID
+// datapath specifically, separate from the overall (""), always-serving
+// status the credential-refresh/log-rotation loop reports -- so a BPF
+// datapath degradation (e.g. something external detaches the tc filter)
+// doesn't get conflated with, or masked by, the rest of this container's
+// unrelated responsibilities.
+const ebpfHealthServiceName = "ebpf-datapath"
 
 var (
 	// Host paths, configurable for testing
@@ -165,6 +194,12 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
+	// bgpv1alpha1 registration is required for gc.SweepEBPFVRFTable's
+	// BGPRouter/BGPVRFInstance List calls (Milestone 7.3) -- newK8sClientFn
+	// below is shared with Bootstrap's plain Node lookup, which doesn't
+	// need it, but the client itself must know about every kind either
+	// caller lists.
+	_ = bgpv1alpha1.AddToScheme(scheme)
 }
 
 var newK8sClientFn = func() (client.Client, error) {
@@ -178,6 +213,23 @@ var newK8sClientFn = func() (client.Client, error) {
 // addrListFn can be overridden in tests to mock netlink interface addresses.
 var addrListFn = func(family int) ([]netlink.Addr, error) {
 	return netlink.AddrList(nil, family)
+}
+
+// ebpfStartFn loads, pins, and attaches the eBPF/TC-BPF uSID datapath, then
+// keeps its resolved interface set re-evaluated against netlink link/route
+// change events for the life of ctx (design plan
+// .local/plan-ebpf-xdp-usid-datapath.md §4.1, §4.4, §5.4; Milestones 3.1
+// and 3.2 of .local/implementation-plan-ebpf-xdp-usid-datapath.md). It is a
+// package-level override point -- like addrListFn and newK8sClientFn above
+// -- so tests can exercise Run's wiring without needing root, a real kernel
+// BPF stack, or a live network interface. The returned io.Closer is
+// internal/plumbing/ebpf/attach.StartWatching's *prog.UsidObjects in
+// production; Run keeps it open for the process lifetime and Closes it on
+// shutdown (see the attach package doc comment for why that does not
+// disrupt already-attached forwarding). Canceling ctx stops the background
+// netlink watch loop but does not, by itself, close the returned object.
+var ebpfStartFn = func(ctx context.Context, pinDir string) (io.Closer, []string, error) {
+	return attach.StartWatching(ctx, pinDir)
 }
 
 // resolveLogLevel reads GALACTIC_CNI_LOG_LEVEL and returns a validated level
@@ -340,13 +392,131 @@ users:
 	return atomicWriteFile(kubeconfigPath, []byte(kubeconfigTemplate), 0600)
 }
 
+// ebpfDatapathState bundles what startEBPFDatapath resolves for Run to use
+// afterward (health polling, metrics, the GC sweep) -- a named type purely
+// to avoid a many-value return signature.
+type ebpfDatapathState struct {
+	objs      *prog.UsidObjects
+	ifaces    []string
+	k8sClient client.Client
+	namespace string
+	nodeName  string
+}
+
+// startEBPFDatapath is Run's eBPF-datapath startup path, split out solely
+// to keep Run's own cyclomatic complexity within golangci-lint's gocyclo
+// budget -- behaviorally this is inlined exactly where it used to live. A
+// failure here (including a failed kernel preflight check, design plan §6)
+// is fatal: Run returns an error rather than falling back to a partial or
+// unsafe datapath state -- this is the only forwarding path, there is no
+// legacy path to fall back to.
+func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathState, io.Closer, error) {
+	attach.SetHooks(m.Events.Hooks())
+
+	datapath, ifaces, err := ebpfStartFn(ctx, attach.PinDir)
+	if err != nil {
+		return ebpfDatapathState{}, nil, fmt.Errorf("start eBPF uSID datapath: %w", err)
+	}
+	slog.Info("eBPF uSID datapath loaded, pinned, and attached", "interfaces", ifaces, "pinDir", attach.PinDir)
+
+	state := ebpfDatapathState{ifaces: ifaces}
+
+	// ebpfStartFn's io.Closer is *prog.UsidObjects in production (test
+	// fakes stand in a plain mock closer, which correctly leaves
+	// metrics/health/GC wiring inert below -- see installer_test.go's
+	// fakeDatapathCloser).
+	if objs, ok := datapath.(*prog.UsidObjects); ok {
+		state.objs = objs
+		if err := m.RegisterDatapathCollector(objs); err != nil {
+			slog.Warn("Failed to register eBPF datapath metrics collector", "err", err)
+		}
+	}
+
+	// Best-effort setup for the eBPF vrf_table GC sweep (Milestone 7.3).
+	// A failure here is not fatal to Run -- unlike the datapath start
+	// above, GC is a background maintenance task, not a hard requirement
+	// for the datapath to forward traffic -- it just means this node's
+	// sweep ticker stays inert until the next restart.
+	if hostConf, err := loadHostConf(HostConflist); err != nil {
+		slog.Warn("eBPF vrf_table GC sweep disabled: failed to load host conf", "err", err)
+	} else if k8sClient, err := newK8sClientFn(); err != nil {
+		slog.Warn("eBPF vrf_table GC sweep disabled: failed to create k8s client", "err", err)
+	} else {
+		state.k8sClient, state.namespace, state.nodeName = k8sClient, hostConf.Namespace, hostConf.NodeName
+	}
+
+	return state, datapath, nil
+}
+
 // Run executes the CNI installer main container tasks:
-// 1. Sets up log rotation periodically.
-// 2. Starts a simple ServiceAccount token refresh ticker.
-// 3. Deferred cleanup of stale .bin wrapper file.
-// 4. Starts the gRPC health check server.
-func Run(ctx context.Context, grpcHealthPort int) error {
-	slog.Info("Starting CNI installer run daemon", "grpcHealthPort", grpcHealthPort)
+//  1. Loads/pins/attaches the eBPF/TC-BPF uSID datapath and keeps its
+//     attachment set re-evaluated against netlink link/route change events
+//     for the life of ctx (design plan §4.1, §4.4, §5.4; Milestones 3.1
+//     and 3.2 of .local/implementation-plan-ebpf-xdp-usid-datapath.md) --
+//     the only forwarding path. A failure here (including a failed kernel
+//     preflight check, design plan §6) is fatal: Run returns an error
+//     rather than falling back to a partial or unsafe datapath state.
+//     Once running, the netlink-driven re-attachment loop logs and retries
+//     its own failures rather than propagating them back into Run -- see
+//     internal/plumbing/ebpf/attach.Watch's doc comment. Datapath
+//     load/attach/detach events are counted via
+//     internal/plumbing/ebpf/metrics's EventCounters (Milestone 4), and
+//     live vrf_table/locator_table/drop_reasons state is exposed through
+//     the same metrics endpoint.
+//  2. Serves Prometheus metrics on metricsPort.
+//  3. Sets up log rotation periodically.
+//  4. Starts a simple ServiceAccount token refresh ticker.
+//  5. Deferred cleanup of stale .bin wrapper file.
+//  6. Starts the gRPC health check server -- the overall ("") service
+//     always reports SERVING once the process is up (credential
+//     refresh/log rotation have no meaningful "unhealthy" state of their
+//     own); a separate ebpfHealthServiceName ("ebpf-datapath") service is
+//     polled on a ticker and reports the live result of
+//     internal/plumbing/ebpf/attach.Health -- exit criterion "health check
+//     fails correctly when the program is unloaded".
+//  7. Periodically sweeps stale vrf_table entries via gc.SweepEBPFVRFTable
+//     (design plan §5.3; Milestone 7.3). This runs from here, not from
+//     galactic-router's existing GC controller
+//     (internal/controller/gc_controller.go), because the pinned maps
+//     only exist inside this container -- see gc.SweepEBPFVRFTable's own
+//     doc comment for the full reasoning.
+func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
+	slog.Info("Starting CNI installer run daemon", "grpcHealthPort", grpcHealthPort, "metricsPort", metricsPort)
+
+	m := metrics.New()
+
+	ebpfState, datapath, err := startEBPFDatapath(ctx, m)
+	if err != nil {
+		return err
+	}
+	if datapath != nil {
+		defer func() {
+			if err := datapath.Close(); err != nil {
+				slog.Warn("Failed to close eBPF uSID datapath objects", "err", err)
+			}
+		}()
+	}
+
+	// Serve Prometheus metrics at the conventional /metrics scrape path.
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", m.Handler())
+	metricsSrv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", metricsPort),
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		if err := metricsSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("Metrics server exited with error", "err", err)
+		}
+	}()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := metricsSrv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("Failed to gracefully shut down metrics server", "err", err)
+		}
+	}()
 
 	// Start gRPC health check server
 	var lc net.ListenConfig
@@ -358,6 +528,9 @@ func Run(ctx context.Context, grpcHealthPort int) error {
 	healthSrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	if ebpfState.objs != nil {
+		healthSrv.SetServingStatus(ebpfHealthServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+	}
 
 	go func() {
 		if err := grpcSrv.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
@@ -376,6 +549,20 @@ func Run(ctx context.Context, grpcHealthPort int) error {
 	// Deferred old binary cleanup after 2 minutes
 	cleanupTimer := time.NewTimer(2 * time.Minute)
 	defer cleanupTimer.Stop()
+
+	// eBPF datapath health poll -- only meaningful once datapathObjs is
+	// set (eBPF datapath enabled and actually running); otherwise this
+	// fires harmlessly and does nothing every tick.
+	ebpfHealthTicker := time.NewTicker(ebpfHealthCheckInterval)
+	defer ebpfHealthTicker.Stop()
+	var ebpfLastHealthy = true // matches the initial SetServingStatus(SERVING) above
+
+	// eBPF vrf_table GC sweep (Milestone 7.3) -- only meaningful once
+	// gcK8sClient is set (eBPF datapath enabled and host conf/k8s client
+	// setup above succeeded); otherwise this fires harmlessly and does
+	// nothing every tick, same as the health poll above.
+	ebpfGCSweepTicker := time.NewTicker(ebpfGCSweepInterval)
+	defer ebpfGCSweepTicker.Stop()
 
 	for {
 		select {
@@ -405,6 +592,37 @@ func Run(ctx context.Context, grpcHealthPort int) error {
 			logFileHostPath := getLogFileHostPath()
 			if logFileHostPath != "" {
 				rotateLogFile(logFileHostPath)
+			}
+
+		case <-ebpfHealthTicker.C:
+			if ebpfState.objs == nil {
+				continue
+			}
+			h := attach.Handle{Objs: ebpfState.objs}
+			healthErr := h.Healthy()
+			healthy := healthErr == nil
+			if healthy != ebpfLastHealthy {
+				if healthy {
+					slog.Info("eBPF uSID datapath health check recovered")
+				} else {
+					slog.Error("eBPF uSID datapath health check failed", "err", healthErr)
+				}
+				ebpfLastHealthy = healthy
+			}
+			status := grpc_health_v1.HealthCheckResponse_NOT_SERVING
+			if healthy {
+				status = grpc_health_v1.HealthCheckResponse_SERVING
+			}
+			healthSrv.SetServingStatus(ebpfHealthServiceName, status)
+
+		case <-ebpfGCSweepTicker.C:
+			if ebpfState.k8sClient == nil {
+				continue
+			}
+			result := gc.SweepEBPFVRFTable(ctx, ebpfState.k8sClient, ebpfState.namespace, ebpfState.nodeName, attach.PinDir)
+			if result.EBPFVRFEntriesRemoved > 0 || result.Errors > 0 {
+				slog.Info("eBPF vrf_table GC sweep complete",
+					"removed", result.EBPFVRFEntriesRemoved, "errors", result.Errors)
 			}
 		}
 	}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -6,11 +6,15 @@ package installer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,7 +28,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 )
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN/CAP_SYS_ADMIN) to load/attach a real BPF " +
+			"program; re-run via sudo")
+	}
+}
 
 func TestResolveLogLevel(t *testing.T) {
 	tests := []struct {
@@ -261,6 +274,16 @@ func TestBootstrap(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
+	// This test exercises Run's general daemon behavior (health server,
+	// log rotation, shutdown) -- not the eBPF datapath itself (covered by
+	// the TestRun_EBPFDatapathEnabled_* tests below), so stand in a fake
+	// ebpfStartFn rather than requiring root/a real kernel BPF stack here.
+	origEBPFStartFn := ebpfStartFn
+	t.Cleanup(func() { ebpfStartFn = origEBPFStartFn })
+	ebpfStartFn = func(_ context.Context, _ string) (io.Closer, []string, error) {
+		return &fakeDatapathCloser{}, []string{"eth0"}, nil
+	}
+
 	// Set up directories
 	tmpDir := t.TempDir()
 	HostBinDir = filepath.Join(tmpDir, "host", "opt", "cni", "bin")
@@ -300,7 +323,7 @@ func TestRun(t *testing.T) {
 	// Run in background
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- Run(ctx, healthPort)
+		errCh <- Run(ctx, healthPort, healthPort+1000)
 	}()
 
 	// Query gRPC health endpoint
@@ -335,4 +358,211 @@ func TestRun(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not exit on context cancel")
 	}
+}
+
+// fakeDatapathCloser is a mocked io.Closer standing in for
+// *prog.UsidObjects in tests, so Run's eBPF datapath wiring can be
+// exercised without root, a real kernel BPF stack, or a live network
+// interface. closed is an atomic.Bool (not a bare bool) because Run's
+// deferred Close() runs on the goroutine Run itself executes on, which
+// this test observes from its own goroutine with no other synchronization
+// between the two.
+type fakeDatapathCloser struct {
+	closed atomic.Bool
+	err    error
+}
+
+func (f *fakeDatapathCloser) Close() error {
+	f.closed.Store(true)
+	return f.err
+}
+
+// TestRun_EBPFDatapathEnabled_StartsAndClosesOnShutdown covers Milestone
+// 3.1's wiring of the eBPF uSID datapath into the run subcommand: Run
+// calls ebpfStartFn with attach.PinDir and closes the returned object on
+// shutdown.
+func TestRun_EBPFDatapathEnabled_StartsAndClosesOnShutdown(t *testing.T) {
+	origEBPFStartFn := ebpfStartFn
+	t.Cleanup(func() { ebpfStartFn = origEBPFStartFn })
+
+	fakeDP := &fakeDatapathCloser{}
+	var gotPinDir atomic.Value
+	ebpfStartFn = func(_ context.Context, pinDir string) (io.Closer, []string, error) {
+		gotPinDir.Store(pinDir)
+		return fakeDP, []string{"eth0"}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	healthPort := 25180
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, healthPort, healthPort+1000)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	if got, _ := gotPinDir.Load().(string); got != attach.PinDir {
+		t.Errorf("ebpfStartFn pinDir = %q, want %q", got, attach.PinDir)
+	}
+	if fakeDP.closed.Load() {
+		t.Error("datapath closed before shutdown")
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not exit on context cancel")
+	}
+
+	if !fakeDP.closed.Load() {
+		t.Error("datapath was not closed on shutdown")
+	}
+}
+
+// TestRun_EBPFDatapathEnabled_StartFailureIsFatal covers the milestone's
+// requirement that a preflight/load/attach failure blocks the datapath --
+// here, that failure must also be fatal to Run itself, not silently
+// swallowed or degraded into a partial datapath state.
+func TestRun_EBPFDatapathEnabled_StartFailureIsFatal(t *testing.T) {
+	origEBPFStartFn := ebpfStartFn
+	t.Cleanup(func() { ebpfStartFn = origEBPFStartFn })
+
+	wantErr := errors.New("simulated preflight/load/attach failure")
+	ebpfStartFn = func(_ context.Context, _ string) (io.Closer, []string, error) {
+		return nil, nil, wantErr
+	}
+
+	err := Run(context.Background(), 25181, 26181)
+	if err == nil {
+		t.Fatal("Run() error = nil, want the eBPF datapath start failure surfaced")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Run() error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+// TestRun_EBPFDatapathEnabled_MetricsAndHealthReflectRealDatapath is
+// Milestone 4's real-kernel exit criterion, exercised through Run() itself
+// rather than attach/metrics' own lower-level unit tests: metrics are
+// visible in a local test run, and the gRPC "ebpf-datapath" health service
+// flips to NOT_SERVING when the program is detached, then recovers once
+// re-attached. Attaches to "lo" (always present, no test network namespace
+// needed -- lo carries no traffic this test could disrupt) via
+// GALACTIC_CNI_EBPF_INTERFACES, using a throwaway pin directory under the
+// real bpffs so it never collides with attach.PinDir's production path.
+func TestRun_EBPFDatapathEnabled_MetricsAndHealthReflectRealDatapath(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-run-test-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	t.Setenv(config.EnvCNIEBPFInterfaces, "lo")
+
+	origEBPFStartFn := ebpfStartFn
+	t.Cleanup(func() { ebpfStartFn = origEBPFStartFn })
+	ebpfStartFn = func(ctx context.Context, _ string) (io.Closer, []string, error) {
+		return attach.StartWatching(ctx, pinDir)
+	}
+
+	origInterval := ebpfHealthCheckInterval
+	t.Cleanup(func() { ebpfHealthCheckInterval = origInterval })
+	ebpfHealthCheckInterval = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const healthPort = 25182
+	const metricsPort = 26182
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Run(ctx, healthPort, metricsPort)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-errCh:
+		case <-time.After(2 * time.Second):
+			t.Error("Run did not exit on context cancel during cleanup")
+		}
+	})
+
+	// Allow Load/Attach and both listeners to come up.
+	time.Sleep(300 * time.Millisecond)
+
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("127.0.0.1:%d", healthPort),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	hc := grpc_health_v1.NewHealthClient(conn)
+
+	checkStatus := func(t *testing.T, want grpc_health_v1.HealthCheckResponse_ServingStatus) {
+		t.Helper()
+		deadline := time.Now().Add(2 * time.Second)
+		var last grpc_health_v1.HealthCheckResponse_ServingStatus
+		for time.Now().Before(deadline) {
+			resp, err := hc.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ebpfHealthServiceName})
+			if err != nil {
+				t.Fatalf("Health check for %q failed: %v", ebpfHealthServiceName, err)
+			}
+			last = resp.Status
+			if last == want {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Fatalf("Health status for %q = %v, want %v (timed out waiting)", ebpfHealthServiceName, last, want)
+	}
+
+	// Initially attached: SERVING.
+	checkStatus(t, grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// Metrics endpoint is up and exposes this milestone's namespace.
+	metricsReq, err := http.NewRequestWithContext(
+		context.Background(), http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/metrics", metricsPort), nil)
+	if err != nil {
+		t.Fatalf("build /metrics request: %v", err)
+	}
+	metricsResp, err := http.DefaultClient.Do(metricsReq)
+	if err != nil {
+		t.Fatalf("GET /metrics: %v", err)
+	}
+	defer func() { _ = metricsResp.Body.Close() }()
+	if metricsResp.StatusCode != http.StatusOK {
+		t.Errorf("GET /metrics status = %d, want 200", metricsResp.StatusCode)
+	}
+	body := make([]byte, 64*1024)
+	n, _ := metricsResp.Body.Read(body)
+	if !strings.Contains(string(body[:n]), "galactic_usid_") {
+		t.Errorf("GET /metrics body does not contain the galactic_usid_ namespace: %q", string(body[:n]))
+	}
+
+	// Kill the attach (without closing our own fds -- same distinction
+	// attach's own TestHealth_RealDatapath_FlipsAfterAttachIsKilled draws)
+	// and confirm the health service flips.
+	if err := attach.Detach([]string{"lo"}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	checkStatus(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// Re-attach and confirm recovery.
+	objs, ifaces, err := ebpfStartFn(ctx, pinDir)
+	if err != nil {
+		t.Fatalf("re-attach via ebpfStartFn: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Close() })
+	if len(ifaces) != 1 || ifaces[0] != "lo" {
+		t.Fatalf("re-attach ifaces = %v, want [lo]", ifaces)
+	}
+	checkStatus(t, grpc_health_v1.HealthCheckResponse_SERVING)
 }


### PR DESCRIPTION
## Summary

Adds `SweepEBPFVRFTable`, a GC pass that reconciles the eBPF uSID datapath's `vrf_table` map entries against live `BGPVRFInstance` CRDs, using a generation-cutoff scheme to avoid a register/sweep race. This runs from `galactic-cni`'s `run` container rather than `galactic-router`'s existing GC controller: the pinned `vrf_table` map only exists inside that container, which has the `/sys/fs/bpf` hostPath mount and `CAP_BPF` that `galactic-router`'s DaemonSet doesn't need for anything else. `routerNamesForNode` gains a fuller sibling, `routersForNode`, since the sweep needs each router's full `Spec.SRv6Locator`, not just its name.

Wires `installer.Run` to load/attach/pin the eBPF datapath at startup, serve `/metrics` (Prometheus), report an `ebpf-datapath` gRPC health sub-service, and run the GC sweep on its own ticker. Adds a `--metrics-port` CLI flag to `galactic-cni run`.

> [!NOTE]
> This depends only on #283 (the datapath control-plane packages), not on the CNI ADD cutover in #285/#286 — the sweep reconciles directly against `BGPRouter`/`BGPVRFInstance` CRD state rather than anything `registerEBPFDatapath` writes, so it's a sibling branch in the stack rather than stacked on top of the CNI cutover.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/gc/... ./internal/installer/... ./cmd/...`
- [x] `task lint` (0 issues)

Part of the eBPF uSID datapath cutover stack (base: #283).