### PR TITLE
fix(cni): reject addressing keys left outside the ipam block

### DIFF
--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -62,6 +62,17 @@ func assertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
 	}
 }
 
+// movedKeyConf builds an otherwise-valid galactic-cni config carrying the
+// supplied raw JSON member(s) at the top level, for the addressing keys
+// that belong inside the "ipam" block.
+func movedKeyConf(members string) string {
+	return fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test","type":"galactic-cni",`+
+			`"vpc":"%s","vpcattachment":"%s",%s}`,
+		testVPC, testAttachment, members,
+	)
+}
+
 // ---- parseConf -----------------------------------------------------------
 
 func TestParseConf(t *testing.T) {
@@ -194,6 +205,50 @@ func TestParseConf(t *testing.T) {
 				`{"cniVersion":"1.0.0","name":"test",`+
 					`"type":"galactic-cni","vpc":"%s",`+
 					`"vpcattachment":"%s","ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00:10:ff01::/48"}}`,
+				testVPC, testAttachment,
+			),
+			wantVPC: testVPC,
+		},
+		{
+			name:     "top-level ipv6_subnet is rejected",
+			input:    movedKeyConf(`"ipv6_subnet":"fd00:10:ff01::/48"`),
+			wantErr:  "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level ipv4_subnet is rejected",
+			input:    movedKeyConf(`"ipv4_subnet":"172.20.1.0/24"`),
+			wantErr:  "addressing field 'ipv4_subnet' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level address_families is rejected",
+			input:    movedKeyConf(`"address_families":["ipv6"]`),
+			wantErr:  "addressing field 'address_families' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level static_ip is rejected",
+			input:    movedKeyConf(`"static_ip":"fd00::1234"`),
+			wantErr:  "addressing field 'static_ip' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name: "every moved key is named at once",
+			input: movedKeyConf(`"ipv6_subnet":"fd00::/48","ipv4_subnet":"172.20.1.0/24",` +
+				`"address_families":["ipv6"],"static_ip":"fd00::1"`),
+			wantErr: "addressing fields 'ipv6_subnet', 'ipv4_subnet', 'address_families', " +
+				"'static_ip' belong inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name: "same keys inside the ipam block still parse",
+			input: fmt.Sprintf(
+				`{"cniVersion":"1.0.0","name":"test",`+
+					`"type":"galactic-cni","vpc":"%s","vpcattachment":"%s",`+
+					`"ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00:10:ff01::/48",`+
+					`"ipv4_subnet":"172.20.1.0/24","address_families":["ipv6","ipv4"],`+
+					`"static_ip":"fd00::1234"}}`,
 				testVPC, testAttachment,
 			),
 			wantVPC: testVPC,

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -250,6 +250,13 @@ func parseConf(data []byte) (*PluginConf, error) {
 		}
 	}
 
+	// Refuse a config still written against the old flat addressing shape
+	// before anything else happens — those keys would otherwise be dropped
+	// as unknown fields and the pod would attach with no addresses at all.
+	if err := hostconf.RejectMovedIPAMKeys(data); err != nil {
+		return nil, err
+	}
+
 	// Load host CNI config
 	hostConf, err := loadHostConf(ConfFile)
 	if err != nil {
@@ -302,8 +309,9 @@ func parseConf(data []byte) (*PluginConf, error) {
 	// validation live inside internal/cniipam, since they're only ever
 	// read by whichever binary "ipam.type" names — this plugin passes its
 	// own StdinData straight through unmodified when it delegates
-	// (ops_add.go/ops_del.go), so validating them here too would just be
-	// redundant work on the same bytes.
+	// (ops_add.go/ops_del.go), so validating their values here too would
+	// just be redundant work on the same bytes. Their *placement* is this
+	// plugin's concern, though — see the RejectMovedIPAMKeys call above.
 
 	if conf.PrevResult != nil {
 		if err := validatePrevResult(conf.PrevResult); err != nil {

--- a/internal/cni/hostconf/hostconf.go
+++ b/internal/cni/hostconf/hostconf.go
@@ -17,6 +17,11 @@
 // reading a well-known path off disk, independent of how it was actually
 // invoked. Bootstrap only ever writes one entry, typed PluginType, so every
 // caller in this repo passes that same constant.
+//
+// It also carries RejectMovedIPAMKeys, the guard every master plugin runs
+// over that per-attachment config — shared here for the same reason Load
+// is, so the two master plugins cannot drift apart on which keys they
+// refuse.
 package hostconf
 
 import (
@@ -26,7 +31,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/vishvananda/netlink"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -93,6 +100,69 @@ func Load(filePath string, acceptedTypes ...string) (*HostConf, error) {
 	}
 
 	return nil, fmt.Errorf("conflist at %q does not contain a plugin with type in %v", filePath, acceptedTypes)
+}
+
+// movedIPAMKeys holds exactly the addressing keys that used to sit at the
+// top level of a master plugin's config and now live inside its "ipam"
+// block. Every field is a json.RawMessage so presence is all that is
+// decoded: a wrong-typed value must still be reported as present rather
+// than failing the decode, and no value here is ever read.
+type movedIPAMKeys struct {
+	IPv6Subnet      json.RawMessage `json:"ipv6_subnet"`
+	IPv4Subnet      json.RawMessage `json:"ipv4_subnet"`
+	AddressFamilies json.RawMessage `json:"address_families"`
+	StaticIP        json.RawMessage `json:"static_ip"`
+}
+
+// RejectMovedIPAMKeys reports a CNI validation error (code 7) when data
+// carries any of the moved addressing keys at the top level of a master
+// plugin's config.
+//
+// Whether a master plugin allocates addresses at all is decided purely by
+// whether the "ipam" block is present. encoding/json drops unknown fields,
+// so a config still written against the old flat shape parses cleanly, the
+// pod attaches with a working interface and no addresses, and its
+// BGPAdvertisement is created advertising nothing — no error, no warning.
+// Guessing wrong about a pod's addressing is worse than refusing to attach
+// it, so the keys are refused by name instead.
+func RejectMovedIPAMKeys(data []byte) error {
+	var moved movedIPAMKeys
+	// A decode error here is the caller's own to report: every master
+	// plugin unmarshals the same bytes into its full config first, so
+	// malformed JSON has already been rejected with its own message.
+	if err := json.Unmarshal(data, &moved); err != nil {
+		return nil
+	}
+
+	var found []string
+	for _, key := range []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{"ipv6_subnet", moved.IPv6Subnet},
+		{"ipv4_subnet", moved.IPv4Subnet},
+		{"address_families", moved.AddressFamilies},
+		{"static_ip", moved.StaticIP},
+	} {
+		// An explicit JSON null carries no addressing intent, so it reads
+		// the same as the key being absent.
+		if len(key.raw) > 0 && string(key.raw) != "null" {
+			found = append(found, "'"+key.name+"'")
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+
+	field, belong := "field", "belongs"
+	if len(found) > 1 {
+		field, belong = "fields", "belong"
+	}
+	return &types.Error{
+		Code: 7,
+		Msg: fmt.Sprintf("addressing %s %s %s inside the 'ipam' block, not at the top level of the config",
+			field, strings.Join(found, ", "), belong),
+	}
 }
 
 // detectScheme returns a minimal scheme containing only corev1 types needed

--- a/internal/cni/hostconf/hostconf_test.go
+++ b/internal/cni/hostconf/hostconf_test.go
@@ -8,7 +8,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 func TestLoadMissingFile(t *testing.T) {
@@ -74,6 +77,83 @@ func TestLoadMatchingPluginType(t *testing.T) {
 	}
 	if conf.LogLevel != "debug" {
 		t.Errorf("LogLevel = %q, want %q", conf.LogLevel, "debug")
+	}
+}
+
+func TestRejectMovedIPAMKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:  "no addressing keys at all",
+			input: `{"cniVersion":"1.0.0","type":"galactic-cni","vpc":"abc"}`,
+		},
+		{
+			name:  "keys inside the ipam block",
+			input: `{"type":"galactic-cni","ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00::/48","static_ip":"fd00::1"}}`,
+		},
+		{
+			name:    "top-level ipv6_subnet",
+			input:   `{"type":"galactic-cni","ipv6_subnet":"fd00::/48"}`,
+			wantErr: "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
+		},
+		{
+			name:    "top-level ipv4_subnet",
+			input:   `{"type":"galactic-cni","ipv4_subnet":"172.20.1.0/24"}`,
+			wantErr: "addressing field 'ipv4_subnet' belongs inside the 'ipam' block",
+		},
+		{
+			name:    "top-level address_families",
+			input:   `{"type":"galactic-cni","address_families":["ipv6"]}`,
+			wantErr: "addressing field 'address_families' belongs inside the 'ipam' block",
+		},
+		{
+			name:    "top-level static_ip",
+			input:   `{"type":"galactic-cni","static_ip":"fd00::1234"}`,
+			wantErr: "addressing field 'static_ip' belongs inside the 'ipam' block",
+		},
+		{
+			name:    "wrong-typed value is still reported as present",
+			input:   `{"type":"galactic-cni","ipv6_subnet":42}`,
+			wantErr: "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
+		},
+		{
+			name:  "explicit null carries no addressing intent",
+			input: `{"type":"galactic-cni","ipv6_subnet":null,"static_ip":null}`,
+		},
+		{
+			name:    "several keys are all named",
+			input:   `{"type":"galactic-cni","ipv4_subnet":"172.20.1.0/24","static_ip":"fd00::1"}`,
+			wantErr: "addressing fields 'ipv4_subnet', 'static_ip' belong inside the 'ipam' block",
+		},
+		{
+			name:  "malformed JSON is left to the caller to report",
+			input: "not json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RejectMovedIPAMKeys([]byte(tt.input))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			var cniErr *types.Error
+			if !errors.As(err, &cniErr) {
+				t.Fatalf("expected *types.Error, got %T: %v", err, err)
+			}
+			if cniErr.Code != 7 {
+				t.Errorf("Code = %d, want 7", cniErr.Code)
+			}
+			if !strings.Contains(cniErr.Msg, tt.wantErr) {
+				t.Errorf("Msg = %q, want it to contain %q", cniErr.Msg, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/cnitap/cnitap_test.go
+++ b/internal/cnitap/cnitap_test.go
@@ -55,6 +55,16 @@ func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
 	return ipnet
 }
 
+// movedKeyConf builds an otherwise-valid galactic-tap-cni config carrying
+// the supplied raw JSON member(s) at the top level, for the addressing keys
+// that belong inside the "ipam" block.
+func movedKeyConf(members string) string {
+	return fmt.Sprintf(
+		`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s",%s}`,
+		testVPC, testAttachment, members,
+	)
+}
+
 // ---- parseConf -----------------------------------------------------------
 
 func TestParseConf(t *testing.T) {
@@ -87,6 +97,44 @@ func TestParseConf(t *testing.T) {
 				testInvalidBase62, testAttachment),
 			wantErr:  fmt.Sprintf("invalid base62 value for field 'vpc': %q", testInvalidBase62),
 			wantCode: 7,
+		},
+		{
+			name:     "top-level ipv6_subnet is rejected",
+			input:    movedKeyConf(`"ipv6_subnet":"fd00:10:ff01::/48"`),
+			wantErr:  "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level ipv4_subnet is rejected",
+			input:    movedKeyConf(`"ipv4_subnet":"172.20.1.0/24"`),
+			wantErr:  "addressing field 'ipv4_subnet' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level address_families is rejected",
+			input:    movedKeyConf(`"address_families":["ipv6"]`),
+			wantErr:  "addressing field 'address_families' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name:     "top-level static_ip is rejected",
+			input:    movedKeyConf(`"static_ip":"fd00::1234"`),
+			wantErr:  "addressing field 'static_ip' belongs inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name: "every moved key is named at once",
+			input: movedKeyConf(`"ipv6_subnet":"fd00::/48","ipv4_subnet":"172.20.1.0/24",` +
+				`"address_families":["ipv6"],"static_ip":"fd00::1"`),
+			wantErr: "addressing fields 'ipv6_subnet', 'ipv4_subnet', 'address_families', " +
+				"'static_ip' belong inside the 'ipam' block",
+			wantCode: 7,
+		},
+		{
+			name: "same keys inside the ipam block still parse",
+			input: movedKeyConf(`"ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00:10:ff01::/48",` +
+				`"ipv4_subnet":"172.20.1.0/24","address_families":["ipv6","ipv4"],"static_ip":"fd00::1234"}`),
+			wantVPC: testVPC,
 		},
 	}
 

--- a/internal/cnitap/config.go
+++ b/internal/cnitap/config.go
@@ -221,6 +221,12 @@ func parseConf(data []byte) (*PluginConf, error) {
 		}
 	}
 
+	// Refuse a config still written against the old flat addressing shape —
+	// see internal/cni's own parseConf, identical here.
+	if err := hostconf.RejectMovedIPAMKeys(data); err != nil {
+		return nil, err
+	}
+
 	hostConf, err := loadHostConf(ConfFile)
 	if err != nil {
 		return nil, fmt.Errorf("load host CNI config: %w", err)
@@ -258,9 +264,10 @@ func parseConf(data []byte) (*PluginConf, error) {
 
 	// Whether IPAM runs at all is decided entirely by "ipam" block
 	// presence — see internal/cni's own parseConf for the full reasoning,
-	// identical here. Addressing fields and their validation live inside
-	// internal/cniipam, invoked via delegation with this plugin's own
-	// StdinData passed straight through unmodified.
+	// identical here. Addressing fields and their value validation live
+	// inside internal/cniipam, invoked via delegation with this plugin's
+	// own StdinData passed straight through unmodified; their placement is
+	// checked by the RejectMovedIPAMKeys call above.
 
 	if conf.PrevResult != nil {
 		if err := validatePrevResult(conf.PrevResult); err != nil {


### PR DESCRIPTION
A pod could come up with a working interface, no addresses at all, and a route advertisement carrying nothing — and nothing anywhere reported a problem.

That happened whenever a network config was still written against the older layout, with the addressing settings sitting at the top level rather than inside the addressing block they moved into; the stale settings were quietly discarded as unrecognised, so the plugin concluded there was no addressing to do.

Attaching now fails outright on such a config, with an error naming each misplaced setting and stating where it belongs, so the operator emitting the old shape gets told exactly what to change.

Guessing wrong about a workload's addressing is worse than refusing to attach it.

## Test plan

- New table-driven cases on both master plugins: one per misplaced addressing setting, one with all four present at once, and one proving the current layout still parses and attaches.
- New cases on the shared guard itself for the edge behaviour: a wrong-typed value is still reported as misplaced, an explicit null reads as absent, and malformed input is left to the caller's own parse error.
- Lint and format checks pass locally over both plugins, cross-compiled for Linux. The plugins themselves are Linux-only and their tests do not run on macOS, so the suites run in CI; the shared guard's own cases were executed locally against an isolated copy and all pass.

Related to #327
