### PR TITLE
fix(cnibgp): share BGPVRFInstance and Argument per (VPC, node)

### DIFF
--- a/internal/cni/crdnames/crdnames.go
+++ b/internal/cni/crdnames/crdnames.go
@@ -69,10 +69,16 @@ func NetNSKey(containerID string) string {
 }
 
 // BGPVRFInstanceName returns the deterministic name for a BGPVRFInstance.
-// Each VPCAttachment is unique per interface across the cluster, so the
-// (vpc, vpcAttachment) pair is a reliable 1:1 key.
-func BGPVRFInstanceName(vpc, vpcAttachment string) string {
-	return fmt.Sprintf("%s-%s", vpc, vpcAttachment)
+// Unlike BGPAdvertisementName, this is keyed by (vpc, node) rather than
+// (vpc, vpcAttachment): the underlying kernel VRF is shared by every
+// attachment (pod or VM) on this VPC on this node (see internal/plumbing/vrf
+// and internal/plumbing/intf's GenerateInterfaceNameVRF), so every attachment
+// on the same VPC/node must resolve to the same BGPVRFInstance rather than
+// creating its own. This is the one CRD name that needs node identity at
+// all — the kernel side never does, since interface names only need to be
+// unique within one host's own namespace.
+func BGPVRFInstanceName(vpc, nodeName string) string {
+	return fmt.Sprintf("%s-%s", vpc, nodeName)
 }
 
 // BGPAdvertisementName returns the deterministic name for a

--- a/internal/cni/crdnames/crdnames_test.go
+++ b/internal/cni/crdnames/crdnames_test.go
@@ -10,15 +10,29 @@ import (
 )
 
 func TestBGPVRFInstanceName(t *testing.T) {
-	tests := []struct{ vpc, attachment, want string }{
-		{"abc", "def", "abc-def"},
-		{"0000000jU", "00G", "0000000jU-00G"},
+	tests := []struct{ vpc, nodeName, want string }{
+		{"abc", "worker-1", "abc-worker-1"},
+		{"0000000jU", "dfw-worker", "0000000jU-dfw-worker"},
 	}
 	for _, tt := range tests {
-		got := BGPVRFInstanceName(tt.vpc, tt.attachment)
+		got := BGPVRFInstanceName(tt.vpc, tt.nodeName)
 		if got != tt.want {
-			t.Errorf("BGPVRFInstanceName(%q, %q) = %q, want %q", tt.vpc, tt.attachment, got, tt.want)
+			t.Errorf("BGPVRFInstanceName(%q, %q) = %q, want %q", tt.vpc, tt.nodeName, got, tt.want)
 		}
+	}
+}
+
+// TestBGPVRFInstanceNameSharedAcrossAttachments verifies that two different
+// attachments (vpcAttachment values) on the same VPC and node converge on
+// the identical BGPVRFInstance name — the whole point of keying this by
+// (vpc, node) instead of (vpc, vpcAttachment).
+func TestBGPVRFInstanceNameSharedAcrossAttachments(t *testing.T) {
+	const vpc, nodeName = "abc", "dfw-worker"
+	first := BGPVRFInstanceName(vpc, nodeName)
+	second := BGPVRFInstanceName(vpc, nodeName)
+	if first != second {
+		t.Errorf("BGPVRFInstanceName(%q, %q) should be stable regardless of caller/attachment, got %q and %q",
+			vpc, nodeName, first, second)
 	}
 }
 

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -61,17 +61,20 @@ type publishConfig struct {
 }
 
 // publishResult records what publishBGPState actually created, so cmdAdd
-// can fold it into its own rollback tracker.
+// can fold it into its own rollback tracker. There is no record of the eBPF
+// vrf_table registration: it's shared by every attachment on this VPC/node
+// (see crdnames.BGPVRFInstanceName) with no "did I just create this"
+// signal the way a k8s object's CreateOrUpdate result gives us, so a failed
+// ADD must never unregister it — see resourceTracker.cleanup's doc comment.
 type publishResult struct {
-	vrfInstanceCreated   bool
 	advertisementCreated bool
-	// ebpfRegistered, ebpfBlock, and ebpfArgument record the eBPF uSID
-	// datapath's vrf_table registration, if one actually happened (the
-	// BGPRouter may not be configured, in which case ebpfRegistered stays
-	// false). See unregisterEBPFDatapath for rolling this back.
-	ebpfRegistered bool
-	ebpfBlock      uint64
-	ebpfArgument   uint16
+	// vrfInstanceCreated is true only when this ADD's own CreateOrUpdate
+	// call for the (shared) BGPVRFInstance reported OperationResultCreated —
+	// i.e. this is the first attachment on this VPC/node, not one reusing an
+	// already-live sibling's CRD. See resourceTracker.cleanup's doc comment
+	// for why that distinction, not "CreateOrUpdate succeeded" alone, is
+	// what makes rollback-deletion safe.
+	vrfInstanceCreated bool
 }
 
 // isTransientError reports whether err is a transient failure that may
@@ -325,8 +328,13 @@ func publishBGPState(
 			return err
 		}
 
-		vrfID, err := allocateArgument(
-			ctx, k8s, namespace, bgp.routerName, crdnames.BGPVRFInstanceName(cfg.vpc, cfg.vpcAttachment))
+		// The BGPVRFInstance name is keyed by (vpc, node) — not (vpc,
+		// vpcAttachment) — since the underlying kernel VRF is shared by every
+		// attachment on this VPC on this node. allocateArgument's own
+		// idempotent-by-name lookup means every attachment sharing a VPC/node
+		// converges on the same CRD and the same Argument.
+		vrfName := crdnames.BGPVRFInstanceName(cfg.vpc, nodeName)
+		vrfID, err := allocateArgument(ctx, k8s, namespace, bgp.routerName, vrfName)
 		if err != nil {
 			return err
 		}
@@ -336,37 +344,43 @@ func publishBGPState(
 			return fmt.Errorf("compute route target: %w", err)
 		}
 
-		vrfName := crdnames.BGPVRFInstanceName(cfg.vpc, cfg.vpcAttachment)
 		vrfInst := &bgpv1alpha1.BGPVRFInstance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vrfName,
 				Namespace: namespace,
 			},
 		}
-		_, err = controllerutil.CreateOrUpdate(ctx, k8s, vrfInst, func() error {
+		op, err := controllerutil.CreateOrUpdate(ctx, k8s, vrfInst, func() error {
 			vrfInst.Spec = buildVRFInstanceSpec(bgp.routerName, rtValue, vrfID)
 			return nil
 		})
 		if err != nil {
 			return fmt.Errorf("apply BGPVRFInstance: %w", err)
 		}
-		result.vrfInstanceCreated = true
+		if op == controllerutil.OperationResultCreated {
+			result.vrfInstanceCreated = true
+		}
 		slog.Debug("BGP: BGPVRFInstance applied", "name", vrfName, "namespace", namespace,
-			"vrfID", vrfID, "routeTarget", rtValue, "router", bgp.routerName)
+			"vrfID", vrfID, "routeTarget", rtValue, "router", bgp.routerName, "operation", op)
 
+		// A collision here means allocateArgument's read-then-write raced
+		// against another VPC's first attachment on this same node landing
+		// on the same "lowest free slot" before either write was visible to
+		// the other — only possible when this CreateOrUpdate was a genuine
+		// create (result.vrfInstanceCreated), never when reusing an
+		// already-live sibling's CRD (whose VRFID was already validated
+		// when it was first created). Rollback needs that distinction to
+		// safely self-heal this race — see resourceTracker.cleanup.
 		if err := checkArgumentCollision(ctx, k8s, namespace, bgp.routerName, vrfName, vrfID); err != nil {
 			return err
 		}
 
-		registered, ebpfBlock, err := registerEBPFDatapath(
-			bgp, cfg.vpc, cfg.ifaceType, uint16(vrfID), ebpfPinDir)
-		if err != nil {
+		// The return values aren't tracked for rollback: the vrf_table entry
+		// they'd describe is shared by every attachment on this VPC/node,
+		// same as the BGPVRFInstance above — see resourceTracker.cleanup's
+		// doc comment for why a failed ADD must never unregister it.
+		if _, err := registerEBPFDatapath(bgp, cfg.vpc, cfg.ifaceType, uint16(vrfID), ebpfPinDir); err != nil {
 			return fmt.Errorf("register eBPF uSID datapath: %w", err)
-		}
-		if registered {
-			result.ebpfRegistered = true
-			result.ebpfBlock = ebpfBlock
-			result.ebpfArgument = uint16(vrfID)
 		}
 
 		adv := &bgpv1alpha1.BGPAdvertisement{
@@ -413,52 +427,52 @@ func publishBGPState(
 // returned as an error.
 func registerEBPFDatapath(
 	bgp bgpConfig, vpc, ifaceType string, argument uint16, pinDir string,
-) (registered bool, block uint64, err error) {
+) (registered bool, err error) {
 	if bgp.srv6Locator == "" || bgp.nodeID == 0 {
-		return false, 0, nil
+		return false, nil
 	}
 
 	if bgp.nodeID < uformat.NodeIDMin || bgp.nodeID > uformat.NodeIDMax {
-		return false, 0, fmt.Errorf("eBPF registration: nodeID %d out of range [%#x,%#x]",
+		return false, fmt.Errorf("eBPF registration: nodeID %d out of range [%#x,%#x]",
 			bgp.nodeID, uint16(uformat.NodeIDMin), uint16(uformat.NodeIDMax))
 	}
 
 	egressKind, err := egressKindForInterfaceType(ifaceType)
 	if err != nil {
-		return false, 0, fmt.Errorf("determine eBPF egress kind: %w", err)
+		return false, fmt.Errorf("determine eBPF egress kind: %w", err)
 	}
 
 	prefix, err := netip.ParsePrefix(bgp.srv6Locator)
 	if err != nil {
-		return false, 0, fmt.Errorf("parse SRv6 locator %q for eBPF registration: %w", bgp.srv6Locator, err)
+		return false, fmt.Errorf("parse SRv6 locator %q for eBPF registration: %w", bgp.srv6Locator, err)
 	}
-	block, err = uformat.Block(prefix.Addr())
+	block, err := uformat.Block(prefix.Addr())
 	if err != nil {
-		return false, 0, fmt.Errorf("derive eBPF uSID Block from locator %q: %w", bgp.srv6Locator, err)
+		return false, fmt.Errorf("derive eBPF uSID Block from locator %q: %w", bgp.srv6Locator, err)
 	}
 
 	vrfTableID, err := vrf.TableID(vpc)
 	if err != nil {
-		return false, 0, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
+		return false, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
 	}
 
 	registry, closer, err := usidmap.OpenPinnedRegistry(pinDir)
 	if err != nil {
-		return false, 0, fmt.Errorf("open pinned eBPF uSID maps: %w", err)
+		return false, fmt.Errorf("open pinned eBPF uSID maps: %w", err)
 	}
 	defer func() { _ = closer.Close() }()
 
 	if err := registry.Locator.Register(block, uint16(bgp.nodeID)); err != nil {
-		return false, 0, fmt.Errorf("register eBPF locator_table entry: %w", err)
+		return false, fmt.Errorf("register eBPF locator_table entry: %w", err)
 	}
 	if err := registry.Function.Register(block, uformat.FunctionEndDT46); err != nil {
-		return false, 0, fmt.Errorf("register eBPF function_table entry: %w", err)
+		return false, fmt.Errorf("register eBPF function_table entry: %w", err)
 	}
 
 	if err := registry.VRF.Register(block, argument, vrfTableID, egressKind); err != nil {
-		return false, 0, fmt.Errorf("register eBPF vrf_table entry: %w", err)
+		return false, fmt.Errorf("register eBPF vrf_table entry: %w", err)
 	}
-	return true, block, nil
+	return true, nil
 }
 
 // egressKindForInterfaceType maps a "veth"/"tap" interface type string to the
@@ -474,39 +488,4 @@ func egressKindForInterfaceType(ifaceType string) (uint32, error) {
 	default:
 		return 0, fmt.Errorf("unknown interface type %q", ifaceType)
 	}
-}
-
-// unregisterEBPFDatapath removes the vrf_table entry registerEBPFDatapath
-// wrote for this (block, argument) pair, from cmdAdd's failed-ADD rollback
-// path. Idempotent: not an error if the entry is already gone.
-//
-// expectedVRFTableID must be this attachment's own VRF table id (recomputed
-// by the caller via vrf.TableID). Only deletes the entry when it still
-// resolves to expectedVRFTableID, and leaves it alone otherwise — see
-// resourceTracker.cleanup's doc comment for the race this guards against.
-func unregisterEBPFDatapath(block uint64, argument uint16, expectedVRFTableID uint32, pinDir string) error {
-	registry, closer, err := usidmap.OpenPinnedRegistry(pinDir)
-	if err != nil {
-		return fmt.Errorf("open pinned eBPF uSID maps: %w", err)
-	}
-	defer func() { _ = closer.Close() }()
-
-	entry, ok, err := registry.VRF.Get(block, argument)
-	if err != nil {
-		return fmt.Errorf("read eBPF vrf_table entry before unregister: %w", err)
-	}
-	if !ok {
-		return nil
-	}
-	if entry.VRFTableID != expectedVRFTableID {
-		slog.Warn("Rollback: eBPF vrf_table entry no longer belongs to this attachment, leaving it in place",
-			"block", block, "argument", argument,
-			"expectedVRFTableID", expectedVRFTableID, "currentVRFTableID", entry.VRFTableID)
-		return nil
-	}
-
-	if err := registry.VRF.Unregister(block, argument); err != nil {
-		return fmt.Errorf("unregister eBPF vrf_table entry: %w", err)
-	}
-	return nil
 }

--- a/internal/cnibgp/bgp_ebpf_test.go
+++ b/internal/cnibgp/bgp_ebpf_test.go
@@ -31,7 +31,7 @@ func requireRoot(t *testing.T) {
 // must do nothing (no error, no attempt to open any pinned map).
 func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "", nodeID: 0}
-	registered, _, err := registerEBPFDatapath(
+	registered, err := registerEBPFDatapath(
 		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err != nil {
 		t.Errorf("registerEBPFDatapath with unconfigured BGPRouter = %v, want nil (no-op)", err)
@@ -48,7 +48,7 @@ func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 // wraps to 1) must be rejected here, before any pinned map is even opened.
 func TestRegisterEBPFDatapath_RejectsOutOfRangeNodeID(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "2001:db8:1::/48", nodeID: 0x10001} // wraps to uint16(1) if narrowed unchecked
-	registered, _, err := registerEBPFDatapath(
+	registered, err := registerEBPFDatapath(
 		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err == nil {
 		t.Fatal("registerEBPFDatapath with nodeID=0x10001 = nil error, want an out-of-range rejection")
@@ -63,7 +63,7 @@ func TestRegisterEBPFDatapath_RejectsOutOfRangeNodeID(t *testing.T) {
 
 // TestRegisterEBPFDatapath_RegistersAllThreeTables: a single
 // registerEBPFDatapath call populates locator_table, function_table, and
-// vrf_table consistently for the same vpc, against real pinned eBPF maps
+// vrf_table consistently for the same VPC, against real pinned eBPF maps
 // under a throwaway pin directory — not the production attach.PinDir.
 func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	requireRoot(t)
@@ -89,7 +89,7 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	t.Cleanup(func() { _ = loaderObjs.Close() })
 
 	cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
-	registered, _, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
+	registered, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
 	if err != nil {
 		t.Fatalf("registerEBPFDatapath: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 		t.Fatalf("vrf_table entries = %+v, want exactly 1", entries)
 	}
 	if entries[0].VRFTableID != vrfTableID {
-		t.Errorf("vrf_table entry VRFTableID = %#x, want %#x (this attachment's real VRF table id)",
+		t.Errorf("vrf_table entry VRFTableID = %#x, want %#x (this VPC's real VRF table id)",
 			entries[0].VRFTableID, vrfTableID)
 	}
 	if entries[0].EgressKind != usidmap.EgressKindVeth {
@@ -141,20 +141,29 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	}
 }
 
-// TestUnregisterEBPFDatapath_RemovesOwnEntry covers UnregisterEBPFDatapath's
-// normal path: an entry this attachment registered gets removed when its
-// VRFTableID still matches.
-func TestUnregisterEBPFDatapath_RemovesOwnEntry(t *testing.T) {
+// TestRegisterEBPFDatapath_SecondAttachmentSharesEntry covers the whole
+// point of keying vrf_table registration by VPC alone: a second attachment
+// on the same VPC (different Argument would be a bug — allocateArgument's
+// idempotent-by-name lookup is what keeps every attachment on this VPC/node
+// converging on one shared Argument, exercised at the cnibgp package level
+// in bgp_test.go) re-registering the identical (block, argument) key is a
+// harmless idempotent overwrite, not a collision — repeat registration is
+// the ordinary case (see usidmap.VRF.Register's own doc comment), and here
+// specifically it's what two live sibling attachments both depend on.
+func TestRegisterEBPFDatapath_SecondAttachmentSharesEntry(t *testing.T) {
 	requireRoot(t)
 
-	if err := vrf.Add(testVPC); err != nil {
+	const (
+		vpc     = testVPC
+		locator = "2001:db8:1::/48"
+		nodeID  = int32(5)
+		vrfID   = int32(42)
+	)
+
+	if err := vrf.Add(vpc); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
-	vrfTableID, err := vrf.TableID(testVPC)
-	if err != nil {
-		t.Fatalf("vrf.TableID: %v", err)
-	}
+	t.Cleanup(func() { _ = vrf.Delete(vpc) })
 
 	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
 	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
@@ -164,47 +173,19 @@ func TestUnregisterEBPFDatapath_RemovesOwnEntry(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = loaderObjs.Close() })
 
-	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
+	cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
+	if _, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir); err != nil {
+		t.Fatalf("first attachment's registerEBPFDatapath: %v", err)
+	}
+	// A second attachment on the same VPC/node resolves the same Argument
+	// (allocateArgument's idempotent lookup) and re-registers the same key.
+	registered, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
 	if err != nil {
-		t.Fatalf("OpenPinnedRegistry: %v", err)
+		t.Fatalf("second attachment's registerEBPFDatapath: %v", err)
 	}
-	defer func() { _ = closer.Close() }()
-
-	const testBlock uint64 = 0x0102030405
-	const testArgument uint16 = 0x042
-
-	if err := reg.VRF.Register(testBlock, testArgument, vrfTableID, usidmap.EgressKindVeth); err != nil {
-		t.Fatalf("seed vrf_table entry: %v", err)
+	if !registered {
+		t.Fatal("second attachment's registerEBPFDatapath reported registered=false, want true")
 	}
-
-	if err := unregisterEBPFDatapath(testBlock, testArgument, vrfTableID, pinDir); err != nil {
-		t.Fatalf("UnregisterEBPFDatapath: %v", err)
-	}
-
-	if _, ok, err := reg.VRF.Get(testBlock, testArgument); err != nil || ok {
-		t.Errorf("vrf_table entry after unregister: ok=%v err=%v, want ok=false", ok, err)
-	}
-}
-
-// TestUnregisterEBPFDatapath_LeavesEntryOwnedByAnotherAttachment covers the
-// race UnregisterEBPFDatapath guards against: retryK8sOps can re-run
-// PublishBGPStateK8s's whole closure on a later attempt without
-// re-registering the eBPF entry, so by the time a later attempt's
-// checkArgumentCollision failure triggers a caller's rollback, the (block,
-// argument) slot this attachment originally wrote may have since been
-// overwritten by the very other attachment the collision was detected
-// against. Unregistering unconditionally would delete a live attachment's
-// forwarding entry instead of this rolled-back one's own.
-func TestUnregisterEBPFDatapath_LeavesEntryOwnedByAnotherAttachment(t *testing.T) {
-	requireRoot(t)
-
-	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
-	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
-	loaderObjs, err := attach.Load(pinDir)
-	if err != nil {
-		t.Fatalf("attach.Load: %v", err)
-	}
-	t.Cleanup(func() { _ = loaderObjs.Close() })
 
 	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
 	if err != nil {
@@ -212,28 +193,12 @@ func TestUnregisterEBPFDatapath_LeavesEntryOwnedByAnotherAttachment(t *testing.T
 	}
 	defer func() { _ = closer.Close() }()
 
-	const testBlock uint64 = 0x0102030405
-	const testArgument uint16 = 0x042
-	const anotherAttachmentsVRFTableID uint32 = 0x9999
-	const thisAttachmentsVRFTableID uint32 = 0x1111
-
-	// Simulate the colliding attachment having since overwritten this same
-	// (block, argument) slot with its own, different VRF table id.
-	if err := reg.VRF.Register(testBlock, testArgument, anotherAttachmentsVRFTableID, usidmap.EgressKindVeth); err != nil {
-		t.Fatalf("seed vrf_table entry: %v", err)
+	entries, err := reg.VRF.List()
+	if err != nil {
+		t.Fatalf("VRF.List: %v", err)
 	}
-
-	if err := unregisterEBPFDatapath(testBlock, testArgument, thisAttachmentsVRFTableID, pinDir); err != nil {
-		t.Fatalf("UnregisterEBPFDatapath: %v", err)
-	}
-
-	entry, ok, err := reg.VRF.Get(testBlock, testArgument)
-	if err != nil || !ok {
-		t.Fatalf("vrf_table entry after unregister: ok=%v err=%v, want ok=true (must survive, it's not this attachment's)",
-			ok, err)
-	}
-	if entry.VRFTableID != anotherAttachmentsVRFTableID {
-		t.Errorf("vrf_table entry VRFTableID after unregister = %#x, want unchanged %#x",
-			entry.VRFTableID, anotherAttachmentsVRFTableID)
+	if len(entries) != 1 {
+		t.Errorf("vrf_table entries after two attachments share one VPC = %+v, want exactly 1 (shared, not duplicated)",
+			entries)
 	}
 }

--- a/internal/cnibgp/ops_add.go
+++ b/internal/cnibgp/ops_add.go
@@ -41,6 +41,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	tracker := &resourceTracker{
 		vpc:           pluginConf.VPC,
 		vpcAttachment: pluginConf.VPCAttachment,
+		nodeName:      nodeName,
 		namespace:     namespace,
 	}
 

--- a/internal/cnibgp/ops_check.go
+++ b/internal/cnibgp/ops_check.go
@@ -54,7 +54,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	var errs []error
 
 	vrfInst := &bgpv1alpha1.BGPVRFInstance{}
-	vrfName := crdnames.BGPVRFInstanceName(pluginConf.VPC, pluginConf.VPCAttachment)
+	vrfName := crdnames.BGPVRFInstanceName(pluginConf.VPC, cniConfig.NodeName)
 	vrfErr := k8s.Get(ctx, client.ObjectKey{Name: vrfName, Namespace: pluginConf.Namespace}, vrfInst)
 	if vrfErr != nil {
 		errs = append(errs, fmt.Errorf("BGPVRFInstance %s: %w", vrfName, vrfErr))

--- a/internal/cnibgp/resource.go
+++ b/internal/cnibgp/resource.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.datum.net/galactic/internal/cni/crdnames"
-	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
@@ -55,15 +54,37 @@ func newK8sClient() (client.Client, error) {
 // assigns the whole publishResult from publishBGPState in one shot
 // (tracker.publishResult = result).
 type resourceTracker struct {
-	vpc, vpcAttachment string
-	namespace          string
-	k8s                client.Client
+	vpc, vpcAttachment, nodeName string
+	namespace                    string
+	k8s                          client.Client
 
 	publishResult
 }
 
 // cleanup rolls back all tracked resources. Errors are logged but never
 // returned — the caller already has a failure.
+//
+// Deliberately conditional: deleting the BGPVRFInstance CRD only when this
+// ADD's own attempt just created it (vrfInstanceCreated), and never
+// unregistering the eBPF vrf_table entry registerEBPFDatapath wrote at all.
+// Unlike the BGPAdvertisement below (still a reliable 1:1 key per
+// attachment — see crdnames.BGPAdvertisementName), both the BGPVRFInstance
+// and the vrf_table entry are shared by every attachment on this VPC on
+// this node (crdnames.BGPVRFInstanceName): once a second attachment's ADD
+// reuses an already-live sibling's CRD/eBPF entry (publishBGPState's
+// CreateOrUpdate and usidmap.VRF.Register are both idempotent-by-name/key,
+// so this is the ordinary case, not an edge case), unconditionally rolling
+// either back here would tear down a live sibling's VRF out from under it.
+// This is the same reasoning internal/cni/veth and internal/plumbing/vrf
+// already apply on the kernel side (see vrf.Delete's doc comment): shared
+// per-(vpc,node) state is exclusively galactic-router's GC controller's job
+// to reclaim, once it has confirmed via every BGPAdvertisement for this
+// VPC/node that none remain (internal/gc's CollectOrphanedCRDs and
+// SweepEBPFVRFTable) — the eBPF entry has no cheap "did I just create this"
+// signal the way a k8s object's CreateOrUpdate result gives us, so it stays
+// unconditional there; the BGPVRFInstance does, which is what lets a
+// checkArgumentCollision rejection of a freshly-created instance (see
+// publishBGPState) self-heal on retry instead of wedging permanently.
 func (rt *resourceTracker) cleanup(ctx context.Context) {
 	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
 		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
@@ -86,28 +107,15 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 	if rt.vrfInstanceCreated && rt.k8s != nil {
 		vrfInst := &bgpv1alpha1.BGPVRFInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crdnames.BGPVRFInstanceName(rt.vpc, rt.vpcAttachment),
+				Name:      crdnames.BGPVRFInstanceName(rt.vpc, rt.nodeName),
 				Namespace: rt.namespace,
 			},
 		}
 		if err := rt.k8s.Delete(ctx, vrfInst); client.IgnoreNotFound(err) != nil {
-			slog.Error("Rollback: failed to delete BGPVRFInstance", "err", err,
+			slog.Error("Rollback: failed to delete freshly-created BGPVRFInstance", "err", err,
 				"name", vrfInst.Name, "namespace", rt.namespace)
 		} else {
-			slog.Debug("Rollback: deleted BGPVRFInstance", "name", vrfInst.Name, "namespace", rt.namespace)
-		}
-	}
-
-	if rt.ebpfRegistered {
-		if vrfTableID, err := vrf.TableID(rt.vpc); err != nil {
-			slog.Error("Rollback: failed to resolve VRF table id, skipping eBPF vrf_table unregister", "err", err,
-				"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)
-		} else if err := unregisterEBPFDatapath(rt.ebpfBlock, rt.ebpfArgument, vrfTableID, ebpfPinDir); err != nil {
-			slog.Error("Rollback: failed to unregister eBPF vrf_table entry", "err", err,
-				"block", rt.ebpfBlock, "argument", rt.ebpfArgument)
-		} else {
-			slog.Debug("Rollback: unregistered eBPF vrf_table entry",
-				"block", rt.ebpfBlock, "argument", rt.ebpfArgument)
+			slog.Debug("Rollback: deleted freshly-created BGPVRFInstance", "name", vrfInst.Name, "namespace", rt.namespace)
 		}
 	}
 }

--- a/internal/cnibgp/resource_test.go
+++ b/internal/cnibgp/resource_test.go
@@ -6,274 +6,111 @@ package cnibgp
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"go.datum.net/galactic/internal/cni/crdnames"
-	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
-	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
-	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-const testDefaultNamespace = "default"
+const testNodeName = "dfw-worker"
+const testNamespace = "galactic-system"
 
-// ---- resourceTracker.cleanup: zero-value / partial state -------------------
-
-// TestResourceTrackerCleanup_ZeroValue verifies cleanup with a zero-value
-// tracker doesn't panic — it's called from cmdAdd's defer, and the caller
-// may have failed before setting any fields (e.g. newK8sClient itself
-// failed, so tracker.k8s is nil).
-func TestResourceTrackerCleanup_ZeroValue(t *testing.T) {
-	tracker := &resourceTracker{}
-	tracker.cleanup(context.Background()) // must not panic
-}
-
-// TestResourceTrackerCleanup_NilK8sClientSkipsCRDDeletes verifies cleanup
-// doesn't attempt a Delete through a nil client even when the created-flags
-// say there's something to roll back — this shouldn't happen in practice
-// (tracker.k8s is set right after newK8sClient succeeds, before anything
-// else can set vrfInstanceCreated/advertisementCreated), but cleanup's own
-// nil check is what actually prevents the panic if it ever does.
-func TestResourceTrackerCleanup_NilK8sClientSkipsCRDDeletes(t *testing.T) {
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		namespace:     testDefaultNamespace,
-		publishResult: publishResult{
-			vrfInstanceCreated:   true,
-			advertisementCreated: true,
-		},
+// TestResourceTrackerCleanup_DeletesFreshlyCreatedVRFInstance covers the
+// regression this test guards against: allocateArgument's read-then-write
+// can race two different VPCs' first attachment on the same node onto the
+// same "lowest free slot," which checkArgumentCollision then rejects. If
+// rollback never deleted the just-created (and now known-invalid)
+// BGPVRFInstance, every retry would hit the identical collision forever —
+// nothing else clears it, since GC only reclaims once every BGPAdvertisement
+// for the VPC is gone, not a collision. vrfInstanceCreated=true (this ADD's
+// own CreateOrUpdate reported OperationResultCreated) is what makes deleting
+// it here safe: this exact ADD invocation just created it moments ago, so no
+// sibling attachment could have started depending on it yet.
+func TestResourceTrackerCleanup_DeletesFreshlyCreatedVRFInstance(t *testing.T) {
+	name := crdnames.BGPVRFInstanceName(testVPC, testNodeName)
+	existing := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 	}
-	tracker.cleanup(context.Background()) // must not panic
-}
+	k8s := fakeClient(existing)
 
-// ---- resourceTracker.cleanup: CRD rollback ---------------------------------
-
-// TestResourceTrackerCleanup_DeletesOnlyWhatWasCreated exercises cleanup's
-// actual wiring end to end: given a tracker whose publishResult says only
-// the BGPVRFInstance was created (advertisementCreated stays false, as it
-// would if publishBGPState failed between the two), cleanup must delete the
-// BGPVRFInstance and leave any BGPAdvertisement alone.
-func TestResourceTrackerCleanup_DeletesOnlyWhatWasCreated(t *testing.T) {
-	namespace := testDefaultNamespace
-	vrfName := crdnames.BGPVRFInstanceName(testVPC, testAttachment)
-	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
-
-	existingVRFInst := &bgpv1alpha1.BGPVRFInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: vrfName, Namespace: namespace},
-	}
-	// A BGPAdvertisement that was NOT created by this ADD (e.g. left over
-	// from another container sharing the same attachment) — cleanup must
-	// not touch it, since advertisementCreated is false.
-	untouchedAdv := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: namespace},
-	}
-
-	k8s := fakeClient(existingVRFInst, untouchedAdv)
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		namespace:     namespace,
-		k8s:           k8s,
+	rt := &resourceTracker{
+		vpc: testVPC, vpcAttachment: testAttachment, nodeName: testNodeName,
+		namespace: testNamespace, k8s: k8s,
 		publishResult: publishResult{vrfInstanceCreated: true},
 	}
+	rt.cleanup(context.Background())
 
-	tracker.cleanup(context.Background())
-
-	if err := k8s.Get(context.Background(), client.ObjectKey{Name: vrfName, Namespace: namespace},
-		&bgpv1alpha1.BGPVRFInstance{}); err == nil {
-		t.Error("BGPVRFInstance still exists after cleanup, want deleted")
-	}
-	if err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: namespace},
-		&bgpv1alpha1.BGPAdvertisement{}); err != nil {
-		t.Errorf("BGPAdvertisement Get after cleanup = %v, want it left untouched (advertisementCreated was false)", err)
+	got := &bgpv1alpha1.BGPVRFInstance{}
+	err := k8s.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("BGPVRFInstance %q after cleanup: err=%v, want NotFound (deleted)", name, err)
 	}
 }
 
-// TestResourceTrackerCleanup_DeletesBothCRDsWhenBothCreated covers the
-// common failure path: both CRDs were created, then something later in
-// publishBGPState (or types.PrintResult) failed, so both must roll back.
-func TestResourceTrackerCleanup_DeletesBothCRDsWhenBothCreated(t *testing.T) {
-	namespace := testDefaultNamespace
-	vrfName := crdnames.BGPVRFInstanceName(testVPC, testAttachment)
+// TestResourceTrackerCleanup_PreservesReusedVRFInstance covers the sharing
+// side: when this ADD's own CreateOrUpdate found the BGPVRFInstance already
+// live (a sibling attachment created it), vrfInstanceCreated stays false —
+// cleanup on this attachment's own failed ADD must leave that sibling's VRF
+// alone.
+func TestResourceTrackerCleanup_PreservesReusedVRFInstance(t *testing.T) {
+	name := crdnames.BGPVRFInstanceName(testVPC, testNodeName)
+	existing := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec:       bgpv1alpha1.BGPVRFInstanceSpec{VRFID: 7},
+	}
+	k8s := fakeClient(existing)
+
+	rt := &resourceTracker{
+		vpc: testVPC, vpcAttachment: testAttachment, nodeName: testNodeName,
+		namespace: testNamespace, k8s: k8s,
+		publishResult: publishResult{vrfInstanceCreated: false}, // this attachment only reused a sibling's CRD
+	}
+	rt.cleanup(context.Background())
+
+	got := &bgpv1alpha1.BGPVRFInstance{}
+	if err := k8s.Get(context.Background(), client.ObjectKey{Name: name, Namespace: testNamespace}, got); err != nil {
+		t.Fatalf("BGPVRFInstance %q after cleanup: %v, want it to still exist", name, err)
+	}
+	if got.Spec.VRFID != 7 {
+		t.Errorf("BGPVRFInstance survived with VRFID = %d, want unchanged 7", got.Spec.VRFID)
+	}
+}
+
+// TestResourceTrackerCleanup_NeverUnregistersEBPFEntry documents that
+// cleanup has nothing left to do for the eBPF vrf_table registration at
+// all — there's no field to unregister it with, unlike the BGPVRFInstance
+// CRD above. A zero-value tracker (as if the ADD failed before creating
+// anything) must not panic.
+func TestResourceTrackerCleanup_NeverUnregistersEBPFEntry(t *testing.T) {
+	rt := &resourceTracker{}
+	rt.cleanup(context.Background()) // should not panic; nothing to roll back
+}
+
+// TestResourceTrackerCleanup_DeletesOwnAdvertisementOnly covers the
+// still-1:1 BGPAdvertisement case alongside the now-conditional
+// BGPVRFInstance case, so the two don't regress into sharing the same
+// on/off switch.
+func TestResourceTrackerCleanup_DeletesOwnAdvertisementOnly(t *testing.T) {
 	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
-
-	k8s := fakeClient(
-		&bgpv1alpha1.BGPVRFInstance{ObjectMeta: metav1.ObjectMeta{Name: vrfName, Namespace: namespace}},
-		&bgpv1alpha1.BGPAdvertisement{ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: namespace}},
-	)
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		namespace:     namespace,
-		k8s:           k8s,
-		publishResult: publishResult{vrfInstanceCreated: true, advertisementCreated: true},
+	existing := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: testNamespace},
 	}
+	k8s := fakeClient(existing)
 
-	tracker.cleanup(context.Background())
-
-	if err := k8s.Get(context.Background(), client.ObjectKey{Name: vrfName, Namespace: namespace},
-		&bgpv1alpha1.BGPVRFInstance{}); err == nil {
-		t.Error("BGPVRFInstance still exists after cleanup, want deleted")
+	rt := &resourceTracker{
+		vpc: testVPC, vpcAttachment: testAttachment, nodeName: testNodeName,
+		namespace: testNamespace, k8s: k8s,
+		publishResult: publishResult{advertisementCreated: true},
 	}
-	if err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: namespace},
-		&bgpv1alpha1.BGPAdvertisement{}); err == nil {
-		t.Error("BGPAdvertisement still exists after cleanup, want deleted")
-	}
-}
+	rt.cleanup(context.Background())
 
-// TestResourceTrackerCleanup_MissingCRDsAreNotError covers cleanup's use of
-// client.IgnoreNotFound: a CRD already gone (e.g. a retry after a partial
-// prior rollback) must not surface as an error — cleanup never returns one.
-func TestResourceTrackerCleanup_MissingCRDsAreNotError(t *testing.T) {
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		namespace:     testDefaultNamespace,
-		k8s:           fakeClient(),
-		publishResult: publishResult{vrfInstanceCreated: true, advertisementCreated: true},
-	}
-
-	tracker.cleanup(context.Background()) // must not panic; nothing to delete
-}
-
-// ---- resourceTracker.cleanup: eBPF rollback --------------------------------
-
-// TestResourceTrackerCleanup_UnregistersOwnEBPFEntry covers the eBPF branch
-// of cleanup's own wiring (not unregisterEBPFDatapath in isolation, which
-// bgp_ebpf_test.go already covers): a tracker with ebpfRegistered=true must
-// resolve this attachment's own VRF table id and remove exactly the
-// vrf_table entry it registered.
-func TestResourceTrackerCleanup_UnregistersOwnEBPFEntry(t *testing.T) {
-	requireRoot(t)
-
-	if err := vrf.Add(testVPC); err != nil {
-		t.Fatalf("vrf.Add: %v", err)
-	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
-	vrfTableID, err := vrf.TableID(testVPC)
-	if err != nil {
-		t.Fatalf("vrf.TableID: %v", err)
-	}
-
-	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
-	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
-	// cleanup (resource.go) reads the pin directory from the package-level
-	// ebpfPinDir var, not attach.PinDir directly — point it at this test's
-	// own throwaway directory instead of the real production one.
-	origPinDir := ebpfPinDir
-	ebpfPinDir = pinDir
-	t.Cleanup(func() { ebpfPinDir = origPinDir })
-
-	loaderObjs, err := attach.Load(pinDir)
-	if err != nil {
-		t.Fatalf("attach.Load: %v", err)
-	}
-	t.Cleanup(func() { _ = loaderObjs.Close() })
-
-	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
-	if err != nil {
-		t.Fatalf("OpenPinnedRegistry: %v", err)
-	}
-	defer func() { _ = closer.Close() }()
-
-	const testBlock uint64 = 0x0102030405
-	const testArgument uint16 = 0x042
-	if err := reg.VRF.Register(testBlock, testArgument, vrfTableID, usidmap.EgressKindVeth); err != nil {
-		t.Fatalf("seed vrf_table entry: %v", err)
-	}
-
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		publishResult: publishResult{
-			ebpfRegistered: true,
-			ebpfBlock:      testBlock,
-			ebpfArgument:   testArgument,
-		},
-	}
-
-	tracker.cleanup(context.Background())
-
-	if _, ok, err := reg.VRF.Get(testBlock, testArgument); err != nil || ok {
-		t.Errorf("vrf_table entry after cleanup: ok=%v err=%v, want ok=false", ok, err)
-	}
-}
-
-// TestResourceTrackerCleanup_LeavesEBPFEntryOwnedByAnotherAttachment is the
-// rollback-collision race exercised at resourceTracker.cleanup's own level
-// (bgp_ebpf_test.go's TestUnregisterEBPFDatapath_LeavesEntryOwnedByAnotherAttachment
-// covers the same guard one layer lower, calling unregisterEBPFDatapath
-// directly). retryK8sOps can re-run publishBGPState's whole closure without
-// re-registering the eBPF entry, so a later attempt's checkArgumentCollision
-// failure can trigger cleanup after the (block, argument) slot this
-// attachment originally wrote has already been overwritten by the very
-// other attachment the collision was detected against. cleanup must resolve
-// its own vrf.TableID and leave the slot alone when it no longer matches,
-// rather than deleting a live attachment's forwarding entry.
-func TestResourceTrackerCleanup_LeavesEBPFEntryOwnedByAnotherAttachment(t *testing.T) {
-	requireRoot(t)
-
-	if err := vrf.Add(testVPC); err != nil {
-		t.Fatalf("vrf.Add: %v", err)
-	}
-	t.Cleanup(func() { _ = vrf.Delete(testVPC) })
-
-	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
-	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
-	// cleanup (resource.go) reads the pin directory from the package-level
-	// ebpfPinDir var, not attach.PinDir directly — point it at this test's
-	// own throwaway directory instead of the real production one.
-	origPinDir := ebpfPinDir
-	ebpfPinDir = pinDir
-	t.Cleanup(func() { ebpfPinDir = origPinDir })
-
-	loaderObjs, err := attach.Load(pinDir)
-	if err != nil {
-		t.Fatalf("attach.Load: %v", err)
-	}
-	t.Cleanup(func() { _ = loaderObjs.Close() })
-
-	reg, closer, err := usidmap.OpenPinnedRegistry(pinDir)
-	if err != nil {
-		t.Fatalf("OpenPinnedRegistry: %v", err)
-	}
-	defer func() { _ = closer.Close() }()
-
-	const testBlock uint64 = 0x0102030405
-	const testArgument uint16 = 0x042
-	const anotherAttachmentsVRFTableID uint32 = 0x9999
-
-	// Simulate the colliding (winning) attachment having since overwritten
-	// this same (block, argument) slot with its own, different VRF table id.
-	if err := reg.VRF.Register(testBlock, testArgument, anotherAttachmentsVRFTableID, usidmap.EgressKindVeth); err != nil {
-		t.Fatalf("seed vrf_table entry: %v", err)
-	}
-
-	tracker := &resourceTracker{
-		vpc:           testVPC,
-		vpcAttachment: testAttachment,
-		publishResult: publishResult{
-			ebpfRegistered: true,
-			ebpfBlock:      testBlock,
-			ebpfArgument:   testArgument,
-		},
-	}
-
-	tracker.cleanup(context.Background())
-
-	entry, ok, err := reg.VRF.Get(testBlock, testArgument)
-	if err != nil || !ok {
-		t.Fatalf("vrf_table entry after cleanup: ok=%v err=%v, want ok=true (must survive, it's not this attachment's)",
-			ok, err)
-	}
-	if entry.VRFTableID != anotherAttachmentsVRFTableID {
-		t.Errorf("vrf_table entry VRFTableID after cleanup = %#x, want unchanged %#x",
-			entry.VRFTableID, anotherAttachmentsVRFTableID)
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: testNamespace}, got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("BGPAdvertisement %q after cleanup: err=%v, want NotFound (deleted)", advName, err)
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -364,12 +364,13 @@ func testChainedGalacticBGP(t *testing.T, podName string, tapResult map[string]a
 	t.Helper()
 
 	const vpc, vpcAttachment = "1", "1"
-	crdName := vpc + "-" + vpcAttachment
+	vrfCRDName := vpc + "-" + nodeName()    // BGPVRFInstance keyed by (vpc, node)
+	advCRDName := vpc + "-" + vpcAttachment // BGPAdvertisement keyed by (vpc, vpcAttachment)
 	t.Cleanup(func() {
 		//nolint:errcheck // best-effort cleanup, mirrors deletePod
-		kubectl(context.Background(), "delete", "bgpvrfinstance", crdName, "--ignore-not-found")
+		kubectl(context.Background(), "delete", "bgpvrfinstance", vrfCRDName, "--ignore-not-found")
 		//nolint:errcheck // best-effort cleanup, mirrors deletePod
-		kubectl(context.Background(), "delete", "bgpadvertisement", crdName, "--ignore-not-found")
+		kubectl(context.Background(), "delete", "bgpadvertisement", advCRDName, "--ignore-not-found")
 	})
 
 	prevResultJSON, err := json.Marshal(tapResult)
@@ -414,12 +415,11 @@ NODE_NAME=` + nodeName() + ` \
 
 	// galactic-bgp is the last plugin in the chain: its own result is
 	// prevResult passed through unchanged, not a new one it builds itself.
-	jsonStart := strings.Index(addOut, "{")
-	if jsonStart == -1 {
-		t.Fatalf("no JSON found in galactic-bgp ADD output:\n%s", addOut)
-	}
+	// Decode only the first JSON value so trailing log lines are ignored.
 	var bgpResult map[string]any
-	if err := json.Unmarshal([]byte(addOut[jsonStart:]), &bgpResult); err != nil {
+	if jsonStart := strings.Index(addOut, "{"); jsonStart == -1 {
+		t.Fatalf("no JSON found in galactic-bgp ADD output:\n%s", addOut)
+	} else if err := json.NewDecoder(strings.NewReader(addOut[jsonStart:])).Decode(&bgpResult); err != nil {
 		t.Fatalf("galactic-bgp ADD output is not valid JSON: %v\noutput:\n%s", err, addOut)
 	}
 	if bgpIfaces, _ := bgpResult["interfaces"].([]any); len(bgpIfaces) != 1 {
@@ -427,11 +427,11 @@ NODE_NAME=` + nodeName() + ` \
 			len(bgpIfaces))
 	}
 
-	if out, err := kubectl(t.Context(), "get", "bgpvrfinstance", crdName); err != nil {
-		t.Errorf("BGPVRFInstance %s not found after galactic-bgp ADD: %v\n%s", crdName, err, out)
+	if out, err := kubectl(t.Context(), "get", "bgpvrfinstance", vrfCRDName); err != nil {
+		t.Errorf("BGPVRFInstance %s not found after galactic-bgp ADD: %v\n%s", vrfCRDName, err, out)
 	}
-	if out, err := kubectl(t.Context(), "get", "bgpadvertisement", crdName); err != nil {
-		t.Errorf("BGPAdvertisement %s not found after galactic-bgp ADD: %v\n%s", crdName, err, out)
+	if out, err := kubectl(t.Context(), "get", "bgpadvertisement", advCRDName); err != nil {
+		t.Errorf("BGPAdvertisement %s not found after galactic-bgp ADD: %v\n%s", advCRDName, err, out)
 	}
 
 	// CHECK reads back the locator_table/function_table/vrf_table entries


### PR DESCRIPTION
## Summary

The BGPVRFInstance CRD and its SRv6 Argument were still allocated per attachment instead of per VPC per node, wasting an Argument slot for every extra attachment sharing a VPC. This makes every attachment on the same VPC/node converge on one CRD and Argument, and fixes rollback so a failed attachment's cleanup can no longer delete a live sibling's shared state.

## Test plan

- [ ] `task ci` passes (lint, build, unit tests)
- [ ] A failed ADD's rollback never deletes a still-live sibling attachment's BGPVRFInstance
- [ ] Two different VPCs' first attachment landing on the same node at the same time no longer wedges permanently on an argument collision

---

**Stack** (merge bottom to top):

- #311 fix(vrf): key kernel VRF by VPC, not (VPC, attachment)
- #312 fix(cnibgp): share BGPVRFInstance and Argument per (VPC, node) (this PR)
- #313 fix(containerlab): give ns30/ns40 two attachments, not one shared


🤖 Generated with [Claude Code](https://claude.com/claude-code)
