### PR TITLE
test(containerlab): assert same-node VPC fixtures actually stay same-node

### DIFF
--- a/deploy/containerlab/docs/tenants.md
+++ b/deploy/containerlab/docs/tenants.md
@@ -24,8 +24,8 @@ They differ only in scope and addressing:
 | `ns50` | dfw, sjc, iad (3-site)       | IPv4 + public IPv6 ptp | `G000000050V` | Also defines a `public` NAD with an IPv6 IPAM pool for external-connectivity testing. |
 | `ns10` | dfw, sjc, iad (3-site)       | IPv6-only (fd20 ULA) | `G000000010V` | No `ipv4_subnet` at all. |
 | `ns20` | dfw, sjc, iad (3-site)       | Dual-stack (fd20 ULA + IPv4) | `G000000020V` | Both families active; exercises the dual-stack IPAM path. |
-| `ns30` | dfw only, 2 attachments      | IPv6-only (fd20 ULA) | `G000000030V` | Two distinct attachments (`private`/`private-b`, distinct `vpcattachment` values, same `vpc`), each its own single-replica Deployment, both land on `dfw-worker` and share one VRF — same-node connectivity, no cross-site hop. |
-| `ns40` | iad only, 2 attachments      | IPv4-only | `G000000040V` | Two distinct attachments (`private`/`private-b`), each its own single-replica Deployment, both land on `iad-worker` (not `iad-worker-control`, which is tainted for the route-reflector role) and share one VRF. |
+| `ns30` | dfw only, 2 attachments      | IPv6-only (fd20 ULA) | `G000000030V` | Two distinct attachments (`private`/`private-b`, distinct `vpcattachment` values, same `vpc`), each its own single-replica Deployment, both land on `dfw-worker` and share one VRF — same-node connectivity, no cross-site hop. `verify:ns30` asserts the two pods share a node. |
+| `ns40` | iad only, 2 attachments      | IPv4-only | `G000000040V` | Two distinct attachments (`private`/`private-b`), each its own single-replica Deployment, both land on `iad-worker` (not `iad-worker-control`, which is tainted for the route-reflector role) and share one VRF. `verify:ns40` asserts the two pods share a node. |
 
 The VRF interface name follows `G<vpc, zero-padded to 9>V` on every worker —
 e.g. `ns20` (`vpc="20"`) is `G000000020V`. Unlike the host/guest veth
@@ -182,12 +182,21 @@ task verify:ns30   # same-node pod-to-pod, IPv6 (dfw)
 task verify:ns40   # same-node pod-to-pod, IPv4 (iad)
 ```
 
+The two single-site scripts check one thing the 3-site ones don't: before
+pinging, they compare both pods' `.spec.nodeName` (`lib.sh`'s
+`pod_scheduling_node`) and exit non-zero if the pair is split across workers.
+Nothing in either fixture pins the pods together — see the [table
+above](#overview) for what actually keeps them there today — and a split pair
+would still ping fine over the cross-site path, so without the assertion these
+VPCs would silently stop exercising the same-node/same-VRF case they exist for.
+
 `task verify` (via `task verify:scenarios`) runs all five. Use the scripts as
 the reference for how to resolve pod names/addresses by hand (`lib.sh`'s
-`pod_name`/`pod_ip4`/`pod_ip6`/`ping_pod` helpers) if you need to reproduce a
-step manually while debugging — e.g. to ping the `ns30` pods on dfw directly.
-`ns30`'s two pods are two distinct attachments/labels, not two replicas of
-one, so each is resolved by its own `pod_name` call rather than `pod_names`:
+`pod_name`/`pod_scheduling_node`/`pod_ip4`/`pod_ip6`/`ping_pod` helpers) if you
+need to reproduce a step manually while debugging — e.g. to ping the `ns30`
+pods on dfw directly. `ns30`'s two pods are two distinct attachments/labels,
+not two replicas of one, so each is resolved by its own `pod_name` call
+rather than `pod_names`:
 
 ```bash
 source scripts/lib.sh
@@ -282,6 +291,10 @@ assuming the affinity alone keeps pods off it:
 ```bash
 docker exec iad-control-plane kubectl describe node iad-worker-control | grep -A2 Taints
 ```
+
+If the taint is gone the pods schedule fine but may split across the two
+workers, in which case `task verify:ns40` fails with an `expected both ns40
+pods on one node` error naming the node each pod landed on.
 
 ## See also
 

--- a/deploy/containerlab/scripts/lib.sh
+++ b/deploy/containerlab/scripts/lib.sh
@@ -63,6 +63,16 @@ pod_names() {
   docker exec "${node}" kubectl get pods -n "${ns}" -l "${label}" -o jsonpath='{.items[*].metadata.name}'
 }
 
+# pod_scheduling_node NODE NAMESPACE POD
+# The Kubernetes node POD is scheduled onto (.spec.nodeName), e.g. "dfw-worker".
+# Not to be confused with this helper's own NODE argument, which — as everywhere
+# else in this file — is the docker container kubectl runs in (a site's Kind
+# control-plane container), not a scheduling target.
+pod_scheduling_node() {
+  local node="$1" ns="$2" pod="$3"
+  docker exec "${node}" kubectl get pod -n "${ns}" "${pod}" -o jsonpath='{.spec.nodeName}'
+}
+
 # pod_ip4 NODE NAMESPACE POD
 # POD's IPv4 address on eth0 (the VPC interface). Every ns*/base/pod.yaml
 # attaches its NAD via the v1.multus-cni.io/default-network annotation, which

--- a/deploy/containerlab/scripts/verify-ns30.sh
+++ b/deploy/containerlab/scripts/verify-ns30.sh
@@ -25,6 +25,20 @@ for label in "${LABELS[@]}"; do
   PODS+=("${pod}")
 done
 
+# ns30 exists to prove two attachments on one VPC share a single kernel VRF on
+# one worker, so both pods landing on the same node is the subject of the test,
+# not an incidental detail. Nothing in the fixture pins them together — dfw
+# just happens to have exactly one schedulable worker — so if that ever changes
+# the pings below would still pass over the cross-node path and quietly stop
+# testing what ns30 is named for. Assert it instead.
+SCHED0=$(pod_scheduling_node "${NODE}" "${NS}" "${PODS[0]}")
+SCHED1=$(pod_scheduling_node "${NODE}" "${NS}" "${PODS[1]}")
+if [ "${SCHED0}" != "${SCHED1}" ]; then
+  echo "expected both ns30 pods on one node, found ${PODS[0]} on ${SCHED0} and ${PODS[1]} on ${SCHED1}" >&2
+  exit 1
+fi
+echo "both pods scheduled on ${SCHED0}"
+
 IP0=$(pod_ip6 "${NODE}" "${NS}" "${PODS[0]}")
 IP1=$(pod_ip6 "${NODE}" "${NS}" "${PODS[1]}")
 echo "${PODS[0]}: ${IP0}"

--- a/deploy/containerlab/scripts/verify-ns40.sh
+++ b/deploy/containerlab/scripts/verify-ns40.sh
@@ -25,6 +25,21 @@ for label in "${LABELS[@]}"; do
   PODS+=("${pod}")
 done
 
+# ns40 exists to prove two attachments on one VPC share a single kernel VRF on
+# one worker, so both pods landing on the same node is the subject of the test,
+# not an incidental detail. Nothing in the fixture pins them together — iad has
+# a second worker, and only the route-reflector NoSchedule taint on
+# iad-worker-control keeps the pair on iad-worker — so if that taint goes away
+# the pings below would still pass over the cross-node path and quietly stop
+# testing what ns40 is named for. Assert it instead.
+SCHED0=$(pod_scheduling_node "${NODE}" "${NS}" "${PODS[0]}")
+SCHED1=$(pod_scheduling_node "${NODE}" "${NS}" "${PODS[1]}")
+if [ "${SCHED0}" != "${SCHED1}" ]; then
+  echo "expected both ns40 pods on one node, found ${PODS[0]} on ${SCHED0} and ${PODS[1]} on ${SCHED1}" >&2
+  exit 1
+fi
+echo "both pods scheduled on ${SCHED0}"
+
 IP0=$(pod_ip4 "${NODE}" "${NS}" "${PODS[0]}")
 IP1=$(pod_ip4 "${NODE}" "${NS}" "${PODS[1]}")
 echo "${PODS[0]}: ${IP0}"


### PR DESCRIPTION
## Summary

Two of the lab's tenant VPCs exist to prove one specific thing: when a single VPC has two attachments on the same worker, both share one kernel VRF and talk to each other locally, with no cross-site hop involved.

Nothing in either fixture actually held the two workloads on one worker — that was a side effect of how the lab clusters happen to be shaped today, and reshaping a cluster would quietly scatter them.

Scattered workloads still ping each other successfully over the cross-site path, so the checks would keep passing while no longer testing the thing they are named for.

Both checks now compare where the two workloads were placed and fail with a clear message naming each one's location when they end up apart, so the day that property goes away the lab says so instead of going green.

## Test plan

- Shell syntax check on every touched script passed.
- Static shell analysis on the same scripts is clean.
- The real check is a live lab run of both scenario verifications, once against the current lab and once with the placement property deliberately broken to confirm the new failure fires. That has not been done — a lab was not available in this environment.

Related to #336
