### PR TITLE
fix: SEG6 encap mode, IPv4 SID advertisement, reconcile skip-on-error

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -28,6 +28,7 @@ import (
 	"go.datum.net/galactic/internal/hash"
 	"go.datum.net/galactic/internal/metadata"
 	"go.datum.net/galactic/internal/plumbing/loaddr"
+	"go.datum.net/galactic/internal/plumbing/srv6"
 	"go.datum.net/galactic/internal/reconcile"
 	galacticruntime "go.datum.net/galactic/internal/runtime"
 	"go.datum.net/galactic/internal/runtime/frr"
@@ -77,6 +78,19 @@ func runCmd(cfg *config.RouterConfig) error {
 	switch mode {
 	case config.ModeTenant:
 		factory = gobgp.NewRuntimeFactory(int32(bgpListenPort), bgpLocalAddr)
+		// Pre-flight SEG6 reduced-encap check (log-and-continue, same
+		// non-fatal posture as checkWatchPermissions' RBAC pre-flight
+		// below -- the control plane still has useful work to do without
+		// a working data plane). A kernel that fails this will instead
+		// fail every single cross-region EVPN path install later, one at a
+		// time, each logged individually by internal/runtime/gobgp/monitor.go
+		// with no standing signal that the *kernel itself* -- not any one
+		// path -- is the problem; this turns that into one clear
+		// diagnostic up front.
+		if err := srv6.CheckSEG6EncapRed(); err != nil {
+			log.Printf("SEG6 reduced-encap pre-flight failed: %v -- every cross-region uSID path this node "+
+				"tries to install will fail identically until this kernel is upgraded", err)
+		}
 	case config.ModeFabric:
 		factory = frr.NewRuntimeFactory()
 	case config.ModeTransit:

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -9,8 +9,27 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netlink/nl"
 )
+
+// seg6IptunModeEncapRed is the kernel's SEG6_IPTUN_MODE_ENCAP_RED
+// (include/uapi/linux/seg6_iptunnel.h) -- "reduced" encapsulation, which
+// omits the Segment Routing Header entirely when the segment list has only
+// one entry (our uSID case, always a single compressed SID). The
+// vishvananda/netlink version pinned in go.mod only exposes
+// SEG6_IPTUN_MODE_INLINE/_ENCAP (nl.SEG6_IPTUN_MODE_ENCAP, plain "full"
+// encap, always adds an 8+16-byte Routing Header even for one segment) --
+// there is no library constant for this mode, but SEG6Encap.Mode is a plain
+// int with no validation, so the raw kernel value works unchanged.
+// usid.c's ingress decap strips exactly sizeof(struct usid_ip6hdr) (40
+// bytes, the outer IPv6 header alone) with no allowance for a Routing
+// Header; installing routes in "full encap" mode put a live 24-byte SRH
+// between that stripped header and the inner packet, so decap
+// misidentified the SRH's first byte as the inner IP version and every
+// cross-region uSID packet was dropped (DROP_REASON_UNKNOWN_INNER_VERSION)
+// -- confirmed live via the datapath's own drops_total metric before this
+// fix, and by byte-for-byte comparing tcpdump's outer-packet capture
+// (RT6 Routing Header, type 4) against usid.c's step 7 strip width.
+const seg6IptunModeEncapRed = 3
 
 // RouteEgressAdd installs a SEG6 encap route for prefix into routing table
 // tableID, encapsulating to the given SRv6 SID (gateway). The outgoing
@@ -24,13 +43,12 @@ import (
 // what happened before this check existed (an EVPN path with no usable SID
 // attribute was fed straight through). Fail loudly instead.
 //
-// The resolved next-hop is attached via RTA_VIA (netlink.Route.Via), not the
-// plain Gw field. SRv6 SIDs are IPv6-only in this architecture, but prefix —
-// the inner destination being matched — can be IPv4 (an IPv4 VPC prefix
-// egressing over an IPv6 SRv6 underlay). Gw requires its address to share
-// Dst's family and the kernel rejects the mismatch outright; Via carries a
-// next-hop of a different family than Dst by design, which is exactly this
-// case: an IPv4 route whose next-hop is only reachable over an IPv6 link.
+// The SID is always an IPv6 address (RFC 9252), but prefix may be an IPv4
+// VPC subnet (End.DT46) — so the resolved next-hop's family can differ from
+// prefix's. netlink.Route.Gw requires the same family as Dst (the kernel
+// route message carries one address family for the whole route); a
+// different-family next-hop must instead go through RTA_VIA, which
+// netlink.Route exposes as the Via field.
 func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	if gateway == nil || gateway.IsUnspecified() {
 		return fmt.Errorf("refusing to install seg6 encap route for %s: gateway %s is not a usable SRv6 SID", prefix, gateway)
@@ -43,7 +61,7 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 		return fmt.Errorf("no route to gateway %s", gateway)
 	}
 	encap := &netlink.SEG6Encap{
-		Mode:     nl.SEG6_IPTUN_MODE_ENCAP,
+		Mode:     seg6IptunModeEncapRed,
 		Segments: []net.IP{gateway},
 	}
 	route := &netlink.Route{
@@ -52,8 +70,16 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 		Encap:     encap,
 		LinkIndex: routes[0].LinkIndex,
 	}
-	if len(routes[0].Gw) > 0 {
-		route.Via = &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: routes[0].Gw}
+	if gw := routes[0].Gw; len(gw) > 0 {
+		gwFamily := netlink.FAMILY_V6
+		if gw.To4() != nil {
+			gwFamily = netlink.FAMILY_V4
+		}
+		if (prefix.IP.To4() != nil) == (gwFamily == netlink.FAMILY_V4) {
+			route.Gw = gw
+		} else {
+			route.Via = &netlink.Via{AddrFamily: gwFamily, Addr: gw}
+		}
 	}
 	return netlink.RouteReplace(route)
 }
@@ -65,4 +91,68 @@ func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
 		Table: int(tableID),
 		Encap: &netlink.SEG6Encap{},
 	})
+}
+
+// checkSEG6EncapRedTableID and checkSEG6EncapRedDst are CheckSEG6EncapRed's
+// scratch route: a table ID and destination chosen to be as far as
+// possible from anything a real VRF or route could ever use.
+// RouteEgressAdd's own tableIDs come from vrf.TableID (kernel-assigned per
+// VRF device at creation, typically a small integer); checkSEG6EncapRedDst
+// sits inside RFC 3849's documentation-only IPv6 range, never a real
+// destination any route table would legitimately hold. So even in the
+// astronomically unlikely case of a table-ID collision, this only ever
+// adds, then immediately removes, one inert, unreachable route -- it never
+// touches anything a real VRF's forwarding depends on.
+var (
+	checkSEG6EncapRedTableID = 0xFFFFFFF0
+	checkSEG6EncapRedDst     = &net.IPNet{IP: net.ParseIP("2001:db8:ffff:ffff::1"), Mask: net.CIDRMask(128, 128)}
+	checkSEG6EncapRedSeg     = net.ParseIP("::1")
+)
+
+// CheckSEG6EncapRed probes whether the running kernel's SEG6 iptunnel
+// implementation actually supports SEG6_IPTUN_MODE_ENCAP_RED (see
+// seg6IptunModeEncapRed's doc comment above for why RouteEgressAdd depends
+// on this mode specifically, not plain full encap) by installing, then
+// immediately removing, a real route using that exact mode against the
+// loopback interface -- the same "attempt it for real" idiom
+// internal/plumbing/ebpf/preflight uses for its own kernel-capability
+// probes, since SEG6 encap modes are a netlink LWT-encapsulation
+// attribute, not something kernel BTF describes the way eBPF helper
+// support is.
+//
+// A kernel too old for reduced encap doesn't reject this any differently
+// from any other route-install failure -- RouteEgressAdd itself would fail
+// identically and silently for every single cross-region EVPN path this
+// router ever tries to install (internal/runtime/gobgp/monitor.go logs
+// each failure once, but never retries or otherwise surfaces it as a
+// standing, actionable signal). Calling this once at startup turns that
+// into one clear, node-level diagnostic instead.
+func CheckSEG6EncapRed() error {
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("check SEG6 reduced-encap support: look up loopback interface: %w", err)
+	}
+
+	route := &netlink.Route{
+		Dst:       checkSEG6EncapRedDst,
+		Table:     checkSEG6EncapRedTableID,
+		LinkIndex: lo.Attrs().Index,
+		Encap: &netlink.SEG6Encap{
+			Mode:     seg6IptunModeEncapRed,
+			Segments: []net.IP{checkSEG6EncapRedSeg},
+		},
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf(
+			"kernel rejected a SEG6_IPTUN_MODE_ENCAP_RED route -- RouteEgressAdd depends on this mode "+
+				"for every cross-region uSID path (see egress.go's seg6IptunModeEncapRed doc comment): %w", err)
+	}
+
+	// Best-effort cleanup: the capability itself was already proven by the
+	// successful RouteReplace above, so a failure here doesn't change this
+	// check's verdict -- it just leaves one harmless scratch route behind
+	// in a table ID nothing else uses (see the doc comment above).
+	_ = netlink.RouteDel(route)
+
+	return nil
 }

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -6,8 +6,21 @@ package srv6
 
 import (
 	"net"
+	"os"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
+
+// requireRoot skips the test unless running as root (CAP_NET_ADMIN to
+// install/remove a real kernel route) -- same pattern used throughout this
+// codebase (e.g. internal/plumbing/ebpf/prog/usid_test.go's requireRoot).
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_NET_ADMIN) to install/remove a real kernel route; re-run via sudo")
+	}
+}
 
 // TestRouteEgressAddRejectsUnspecifiedGateway verifies that RouteEgressAdd
 // refuses to install a seg6 encap route when it isn't handed a real SRv6 SID.
@@ -38,5 +51,50 @@ func TestRouteEgressAddRejectsUnspecifiedGateway(t *testing.T) {
 				t.Errorf("RouteEgressAdd(%v) = nil error, want an error rejecting the unusable gateway", tt.gateway)
 			}
 		})
+	}
+}
+
+// TestCheckSEG6EncapRed exercises CheckSEG6EncapRed against the real
+// running kernel: on a kernel new enough for SEG6_IPTUN_MODE_ENCAP_RED
+// (this environment is documented to have one), it must return nil, and
+// must leave no trace of its scratch probe route behind afterward -- the
+// same "attempt it for real, prove it cleans up" bar
+// internal/plumbing/ebpf/preflight's own kernel-capability probes hold
+// themselves to.
+func TestCheckSEG6EncapRed(t *testing.T) {
+	requireRoot(t)
+
+	if err := CheckSEG6EncapRed(); err != nil {
+		t.Fatalf("CheckSEG6EncapRed() = %v, want nil (this environment is documented to support "+
+			"SEG6_IPTUN_MODE_ENCAP_RED)", err)
+	}
+
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{
+		Table: checkSEG6EncapRedTableID,
+	}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		t.Fatalf("list routes in scratch table %#x: %v", checkSEG6EncapRedTableID, err)
+	}
+	for _, r := range routes {
+		if r.Dst != nil && r.Dst.String() == checkSEG6EncapRedDst.String() {
+			t.Errorf("scratch probe route %s still present in table %#x after CheckSEG6EncapRed returned",
+				r.Dst, checkSEG6EncapRedTableID)
+		}
+	}
+}
+
+// TestCheckSEG6EncapRed_Idempotent covers calling CheckSEG6EncapRed twice
+// in a row -- RouteEgressAdd's own production call sites hit RouteReplace
+// repeatedly by design (backfillEVPNRoutes' doc comment calls re-applying
+// an already-installed route "a harmless no-op"), so this probe must
+// tolerate the same on its own scratch route.
+func TestCheckSEG6EncapRed_Idempotent(t *testing.T) {
+	requireRoot(t)
+
+	if err := CheckSEG6EncapRed(); err != nil {
+		t.Fatalf("first CheckSEG6EncapRed() = %v, want nil", err)
+	}
+	if err := CheckSEG6EncapRed(); err != nil {
+		t.Fatalf("second CheckSEG6EncapRed() = %v, want nil", err)
 	}
 }

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -9,6 +9,7 @@ package reconcile
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"slices"
 	"sort"
@@ -164,7 +165,17 @@ func (r *Reconciler) BuildDesiredRouter(
 		}
 		srv6SID, err := resolveSRv6SID(router, &adv)
 		if err != nil {
-			return nil, fmt.Errorf("BGPAdvertisement %s/%s: %w", namespace, adv.Name, err)
+			// Skip only this advertisement rather than failing the whole
+			// router build: a single BGPAdvertisement with a VRFID the
+			// eBPF datapath's 12-bit Argument can't represent (e.g. a
+			// pre-cutover object whose VRFID was allocated under the old,
+			// wider legacy scheme) would otherwise take down every peer,
+			// VRF, and advertisement for this node until someone finds and
+			// deletes it -- one stale object should not wedge the whole
+			// router during a rolling upgrade.
+			slog.Warn("BuildDesiredRouter: skipping BGPAdvertisement, could not compute SRv6 SID",
+				"namespace", namespace, "name", adv.Name, "err", err)
+			continue
 		}
 		desired.Advertisements = append(desired.Advertisements, model.DesiredAdvertisement{
 			Name:            adv.Name,

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -5,11 +5,17 @@
 package reconcile
 
 import (
+	"context"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"go.datum.net/galactic/internal/model"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
@@ -133,7 +139,7 @@ func TestResolveSRv6SID(t *testing.T) {
 			router: &bgpv1alpha1.BGPRouter{
 				Spec: bgpv1alpha1.BGPRouterSpec{
 					SRv6Locator: testLocator,
-					NodeID:      0xE000, // one past uformat.NodeIDMax (0xDFFF) -- PR #740's reserved Node-ID range
+					NodeID:      uformat.NodeIDMax + 1, // one past uformat.NodeIDMax -- PR #740's reserved Node-ID range
 				},
 			},
 			adv: &bgpv1alpha1.BGPAdvertisement{
@@ -159,5 +165,102 @@ func TestResolveSRv6SID(t *testing.T) {
 				t.Errorf("resolveSRv6SID() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// buildDesiredRouterTestScheme builds a fake client scheme plus the field
+// indexes BuildDesiredRouter's client.MatchingFields lookups require
+// (mirroring internal/controller.RegisterIndexes, without importing that
+// package -- a controller/reconcile layering inversion just for a test).
+func buildDesiredRouterTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme (client-go): %v", err)
+	}
+	if err := bgpv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme (bgpv1alpha1): %v", err)
+	}
+	return s
+}
+
+func routerRefIndexer(obj client.Object) []string {
+	switch o := obj.(type) {
+	case *bgpv1alpha1.BGPAdvertisement:
+		return []string{o.Spec.RouterRef.Name}
+	case *bgpv1alpha1.BGPVRFInstance:
+		if o.Spec.RouterRef == nil {
+			return nil
+		}
+		return []string{o.Spec.RouterRef.Name}
+	default:
+		return nil
+	}
+}
+
+// TestBuildDesiredRouter_SkipsAdvertisementWithOutOfRangeVRFID guards
+// against a regression of the fix where one BGPAdvertisement whose VRFID
+// the eBPF datapath's 12-bit Argument can't represent (e.g. a pre-cutover
+// object allocated under the old, wider legacy VRFID scheme, still valid
+// per the CRD's own wider field maximum) used to abort resolveSRv6SID's
+// caller entirely -- discarding peers, VRFs, and every other advertisement
+// for the whole router, not just the one bad object. It must instead be
+// skipped on its own, leaving every valid advertisement intact.
+func TestBuildDesiredRouter_SkipsAdvertisementWithOutOfRangeVRFID(t *testing.T) {
+	const (
+		namespace  = "default"
+		nodeName   = "node-a"
+		routerName = "router-a"
+	)
+
+	router := &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: routerName, Namespace: namespace},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Kind: "Node", Name: nodeName},
+			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
+			LocalASN:    65000,
+			SRv6Locator: testLocator,
+			NodeID:      7,
+		},
+	}
+	validAdv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-adv", Namespace: namespace},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: routerName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{"2001:db8:1::/64"},
+			VRFID:         ptrInt32(42),
+			Function:      ptrFunction(bgpv1alpha1.SRv6FunctionEndDT46),
+		},
+	}
+	badAdv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-adv", Namespace: namespace},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: routerName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{"2001:db8:2::/64"},
+			VRFID:         ptrInt32(int32(uformat.ArgumentMax) + 1),
+			Function:      ptrFunction(bgpv1alpha1.SRv6FunctionEndDT46),
+		},
+	}
+
+	k8s := fake.NewClientBuilder().
+		WithScheme(buildDesiredRouterTestScheme(t)).
+		WithObjects(router, validAdv, badAdv).
+		WithIndex(&bgpv1alpha1.BGPAdvertisement{}, ".spec.routerRef.name", routerRefIndexer).
+		WithIndex(&bgpv1alpha1.BGPVRFInstance{}, ".spec.routerRef.name", routerRefIndexer).
+		Build()
+
+	r := New(k8s, nodeName, string(bgpv1alpha1.RouterRoleTenant), "2001:db8:ffff::1")
+
+	got, err := r.BuildDesiredRouter(context.Background(), router)
+	if err != nil {
+		t.Fatalf("BuildDesiredRouter: unexpected error: %v (bad-adv should be skipped, not fail the whole build)", err)
+	}
+	if len(got.Advertisements) != 1 {
+		t.Fatalf("Advertisements = %+v, want exactly 1 (bad-adv skipped, valid-adv kept)", got.Advertisements)
+	}
+	if got.Advertisements[0].Name != "valid-adv" {
+		t.Errorf("Advertisements[0].Name = %q, want %q", got.Advertisements[0].Name, "valid-adv")
 	}
 }


### PR DESCRIPTION
## Summary

Three independent bug fixes found while validating the eBPF uSID cutover, bundled together since none of them touch the eBPF datapath itself:

- **`internal/plumbing/srv6/egress.go`** switches SEG6 encapsulation from `SEG6_IPTUN_MODE_ENCAP` ("full" encap, always adds a Routing Header) to the kernel's `SEG6_IPTUN_MODE_ENCAP_RED` ("reduced" encap, omits it for a single-segment list). `usid.c`'s ingress decap strips exactly a fixed 40-byte outer IPv6 header with no allowance for a Routing Header, so full encap corrupted every cross-region uSID packet — confirmed live via the datapath's drop counters. Also adds `netlink.Via`/family handling so an IPv4 VPC prefix (End.DT46) can egress through an IPv6 SID next-hop without violating netlink's same-family route constraint, and `CheckSEG6EncapRed`, a startup kernel-capability probe wired into `galactic-router`'s tenant-mode startup.
- **`internal/runtime/gobgp/{monitor,paths}.go`** attaches the RFC 9252 BGP Prefix-SID path attribute to every advertised path and prefers it over the EVPN NLRI's `GWIPAddress` field on receive, since `GWIPAddress` can't carry an IPv6 SID alongside an IPv4 EVPN Type-5 prefix — this was silently losing the SID for IPv4-only attachments.
- **`internal/reconcile/reconcile.go`**: `BuildDesiredRouter` now skips (logs + continues past) a single `BGPAdvertisement` whose SID can't be computed instead of failing the whole router build — one malformed advertisement no longer takes down every other VRF's paths on that node.

> [!NOTE]
> Depends on #285's `usid.go` rewrite (`ComputeSID` onto the uFMT 48+16 layout) — `reconcile.go` calls `ComputeSID` directly and its tests assert against uFMT-encoded values, so this can't land ahead of that PR despite touching none of the eBPF tree itself.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/plumbing/srv6/... ./internal/runtime/gobgp/... ./internal/reconcile/... ./cmd/galactic-router/...`
- [x] `task lint` (0 issues)

Part of the eBPF uSID datapath cutover stack (base: #285).