### PR TITLE
ci: run the workflow on STACKS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+  # Deliberately unfiltered by base branch: stacked pull requests target
+  # another pull request's branch rather than main, and a "branches: [main]"
+  # filter here skips this whole workflow for them -- leaving only the
+  # publish jobs and the CLA check reporting, which reads as a green pull
+  # request that was never tested.
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   GO_VERSION: '1.26'


### PR DESCRIPTION
Stacked pull requests get no CI at all right now. The `pull_request` trigger is filtered to `branches: [main]`, so anything based on another PR's branch only ever shows the publish jobs and the CLA check going green. #315 and #316 have sat like that since 2026-08-08.

This drops the filter and adds `workflow_dispatch`. Being main-based, this PR runs its own CI, which is the proof it works.

Existing stacked PRs pick it up on their next rebase.

Related to #319
