### PR TITLE
chore(cni): drop the duplicated missing-conflist unwrap helper

### DIFF
--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -71,7 +72,7 @@ func loadHostConf(filePath string) (*HostConf, error) {
 	}
 	conf, err := hostconf.Load(filePath, hostconf.PluginType)
 	if err != nil {
-		if os.IsNotExist(unwrapPathError(err)) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return &HostConf{Namespace: config.DefaultNamespace}, nil
 		}
 		return nil, err
@@ -80,20 +81,6 @@ func loadHostConf(filePath string) (*HostConf, error) {
 		conf.Namespace = config.DefaultNamespace
 	}
 	return conf, nil
-}
-
-// unwrapPathError returns the innermost *os.PathError-shaped error wrapped
-// by err, if any, so os.IsNotExist (which does not itself traverse %w
-// wrapping) can still recognize a missing conflist file wrapped by
-// hostconf.Load's fmt.Errorf("read conflist file %q: %w", ...).
-func unwrapPathError(err error) error {
-	for {
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			return err
-		}
-		err = unwrapped
-	}
 }
 
 // parseLogLevel maps a config-supplied level name to a slog.Level. Matching is

--- a/internal/cnibgp/config.go
+++ b/internal/cnibgp/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func loadHostConf(filePath string) (*HostConf, error) {
 	}
 	conf, err := hostconf.Load(filePath, hostconf.PluginType)
 	if err != nil {
-		if os.IsNotExist(unwrapPathError(err)) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return &HostConf{Namespace: config.DefaultNamespace}, nil
 		}
 		return nil, err
@@ -81,19 +82,6 @@ func loadHostConf(filePath string) (*HostConf, error) {
 		conf.Namespace = config.DefaultNamespace
 	}
 	return conf, nil
-}
-
-// unwrapPathError returns the innermost error wrapped by err, so
-// os.IsNotExist (which does not itself traverse %w wrapping) can still
-// recognize a missing conflist file wrapped by hostconf.Load.
-func unwrapPathError(err error) error {
-	for {
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			return err
-		}
-		err = unwrapped
-	}
 }
 
 // parseLogLevel maps a config-supplied level name to a slog.Level.

--- a/internal/cniroute/config.go
+++ b/internal/cniroute/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -72,26 +73,12 @@ func loadHostConf(filePath string) (*HostConf, error) {
 	}
 	conf, err := hostconf.Load(filePath, hostconf.PluginType)
 	if err != nil {
-		if os.IsNotExist(unwrapPathError(err)) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return &HostConf{}, nil
 		}
 		return nil, err
 	}
 	return conf, nil
-}
-
-// unwrapPathError returns the innermost *os.PathError-shaped error wrapped
-// by err, if any, so os.IsNotExist (which does not itself traverse %w
-// wrapping) can still recognize a missing conflist file wrapped by
-// hostconf.Load's fmt.Errorf("read conflist file %q: %w", ...).
-func unwrapPathError(err error) error {
-	for {
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			return err
-		}
-		err = unwrapped
-	}
 }
 
 // parseLogLevel maps a config-supplied level name to a slog.Level. Matching

--- a/internal/cnitap/config.go
+++ b/internal/cnitap/config.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -65,7 +66,7 @@ func loadHostConf(filePath string) (*HostConf, error) {
 	}
 	conf, err := hostconf.Load(filePath, hostconf.PluginType)
 	if err != nil {
-		if os.IsNotExist(unwrapPathError(err)) {
+		if errors.Is(err, fs.ErrNotExist) {
 			return &HostConf{Namespace: config.DefaultNamespace}, nil
 		}
 		return nil, err
@@ -74,19 +75,6 @@ func loadHostConf(filePath string) (*HostConf, error) {
 		conf.Namespace = config.DefaultNamespace
 	}
 	return conf, nil
-}
-
-// unwrapPathError returns the innermost error wrapped by err, so
-// os.IsNotExist (which does not itself traverse %w wrapping) can still
-// recognize a missing conflist file wrapped by hostconf.Load.
-func unwrapPathError(err error) error {
-	for {
-		unwrapped := errors.Unwrap(err)
-		if unwrapped == nil {
-			return err
-		}
-		err = unwrapped
-	}
 }
 
 // parseLogLevel maps a config-supplied level name to a slog.Level. Matching is


### PR DESCRIPTION
## Summary

Four of the CNI plugins each carried a private copy of the same twelve-line helper, written around a limitation the standard library's missing-file check no longer has.

The loader they call already wraps its errors the modern way, so the one-line check recognizes a missing file on its own.

This deletes all four copies and uses that one-liner.

Runtime behavior holds: a node without the shared config file still falls back to defaults, and every other read failure still surfaces.

## Test plan

Formatting and static analysis pass clean over the affected packages, cross-compiled for Linux since they are Linux-only. Existing unit tests already cover the missing-file fallback and run in CI on this branch.

Related to #326
