### PR TITLE
fix(vrf): key kernel VRF by VPC, not (VPC, attachment)

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -822,9 +822,6 @@ func TestResourceTrackerFieldsSet(t *testing.T) {
 	if tracker.vpcAttachment != testAttachment {
 		t.Errorf("vpcAttachment = %q, want %q", tracker.vpcAttachment, testAttachment)
 	}
-	if tracker.vrfCreated {
-		t.Error("vrfCreated should be false by default")
-	}
 }
 
 // ---- cmdStatus ---------------------------------------------------------

--- a/internal/cni/hostgw/hostgw.go
+++ b/internal/cni/hostgw/hostgw.go
@@ -33,12 +33,28 @@ import (
 )
 
 // ConfigureHostGateway assigns each configured family's gateway address as a
-// host address (/128 for IPv6, /32 for IPv4 on veth) on the host-side
-// interface (veth or tap) and installs an explicit pod-subnet route for that
-// family into the VRF table. IPv4 is skipped entirely when the attachment is
-// IPv6-only.
+// host address (/128 for IPv6, /32 for IPv4 on veth) on this attachment's
+// own host-side interface (veth or tap) and installs an explicit pod-subnet
+// route for that family into the (now VPC-shared, not per-attachment) VRF
+// table. IPv4 is skipped entirely when the attachment is IPv6-only.
 //
-// Using a full-length host address (not the pod subnet mask) prevents the
+// The gateway address is deliberately kept on this attachment's own link
+// rather than the shared VRF device, even though the VRF/table are shared
+// by every attachment on this VPC on this node (internal/plumbing/vrf) —
+// this was tried and reverted (see git history): IPv6 NDP resolution for an
+// address only works on links that address is actually configured on
+// (or has an explicit proxy-neighbor entry for); unlike IPv4's proxy_arp,
+// enabling net.ipv6.conf.*.proxy_ndp does not make the kernel auto-answer
+// for an address it can merely *route* to via another interface. Since a
+// VRF master device and its enslaved links are still separate link-layer
+// segments to NDP, a gateway address bound only to the VRF device is
+// invisible to Neighbor Solicitations arriving on any one attachment's own
+// veth/tap, and every guest's default-route NDP resolution fails outright.
+// Each attachment has its own distinct gateway address anyway (from its own
+// IPAM subnet), so there's no actual duplication to avoid by centralizing
+// it — keeping it per-attachment is both correct and no more wasteful.
+//
+// Using a full-length gateway address (not the pod subnet mask) prevents the
 // kernel from auto-creating a subnet-router anycast entry in the VRF local
 // table. When the pod address equals the subnet network address the anycast
 // absorbs seg6local-decapped inner packets before they reach the guest
@@ -65,14 +81,17 @@ func ConfigureHostGateway(vpc, vpcAttachment string, res *cniipam.IPAMResult, gu
 	if err != nil {
 		return fmt.Errorf("get host interface %q: %w", hostName, err)
 	}
-	tableID, err := vrf.TableID(vpc, vpcAttachment)
+	tableID, err := vrf.TableID(vpc)
 	if err != nil {
 		return fmt.Errorf("get VRF table ID for pod subnet route: %w", err)
 	}
 
 	if res.IPv6Gateway != nil {
 		gwNet := &net.IPNet{IP: res.IPv6Gateway, Mask: net.CIDRMask(128, 128)}
-		if err := installGatewayRoute(hostLink, gwNet, res.IPv6Subnet, netlink.FAMILY_V6, int(tableID), 0); err != nil {
+		if err := installGatewayAddress(hostLink, gwNet, 0); err != nil {
+			return err
+		}
+		if err := installPodSubnetRoute(hostLink, res.IPv6Subnet, netlink.FAMILY_V6, int(tableID)); err != nil {
 			return err
 		}
 		if guestHWAddr != nil {
@@ -84,8 +103,11 @@ func ConfigureHostGateway(vpc, vpcAttachment string, res *cniipam.IPAMResult, gu
 	if res.IPv4Gateway != nil {
 		ipv4Mask, addrFlags := ipv4GatewayAddrParams(hostLink)
 		gwNet := &net.IPNet{IP: res.IPv4Gateway, Mask: ipv4Mask}
+		if err := installGatewayAddress(hostLink, gwNet, addrFlags); err != nil {
+			return err
+		}
 		ipv4Subnet := &net.IPNet{IP: res.IPv4Address, Mask: net.CIDRMask(32, 32)}
-		if err := installGatewayRoute(hostLink, gwNet, ipv4Subnet, netlink.FAMILY_V4, int(tableID), addrFlags); err != nil {
+		if err := installPodSubnetRoute(hostLink, ipv4Subnet, netlink.FAMILY_V4, int(tableID)); err != nil {
 			return err
 		}
 		if guestHWAddr != nil {
@@ -138,18 +160,26 @@ func ipv4GatewayAddrParams(hostLink netlink.Link) (net.IPMask, int) {
 	return net.CIDRMask(32, 32), 0
 }
 
-// installGatewayRoute assigns gwNet as a host address on hostLink and
-// installs an explicit route to subnet into the given VRF table, for one
-// address family. Idempotent: existing matching routes/addresses are left
-// alone, and conflicting ones return an error rather than being overwritten.
-func installGatewayRoute(hostLink netlink.Link, gwNet, subnet *net.IPNet, family, tableID, addrFlags int) error {
-	hostName := hostLink.Attrs().Name
+// installGatewayAddress assigns gwNet as an address on hostLink (this
+// attachment's own host-side interface — see ConfigureHostGateway's doc
+// comment for why not the shared VRF device). Idempotent: EEXIST from a
+// prior attempt having already installed the identical address is not an
+// error.
+func installGatewayAddress(hostLink netlink.Link, gwNet *net.IPNet, addrFlags int) error {
 	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet, Flags: addrFlags}); err != nil {
 		if !errors.Is(err, syscall.EEXIST) {
-			return fmt.Errorf("add gateway address %s to host interface %q: %w", gwNet, hostName, err)
+			return fmt.Errorf("add gateway address %s to host interface %q: %w", gwNet, hostLink.Attrs().Name, err)
 		}
 	}
+	return nil
+}
 
+// installPodSubnetRoute installs an explicit route to subnet, into the given
+// VRF table, pointing at hostLink (this attachment's own host-side
+// interface), for one address family. Idempotent: an existing matching
+// route is left alone, and a conflicting one returns an error rather than
+// being overwritten.
+func installPodSubnetRoute(hostLink netlink.Link, subnet *net.IPNet, family, tableID int) error {
 	desiredRoute := &netlink.Route{
 		Dst:       subnet,
 		LinkIndex: hostLink.Attrs().Index,

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -80,10 +80,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 	}()
 
-	if err := vrf.Add(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+	if err := vrf.Add(pluginConf.VPC); err != nil {
 		return fmt.Errorf("add VRF: %w", err)
 	}
-	tracker.vrfCreated = true
 	slog.Debug("ADD: VRF ready", "vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 
 	if err := veth.Add(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.MTU); err != nil {

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -174,8 +174,8 @@ var probeAPIServer = probeAPIServerFn
 func checkNodeLevelState(vpc, vpcAttachment string) (string, []error) {
 	var errs []error
 
-	if err := vrf.Exists(vpc, vpcAttachment); err != nil {
-		errs = append(errs, fmt.Errorf("vrf %s-%s: %w", vpc, vpcAttachment, err))
+	if err := vrf.Exists(vpc); err != nil {
+		errs = append(errs, fmt.Errorf("vrf %s: %w", vpc, err))
 	}
 
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)

--- a/internal/cni/resource.go
+++ b/internal/cni/resource.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.datum.net/galactic/internal/cni/veth"
-	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
 var cniScheme = runtime.NewScheme()
@@ -54,7 +53,6 @@ func newK8sClient() (client.Client, error) {
 // so this one no longer needs to know anything about either.
 type resourceTracker struct {
 	vpc, vpcAttachment string
-	vrfCreated         bool
 
 	// ipamDelegated, ipamType, and ipamStdin record enough to release the
 	// IPAM allocation during rollback. Set as soon as pluginConf.IPAM != nil
@@ -78,6 +76,18 @@ type resourceTracker struct {
 // here is ipam.ExecDel, which (like ExecAdd) shells out to the delegated
 // plugin binary rather than making a k8s API call (BGP CRD/eBPF rollback is
 // galactic-bgp's own tracker now).
+//
+// Deliberately absent: deleting the VRF. veth.Delete below only removes
+// this attachment's own host/guest veth pair, which is genuinely private to
+// it — but the VRF itself is now shared by every attachment on this VPC on
+// this node (internal/plumbing/vrf keys it by VPC alone), and vrf.Add is
+// idempotent, so there's no way to distinguish "I created it" from "a
+// sibling attachment already had." Deleting it on this attachment's own
+// failed ADD could tear down a still-live sibling's VRF out from under it —
+// the same reasoning internal/cnibgp's resourceTracker applies to the
+// BGPVRFInstance CRD and eBPF vrf_table entry. Reclaiming it is exclusively
+// galactic-router's GC controller's job, once it has confirmed via every
+// BGPAdvertisement for this VPC/node that none remain.
 func (rt *resourceTracker) cleanup() {
 	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
 		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
@@ -99,13 +109,5 @@ func (rt *resourceTracker) cleanup() {
 			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 	} else {
 		slog.Debug("Rollback: deleted veth", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
-	}
-
-	// 3. Delete VRF (flushes all routes, removes VRF interface)
-	if err := vrf.Delete(rt.vpc, rt.vpcAttachment); err != nil {
-		slog.Error("Rollback: failed to delete VRF", "err", err,
-			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
-	} else {
-		slog.Debug("Rollback: deleted VRF", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 	}
 }

--- a/internal/cni/route/route.go
+++ b/internal/cni/route/route.go
@@ -45,8 +45,8 @@ func assembleRoute(vrfID uint32, prefix, nextHop, dev string) (*netlink.Route, e
 	}, nil
 }
 
-func Add(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
-	vrfID, err := vrf.TableID(vpc, vpcAttachment)
+func Add(vpc, prefix, nextHop, dev string) error {
+	vrfID, err := vrf.TableID(vpc)
 	if err != nil {
 		return err
 	}
@@ -61,8 +61,8 @@ func Add(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
 	return nil
 }
 
-func Delete(vpc, vpcAttachment string, prefix, nextHop, dev string) error {
-	vrfID, err := vrf.TableID(vpc, vpcAttachment)
+func Delete(vpc, prefix, nextHop, dev string) error {
+	vrfID, err := vrf.TableID(vpc)
 	if err != nil {
 		return err
 	}

--- a/internal/cni/tap/tap.go
+++ b/internal/cni/tap/tap.go
@@ -64,7 +64,7 @@ func updateForwardRule(interfaceName string, action string) error {
 // applies sysctls and iptables FORWARD rules. Idempotent — repairs state
 // if the tap already exists (crash-recovery).
 func Add(vpc, vpcAttachment string, mtu int) error {
-	vrfName := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	vrfName := intf.GenerateInterfaceNameVRF(vpc)
 	tapName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 
 	vrfLink, err := netlink.LinkByName(vrfName)

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -80,7 +80,7 @@ func updateForwardRule(interfaceName string, action string) error {
 }
 
 func Add(vpc, vpcAttachment string, mtu int) error {
-	vrfName := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	vrfName := intf.GenerateInterfaceNameVRF(vpc)
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	guestName := intf.GenerateInterfaceNameGuest(vpc, vpcAttachment)
 

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -359,7 +359,7 @@ func publishBGPState(
 		}
 
 		registered, ebpfBlock, err := registerEBPFDatapath(
-			bgp, cfg.vpc, cfg.vpcAttachment, cfg.ifaceType, uint16(vrfID), ebpfPinDir)
+			bgp, cfg.vpc, cfg.ifaceType, uint16(vrfID), ebpfPinDir)
 		if err != nil {
 			return fmt.Errorf("register eBPF uSID datapath: %w", err)
 		}
@@ -412,7 +412,7 @@ func publishBGPState(
 // intentionally not set up for this attachment. Any other failure is
 // returned as an error.
 func registerEBPFDatapath(
-	bgp bgpConfig, vpc, vpcAttachment, ifaceType string, argument uint16, pinDir string,
+	bgp bgpConfig, vpc, ifaceType string, argument uint16, pinDir string,
 ) (registered bool, block uint64, err error) {
 	if bgp.srv6Locator == "" || bgp.nodeID == 0 {
 		return false, 0, nil
@@ -437,7 +437,7 @@ func registerEBPFDatapath(
 		return false, 0, fmt.Errorf("derive eBPF uSID Block from locator %q: %w", bgp.srv6Locator, err)
 	}
 
-	vrfTableID, err := vrf.TableID(vpc, vpcAttachment)
+	vrfTableID, err := vrf.TableID(vpc)
 	if err != nil {
 		return false, 0, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
 	}

--- a/internal/cnibgp/bgp_ebpf_test.go
+++ b/internal/cnibgp/bgp_ebpf_test.go
@@ -32,7 +32,7 @@ func requireRoot(t *testing.T) {
 func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "", nodeID: 0}
 	registered, _, err := registerEBPFDatapath(
-		cfg, testVPC, testAttachment, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
+		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err != nil {
 		t.Errorf("registerEBPFDatapath with unconfigured BGPRouter = %v, want nil (no-op)", err)
 	}
@@ -49,7 +49,7 @@ func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 func TestRegisterEBPFDatapath_RejectsOutOfRangeNodeID(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "2001:db8:1::/48", nodeID: 0x10001} // wraps to uint16(1) if narrowed unchecked
 	registered, _, err := registerEBPFDatapath(
-		cfg, testVPC, testAttachment, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
+		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err == nil {
 		t.Fatal("registerEBPFDatapath with nodeID=0x10001 = nil error, want an out-of-range rejection")
 	}
@@ -63,24 +63,22 @@ func TestRegisterEBPFDatapath_RejectsOutOfRangeNodeID(t *testing.T) {
 
 // TestRegisterEBPFDatapath_RegistersAllThreeTables: a single
 // registerEBPFDatapath call populates locator_table, function_table, and
-// vrf_table consistently for the same (vpc, vpcAttachment), against real
-// pinned eBPF maps under a throwaway pin directory — not the production
-// attach.PinDir.
+// vrf_table consistently for the same vpc, against real pinned eBPF maps
+// under a throwaway pin directory — not the production attach.PinDir.
 func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	requireRoot(t)
 
 	const (
-		vpc           = testVPC
-		vpcAttachment = testAttachment
-		locator       = "2001:db8:1::/48"
-		nodeID        = int32(5)
-		vrfID         = int32(42)
+		vpc     = testVPC
+		locator = "2001:db8:1::/48"
+		nodeID  = int32(5)
+		vrfID   = int32(42)
 	)
 
-	if err := vrf.Add(vpc, vpcAttachment); err != nil {
+	if err := vrf.Add(vpc); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
-	t.Cleanup(func() { _ = vrf.Delete(vpc, vpcAttachment) })
+	t.Cleanup(func() { _ = vrf.Delete(vpc) })
 
 	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
 	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
@@ -91,7 +89,7 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	t.Cleanup(func() { _ = loaderObjs.Close() })
 
 	cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
-	registered, _, err := registerEBPFDatapath(cfg, vpc, vpcAttachment, ifaceTypeVeth, uint16(vrfID), pinDir)
+	registered, _, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
 	if err != nil {
 		t.Fatalf("registerEBPFDatapath: %v", err)
 	}
@@ -105,7 +103,7 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	}
 	defer func() { _ = closer.Close() }()
 
-	vrfTableID, err := vrf.TableID(vpc, vpcAttachment)
+	vrfTableID, err := vrf.TableID(vpc)
 	if err != nil {
 		t.Fatalf("vrf.TableID: %v", err)
 	}
@@ -149,11 +147,11 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 func TestUnregisterEBPFDatapath_RemovesOwnEntry(t *testing.T) {
 	requireRoot(t)
 
-	if err := vrf.Add(testVPC, testAttachment); err != nil {
+	if err := vrf.Add(testVPC); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC, testAttachment) })
-	vrfTableID, err := vrf.TableID(testVPC, testAttachment)
+	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
+	vrfTableID, err := vrf.TableID(testVPC)
 	if err != nil {
 		t.Fatalf("vrf.TableID: %v", err)
 	}

--- a/internal/cnibgp/ops_check.go
+++ b/internal/cnibgp/ops_check.go
@@ -121,7 +121,7 @@ func checkEBPFEntry(ctx context.Context, k8s client.Client, pluginConf *PluginCo
 		return fmt.Errorf("derive eBPF uSID Block from locator %q: %w", bgp.srv6Locator, err)
 	}
 
-	vrfTableID, err := vrf.TableID(pluginConf.VPC, pluginConf.VPCAttachment)
+	vrfTableID, err := vrf.TableID(pluginConf.VPC)
 	if err != nil {
 		return fmt.Errorf("get VRF table ID: %w", err)
 	}

--- a/internal/cnibgp/resource.go
+++ b/internal/cnibgp/resource.go
@@ -99,7 +99,7 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 	}
 
 	if rt.ebpfRegistered {
-		if vrfTableID, err := vrf.TableID(rt.vpc, rt.vpcAttachment); err != nil {
+		if vrfTableID, err := vrf.TableID(rt.vpc); err != nil {
 			slog.Error("Rollback: failed to resolve VRF table id, skipping eBPF vrf_table unregister", "err", err,
 				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 		} else if err := unregisterEBPFDatapath(rt.ebpfBlock, rt.ebpfArgument, vrfTableID, ebpfPinDir); err != nil {

--- a/internal/cnibgp/resource_test.go
+++ b/internal/cnibgp/resource_test.go
@@ -152,11 +152,11 @@ func TestResourceTrackerCleanup_MissingCRDsAreNotError(t *testing.T) {
 func TestResourceTrackerCleanup_UnregistersOwnEBPFEntry(t *testing.T) {
 	requireRoot(t)
 
-	if err := vrf.Add(testVPC, testAttachment); err != nil {
+	if err := vrf.Add(testVPC); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC, testAttachment) })
-	vrfTableID, err := vrf.TableID(testVPC, testAttachment)
+	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
+	vrfTableID, err := vrf.TableID(testVPC)
 	if err != nil {
 		t.Fatalf("vrf.TableID: %v", err)
 	}
@@ -219,10 +219,10 @@ func TestResourceTrackerCleanup_UnregistersOwnEBPFEntry(t *testing.T) {
 func TestResourceTrackerCleanup_LeavesEBPFEntryOwnedByAnotherAttachment(t *testing.T) {
 	requireRoot(t)
 
-	if err := vrf.Add(testVPC, testAttachment); err != nil {
+	if err := vrf.Add(testVPC); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC, testAttachment) })
+	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
 
 	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
 	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })

--- a/internal/cniroute/ops_add.go
+++ b/internal/cniroute/ops_add.go
@@ -54,7 +54,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	}()
 
 	for _, termination := range pluginConf.Terminations {
-		if err := route.Add(pluginConf.VPC, pluginConf.VPCAttachment, termination.Network, termination.Via, dev); err != nil {
+		if err := route.Add(pluginConf.VPC, termination.Network, termination.Via, dev); err != nil {
 			return fmt.Errorf("add route %s: %w", termination.Network, err)
 		}
 		tracker.added = append(tracker.added, termination)

--- a/internal/cniroute/ops_check.go
+++ b/internal/cniroute/ops_check.go
@@ -57,7 +57,7 @@ func cmdStatus(args *skel.CmdArgs) error {
 // checkTerminationRoutes verifies that all termination routes exist in the
 // VRF table for the given VPC/VPCAttachment pair.
 func checkTerminationRoutes(vpc, vpcAttachment string, terminations []Termination) error {
-	tableID, err := vrf.TableID(vpc, vpcAttachment)
+	tableID, err := vrf.TableID(vpc)
 	if err != nil {
 		return fmt.Errorf("get VRF table ID: %w", err)
 	}

--- a/internal/cniroute/resource.go
+++ b/internal/cniroute/resource.go
@@ -27,7 +27,7 @@ func (rt *resourceTracker) cleanup() {
 		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 
 	for _, term := range rt.added {
-		if err := route.Delete(rt.vpc, rt.vpcAttachment, term.Network, term.Via, rt.dev); err != nil {
+		if err := route.Delete(rt.vpc, term.Network, term.Via, rt.dev); err != nil {
 			slog.Error("Rollback: failed to delete route", "err", err,
 				"network", term.Network, "via", term.Via, "dev", rt.dev)
 		} else {

--- a/internal/cnitap/ops_add.go
+++ b/internal/cnitap/ops_add.go
@@ -72,10 +72,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 	}()
 
-	if err := vrf.Add(pluginConf.VPC, pluginConf.VPCAttachment); err != nil {
+	if err := vrf.Add(pluginConf.VPC); err != nil {
 		return fmt.Errorf("add VRF: %w", err)
 	}
-	tracker.vrfCreated = true
 	slog.Debug("ADD: VRF ready", "vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
 
 	if err := tap.Add(pluginConf.VPC, pluginConf.VPCAttachment, pluginConf.MTU); err != nil {

--- a/internal/cnitap/ops_check.go
+++ b/internal/cnitap/ops_check.go
@@ -144,8 +144,8 @@ var probeAPIServer = probeAPIServerFn
 func checkNodeLevelState(vpc, vpcAttachment string) (string, []error) {
 	var errs []error
 
-	if err := vrf.Exists(vpc, vpcAttachment); err != nil {
-		errs = append(errs, fmt.Errorf("vrf %s-%s: %w", vpc, vpcAttachment, err))
+	if err := vrf.Exists(vpc); err != nil {
+		errs = append(errs, fmt.Errorf("vrf %s: %w", vpc, err))
 	}
 
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)

--- a/internal/cnitap/resource.go
+++ b/internal/cnitap/resource.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.datum.net/galactic/internal/cni/tap"
-	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
 var cniScheme = runtime.NewScheme()
@@ -53,7 +52,6 @@ func newK8sClient() (client.Client, error) {
 // route's own, with its own smaller tracker (internal/cniroute).
 type resourceTracker struct {
 	vpc, vpcAttachment string
-	vrfCreated         bool
 
 	// ipamDelegated, ipamType, and ipamStdin record enough to release the
 	// IPAM allocation during rollback — see internal/cni's own
@@ -65,6 +63,15 @@ type resourceTracker struct {
 	ipamStdin     []byte
 }
 
+// Deliberately absent: deleting the VRF. tap.Delete below only removes this
+// attachment's own tap device, which is genuinely private to it — but the
+// VRF itself is shared by every attachment on this VPC on this node
+// (internal/plumbing/vrf), and vrf.Add is idempotent, so a "vrfCreated" flag
+// here could never distinguish "I created it" from "a sibling attachment
+// already had." Deleting it on this attachment's own failed ADD could tear
+// down a still-live sibling's VRF out from under it — see internal/cni's own
+// resourceTracker.cleanup for the identical reasoning. Reclaiming it is
+// exclusively galactic-router's GC controller's job.
 func (rt *resourceTracker) cleanup() {
 	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
 		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
@@ -82,12 +89,5 @@ func (rt *resourceTracker) cleanup() {
 			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 	} else {
 		slog.Debug("Rollback: deleted tap", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
-	}
-
-	if err := vrf.Delete(rt.vpc, rt.vpcAttachment); err != nil {
-		slog.Error("Rollback: failed to delete VRF", "err", err,
-			"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
-	} else {
-		slog.Debug("Rollback: deleted VRF", "vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
 	}
 }

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -50,9 +50,11 @@ type CleanupResult struct {
 }
 
 // vrfNameRegex matches the deterministic VRF interface name pattern used by
-// Galactic. The template is "G%09s%03sV" where %09s is the base62 VPC and
-// %03s is the base62 VPCAttachment. Base62 includes digits and letters.
-var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})([A-Za-z0-9]{3})V$`)
+// Galactic. The template is "G%09sV" where %09s is the base62 VPC — the
+// kernel VRF is shared by every attachment on this VPC on this node, so
+// unlike the host/guest veth templates it carries no VPCAttachment segment.
+// Base62 includes digits and letters.
+var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})V$`)
 
 // routerNamesForNode returns the names of every BGPRouter in the namespace
 // whose TargetRef points at nodeName. BGPAdvertisement/BGPVRFInstance CRDs
@@ -99,9 +101,20 @@ func routersForNode(
 	return routers, nil
 }
 
+// vpcFromName extracts the VPC segment from a "vpc-suffix" CRD name —
+// BGPAdvertisement's vpc-vpcAttachment (crdnames.BGPAdvertisementName) or
+// BGPVRFInstance's vpc-node (crdnames.BGPVRFInstanceName). The base62 VPC
+// value itself never contains '-', so the first segment is always
+// unambiguous regardless of what the suffix contains — including a node
+// name that itself contains '-' (e.g. "dfw-worker-control").
+func vpcFromName(name string) string {
+	vpc, _, _ := strings.Cut(name, "-")
+	return vpc
+}
+
 // CollectOrphanedCRDs scans BGPAdvertisement and BGPVRFInstance CRDs owned by
 // nodeName's BGPRouter(s) in the given namespace and returns those whose
-// associated container no longer exists on this node.
+// associated container(s)/attachment(s) no longer exist on this node.
 //
 // A CRD is considered orphaned when:
 //   - It is a BGPAdvertisement targeting one of nodeName's BGPRouters, with
@@ -111,8 +124,13 @@ func routersForNode(
 //     annotation entry without removing old ones — see cmdDel in
 //     internal/cni/ops_del.go), so the object is only orphaned once every
 //     container that ever referenced it is gone, not just one.
-//   - It is a BGPVRFInstance whose name matches a BGPAdvertisement that
-//     is itself orphaned (same vpc-vpcattachment name).
+//   - It is a BGPVRFInstance (named vpc-node — crdnames.BGPVRFInstanceName —
+//     shared by every attachment on this VPC on this node, unlike the 1:1
+//     BGPAdvertisement) whose VPC has no surviving BGPAdvertisement: every
+//     BGPAdvertisement whose name's vpc segment matches is either orphaned
+//     or absent entirely. A BGPAdvertisement this pass could not determine
+//     the liveness of (no netns annotations at all) counts as surviving,
+//     not orphaned — GC must never guess a shared VRF is safe to reclaim.
 func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]OrphanedCRD, error) {
 	routerNames, err := routerNamesForNode(ctx, k8s, namespace, nodeName)
 	if err != nil {
@@ -125,18 +143,25 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 	}
 
 	var orphaned []OrphanedCRD
-	orphanedAdvNames := make(map[string]struct{})
+	// vpcSurvives records every VPC (attachments owned by this node's
+	// router(s) only) with at least one BGPAdvertisement that is live, or
+	// whose liveness could not be determined — the shared BGPVRFInstance for
+	// that VPC must not be touched while any of these remain.
+	vpcSurvives := make(map[string]struct{})
 
 	for _, adv := range advList.Items {
 		if _, ownedByThisNode := routerNames[adv.Spec.RouterRef.Name]; !ownedByThisNode {
 			// Belongs to a router on another node — not ours to judge.
 			continue
 		}
+		vpc := vpcFromName(adv.Name)
 
 		netnsPaths := collectNetNSPaths(&adv)
 		if len(netnsPaths) == 0 {
 			// No netns annotations — skip (might be legacy or manually
-			// created). We cannot determine if it is orphaned.
+			// created). We cannot determine if it is orphaned, so its VPC
+			// must be treated as surviving.
+			vpcSurvives[vpc] = struct{}{}
 			continue
 		}
 
@@ -150,6 +175,7 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 		if liveContainerID != "" {
 			// At least one container that attached to this
 			// vpc/vpcAttachment is still alive — not orphaned.
+			vpcSurvives[vpc] = struct{}{}
 			continue
 		}
 
@@ -166,16 +192,30 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 			Kind:        "BGPAdvertisement",
 			ContainerID: anyContainerID,
 		})
-		orphanedAdvNames[adv.Name] = struct{}{}
 	}
 
-	// BGPVRFInstance CRDs share the same name as their corresponding
-	// BGPAdvertisement (both use vpc-vpcattachment naming). If a
-	// BGPAdvertisement is orphaned, its BGPVRFInstance counterpart is
-	// also orphaned.
-	for name := range orphanedAdvNames {
+	// A BGPVRFInstance is orphaned only once every attachment on its VPC —
+	// not just one — is gone, since it's shared by all of them. This counts
+	// across every BGPAdvertisement for the VPC rather than aliasing 1:1 off
+	// a single BGPAdvertisement's name, the way the two used to share an
+	// identical vpc-vpcattachment name before BGPVRFInstance moved to
+	// vpc-node naming.
+	vrfList := &bgpv1alpha1.BGPVRFInstanceList{}
+	if err := k8s.List(ctx, vrfList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPVRFInstances: %w", err)
+	}
+	for _, inst := range vrfList.Items {
+		if inst.Spec.RouterRef == nil {
+			continue
+		}
+		if _, ownedByThisNode := routerNames[inst.Spec.RouterRef.Name]; !ownedByThisNode {
+			continue
+		}
+		if _, survives := vpcSurvives[vpcFromName(inst.Name)]; survives {
+			continue
+		}
 		orphaned = append(orphaned, OrphanedCRD{
-			Name:      name,
+			Name:      inst.Name,
 			Namespace: namespace,
 			Kind:      "BGPVRFInstance",
 		})
@@ -231,16 +271,20 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 }
 
 // CollectOrphanedVRFs scans all VRF interfaces on this node and returns the
-// vpc/vpcAttachment pairs for VRFs whose corresponding BGPAdvertisement CRD,
-// owned by nodeName's BGPRouter(s), no longer exists in the given namespace.
+// names of VRFs whose VPC has no surviving BGPAdvertisement CRD owned by
+// nodeName's BGPRouter(s) in the given namespace.
 //
 // A VRF is considered orphaned when:
 //   - Its interface name matches the Galactic VRF naming pattern.
-//   - No BGPAdvertisement owned by this node (name = vpc-vpcattachment,
-//     RouterRef pointing at one of nodeName's BGPRouters) exists for it.
-//     Other nodes sharing this namespace may coincidentally reuse the same
-//     vpc-vpcattachment name for their own, unrelated attachment — only
-//     this node's own BGPAdvertisements can vouch for a local VRF.
+//   - No BGPAdvertisement owned by this node (name's vpc segment matches,
+//     RouterRef pointing at one of nodeName's BGPRouters) exists for its
+//     VPC. The VRF is shared by every attachment on this VPC on this node
+//     (crdnames.BGPVRFInstanceName), so any one surviving BGPAdvertisement
+//     for the VPC — regardless of which vpcAttachment it names — keeps it
+//     alive, not just a single exact-name match. Other nodes sharing this
+//     namespace may coincidentally reuse the same VPC for their own,
+//     unrelated attachment — only this node's own BGPAdvertisements can
+//     vouch for a local VRF.
 func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]string, error) {
 	vrfs, err := vrf.ListVRFLinks()
 	if err != nil {
@@ -252,31 +296,30 @@ func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, node
 		return nil, err
 	}
 
-	// Build a set of active BGPAdvertisement names owned by this node.
+	// Build the set of VPCs with at least one active BGPAdvertisement owned
+	// by this node.
 	advList := &bgpv1alpha1.BGPAdvertisementList{}
 	if err := k8s.List(ctx, advList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPAdvertisements: %w", err)
 	}
 
-	activeAdvNames := make(map[string]struct{}, len(advList.Items))
+	activeVPCs := make(map[string]struct{}, len(advList.Items))
 	for _, adv := range advList.Items {
 		if _, ownedByThisNode := routerNames[adv.Spec.RouterRef.Name]; !ownedByThisNode {
 			continue
 		}
-		activeAdvNames[adv.Name] = struct{}{}
+		activeVPCs[vpcFromName(adv.Name)] = struct{}{}
 	}
 
 	var orphaned []string
 	for _, v := range vrfs {
-		vpc, vpcAtt, ok := parseVRFName(v.Name)
+		vpc, ok := parseVRFName(v.Name)
 		if !ok {
 			// Not a Galactic VRF — skip.
 			continue
 		}
 
-		// Check if the corresponding BGPAdvertisement exists.
-		advName := fmt.Sprintf("%s-%s", vpc, vpcAtt)
-		if _, exists := activeAdvNames[advName]; !exists {
+		if _, exists := activeVPCs[vpc]; !exists {
 			orphaned = append(orphaned, v.Name)
 		}
 	}
@@ -291,9 +334,8 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 	result := CleanupResult{}
 
 	for _, name := range vrfNames {
-		// We need the vpc/vpcAttachment to call vrf.Delete. Parse the name
-		// back to get those values.
-		vpc, vpcAtt, ok := parseVRFName(name)
+		// We need the vpc to call vrf.Delete. Parse the name back to get it.
+		vpc, ok := parseVRFName(name)
 		if !ok {
 			// Try to delete by name directly.
 			link, err := netlink.LinkByName(name)
@@ -309,14 +351,13 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 			continue
 		}
 
-		if err := vrf.Delete(vpc, vpcAtt); err != nil {
+		if err := vrf.Delete(vpc); err != nil {
 			slog.Error("GC: failed to delete orphaned VRF",
-				"name", name, "vpc", vpc, "vpcAttachment", vpcAtt, "err", err)
+				"name", name, "vpc", vpc, "err", err)
 			result.Errors++
 			continue
 		}
-		slog.Info("GC: removed orphaned VRF",
-			"name", name, "vpc", vpc, "vpcAttachment", vpcAtt)
+		slog.Info("GC: removed orphaned VRF", "name", name, "vpc", vpc)
 		result.OrphanedVRFsRemoved++
 	}
 
@@ -516,15 +557,14 @@ func collectNetNSPaths(adv *bgpv1alpha1.BGPAdvertisement) map[string]string {
 // The interface name template ("G%09s%03sV") zero-pads the base62 components,
 // but BGP CRD names use the raw (unpadded) base62 values. parseVRFName strips
 // leading zeros so the returned values match the CRD naming convention.
-func parseVRFName(name string) (vpc, vpcAttachment string, ok bool) {
-	// The template is "G%09s%03sV" — 1 + 9 + 3 + 1 = 14 characters.
-	// But base62 encoding can produce mixed alphanumeric, so we need a
-	// regex approach.
+func parseVRFName(name string) (vpc string, ok bool) {
+	// The template is "G%09sV" — 1 + 9 + 1 = 11 characters. But base62
+	// encoding can produce mixed alphanumeric, so we need a regex approach.
 	matches := vrfNameRegex.FindStringSubmatch(name)
 	if matches == nil {
-		return "", "", false
+		return "", false
 	}
-	// Strip leading zeros to reverse the %09s/%03s padding. BGP CRD names
-	// use the raw base62 values (e.g. "10-10" not "000000010-010").
-	return strings.TrimLeft(matches[1], "0"), strings.TrimLeft(matches[2], "0"), true
+	// Strip leading zeros to reverse the %09s padding. BGP CRD names use the
+	// raw base62 value (e.g. "10-dfw-worker" not "000000010-dfw-worker").
+	return strings.TrimLeft(matches[1], "0"), true
 }

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testVRFName      = "G0000000jU00GV"
+	testVRFName      = "G0000000jUV"
 	testVRFNameHost  = "G0000000jU00GH"
 	testVRFNameGuest = "G0000000jU00GG"
 	testEth0         = "eth0"
@@ -96,32 +96,28 @@ func TestCollectNetNSPaths(t *testing.T) {
 
 func TestParseVRFName(t *testing.T) {
 	tests := []struct {
-		name       string
-		vrfName    string
-		wantVPC    string
-		wantVPCAtt string
-		wantOk     bool
+		name    string
+		vrfName string
+		wantVPC string
+		wantOk  bool
 	}{
 		{
-			name:       "valid VRF name",
-			vrfName:    testVRFName,
-			wantVPC:    "jU",
-			wantVPCAtt: "G",
-			wantOk:     true,
+			name:    "valid VRF name",
+			vrfName: testVRFName,
+			wantVPC: "jU",
+			wantOk:  true,
 		},
 		{
-			name:       "valid VRF name with digits",
-			vrfName:    "G000000123001V",
-			wantVPC:    "123",
-			wantVPCAtt: "1",
-			wantOk:     true,
+			name:    "valid VRF name with digits",
+			vrfName: "G000000123V",
+			wantVPC: "123",
+			wantOk:  true,
 		},
 		{
-			name:       "small numeric VPC and attachment (regression — GC naming mismatch)",
-			vrfName:    "G000000010010V",
-			wantVPC:    "10",
-			wantVPCAtt: "10",
-			wantOk:     true,
+			name:    "small numeric VPC (regression — GC naming mismatch)",
+			vrfName: "G000000010V",
+			wantVPC: "10",
+			wantOk:  true,
 		},
 		{
 			name:    "not a VRF name (host interface)",
@@ -147,7 +143,7 @@ func TestParseVRFName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotVPC, gotVPCAtt, gotOk := parseVRFName(tt.vrfName)
+			gotVPC, gotOk := parseVRFName(tt.vrfName)
 			if gotOk != tt.wantOk {
 				t.Errorf("parseVRFName(%q) ok = %v, want %v", tt.vrfName, gotOk, tt.wantOk)
 				return
@@ -155,25 +151,23 @@ func TestParseVRFName(t *testing.T) {
 			if gotVPC != tt.wantVPC {
 				t.Errorf("parseVRFName(%q) vpc = %q, want %q", tt.vrfName, gotVPC, tt.wantVPC)
 			}
-			if gotVPCAtt != tt.wantVPCAtt {
-				t.Errorf("parseVRFName(%q) vpcAttachment = %q, want %q", tt.vrfName, gotVPCAtt, tt.wantVPCAtt)
-			}
 		})
 	}
 }
 
 func TestVRFNameRegex(t *testing.T) {
-	// Verify the regex matches the expected VRF naming pattern.
-	// The template is "G%09s%03sV" where %09s is base62-padded VPC
-	// and %03s is base62-padded VPCAttachment.
+	// Verify the regex matches the expected VRF naming pattern. The template
+	// is "G%09sV" where %09s is the base62-padded VPC — no VPCAttachment
+	// segment, since the VRF is shared by every attachment on this VPC on
+	// this node.
 	testCases := []struct {
 		name   string
 		input  string
 		expect bool
 	}{
 		{testVRFName, testVRFName, true},
-		{"G000000000000V", "G000000000000V", true},
-		{"G123456789001V", "G123456789001V", true},
+		{"G000000000V", "G000000000V", true},
+		{"G123456789V", "G123456789V", true},
 		// Non-VRF names should not match.
 		{testVRFNameHost, testVRFNameHost, false},
 		{testVRFNameGuest, testVRFNameGuest, false},
@@ -186,6 +180,30 @@ func TestVRFNameRegex(t *testing.T) {
 			matches := vrfNameRegex.MatchString(tc.input)
 			if matches != tc.expect {
 				t.Errorf("vrfNameRegex.MatchString(%q) = %v, want %v", tc.input, matches, tc.expect)
+			}
+		})
+	}
+}
+
+// TestVPCFromName covers the shared vpc-suffix name parsing used by both
+// CollectOrphanedCRDs (BGPAdvertisement's vpc-vpcAttachment,
+// BGPVRFInstance's vpc-node) and CollectOrphanedVRFs.
+func TestVPCFromName(t *testing.T) {
+	const vpc = "abc"
+	tests := []struct {
+		name    string
+		input   string
+		wantVPC string
+	}{
+		{"BGPAdvertisement-shaped name", vpc + "-def", vpc},
+		{"BGPVRFInstance name with a hyphenated node name", vpc + "-dfw-worker-control", vpc},
+		{"no separator at all", vpc, vpc},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vpcFromName(tt.input); got != tt.wantVPC {
+				t.Errorf("vpcFromName(%q) = %q, want %q", tt.input, got, tt.wantVPC)
 			}
 		})
 	}

--- a/internal/plumbing/intf/intf.go
+++ b/internal/plumbing/intf/intf.go
@@ -15,10 +15,19 @@ import (
 
 const interfaceNameTemplate = "G%09s%03s%s"
 
+// vrfInterfaceNameTemplate has no VPCAttachment segment: the VRF is shared
+// by every attachment (pod or VM) landing on a given VPC on a given node, so
+// it is keyed by VPC alone. Unlike the CRD-level VRF identity (see
+// crdnames.BGPVRFInstanceName), the node itself never needs to appear in the
+// name — kernel interface names only have to be unique within one host's own
+// namespace, and each host only ever creates VRF interfaces for itself.
+const vrfInterfaceNameTemplate = "G%09s%s"
+
 // GenerateInterfaceNameVRF returns the kernel interface name for the VRF
-// associated with the given base62-encoded VPC and VPCAttachment.
-func GenerateInterfaceNameVRF(vpc, vpcAttachment string) string {
-	return fmt.Sprintf(interfaceNameTemplate, vpc, vpcAttachment, "V")
+// associated with the given base62-encoded VPC. The VRF is per-VPC-per-node,
+// shared by every attachment on that VPC on this node — not per-attachment.
+func GenerateInterfaceNameVRF(vpc string) string {
+	return fmt.Sprintf(vrfInterfaceNameTemplate, vpc, "V")
 }
 
 // GenerateInterfaceNameHost returns the kernel interface name for the host-side

--- a/internal/plumbing/intf/intf_test.go
+++ b/internal/plumbing/intf/intf_test.go
@@ -24,10 +24,10 @@ const (
 )
 
 func TestGenerateInterfaceNameVRF(t *testing.T) {
-	expected := "G0000000jU00GV"
-	got := intf.GenerateInterfaceNameVRF(testVPC, testVPCAttachment)
+	expected := "G0000000jUV"
+	got := intf.GenerateInterfaceNameVRF(testVPC)
 	if got != expected {
-		t.Errorf("GenerateInterfaceNameVRF(%s, %s) = %s, want %s", testVPC, testVPCAttachment, got, expected)
+		t.Errorf("GenerateInterfaceNameVRF(%s) = %s, want %s", testVPC, got, expected)
 	}
 }
 

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package vrf manages Linux VRF interfaces for Galactic VPC network isolation.
-// Each VPC attachment gets its own VRF with a unique routing table ID.
-// Requires CAP_NET_ADMIN.
+// Each VPC gets its own VRF with a unique routing table ID, per node — shared
+// by every attachment (pod or VM) landing on that VPC on that node, not
+// per-attachment. Requires CAP_NET_ADMIN.
 package vrf
 
 import (
@@ -30,13 +31,16 @@ const maxVRFID = uint32(math.MaxUint32 - 1)
 // cross-process flock in lock.go.
 var vrfMu sync.Mutex
 
-// Add creates a Linux VRF interface for the given base62-encoded VPC and
-// VPCAttachment, allocating the next available routing table ID and applying
-// the required sysctl settings. Concurrent calls, whether from goroutines in
-// this process or from separate CNI plugin processes on the same node, are
-// serialized. If a VRF with the same name already exists (e.g. left behind
-// by a previous failed cmdAdd with no corresponding cmdDel), Add returns nil.
-func Add(vpc, vpcAttachment string) error {
+// Add creates a Linux VRF interface for the given base62-encoded VPC,
+// allocating the next available routing table ID and applying the required
+// sysctl settings. The VRF is shared by every attachment (pod or VM) on this
+// VPC on this node: concurrent calls — whether from goroutines in this
+// process, from separate CNI plugin processes attaching different pods to
+// the same VPC, or both — are serialized, and Add is idempotent by name. If
+// a VRF with the same name already exists (because another attachment on
+// this VPC already created it, or one was left behind by a previous failed
+// cmdAdd with no corresponding cmdDel), Add returns nil.
+func Add(vpc string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
 
@@ -46,7 +50,7 @@ func Add(vpc, vpcAttachment string) error {
 	}
 	defer func() { _ = lock.close() }()
 
-	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	name := intf.GenerateInterfaceNameVRF(vpc)
 
 	if _, err := netlink.LinkByName(name); err == nil {
 		return nil
@@ -80,9 +84,14 @@ func Add(vpc, vpcAttachment string) error {
 }
 
 // Delete flushes all routes from the VRF routing table and removes the VRF
-// interface for the given base62-encoded VPC and VPCAttachment. Delete is
-// idempotent: if the VRF interface does not exist, it returns nil.
-func Delete(vpc, vpcAttachment string) error {
+// interface for the given base62-encoded VPC. Delete is idempotent: if the
+// VRF interface does not exist, it returns nil. Callers must only invoke
+// Delete once no attachment on this VPC on this node remains live — deleting
+// out from under a still-live sibling attachment breaks it. galactic-cni's
+// own cmdDel never calls this directly for exactly that reason; only
+// galactic-router's GC controller does, after confirming via every
+// BGPAdvertisement for this VPC/node that none are still in use.
+func Delete(vpc string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
 
@@ -92,7 +101,7 @@ func Delete(vpc, vpcAttachment string) error {
 	}
 	defer func() { _ = lock.close() }()
 
-	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+	name := intf.GenerateInterfaceNameVRF(vpc)
 
 	vrfID, err := getVRFIDForInterface(name)
 	if err != nil {
@@ -112,15 +121,15 @@ func Delete(vpc, vpcAttachment string) error {
 }
 
 // TableID returns the Linux routing table ID for the VRF associated with the
-// given base62-encoded VPC and VPCAttachment.
-func TableID(vpc, vpcAttachment string) (uint32, error) {
-	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc, vpcAttachment))
+// given base62-encoded VPC.
+func TableID(vpc string) (uint32, error) {
+	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc))
 }
 
-// Exists reports whether a VRF interface for the given VPC and VPCAttachment
-// exists in the kernel.
-func Exists(vpc, vpcAttachment string) error {
-	name := intf.GenerateInterfaceNameVRF(vpc, vpcAttachment)
+// Exists reports whether a VRF interface for the given VPC exists in the
+// kernel.
+func Exists(vpc string) error {
+	name := intf.GenerateInterfaceNameVRF(vpc)
 	if _, err := netlink.LinkByName(name); err != nil {
 		return fmt.Errorf("VRF interface %q not found", name)
 	}

--- a/internal/plumbing/vrf/vrf_test.go
+++ b/internal/plumbing/vrf/vrf_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vrf_test
+
+import (
+	"os"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/intf"
+	"go.datum.net/galactic/internal/plumbing/vrf"
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_NET_ADMIN) to create real VRF interfaces; re-run via sudo")
+	}
+}
+
+// TestAdd_SharedAcrossCallers is the core regression test for VRF-per-VPC
+// sharing: two "attachments" (simulated here by two independent Add calls
+// for the same VPC, exactly what two sibling CNI ADD invocations for
+// different vpcAttachment values under one VPC do in production) must
+// converge on the identical kernel VRF interface and routing table, not
+// create — or worse, clobber — a second one.
+func TestAdd_SharedAcrossCallers(t *testing.T) {
+	requireRoot(t)
+	const vpc = "vtshr"
+	t.Cleanup(func() { _ = vrf.Delete(vpc) })
+
+	if err := vrf.Add(vpc); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	firstTableID, err := vrf.TableID(vpc)
+	if err != nil {
+		t.Fatalf("TableID after first Add: %v", err)
+	}
+
+	// A second "attachment" on the same VPC.
+	if err := vrf.Add(vpc); err != nil {
+		t.Fatalf("second Add: %v", err)
+	}
+	secondTableID, err := vrf.TableID(vpc)
+	if err != nil {
+		t.Fatalf("TableID after second Add: %v", err)
+	}
+
+	if firstTableID != secondTableID {
+		t.Errorf("table ID changed across two Add calls for the same VPC: %d != %d — "+
+			"a second attachment must reuse the first's VRF, not replace it", firstTableID, secondTableID)
+	}
+
+	if err := vrf.Exists(vpc); err != nil {
+		t.Errorf("Exists after two Add calls: %v", err)
+	}
+}
+
+// TestAdd_DifferentVPCsGetDistinctVRFs verifies the flip side of sharing:
+// two different VPCs never collide on the same kernel VRF/table, even when
+// created back-to-back.
+func TestAdd_DifferentVPCsGetDistinctVRFs(t *testing.T) {
+	requireRoot(t)
+	const vpcA, vpcB = "vtda", "vtdb"
+	t.Cleanup(func() { _ = vrf.Delete(vpcA) })
+	t.Cleanup(func() { _ = vrf.Delete(vpcB) })
+
+	if err := vrf.Add(vpcA); err != nil {
+		t.Fatalf("Add(%q): %v", vpcA, err)
+	}
+	if err := vrf.Add(vpcB); err != nil {
+		t.Fatalf("Add(%q): %v", vpcB, err)
+	}
+
+	tableA, err := vrf.TableID(vpcA)
+	if err != nil {
+		t.Fatalf("TableID(%q): %v", vpcA, err)
+	}
+	tableB, err := vrf.TableID(vpcB)
+	if err != nil {
+		t.Fatalf("TableID(%q): %v", vpcB, err)
+	}
+	if tableA == tableB {
+		t.Errorf("two different VPCs resolved to the same table ID %d, want distinct", tableA)
+	}
+
+	nameA := intf.GenerateInterfaceNameVRF(vpcA)
+	nameB := intf.GenerateInterfaceNameVRF(vpcB)
+	if nameA == nameB {
+		t.Fatalf("GenerateInterfaceNameVRF produced the same name %q for two different VPCs", nameA)
+	}
+}
+
+// TestDelete_Idempotent covers Delete's documented idempotency: deleting a
+// VRF that was never created (or already gone) is not an error.
+func TestDelete_Idempotent(t *testing.T) {
+	requireRoot(t)
+	if err := vrf.Delete("vtnone"); err != nil {
+		t.Errorf("Delete on a nonexistent VRF = %v, want nil", err)
+	}
+}
+
+// TestExists_NotFound covers Exists returning an error for a VPC with no
+// kernel VRF at all.
+func TestExists_NotFound(t *testing.T) {
+	requireRoot(t)
+	if err := vrf.Exists("vtnone"); err == nil {
+		t.Error("Exists for a nonexistent VRF = nil, want an error")
+	}
+}
+
+// TestTableID_NotFound covers TableID returning an error for a VPC with no
+// kernel VRF at all, rather than a zero-value table ID that could be
+// mistaken for a real one.
+func TestTableID_NotFound(t *testing.T) {
+	requireRoot(t)
+	if _, err := vrf.TableID("vtnone"); err == nil {
+		t.Error("TableID for a nonexistent VRF = nil error, want an error")
+	}
+}
+
+// TestDelete_ThenAddRecreates covers the sequential-reuse case documented on
+// Add/Delete: once every attachment on a VPC is gone and GC deletes the VRF,
+// a later attachment on the same VPC gets a fresh VRF rather than erroring
+// out because "something" still looks present.
+func TestDelete_ThenAddRecreates(t *testing.T) {
+	requireRoot(t)
+	const vpc = "vtre1"
+	t.Cleanup(func() { _ = vrf.Delete(vpc) })
+
+	if err := vrf.Add(vpc); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	if err := vrf.Delete(vpc); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := vrf.Exists(vpc); err == nil {
+		t.Fatal("Exists after Delete = nil, want an error (VRF should be gone)")
+	}
+	if err := vrf.Add(vpc); err != nil {
+		t.Fatalf("Add after Delete: %v", err)
+	}
+	if err := vrf.Exists(vpc); err != nil {
+		t.Errorf("Exists after re-Add: %v", err)
+	}
+}

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -97,8 +97,9 @@ func (r *Reconciler) BuildDesiredRouter(
 		return nil, fmt.Errorf("list BGPAdvertisements for router %s/%s: %w", namespace, router.Name, err)
 	}
 
-	// Gather VRF instances. A node hosts one BGPVRFInstance per VPC attachment,
-	// which can number in the thousands, so every instance targeting this
+	// Gather VRF instances. A node hosts one BGPVRFInstance per VPC that has
+	// at least one attachment here — shared by every attachment on that
+	// VPC/node, not one per attachment — so every instance targeting this
 	// router must be carried into DesiredRouter — not just the first.
 	vrfList := &bgpv1alpha1.BGPVRFInstanceList{}
 	if err := r.client.List(ctx, vrfList,

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -165,14 +165,20 @@ func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (uint32,
 	return 0, false
 }
 
-// vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{vpcAttachment}"
-// in base62 — see bgpVRFInstanceName in cni.go.
+// vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{node}"
+// in base62 — see crdnames.BGPVRFInstanceName. The kernel VRF itself is
+// keyed by vpc alone (it's shared by every attachment on this VPC on this
+// node — vrfpkg.TableID needs no node component, since interface names only
+// need to be unique within one host's own namespace), so only the segment
+// before the first '-' matters here; node can itself contain '-' (e.g.
+// "dfw-worker-control"), which is why this splits into exactly 2 parts
+// instead of parsing node back out too.
 func vrfTableID(vrfName string) (uint32, error) {
 	parts := strings.SplitN(vrfName, "-", 2)
 	if len(parts) != 2 {
 		return 0, fmt.Errorf("VRF name %q does not contain '-'", vrfName)
 	}
-	return vrfpkg.TableID(parts[0], parts[1])
+	return vrfpkg.TableID(parts[0])
 }
 
 // evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -220,8 +220,10 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 }
 
 // applyVRFs configures every desired VRF instance and removes stale ones. A
-// node can host thousands of VRFs (one per VPC attachment), so this — unlike
-// the single-VRF code it replaces — must handle the full set, not just one.
+// node can host many VRFs (one per VPC that has at least one attachment on
+// this node, shared by every attachment on that VPC/node — not one per
+// attachment), so this — unlike the single-VRF code it replaces — must
+// handle the full set, not just one.
 func (r *GoBGPRuntime) applyVRFs(
 	ctx context.Context, b *gobgpserver.BgpServer, vrfs []model.DesiredVRFInstance, routerID string,
 ) error {


### PR DESCRIPTION
## Summary

Two pods attaching to the same VPC on the same node collided: the kernel VRF interface was keyed per attachment, so a second attachment's setup saw the first's still-live VRF, mistook it for leftover state from a failed attempt, and deleted it, silently breaking the first pod's networking. The VRF is now shared per VPC per node, matching how a VPC is a per-node routing domain, not a private resource of one attachment.

## Test plan

- [ ] `task ci` passes (lint, build, unit tests)
- [ ] Two attachments sharing a VPC on one node no longer collide on VRF teardown

---

**Stack** (merge bottom to top):

- #311 fix(vrf): key kernel VRF by VPC, not (VPC, attachment) (this PR)
- #312 fix(cnibgp): share BGPVRFInstance and Argument per (VPC, node)
- #313 fix(containerlab): give ns30/ns40 two attachments, not one shared


🤖 Generated with [Claude Code](https://claude.com/claude-code)
