### PR TITLE
fix(gc): reclaim VRFs created before the per-VPC rename

### DIFF
--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -56,6 +56,19 @@ type CleanupResult struct {
 // Base62 includes digits and letters.
 var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})V$`)
 
+// legacyVRFNameRegex matches the VRF interface name Galactic generated before
+// the VRF became per-VPC: the template was "G%09s%03sV", carrying the same
+// VPCAttachment segment the host/guest veth names still do (14 chars). A node
+// upgraded in place keeps whatever VRFs it created under the old template, and
+// those interfaces hold a routing table ID and its routes for as long as they
+// survive — so collection has to recognise them, map them to the same VPC the
+// current name would yield, and reclaim them once nothing references that VPC.
+//
+// This is deliberately a collection-only concern: nothing creates these names
+// any more, and the removal path must NOT resolve one back through
+// intf.GenerateInterfaceNameVRF (see vpcFromVRFName and RemoveOrphanedVRFs).
+var legacyVRFNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})[A-Za-z0-9]{3}V$`)
+
 // routerNamesForNode returns the names of every BGPRouter in the namespace
 // whose TargetRef points at nodeName. BGPAdvertisement/BGPVRFInstance CRDs
 // are namespace-scoped, not node-scoped — a namespace can hold CRDs created
@@ -275,7 +288,12 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 // nodeName's BGPRouter(s) in the given namespace.
 //
 // A VRF is considered orphaned when:
-//   - Its interface name matches the Galactic VRF naming pattern.
+//   - Its interface name matches the Galactic VRF naming pattern — either the
+//     current per-VPC name or the legacy pre-rename name that carried a
+//     VPCAttachment segment, both of which resolve to the same VPC (see
+//     vpcFromVRFName). A node upgraded in place still carries the latter, and
+//     they must be reclaimed too rather than stranding a routing table ID and
+//     its routes forever.
 //   - No BGPAdvertisement owned by this node (name's vpc segment matches,
 //     RouterRef pointing at one of nodeName's BGPRouters) exists for its
 //     VPC. The VRF is shared by every attachment on this VPC on this node
@@ -313,7 +331,7 @@ func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, node
 
 	var orphaned []string
 	for _, v := range vrfs {
-		vpc, ok := parseVRFName(v.Name)
+		vpc, ok := vpcFromVRFName(v.Name)
 		if !ok {
 			// Not a Galactic VRF — skip.
 			continue
@@ -334,20 +352,29 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 	result := CleanupResult{}
 
 	for _, name := range vrfNames {
-		// We need the vpc to call vrf.Delete. Parse the name back to get it.
+		// We need the vpc to call vrf.Delete. Parse the name back to get it —
+		// deliberately with parseVRFName, not vpcFromVRFName: vrf.Delete
+		// rebuilds the current "G%09sV" interface name from the VPC, so a
+		// legacy "G%09s%03sV" interface resolved that way would be looked up
+		// under a name that does not exist and silently reported as removed.
 		vpc, ok := parseVRFName(name)
 		if !ok {
-			// Try to delete by name directly.
+			// Not a current-shape name — this is where a legacy VRF collected
+			// by vpcFromVRFName lands. Delete the interface we actually
+			// observed, by name.
 			link, err := netlink.LinkByName(name)
 			if err != nil {
 				// Already gone — not an error.
 				continue
 			}
 			if delErr := netlink.LinkDel(link); delErr != nil {
-				slog.Error("GC: failed to delete orphaned VRF (parse failed)",
+				slog.Error("GC: failed to delete orphaned VRF by name",
 					"name", name, "err", delErr)
 				result.Errors++
+				continue
 			}
+			slog.Info("GC: removed orphaned VRF by name", "name", name)
+			result.OrphanedVRFsRemoved++
 			continue
 		}
 
@@ -566,5 +593,30 @@ func parseVRFName(name string) (vpc string, ok bool) {
 	}
 	// Strip leading zeros to reverse the %09s padding. BGP CRD names use the
 	// raw base62 value (e.g. "10-dfw-worker" not "000000010-dfw-worker").
+	return strings.TrimLeft(matches[1], "0"), true
+}
+
+// vpcFromVRFName resolves the VPC that a kernel VRF interface belongs to,
+// accepting both the current per-VPC name (parseVRFName) and the legacy
+// pre-rename name (legacyVRFNameRegex). Both shapes carry the same base62 VPC
+// in the same leading position, so a legacy VRF resolves to exactly the VPC
+// its BGPAdvertisements are named after and is judged against them like any
+// other.
+//
+// Only CollectOrphanedVRFs uses this. RemoveOrphanedVRFs deliberately keeps
+// using parseVRFName: it deletes a resolved VPC via vrf.Delete, which rebuilds
+// the *current* interface name from that VPC and so would silently no-op
+// against a legacy interface. Leaving a legacy name unresolved there routes it
+// into the by-name fallback, which deletes the interface actually observed.
+func vpcFromVRFName(name string) (vpc string, ok bool) {
+	if vpc, ok := parseVRFName(name); ok {
+		return vpc, true
+	}
+	matches := legacyVRFNameRegex.FindStringSubmatch(name)
+	if matches == nil {
+		return "", false
+	}
+	// Strip the %09s padding exactly as parseVRFName does, so the VPC matches
+	// CRD naming.
 	return strings.TrimLeft(matches[1], "0"), true
 }

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	testVRFName      = "G0000000jUV"
-	testVRFNameHost  = "G0000000jU00GH"
-	testVRFNameGuest = "G0000000jU00GG"
-	testEth0         = "eth0"
+	testVRFName       = "G0000000jUV"
+	testVRFNameLegacy = "G0000000jU00GV"
+	testVRFNameHost   = "G0000000jU00GH"
+	testVRFNameGuest  = "G0000000jU00GG"
+	testEth0          = "eth0"
 )
 
 func TestCollectNetNSPaths(t *testing.T) {
@@ -120,6 +121,15 @@ func TestParseVRFName(t *testing.T) {
 			wantOk:  true,
 		},
 		{
+			// parseVRFName must keep rejecting the legacy shape: it feeds
+			// vrf.Delete, which rebuilds the current name from the VPC and
+			// would no-op against a legacy interface. RemoveOrphanedVRFs
+			// relies on this to route legacy names into its by-name fallback.
+			name:    "legacy VRF name is not resolvable to a deletable VPC",
+			vrfName: testVRFNameLegacy,
+			wantOk:  false,
+		},
+		{
 			name:    "not a VRF name (host interface)",
 			vrfName: testVRFNameHost,
 			wantOk:  false,
@@ -155,6 +165,79 @@ func TestParseVRFName(t *testing.T) {
 	}
 }
 
+// TestVPCFromVRFName covers the collection-side name resolution, which must
+// accept both the current per-VPC VRF name and the legacy pre-rename name that
+// still carried a VPCAttachment segment. Both resolve to the same VPC, so a
+// VRF created before the rename is judged against the same BGPAdvertisements
+// as one created after it, instead of being skipped as "not a Galactic VRF"
+// and stranding its routing table ID forever.
+func TestVPCFromVRFName(t *testing.T) {
+	tests := []struct {
+		name    string
+		vrfName string
+		wantVPC string
+		wantOk  bool
+	}{
+		{
+			name:    "legacy VRF name resolves to the same VPC",
+			vrfName: testVRFNameLegacy,
+			wantVPC: "jU",
+			wantOk:  true,
+		},
+		{
+			name:    "legacy VRF name with a numeric VPC",
+			vrfName: "G000000010001V",
+			wantVPC: "10",
+			wantOk:  true,
+		},
+		{
+			name:    "current VRF name still resolves",
+			vrfName: testVRFName,
+			wantVPC: "jU",
+			wantOk:  true,
+		},
+		{
+			name:    "current VRF name with a numeric VPC still resolves",
+			vrfName: "G000000010V",
+			wantVPC: "10",
+			wantOk:  true,
+		},
+		{
+			name:    "host veth is still not a VRF",
+			vrfName: testVRFNameHost,
+			wantOk:  false,
+		},
+		{
+			name:    "guest veth is still not a VRF",
+			vrfName: testVRFNameGuest,
+			wantOk:  false,
+		},
+		{
+			name:    "random name is still not a VRF",
+			vrfName: testEth0,
+			wantOk:  false,
+		},
+		{
+			name:    "empty name is still not a VRF",
+			vrfName: "",
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVPC, gotOk := vpcFromVRFName(tt.vrfName)
+			if gotOk != tt.wantOk {
+				t.Errorf("vpcFromVRFName(%q) ok = %v, want %v", tt.vrfName, gotOk, tt.wantOk)
+				return
+			}
+			if gotVPC != tt.wantVPC {
+				t.Errorf("vpcFromVRFName(%q) vpc = %q, want %q", tt.vrfName, gotVPC, tt.wantVPC)
+			}
+		})
+	}
+}
+
 func TestVRFNameRegex(t *testing.T) {
 	// Verify the regex matches the expected VRF naming pattern. The template
 	// is "G%09sV" where %09s is the base62-padded VPC — no VPCAttachment
@@ -168,6 +251,9 @@ func TestVRFNameRegex(t *testing.T) {
 		{testVRFName, testVRFName, true},
 		{"G000000000V", "G000000000V", true},
 		{"G123456789V", "G123456789V", true},
+		// The legacy shape is matched by legacyVRFNameRegex during
+		// collection only — never by this one.
+		{testVRFNameLegacy, testVRFNameLegacy, false},
 		// Non-VRF names should not match.
 		{testVRFNameHost, testVRFNameHost, false},
 		{testVRFNameGuest, testVRFNameGuest, false},


### PR DESCRIPTION
Galactic's per-VPC VRFs were renamed a while back, and garbage collection only ever learned the new name. Any VRF a node created before that rename is invisible to GC — it is skipped as "not ours" and survives forever, quietly holding a routing table ID and its routes long after every workload that needed it is gone. This only bites nodes upgraded in place rather than rebuilt, which is exactly where it is hardest to notice.

Garbage collection now recognises the older name too, resolves it to the same VPC, and reclaims it once nothing on the node still references that VPC.

## Test plan

- New unit tests cover the older name resolving to the right VPC, the current name continuing to resolve, and non-Galactic interface names continuing to be ignored.
- Existing garbage collection unit tests unchanged and still passing.
- No change to how names are generated — only to what cleanup is willing to recognise.

Related to #334