### PR TITLE
refactor(cni): split galactic-cni into installer + galactic-veth/galactic-tap plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ coverage.html
 /galactic
 /galactic-router
 /galactic-cni
-/galactic-tap-cni
+/galactic-veth
+/galactic-tap
 /galactic-ipam
 /galactic-bgp
 /galactic-route

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ See [docs/agents/ARCHITECTURE.md](docs/agents/ARCHITECTURE.md) for a full archit
 
 Galactic is the SRv6 data plane for multi-cloud VPC networking. It consists of two binaries deployed on each Kubernetes node:
 
-- **`galactic-cni`** — CNI plugin that wires containers into VPC networks (VRF, veth, SRv6 ingress route) and writes `BGPAdvertisement` CRDs.
+- **`galactic-veth`** — CNI plugin that wires containers into VPC networks (VRF, veth, SRv6 ingress route) and writes `BGPAdvertisement` CRDs.
 - **`galactic-router`** — controller-runtime reconciler that watches BGP CRDs and drives an embedded GoBGP server per node to distribute EVPN paths.
 
 VPC and VPCAttachment CRD management lives in a separate companion operator; Galactic receives pre-populated identifiers through the CNI config and acts on them.
@@ -27,7 +27,7 @@ VPC and VPCAttachment CRD management lives in a separate companion operator; Gal
 ## Development Workflow
 
 ```
-task build          # produces bin/galactic-cni and bin/galactic-router
+task build          # produces bin/galactic-veth and bin/galactic-router
 task ci             # full pipeline: lint → build → test:unit → test:e2e
 task test           # runs test:unit then test:e2e
 task test:unit      # unit tests with race detection

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ task          # list available tasks
 #### Building
 
 ```bash
-task build           # produces bin/galactic-cni and bin/galactic-router
+task build           # produces bin/galactic-veth and bin/galactic-router
 task lint            # golangci-lint + yamlfmt; lint-fix applies safe auto-fixes
 task ci              # full pipeline: lint → build → test:unit → test:e2e
 ```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -133,7 +133,8 @@ tasks:
         -X go.datum.net/galactic/internal/metadata.GitURL={{.GIT_URL}}
     cmds:
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-cni ./cmd/galactic-cni
-      - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-tap-cni ./cmd/galactic-tap-cni
+      - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-veth ./cmd/galactic-veth
+      - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-tap ./cmd/galactic-tap
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-ipam ./cmd/galactic-ipam
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-bgp ./cmd/galactic-bgp
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-route ./cmd/galactic-route

--- a/cmd/galactic-cni/main.go
+++ b/cmd/galactic-cni/main.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Datum Cloud, Inc.
+// Copyright 2026 Datum Cloud, Inc.
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -11,11 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containernetworking/cni/pkg/version"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
-	"go.datum.net/galactic/internal/cni"
 	"go.datum.net/galactic/internal/installer"
 	"go.datum.net/galactic/internal/metadata"
 )
@@ -23,7 +20,15 @@ import (
 const (
 	appName = "galactic-cni"
 
-	appDesc = `Galactic CNI Plugin
+	appDesc = `Galactic CNI installer
+
+ Bootstraps and maintains the CNI plugin chain on a node: stages every
+ chain binary (galactic-veth, galactic-tap, galactic-ipam, galactic-bgp,
+ galactic-route, host-device) into /opt/cni/bin, writes the static
+ conflist and kubeconfig, and (via "run") keeps credentials fresh and
+ drives the eBPF uSID datapath. This binary is never itself a CNI plugin —
+ the container runtime never execs it via a NAD's "type" field, only the
+ galactic-cni DaemonSet's own init/run containers do.
 
  Find more information at: https://www.datum.net/docs`
 )
@@ -72,14 +77,6 @@ func newRootCommand() *cobra.Command {
 		Use:   appName,
 		Short: strings.Split(appDesc, "\n")[0],
 		Long:  appDesc,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			cni.InitCNIConfig()
-			confFile, _ := cmd.Flags().GetString("conf-file")
-			if confFile != "" {
-				cni.ConfFile = confFile
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
 				fmt.Println(metadata.BuildInfo(appName))
@@ -89,37 +86,10 @@ func newRootCommand() *cobra.Command {
 				fmt.Printf("galactic-cni version %s\n", metadata.Version)
 				return nil
 			}
-			// Handle CNI_COMMAND=VERSION before config validation
-			if os.Getenv("CNI_COMMAND") == "VERSION" {
-				return version.All.Encode(os.Stdout)
-			}
-
-			// Real CNI runtimes (containerd, CRI-O) always pipe the network
-			// config JSON on stdin and close it. If stdin is an interactive
-			// terminal instead, no config will ever arrive, and both skel's
-			// blocking stdin read and the io.ReadAll below would hang
-			// forever. Detect that case up front and print version info
-			// rather than hanging.
-			if term.IsTerminal(int(os.Stdin.Fd())) {
-				fmt.Printf("galactic-cni version %s\n", metadata.Version)
-				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
-				return nil
-			}
-
-			// galactic-cni is veth-only: it always moves an interface into
-			// the container's own netns, so it always needs the CNI
-			// library's normal same-netns rejection check — unlike
-			// galactic-tap-cni (which unconditionally sets
-			// CNI_NETNS_OVERRIDE, since tap workloads never enter a netns
-			// at all), there is no stdin-peeking tap-mode detection here
-			// anymore. Interface kind is which binary you invoke now, not a
-			// config field this process branches on.
-			cni.RunPlugin()
-			return nil
+			return cmd.Help()
 		},
 	}
 
-	cmd.PersistentFlags().String("conf-file", cni.ConfFile, "Path to CNI conflist file")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
 

--- a/cmd/galactic-cni/main_test.go
+++ b/cmd/galactic-cni/main_test.go
@@ -29,8 +29,8 @@ func TestSubcommandsRegistered(t *testing.T) {
 	if !containsString(output, "run") {
 		t.Errorf("expected output to contain 'run', got: %s", output)
 	}
-	if !containsString(output, "--conf-file") {
-		t.Errorf("expected output to contain '--conf-file', got: %s", output)
+	if !containsString(output, "--build-info") {
+		t.Errorf("expected output to contain '--build-info', got: %s", output)
 	}
 }
 

--- a/cmd/galactic-ipam/main.go
+++ b/cmd/galactic-ipam/main.go
@@ -24,7 +24,7 @@ const (
 	appDesc = `Galactic IPAM CNI Plugin
 
  The delegated CNI IPAM plugin in the galactic CNI chain — invoked by
- galactic-cni/galactic-tap-cni's own "ipam" block via the CNI IPAM
+ galactic-veth/galactic-tap's own "ipam" block via the CNI IPAM
  delegation protocol (github.com/containernetworking/cni/pkg/ipam), never
  run directly from a conflist. Has no Kubernetes dependency at all:
  allocation state persists in on-disk marker files under this node's own

--- a/cmd/galactic-route/main.go
+++ b/cmd/galactic-route/main.go
@@ -24,7 +24,7 @@ const (
 	appDesc = `Galactic Route CNI Plugin
 
  The termination-route plugin in the galactic CNI chain — chained after
- galactic-cni/galactic-tap-cni and before galactic-bgp per conflist order,
+ galactic-veth/galactic-tap and before galactic-bgp per conflist order,
  never run standalone, and optional (only present for attachments with
  terminations to install). Has no Kubernetes dependency at all: it only
  installs kernel routes into the VRF routing table the master plugin

--- a/cmd/galactic-tap/main.go
+++ b/cmd/galactic-tap/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	appName = "galactic-tap-cni"
+	appName = "galactic-tap"
 
 	appDesc = `Galactic tap CNI Plugin
 
@@ -71,7 +71,7 @@ func newRootCommand() *cobra.Command {
 			// are host-side. Set the override so the CNI library skips its
 			// same-netns rejection check, which would otherwise reject
 			// kraftlet workloads that pass the host netns. Unconditional
-			// here (unlike galactic-cni, which has no override logic at
+			// here (unlike galactic-veth, which has no override logic at
 			// all): every invocation of this binary is tap mode, so there
 			// is no config content to peek at first.
 			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")

--- a/cmd/galactic-veth/main.go
+++ b/cmd/galactic-veth/main.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Datum Cloud, Inc.
+// Copyright 2025 Datum Cloud, Inc.
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -14,20 +14,14 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"go.datum.net/galactic/internal/cnibgp"
+	"go.datum.net/galactic/internal/cni"
 	"go.datum.net/galactic/internal/metadata"
 )
 
 const (
-	appName = "galactic-bgp"
+	appName = "galactic-veth"
 
-	appDesc = `Galactic BGP CNI Plugin
-
- The BGP/SRv6/eBPF publish plugin in the galactic CNI chain — chained after
- galactic-veth/galactic-tap (and, when present, galactic-route) per
- conflist order, never run standalone. Has zero kernel-interface
- dependency: every address it advertises comes from prevResult, not from a
- runtime call into an interface it doesn't own.
+	appDesc = `Galactic CNI Plugin
 
  Find more information at: https://www.datum.net/docs`
 )
@@ -38,10 +32,10 @@ func newRootCommand() *cobra.Command {
 		Short: strings.Split(appDesc, "\n")[0],
 		Long:  appDesc,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			cnibgp.InitCNIConfig()
+			cni.InitCNIConfig()
 			confFile, _ := cmd.Flags().GetString("conf-file")
 			if confFile != "" {
-				cnibgp.ConfFile = confFile
+				cni.ConfFile = confFile
 			}
 			return nil
 		},
@@ -51,38 +45,43 @@ func newRootCommand() *cobra.Command {
 				return nil
 			}
 			if ok, _ := cmd.Flags().GetBool("version"); ok {
-				fmt.Printf("%s version %s\n", appName, metadata.Version)
+				fmt.Printf("galactic-veth version %s\n", metadata.Version)
 				return nil
 			}
+			// Handle CNI_COMMAND=VERSION before config validation
 			if os.Getenv("CNI_COMMAND") == "VERSION" {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes always pipe the network config JSON on
-			// stdin and close it. If stdin is an interactive terminal
-			// instead, no config will ever arrive and skel's blocking
-			// stdin read would hang forever — print version info instead.
+			// Real CNI runtimes (containerd, CRI-O) always pipe the network
+			// config JSON on stdin and close it. If stdin is an interactive
+			// terminal instead, no config will ever arrive, and both skel's
+			// blocking stdin read and the io.ReadAll below would hang
+			// forever. Detect that case up front and print version info
+			// rather than hanging.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
-				fmt.Printf("%s version %s\n", appName, metadata.Version)
+				fmt.Printf("galactic-veth version %s\n", metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// This plugin never enters a network namespace — it only makes
-			// k8s API calls to publish BGP advertisements. For tap-mode
-			// attachments, CNI_NETNS points at the host netns which equals
-			// this process's ambient netns, so the CNI library's same-netns
-			// rejection check would fire without the override.
-			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")
-
-			cnibgp.RunPlugin()
+			// galactic-veth is veth-only: it always moves an interface into
+			// the container's own netns, so it always needs the CNI
+			// library's normal same-netns rejection check — unlike
+			// galactic-tap (which unconditionally sets
+			// CNI_NETNS_OVERRIDE, since tap workloads never enter a netns
+			// at all), there is no stdin-peeking tap-mode detection here
+			// anymore. Interface kind is which binary you invoke now, not a
+			// config field this process branches on.
+			cni.RunPlugin()
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().String("conf-file", cnibgp.ConfFile, "Path to CNI conflist file")
+	cmd.PersistentFlags().String("conf-file", cni.ConfFile, "Path to CNI conflist file")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
+
 	return cmd
 }
 

--- a/containers/galactic-cni/Dockerfile
+++ b/containers/galactic-cni/Dockerfile
@@ -37,7 +37,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 RUN go generate ./internal/plumbing/ebpf/prog/...
 
-# Build CNI plugin
+# Build galactic-cni, the CNI installer: stages every chain binary onto the
+# host, writes the static conflist/kubeconfig, and (via "run") refreshes
+# credentials and drives the eBPF uSID datapath. It is never itself a CNI
+# plugin -- only the DaemonSet's own init/run containers exec it.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w \
       -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
@@ -48,7 +51,18 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
     -o galactic-cni cmd/galactic-cni/main.go
 
-# Build galactic-tap-cni, the tap master plugin in the galactic CNI chain
+# Build CNI plugin
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
+      -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
+      -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
+      -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE} \
+      -X go.datum.net/galactic/internal/metadata.SPDXLicense=${SPDX_LICENSE} \
+      -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
+    -o galactic-veth cmd/galactic-veth/main.go
+
+# Build galactic-tap, the tap master plugin in the galactic CNI chain
 # (VM workloads: Kata, Firecracker, kraftlet/Unikraft). Ships in this same
 # image/binary set since every plugin in the chain is staged onto the host
 # by the same galactic-cni init container (installer.Bootstrap).
@@ -60,11 +74,11 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE} \
       -X go.datum.net/galactic/internal/metadata.SPDXLicense=${SPDX_LICENSE} \
       -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
-    -o galactic-tap-cni cmd/galactic-tap-cni/main.go
+    -o galactic-tap cmd/galactic-tap/main.go
 
 # Build galactic-ipam, the delegated CNI IPAM plugin in the galactic CNI
 # chain. Ships in this same image/binary set for the same reason
-# galactic-tap-cni does — see its own comment above.
+# galactic-tap does — see its own comment above.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w \
       -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
@@ -77,7 +91,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
 
 # Build galactic-bgp, the BGP/SRv6/eBPF publish plugin in the galactic CNI
 # chain. Ships in this same image/binary set for the same reason
-# galactic-tap-cni/galactic-ipam do — see their own comments above.
+# galactic-tap/galactic-ipam do — see their own comments above.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w \
       -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
@@ -90,7 +104,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
 
 # Build galactic-route, the termination-route plugin in the galactic CNI
 # chain. Ships in this same image/binary set for the same reason
-# galactic-tap-cni/galactic-ipam/galactic-bgp do — see their own comments
+# galactic-tap/galactic-ipam/galactic-bgp do — see their own comments
 # above.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w \
@@ -116,7 +130,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
     -o vmtap-cni cmd/vmtap-cni/main.go
 
-# Build the host-device CNI plugin binary, used by galactic-cni to move
+# Build the host-device CNI plugin binary, used by galactic-veth to move
 # the veth endpoint into the container network namespace. GOBIN can't be set
 # for a cross-compiled `go install` (the toolchain rejects it outright when
 # TARGETARCH differs from the builder's native arch, e.g. arm64 on an amd64
@@ -136,7 +150,8 @@ FROM gcr.io/distroless/static:nonroot AS production
 
 # Copy binaries from builder into the distroless production image
 COPY --from=builder /workspace/galactic-cni /galactic-cni
-COPY --from=builder /workspace/galactic-tap-cni /galactic-tap-cni
+COPY --from=builder /workspace/galactic-veth /galactic-veth
+COPY --from=builder /workspace/galactic-tap /galactic-tap
 COPY --from=builder /workspace/galactic-ipam /galactic-ipam
 COPY --from=builder /workspace/galactic-bgp /galactic-bgp
 COPY --from=builder /workspace/galactic-route /galactic-route
@@ -152,7 +167,8 @@ FROM docker.io/library/alpine:latest
 
 # Copy binaries from the production (distroless) image
 COPY --from=production /galactic-cni /galactic-cni
-COPY --from=production /galactic-tap-cni /galactic-tap-cni
+COPY --from=production /galactic-veth /galactic-veth
+COPY --from=production /galactic-tap /galactic-tap
 COPY --from=production /galactic-ipam /galactic-ipam
 COPY --from=production /galactic-bgp /galactic-bgp
 COPY --from=production /galactic-route /galactic-route

--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -20,14 +20,17 @@ reflector, enabling pods/VMs on different nodes or clusters to reach each other
 via SRv6-encapsulated traffic.
 
 The CNI attach side is a **chain of small binaries**, not one monolithic
-plugin: a master plugin (`galactic-cni` for containers, `galactic-tap-cni` for
+plugin: a master plugin (`galactic-veth` for containers, `galactic-tap` for
 VM workloads) creates the VRF and host-side interface; an optional
 `galactic-route` installs static termination routes; `galactic-bgp` publishes
 the BGP/SRv6/eBPF state. IPAM is delegated to a separate `galactic-ipam`
-binary via the standard CNI IPAM delegation protocol, not chained. All five
-binaries (plus `vmtap-cni`, `host-device`) ship in the same
-`ghcr.io/datum-cloud/galactic-cni` image and are staged onto the host by the
-same init container — see [Repository Layout](#repository-layout) and
+binary via the standard CNI IPAM delegation protocol, not chained. None of
+these five binaries are ever installed by hand: `galactic-cni`, a sixth
+binary that is never itself a CNI plugin (no NAD ever names it in a `"type"`
+field), stages the other five (plus `vmtap-cni`, `host-device`) onto the
+host from its own `init`/`run` DaemonSet containers. All six ship in the
+same `ghcr.io/datum-cloud/galactic-cni` image — see
+[Repository Layout](#repository-layout) and
 [Module / Package Reference](#module--package-reference) below.
 
 VPC and VPCAttachment CRDs are owned by a separate companion operator
@@ -81,8 +84,10 @@ Distinguisher and import/export Route Target.
 ```
 galactic/
 ├── cmd/
-│   ├── galactic-cni/        # veth master plugin binary
-│   ├── galactic-tap-cni/    # tap master plugin binary (VM workloads)
+│   ├── galactic-cni/        # CNI installer binary (init/run DaemonSet
+│   │                        #   subcommands; never itself a CNI plugin)
+│   ├── galactic-veth/       # veth master plugin binary
+│   ├── galactic-tap/        # tap master plugin binary (VM workloads)
 │   ├── galactic-ipam/       # delegated CNI IPAM plugin binary
 │   ├── galactic-bgp/        # BGP/SRv6/eBPF publish plugin binary
 │   ├── galactic-route/      # termination-route plugin binary (optional chain stage)
@@ -103,7 +108,7 @@ galactic/
 │   ├── gc/                  # Orphaned BGPAdvertisement/BGPVRFInstance CRD, stale
 │   │                        #   kernel VRF, and eBPF vrf_table entry cleanup,
 │   │                        #   driven by the GC controller
-│   ├── cni/                 # galactic-cni: veth master plugin (cmdAdd/cmdDel/
+│   ├── cni/                 # galactic-veth: veth master plugin (cmdAdd/cmdDel/
 │   │   │                    #   cmdCheck/cmdStatus, PluginConf parsing, NAD
 │   │   │                    #   annotation, host-device delegation)
 │   │   ├── hostconf/        # Shared static-conflist HostConf schema/loader,
@@ -118,7 +123,7 @@ galactic/
 │   │   ├── route/           # Host-side static routes via netlink
 │   │   ├── tap/             # Tap interface management (VM workloads)
 │   │   └── veth/            # veth pair management
-│   ├── cnitap/              # galactic-tap-cni: tap master plugin (mirrors
+│   ├── cnitap/              # galactic-tap: tap master plugin (mirrors
 │   │                        #   internal/cni; no host-device delegation, no
 │   │                        #   guest netns)
 │   ├── cniipam/             # galactic-ipam: CNI IPAM delegation protocol
@@ -165,7 +170,7 @@ galactic/
 ├── deploy/
 │   └── containerlab/        # ContainerLab lab topology and scripts
 └── containers/
-    ├── galactic-cni/        # galactic-cni/-tap-cni/-ipam/-bgp/-route + vmtap-cni
+    ├── galactic-cni/        # galactic-veth/galactic-tap/-ipam/-bgp/-route + vmtap-cni
     │                        #   + host-device image (e2e test and production publish)
     └── galactic-router/     # galactic-router production image
 ```
@@ -194,8 +199,8 @@ See [docs/agent-startup.md](../agent-startup.md) for the router startup sequence
 | `internal/hash` | `galactic-router` | Change detection |
 | `internal/metadata` | every binary | Build-time version info stamped via `-ldflags` |
 | `internal/gc` | `galactic-router` | Orphaned CRD/VRF/eBPF-entry cleanup, driven by the GC controller's ticker |
-| `internal/cni` | `galactic-cni` | Veth master plugin: cmdAdd/cmdDel/cmdCheck/cmdStatus, PluginConf parsing, NAD annotation, host-device delegation |
-| `internal/cnitap` | `galactic-tap-cni` | Tap master plugin (mirrors `internal/cni`, no guest netns) |
+| `internal/cni` | `galactic-veth` | Veth master plugin: cmdAdd/cmdDel/cmdCheck/cmdStatus, PluginConf parsing, NAD annotation, host-device delegation |
+| `internal/cnitap` | `galactic-tap` | Tap master plugin (mirrors `internal/cni`, no guest netns) |
 | `internal/cniipam` | `galactic-ipam` | Delegated CNI IPAM plugin (no k8s dependency) |
 | `internal/cnibgp` | `galactic-bgp` | BGP/SRv6/eBPF publish plugin (zero kernel-interface dependency) |
 | `internal/cniroute` | `galactic-route` | Termination-route plugin (no k8s dependency) |
@@ -205,23 +210,47 @@ See [docs/agent-startup.md](../agent-startup.md) for the router startup sequence
 | `internal/plumbing/srv6` | `galactic-router` | SID computation (`ComputeSID`) for the BGP Prefix-SID path attribute |
 | `internal/plumbing/ebpf` | `galactic-cni` (attach/metrics via `run`), `galactic-bgp` (registration), `galactic-router` (GC sweep) | TC-BPF uSID datapath: preflight, uformat, prog, attach, usidmap, metrics |
 | `internal/plumbing/vrf` | every CNI-chain binary + router | Linux VRF create/delete/lookup |
-| `internal/plumbing/sysctl` | `galactic-cni`, `galactic-tap-cni` | Interface sysctl helpers |
+| `internal/plumbing/sysctl` | `galactic-veth`, `galactic-tap` | Interface sysctl helpers |
 
 ---
 
 ## Entry Points
 
-### `cmd/galactic-cni/main.go` — CNI plugin
+### `cmd/galactic-cni/main.go` — installer
 
-A cobra command (no viper — see External Dependencies below) with three roles under
-one binary: the CNI plugin invocation itself (root command, invoked by the container
-runtime per the CNI spec), and two DaemonSet-lifecycle subcommands (`init`, `run`) that
-wrap `internal/installer`.
+A cobra command (no viper — see External Dependencies below) hosting the two
+DaemonSet-lifecycle subcommands (`init`, `run`) that wrap `internal/installer`.
+This binary is never itself a CNI plugin — no NAD's `"plugins"` array ever
+names it in a `"type"` field, and the container runtime never execs it. Its
+only callers are the `galactic-cni` DaemonSet's own `install-cni` init
+container and `credential-refresh` long-running container (see Known
+Constraints below for the manifest).
+
+- `init` — `--node-name`/`-n` flag (or `GALACTIC_CNI_NODE_NAME`/`NODE_NAME` env),
+  calls `installer.Bootstrap(ctx, nodeName)`: stages every binary in the CNI chain
+  (`galactic-veth`, `galactic-tap`, `galactic-ipam`, `galactic-bgp`,
+  `galactic-route`, `host-device`) onto the host, does a one-shot dual-stack
+  node-identity check against the Kubernetes API, and writes `ca.crt`/kubeconfig
+  plus the static conflist.
+- `run` — `--grpc-health-port` flag (default `5180`), calls `installer.Run(ctx,
+  grpcHealthPort)`: serves gRPC health checks, manages the eBPF uSID datapath's
+  load/attach lifecycle, and periodically refreshes the kubeconfig token and
+  rotates the CNI log file.
+
+`--build-info` and `--version`/`-V` utility flags are also present on the root
+command, same as every other binary.
+
+### `cmd/galactic-veth/main.go` — CNI plugin
+
+A cobra command with a single role: the CNI plugin invocation itself (root
+command, invoked by the container runtime per the CNI spec). Unlike before the
+CNI installer split (see `cmd/galactic-cni/main.go` above), this binary carries
+no DaemonSet-lifecycle subcommands at all.
 
 `newRootCommand()` builds a root command with a persistent `--conf-file` flag
 (default `cni.DefaultConfFile`, `/etc/cni/net.d/10-galactic.conflist`) plus
 `--build-info` and `--version`/`-V` utility flags. There is no `--node-name` or
-`--enable-local-ipam` flag on this path anymore — those are resolved entirely inside
+`--enable-local-ipam` flag on this path — those are resolved entirely inside
 `internal/cni` at ADD/DEL/CHECK/STATUS time (see Configuration below). On `RunE`:
 
 1. `PersistentPreRunE` overrides `cni.ConfFile` from `--conf-file` if set.
@@ -232,31 +261,20 @@ wrap `internal/installer`.
    `parseConf()` resolves node name, kubeconfig, namespace, and log file on every
    invocation (conflist → env vars → API auto-detect, in that precedence).
 
-`galactic-cni`'s own ADD creates the VRF, veth pair, and (if `"ipam"` is
+`galactic-veth`'s own ADD creates the VRF, veth pair, and (if `"ipam"` is
 present) delegates IPAM and configures the host gateway — it prints its own
 CNI result and returns; BGP/SRv6/eBPF publish is `galactic-bgp`'s job,
 invoked next by the CNI runtime per conflist order, not by this process.
 
-Two subcommands support the DaemonSet (see Known Constraints below for the manifest):
-
-- `init` — `--node-name`/`-n` flag (or `GALACTIC_CNI_NODE_NAME`/`NODE_NAME` env),
-  calls `installer.Bootstrap(ctx, nodeName)`: stages every binary in the CNI chain
-  (`galactic-cni`, `galactic-tap-cni`, `galactic-ipam`, `galactic-bgp`,
-  `galactic-route`, `host-device`) onto the host, does a one-shot dual-stack
-  node-identity check against the Kubernetes API, and writes `ca.crt`/kubeconfig
-  plus the static conflist.
-- `run` — `--grpc-health-port` flag (default `5180`), calls `installer.Run(ctx,
-  grpcHealthPort)`: serves gRPC health checks, manages the eBPF uSID datapath's
-  load/attach lifecycle, and periodically refreshes the kubeconfig token and
-  rotates the CNI log file.
-
 See [docs/cni-cmd-sequence.md](../cni-cmd-sequence.md) for the full ADD/DEL sequence.
 
-### `cmd/galactic-tap-cni/main.go` — tap master plugin
+### `cmd/galactic-tap/main.go` — tap master plugin
 
-Mirrors `cmd/galactic-cni/main.go`'s CNI-invocation role exactly (`internal/cnitap.RunPlugin()`),
-minus the `init`/`run` DaemonSet subcommands — those live only on `galactic-cni`, since
-there's exactly one init container per node regardless of how many workload types it serves.
+Mirrors `cmd/galactic-veth/main.go`'s CNI-invocation role exactly (`internal/cnitap.RunPlugin()`)
+— both are pure CNI plugins with zero DaemonSet-lifecycle subcommands; that
+logic lives solely on the separate `galactic-cni` installer binary, since
+there's exactly one init container per node regardless of how many workload
+types it serves.
 `internal/cnitap` mirrors `internal/cni` (VRF + tap creation, NAD annotation, IPAM
 delegation, host gateway configuration) but never delegates to host-device and never
 configures a guest netns — the VM hypervisor manages the tap fd directly.
@@ -348,28 +366,28 @@ field tables and seven example conflists; summary:
 |-----------------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | `vpc`           | every binary                                          | Base62-encoded 48-bit VPC identifier                                                                        |
 | `vpcattachment` | every binary                                          | Base62-encoded 16-bit VPCAttachment identifier                                                              |
-| `namespace`     | `galactic-cni`/`galactic-tap-cni`/`galactic-bgp`      | Kubernetes namespace for NAD/BGP CRD lookup; resolution order is this field → `GALACTIC_CNI_NAMESPACE` → `HostConf.Namespace` → `galactic-system` |
-| `mtu`           | `galactic-cni`/`galactic-tap-cni`                     | MTU for the host-side interface (veth pair or tap); 0 uses kernel default                                   |
-| `ipam`          | `galactic-cni`/`galactic-tap-cni` (decides whether to delegate), `galactic-ipam` (reads the block's own sub-fields) | IPAM delegation block; `type` names the delegate binary (`galactic-ipam`). See [docs/cni/configuration.md](../cni/configuration.md#ipam-fields). |
+| `namespace`     | `galactic-veth`/`galactic-tap`/`galactic-bgp`         | Kubernetes namespace for NAD/BGP CRD lookup; resolution order is this field → `GALACTIC_CNI_NAMESPACE` → `HostConf.Namespace` → `galactic-system` |
+| `mtu`           | `galactic-veth`/`galactic-tap`                        | MTU for the host-side interface (veth pair or tap); 0 uses kernel default                                   |
+| `ipam`          | `galactic-veth`/`galactic-tap` (decides whether to delegate), `galactic-ipam` (reads the block's own sub-fields) | IPAM delegation block; `type` names the delegate binary (`galactic-ipam`). See [docs/cni/configuration.md](../cni/configuration.md#ipam-fields). |
 | `terminations`  | `galactic-route` only                                 | Static routes to install on the host-side interface (`network`, `via`)                                      |
 
 There is no `interface_type` field anymore — which binary you invoke *is* the
-interface type (`galactic-cni` → veth, `galactic-tap-cni` → tap).
+interface type (`galactic-veth` → veth, `galactic-tap` → tap).
 
-### galactic-cni / galactic-tap-cni / galactic-bgp environment variables
+### galactic-veth / galactic-tap / galactic-bgp environment variables
 
 There is no `--node-name`/`--enable-local-ipam` CLI flag on any plugin invocation
-path (`--node-name` exists only on `galactic-cni`'s own `init` installer
-subcommand). Each binary's own `parseConf()` resolves the settings below on every
+path (`--node-name` exists only on the separate `galactic-cni` installer
+binary's own `init` subcommand). Each binary's own `parseConf()` resolves the settings below on every
 ADD/DEL/CHECK/STATUS call, in the listed precedence, re-exporting the result as a
 process env var. `galactic-ipam` and `galactic-route` skip this table entirely —
 see [docs/cni/configuration.md](../cni/configuration.md#runtime-configuration).
 
 | Variable                          | Resolution precedence (highest first)                                                                 | Default | Resolved by |
 |------------------------------------|--------------------------------------------------------------------------------------------------------|---------|-------------|
-| Node name (`NODE_NAME`)            | `GALACTIC_CNI_NODE_NAME` → `NODE_NAME` → `HostConf.NodeName` (conflist) → `detectNodeNameFromAPI()` (matches local interface addrs against Node `InternalIP`) | _(error if still empty)_ | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
-| Kubeconfig (`KUBECONFIG`)          | `GALACTIC_CNI_KUBECONFIG` → `HostConf.Kubeconfig` (conflist)                                            | `/var/lib/galactic/kubeconfig` | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
-| Namespace                          | `conf.Namespace` (CNI config JSON) → `GALACTIC_CNI_NAMESPACE` → `HostConf.Namespace` (conflist)         | `galactic-system` | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
+| Node name (`NODE_NAME`)            | `GALACTIC_CNI_NODE_NAME` → `NODE_NAME` → `HostConf.NodeName` (conflist) → `detectNodeNameFromAPI()` (matches local interface addrs against Node `InternalIP`) | _(error if still empty)_ | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
+| Kubeconfig (`KUBECONFIG`)          | `GALACTIC_CNI_KUBECONFIG` → `HostConf.Kubeconfig` (conflist)                                            | `/var/lib/galactic/kubeconfig` | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
+| Namespace                          | `conf.Namespace` (CNI config JSON) → `GALACTIC_CNI_NAMESPACE` → `HostConf.Namespace` (conflist)         | `galactic-system` | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
 | Log file                           | `GALACTIC_CNI_LOG_FILE` → `HostConf.LogFile` (conflist)                                                 | `/var/log/galactic/galactic-cni.log` | every binary in the chain |
 | Log level                          | `GALACTIC_CNI_LOG_LEVEL` → `HostConf.LogLevel` (conflist)                                               | `info` | every binary in the chain |
 | `GALACTIC_IPAM_ENABLE_LOCAL_IPAM`  | Read directly as an env var by `galactic-ipam` only (`internal/config/ipam.go`); no conflist/CLI-flag equivalent, and it can no longer manufacture an `"ipam"` block that isn't already present | `false` | `galactic-ipam` only |
@@ -390,7 +408,7 @@ start/outcome plus all warnings/errors; `debug` adds per-resource milestones. Se
 
 ### CNI chain ADD result
 
-On a successful ADD, the master plugin (`galactic-cni`/`galactic-tap-cni`)
+On a successful ADD, the master plugin (`galactic-veth`/`galactic-tap`)
 returns a CNI spec v1.0.0 result with the following structure (veth shown):
 
 ```json
@@ -418,13 +436,13 @@ returns a CNI spec v1.0.0 result with the following structure (veth shown):
 
 The VRF dummy interface (`G{vpc}{att}V`) is **not** reported — it is pre-existing infrastructure created by the `vrf.Add()` plumbing function, not by the CNI attachment itself.
 
-This is the veth-master result. `galactic-tap-cni`'s own result has a single
+This is the veth-master result. `galactic-tap`'s own result has a single
 interface (the host-side tap, empty sandbox, index `0`) — there is no guest
 interface entry since the fd is handed off to the VM hypervisor, not moved
 into a container netns. Both masters run IPAM identically (if `"ipam"` is
 present) and both configure the host gateway (`internal/cni/hostgw`) before
 printing their own result — see
-[Interface Types](../cni/configuration.md#master-plugin-fields-galactic-cni--galactic-tap-cni)
+[Interface Types](../cni/configuration.md#master-plugin-fields-galactic-veth--galactic-tap)
 in the CNI config doc.
 
 The host gateway's IPv4 address is assigned as a `/25` on the host tap (vs.
@@ -446,7 +464,7 @@ On DEL, every binary's result contains only `cniVersion` (empty result). Each
 binary's own DEL only cleans up what it itself created *and* is safe to
 release immediately for that specific container — IPAM deallocation
 (`galactic-ipam`, via its own on-disk marker file) and the guest-netns
-flush/host-device DEL (`galactic-cni` only). It does not attempt to unwind
+flush/host-device DEL (`galactic-veth` only). It does not attempt to unwind
 any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 [docs/cni-cmd-sequence.md](../cni-cmd-sequence.md) and Known Constraints below.
 
@@ -465,16 +483,16 @@ any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 | `internal/hash`               | galactic-router | SHA-256 fingerprint of `DesiredRouter` for no-op suppression                                        | No         |
 | `internal/metadata`           | every binary    | Build-time vars (`Version`, `GitCommit`, `GitTreeState`, `BuildDate`) stamped via `-ldflags`         | No         |
 | `internal/gc`                 | galactic-router | Collects orphaned `BGPAdvertisement`/`BGPVRFInstance` CRDs, stale kernel VRFs, and stale eBPF `vrf_table` entries; invoked by the GC controller's ticker | No |
-| `internal/cni`                | galactic-cni    | Veth master plugin: `cmdAdd`/`cmdDel`/`cmdCheck`/`cmdStatus`; PluginConf parsing; NAD annotation; host-device delegation; delegates kernel work to plumbing | No |
+| `internal/cni`                | galactic-veth   | Veth master plugin: `cmdAdd`/`cmdDel`/`cmdCheck`/`cmdStatus`; PluginConf parsing; NAD annotation; host-device delegation; delegates kernel work to plumbing | No |
 | `internal/hostconf`           | every CNI-chain binary | Shared `HostConf` schema + static-conflist loader, plus API-based node-name auto-detect          | No         |
-| `internal/cni/hostgw`         | galactic-cni, galactic-tap-cni | Host-side gateway address/route configuration for a VPC attachment's allocated IPAM addresses | No |
-| `internal/crdnames`           | galactic-cni, galactic-bgp, galactic-router (gc) | Deterministic `BGPVRFInstance`/`BGPAdvertisement` CRD name + annotation-key derivation | No |
-| `internal/nadpatch`           | galactic-cni, galactic-tap-cni | NAD annotation patch (host interface name) + pod-namespace parsing from `CNI_ARGS`          | No         |
+| `internal/cni/hostgw`         | galactic-veth, galactic-tap | Host-side gateway address/route configuration for a VPC attachment's allocated IPAM addresses | No |
+| `internal/crdnames`           | galactic-veth, galactic-bgp, galactic-router (gc) | Deterministic `BGPVRFInstance`/`BGPAdvertisement` CRD name + annotation-key derivation | No |
+| `internal/nadpatch`           | galactic-veth, galactic-tap | NAD annotation patch (host interface name) + pod-namespace parsing from `CNI_ARGS`          | No         |
 | `internal/cni/ipam`           | galactic-ipam   | IPv6/IPv4 pool allocators + static IP allocator; on-disk marker-file persistence (flock-guarded, keyed by containerID) | Yes (pool allocations + marker files) |
 | `internal/cni/route`          | galactic-route  | Host-side static route add/delete via netlink                                                        | No         |
-| `internal/cni/tap`            | galactic-tap-cni | Tap interface create/delete for VM workloads (Kata, Firecracker, kraftlet/Unikraft)                   | No         |
-| `internal/cni/veth`           | galactic-cni    | veth pair create/delete                                                                               | No         |
-| `internal/cnitap`             | galactic-tap-cni | Tap master plugin (mirrors `internal/cni`; no host-device delegation, no guest netns)                | No         |
+| `internal/cni/tap`            | galactic-tap    | Tap interface create/delete for VM workloads (Kata, Firecracker, kraftlet/Unikraft)                   | No         |
+| `internal/cni/veth`           | galactic-veth   | veth pair create/delete                                                                               | No         |
+| `internal/cnitap`             | galactic-tap    | Tap master plugin (mirrors `internal/cni`; no host-device delegation, no guest netns)                | No         |
 | `internal/cniipam`            | galactic-ipam   | CNI IPAM delegation protocol (`cmdAdd`/`cmdDel`/`cmdCheck`/`cmdStatus`); explicit `"ipam"`-block contract; no k8s dependency | No |
 | `internal/cnibgp`             | galactic-bgp    | BGP/SRv6/eBPF publish: SID/Argument allocation + collision detection, `registerEBPFDatapath`/`unregisterEBPFDatapath`, `BGPVRFInstance`/`BGPAdvertisement` CRUD with retry; learns everything from `prevResult` | No |
 | `internal/cniroute`           | galactic-route  | Termination-route plugin: installs/rolls-back VRF-table routes; no k8s dependency                    | No         |
@@ -484,7 +502,7 @@ any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 | `internal/plumbing/srv6`      | galactic-router | SID computation (`ComputeSID`) for the router's own BGP Prefix-SID path attribute                     | No         |
 | `internal/plumbing/ebpf`      | galactic-cni (attach/metrics via `run`), galactic-bgp (registration), galactic-router (gc sweep) | TC-BPF uSID datapath: kernel preflight, uFMT bit-layout codec, compiled program + bindings, load/pin/attach lifecycle, map read/write API, Prometheus metrics | Yes (pinned BPF maps) |
 | `internal/plumbing/vrf`       | every CNI-chain binary + router | Linux VRF create/delete/lookup via netlink                                                           | No         |
-| `internal/plumbing/sysctl`    | galactic-cni, galactic-tap-cni | Per-interface sysctl helpers                                                                          | No         |
+| `internal/plumbing/sysctl`    | galactic-veth, galactic-tap | Per-interface sysctl helpers                                                                          | No         |
 
 ---
 
@@ -498,7 +516,7 @@ any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 | `github.com/spf13/cobra`               | v1.10.2  | CLI command/flag handling for every binary                |
 | `github.com/spf13/viper`               | v1.21.0  | Config resolution (flags/env/defaults) for `galactic-router` only; every CNI-chain binary resolves config itself (conflist/env/API auto-detect) and does not import viper |
 | `github.com/containernetworking/cni`   | v1.3.0   | CNI plugin spec, skel, invoke                            |
-| `github.com/containernetworking/plugins` | v1.9.1 | `pkg/ipam.ExecAdd`/`ExecDel`/`ExecCheck` (real IPAM delegation to `galactic-ipam`, used by `galactic-cni`/`galactic-tap-cni`); `host-device` plugin, delegated to by `galactic-cni` for moving the guest veth into the pod netns |
+| `github.com/containernetworking/plugins` | v1.9.1 | `pkg/ipam.ExecAdd`/`ExecDel`/`ExecCheck` (real IPAM delegation to `galactic-ipam`, used by `galactic-veth`/`galactic-tap`); `host-device` plugin, delegated to by `galactic-veth` for moving the guest veth into the pod netns |
 | `github.com/vishvananda/netlink`        | pinned pseudo-version | Linux netlink: VRF, veth, SRv6 routes           |
 | `github.com/kenshaw/baseconv`           | v0.1.1   | Base62↔hex conversion for interface names               |
 | `github.com/lorenzosaino/go-sysctl`    | v0.3.1   | Interface sysctl helpers                                 |
@@ -518,7 +536,7 @@ any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 - **CRD-driven config, no sidecar gRPC.** `galactic-router` watches BGP CRDs directly via controller-runtime. `galactic-bgp` writes `BGPVRFInstance`/`BGPAdvertisement` CRDs; the router reconciler picks them up. No in-node gRPC calls between any of the CNI-chain binaries and `galactic-router`.
 - **Hash-based no-op suppression.** SHA-256 over the sorted `DesiredRouter` prevents redundant GoBGP Apply calls on every CRD event.
 - **RuntimeFactory pattern.** `--mode=tenant` (`GALACTIC_ROUTER_ROUTER_MODE=tenant`) selects GoBGP; `--mode=fabric` selects the FRR stub; `--mode=transit` is accepted by validation but returns an error at startup (not yet implemented). The mode is selected at startup; no controller changes are needed to add a new mode.
-- **DEL is intentionally minimal everywhere in the CNI chain; GC reclaims shared state asynchronously.** Every binary's own `cmdDel` only cleans up what it itself created *and* is safe to release immediately per-container (IPAM deallocation via `galactic-ipam`'s own on-disk marker file; guest-netns flush/host-device DEL in `galactic-cni`). None of them delete the VRF, veth/tap, routes, the eBPF `vrf_table` entry, or `BGPAdvertisement`/`BGPVRFInstance` CRDs — those are keyed by `(vpc, vpcAttachment)` and may be shared/reused by another pod/VM (deleting them in DEL would race with a concurrent ADD during restarts). `galactic-router`'s GC controller (ticker-driven, default every 5m) reclaims orphaned CRDs, stale kernel VRFs, and stale eBPF entries once no live container still references them.
+- **DEL is intentionally minimal everywhere in the CNI chain; GC reclaims shared state asynchronously.** Every binary's own `cmdDel` only cleans up what it itself created *and* is safe to release immediately per-container (IPAM deallocation via `galactic-ipam`'s own on-disk marker file; guest-netns flush/host-device DEL in `galactic-veth`). None of them delete the VRF, veth/tap, routes, the eBPF `vrf_table` entry, or `BGPAdvertisement`/`BGPVRFInstance` CRDs — those are keyed by `(vpc, vpcAttachment)` and may be shared/reused by another pod/VM (deleting them in DEL would race with a concurrent ADD during restarts). `galactic-router`'s GC controller (ticker-driven, default every 5m) reclaims orphaned CRDs, stale kernel VRFs, and stale eBPF entries once no live container still references them.
 - **gRPC health, configurable port.** Liveness and readiness probes use the gRPC health protocol (`google.golang.org/grpc/health`) on a configurable port (default `5000`). No HTTP health endpoint.
 
 ---
@@ -528,7 +546,7 @@ any shared, per-attachment kernel/CRD state — see the `cmdDel` note in
 | Layer      | Command          | Framework           | Scope                                                                |
 |------------|------------------|---------------------|------------------------------------------------------------------------|
 | Unit       | `task test:unit` | `go test -race`     | `internal/cni`, `internal/cnitap`, `internal/cniipam`, `internal/cnibgp`, `internal/cniroute` (`buildResult`/`buildVethResult`, `parseConf`, `routeTarget`, `lookupBGPRouter`, `inferFromPrevResult` — each package's own `cmdAdd`/`cmdDel`/`cmdCheck`/`cmdStatus`), `internal/cni/{hostconf,hostgw,crdnames,nadpatch,ipam,route,tap,veth}`, `internal/installer` (`installer_test.go` — `Bootstrap`/`Run` with mocked k8s client and netlink/host paths), `internal/plumbing/{srv6,ebpf}`, `internal/gc`, `internal/reconcile`, `internal/controller`, `internal/plumbing/intf`, `internal/metadata`, `internal/runtime/gobgp` (partial), `internal/runtime/frr` |
-| E2E        | `task test:e2e`  | Kind + `go test`    | `galactic-tap-cni`'s own ADD (VRF + tap + IPAM delegation), kernel capability checks, CNI VERSION report. Does **not** exercise `galactic-route` or `galactic-bgp` (no BGPRouter fixture in the e2e suite) — see Known Constraints below. Full BGPRouter lifecycle coverage for `galactic-router` comes from this same Kind cluster's separate reconciler tests. |
+| E2E        | `task test:e2e`  | Kind + `go test`    | `galactic-tap`'s own ADD (VRF + tap + IPAM delegation), kernel capability checks, CNI VERSION report. Does **not** exercise `galactic-route` or `galactic-bgp` (no BGPRouter fixture in the e2e suite) — see Known Constraints below. Full BGPRouter lifecycle coverage for `galactic-router` comes from this same Kind cluster's separate reconciler tests. |
 | CI full    | `task ci`        | all of the above    | lint → build → test:unit → test:e2e                                  |
 
 `internal/plumbing/vrf` has no unit tests — it requires `CAP_NET_ADMIN` and a real kernel. `internal/cni/route` (wrapped by `internal/cniroute`) also has no unit tests of its own. `internal/plumbing/intf` is pure-function and fully unit-testable.
@@ -547,7 +565,7 @@ Runs on every PR and push to `main`. Two tiers:
 **Publish pipeline:** `.github/workflows/publish.yaml`, modeled on the `compute` repo's. Runs on every push and on published releases, via reusable `datum-cloud/actions` workflows: `publish-galactic-cni-image` and `publish-galactic-router-image` each build and push their own image (`ghcr.io/datum-cloud/galactic-cni`, `ghcr.io/datum-cloud/galactic-router`), and `publish-kustomize-bundles` (which `needs` both image jobs) pushes `config/` as an OCI Kustomize bundle (`ghcr.io/datum-cloud/galactic-kustomize`), using the `images` input (`datum-cloud/actions` v1.20.0+) to stamp each job's real published tag into `config/cni` and `config/router/base` respectively — the bundle ships with matching versioned image references, not `:latest`. This replaces the old single-image `.github/workflows/release.yaml` (removed — see history below) with two per-binary images, matching the split `deploy/containerlab/` already used for local dev.
 
 **Container images:**
-- `containers/galactic-cni/Dockerfile` — multi-stage build (golang builder → distroless → final Alpine stage for `iproute2`/`nsenter`); builds `galactic-cni` plus the delegated `host-device` CNI plugin binary, `ENTRYPOINT ["/galactic-cni"]`. Used both by `task test:e2e` (`scripts/ci.sh e2etest` builds it, tags `galactic-cni:e2e`, `kind load`s it into the ephemeral e2e cluster) and by `publish.yaml` (pushed as `ghcr.io/datum-cloud/galactic-cni`). Both the init container (`/galactic-cni init`) and the long-running container (`/galactic-cni run`) run this same image; the DaemonSet no longer shells out to an `install.sh` script, so the Alpine/`iproute2` final stage exists purely for e2e test needs (kernel `ip`/`nsenter` operations exercised via `task test:e2e`) rather than anything the installer subcommands require. Reusing the e2e-tested artifact for publish is preferred over maintaining a second, untested variant.
+- `containers/galactic-cni/Dockerfile` — multi-stage build (golang builder → distroless → final Alpine stage for `iproute2`/`nsenter`); builds `galactic-cni` (the installer), `galactic-veth`, `galactic-tap`, `galactic-ipam`, `galactic-bgp`, `galactic-route`, `vmtap-cni`, and the delegated `host-device` CNI plugin binary, `ENTRYPOINT ["/galactic-cni"]`. Used both by `task test:e2e` (`scripts/ci.sh e2etest` builds it, tags `galactic-cni:e2e`, `kind load`s it into the ephemeral e2e cluster) and by `publish.yaml` (pushed as `ghcr.io/datum-cloud/galactic-cni`). Both the init container (`/galactic-cni init`) and the long-running container (`/galactic-cni run`) run this same image; the DaemonSet no longer shells out to an `install.sh` script, so the Alpine/`iproute2` final stage exists purely for e2e test needs (kernel `ip`/`nsenter` operations exercised via `task test:e2e`) rather than anything the installer subcommands require. Reusing the e2e-tested artifact for publish is preferred over maintaining a second, untested variant.
 - `containers/galactic-router/Dockerfile` — golang builder → `gcr.io/distroless/static:nonroot`, `ENTRYPOINT ["/galactic-router"]`. No shell or CLI tools: `galactic-router` drives VRF/SRv6/route/BGP state entirely through the netlink and GoBGP Go libraries, never shells out. Pushed by `publish.yaml` as `ghcr.io/datum-cloud/galactic-router`.
 
 **History:** the original `.github/workflows/release.yaml` built and pushed a single `ghcr.io/datum-cloud/galactic:{version,major.minor,major,sha}` image from a shared `containers/galactic/Dockerfile`, but that image only ever built `galactic-cni` while `config/router/base/daemonset.yaml` ran `command: [/galactic-router]` against it — the image advertised a binary it never built. Both were removed. `publish.yaml` and the two per-binary Dockerfiles above fix this by building each binary into its own image, so `config/cni/daemonset.yaml` and `config/router/base/daemonset.yaml` now reference `ghcr.io/datum-cloud/galactic-cni:latest` and `ghcr.io/datum-cloud/galactic-router:latest` respectively — matching images, matching binaries.
@@ -560,8 +578,8 @@ Runs on every PR and push to `main`. Two tiers:
 - **EVPN Type 5 is implemented, not deferred.** `internal/runtime/gobgp/paths.go`'s `buildEVPNPaths` builds real `EVPNIPPrefixRoute` NLRIs, deriving the Route Distinguisher from `routerID + ":0"` (not from the CRD). The `BGPVRFInstance` CRD carries its own explicit `RouteDistinguisher` and import/export Route Targets (see Key Design Decisions above), applied via `internal/runtime/gobgp/runtime.go`'s `applyVRFs`. There is no `ErrMissingRouteDistinguisher` or similar rejection path in the current code.
 - **No binary's `cmdDel` tears down shared kernel/CRD state.** By design (see Key Design Decisions above) — cleanup of VRF, veth/tap, routes, the eBPF `vrf_table` entry, and BGP CRDs is deferred to `galactic-router`'s asynchronous GC controller, not performed synchronously in any chain binary's `cmdDel`.
 - **`internal/plumbing/vrf` and `internal/cni/route` have no unit tests.** `vrf` requires `CAP_NET_ADMIN` and a real kernel; `route` (wrapped by `internal/cniroute`, which does have its own tests) was never backfilled with tests of its own when the CNI plugin-chain split moved its caller out of `internal/cni`. `internal/plumbing/intf` is fully unit-testable (pure functions only). Kernel-path coverage otherwise comes from the e2e suite (`task test:e2e`).
-- **The e2e suite doesn't cover `galactic-route` or `galactic-bgp`.** `TestCNITapInterface` (`tests/e2e/e2e_test.go`) only drives `galactic-tap-cni`'s own ADD — verifying BGP/SRv6/eBPF publish end-to-end would need a `BGPRouter` CRD fixture and additional RBAC the test doesn't set up. This gap predates the CNI plugin-chain split too: the monolithic `galactic-cni` this replaced was never e2e-verified past its own CNI result shape either.
-- **`docs/agents/ARCHITECTURE.md` and `docs/cni-cmd-sequence.md` describe the CNI chain; `vmtap-cni`/`internal/vmtap` (a separate, Cilium-chain-conflist-patching binary for VM tap interfaces, unrelated to the `galactic-cni`/`galactic-tap-cni`/`galactic-ipam`/`galactic-bgp`/`galactic-route` chain) has its own doc at `docs/vmtap-cni/configuration.md`** — cross-referenced from [Repository Layout](#repository-layout) and the [Module / Package Reference](#module--package-reference) table above, but not otherwise elaborated on in this document.
+- **The e2e suite doesn't cover `galactic-route` or `galactic-bgp`.** `TestCNITapInterface` (`tests/e2e/e2e_test.go`) only drives `galactic-tap`'s own ADD — verifying BGP/SRv6/eBPF publish end-to-end would need a `BGPRouter` CRD fixture and additional RBAC the test doesn't set up. This gap predates the CNI plugin-chain split too: the monolithic `galactic-cni` this replaced was never e2e-verified past its own CNI result shape either.
+- **`docs/agents/ARCHITECTURE.md` and `docs/cni-cmd-sequence.md` describe the CNI chain; `vmtap-cni`/`internal/vmtap` (a separate, Cilium-chain-conflist-patching binary for VM tap interfaces, unrelated to the `galactic-veth`/`galactic-tap`/`galactic-ipam`/`galactic-bgp`/`galactic-route` chain) has its own doc at `docs/vmtap-cni/configuration.md`** — cross-referenced from [Repository Layout](#repository-layout) and the [Module / Package Reference](#module--package-reference) table above, but not otherwise elaborated on in this document.
 - **`--mode=transit` is unimplemented.** Accepted by CLI/env validation, but `runCmd` returns an error at startup ("mode=transit is not yet supported").
 - **`galactic-cni`'s install DaemonSet is a Go installer, not a shell script.** `config/cni/configmap.yaml`/`install.sh` were deleted; `config/cni/daemonset.yaml` now runs `hostNetwork: true` with an `install-cni` init container (`command: ["/galactic-cni", "init"]`, calling `installer.Bootstrap`) and a `credential-refresh` main container (`command: ["/galactic-cni", "run"]`, calling `installer.Run`), both on the same image (see CI/CD above). `Bootstrap` writes every binary in the CNI chain to `/opt/cni/bin`, the static conflist to `/etc/cni/net.d/10-galactic.conflist`, and `ca.crt`/kubeconfig to `/var/lib/galactic` (chosen over `/etc/galactic` specifically so it lands under `/var`, the one path immutable-root distros like Talos allow hostPath writes to without a host-level `extraMounts` entry); `Run` refreshes the kubeconfig token every 300s and rotates the CNI log once it exceeds 10MB. `/opt/cni/bin` is fixed by the CNI/kubelet plugin-discovery convention and can't be relocated by this DaemonSet alone — on Talos it needs its own `extraMounts` entry in the machine config if it isn't writable by default. The `run` container also serves gRPC health checks on port `5180` (`livenessProbe`/`readinessProbe` in the DaemonSet spec), and `config/cni/rbac.yaml` grants `get` on `nodes` for `Bootstrap`'s node-identity check.
 - **The uSID TC-BPF datapath (`internal/plumbing/ebpf/prog/usid.c`) doesn't generate PMTUD ICMPv6 errors.** When `bpf_fib_lookup()` returns `BPF_FIB_LKUP_RET_FRAG_NEEDED` (egress route's MTU is smaller than the inner packet), the program counts `DROP_REASON_FIB_FRAG_NEEDED` and silently drops (`TC_ACT_SHOT`) rather than sending an ICMPv6 Packet Too Big back to the original sender — unlike the static-route `SEG6_LOCAL_ACTION_END_DT46` path this datapath replaces, where the kernel's own IPv6 stack emits that ICMP message. Accepted as a known cost of the TC-BPF cutover for this milestone; generating ICMPv6 PTB from the datapath itself is unscheduled future work, not planned for a specific milestone yet.

--- a/docs/agents/CONVENTIONS.md
+++ b/docs/agents/CONVENTIONS.md
@@ -9,7 +9,8 @@ This document defines the coding standards, naming rules, error handling pattern
 ### Module and package layout
 
 - Module: `go.datum.net/galactic`
-- `cmd/galactic-cni/main.go` — CNI plugin entry point; a cobra command (no viper) with the plugin invocation on the root command (calls `cni.RunPlugin()`) and `init`/`run` subcommands wrapping `internal/installer.Bootstrap`/`Run` for the DaemonSet
+- `cmd/galactic-cni/main.go` — CNI installer entry point; a cobra command (no viper) with `init`/`run` subcommands wrapping `internal/installer.Bootstrap`/`Run` for the DaemonSet. Never itself a CNI plugin.
+- `cmd/galactic-veth/main.go` — CNI plugin entry point; a cobra command (no viper) with the plugin invocation on the root command (calls `cni.RunPlugin()`), no other subcommands
 - `cmd/galactic-router/main.go` / `root.go` — router entry point; `main.go` is a thin wrapper, startup logic (reads `GALACTIC_ROUTER_NODE_NAME`/`GALACTIC_ROUTER_ROUTER_MODE`, starts the controller-runtime manager) lives in `root.go`
 - `internal/plumbing/` — low-level kernel and network primitives shared between router and CNI (`intf`, `srv6`, `sysctl`, `vrf`)
 - `internal/controller/` — controller-runtime reconcilers (BGPRouter, BGPPeer, BGPAdvertisement, BGPVRFInstance, BGPPolicy, Secret, Node, GC); also contains field index registration (`indexer.go`) and CRD status helpers (`status.go`)
@@ -17,7 +18,7 @@ This document defines the coding standards, naming rules, error handling pattern
 - `internal/runtime/` — RouterRuntime interface; `gobgp/` (tenant mode) and `frr/` (fabric mode stub)
 - `internal/gc/` — orphaned `BGPAdvertisement`/`BGPVRFInstance` CRD and stale kernel VRF cleanup, invoked by the GC controller's ticker
 - `internal/cni/` — CNI plugin (`cmdAdd`/`cmdDel`/`cmdCheck`, split across `ops_add.go`/`ops_del.go`/`ops_check.go`/`bgp.go`); `ipam/`, `route/`, `tap/`, `veth/` subpackages
-- `internal/installer/` — `galactic-cni` DaemonSet `init`/`run` support (binary staging, conflist/kubeconfig templating, credential refresh, gRPC health server); not a subpackage of `internal/cni`
+- `internal/installer/` — support for `galactic-cni`'s `init`/`run` subcommands (binary staging, conflist/kubeconfig templating, credential refresh, gRPC health server); not a subpackage of `internal/cni`
 - `internal/model/` — internal BGP model types
 - `internal/hash/` — SHA-256 change detection over DesiredRouter
 - `internal/metadata/` — build-time version vars (`Version`, `GitCommit`, etc.) stamped via `-ldflags`

--- a/docs/cni-cmd-sequence.md
+++ b/docs/cni-cmd-sequence.md
@@ -8,10 +8,10 @@ paths.
 The chain is one master plugin, plus up to two optional plugins invoked
 after it in conflist order:
 
-1. **Master** — `galactic-cni` (veth, for containers) or `galactic-tap-cni`
+1. **Master** — `galactic-veth` (veth, for containers) or `galactic-tap`
    (tap, for VM workloads: Kata, Firecracker, kraftlet/Unikraft). Creates
    the VRF and host-side interface, annotates the NAD, delegates IPAM (if
-   an `"ipam"` block is present) and — for `galactic-cni` only —
+   an `"ipam"` block is present) and — for `galactic-veth` only —
    host-device (to move the guest veth into the container netns), then
    configures the host gateway address/route and prints the CNI result.
 2. **`galactic-route`** (optional — present only when the attachment has
@@ -26,13 +26,13 @@ after it in conflist order:
 
 Every binary's own `cmdDel` is a no-op beyond binary-local, per-container
 cleanup (IPAM deallocation, guest netns flush, host-device DEL — all
-`galactic-cni`/`galactic-tap-cni` only). Shared node-level state (VRF,
+`galactic-veth`/`galactic-tap` only). Shared node-level state (VRF,
 host interface, routes, SRv6/eBPF registration, `BGPVRFInstance`,
 `BGPAdvertisement`) is kept because it may still be in use by another
 pod/VM on the same `(vpc, vpcAttachment)`; `galactic-router`'s GC
 controller reclaims it once nothing references it anymore.
 
-## cmdAdd — veth (galactic-cni → galactic-route → galactic-bgp)
+## cmdAdd — veth (galactic-veth → galactic-route → galactic-bgp)
 
 ```mermaid
 sequenceDiagram
@@ -132,7 +132,7 @@ sequenceDiagram
     Runtime-->>Runtime: CNI result (JSON)
 ```
 
-## cmdAdd — tap (galactic-tap-cni → galactic-route → galactic-bgp)
+## cmdAdd — tap (galactic-tap → galactic-route → galactic-bgp)
 
 ```mermaid
 sequenceDiagram
@@ -241,7 +241,7 @@ sequenceDiagram
         CNI-->>Runtime: nil
         deactivate CNI
     else parse succeeds
-        alt "ipam" block present (galactic-cni/galactic-tap-cni only)
+        alt "ipam" block present (galactic-veth/galactic-tap only)
             CNI->>IPAM: ExecDel(ipam.type, stdin)
             activate IPAM
             IPAM->>IPAM: look up this containerID's own marker file, delete it
@@ -249,7 +249,7 @@ sequenceDiagram
             deactivate IPAM
         end
 
-        Note over CNI: galactic-cni only: flush the guest netns'<br/>address/route, then forward DEL to host-device
+        Note over CNI: galactic-veth only: flush the guest netns'<br/>address/route, then forward DEL to host-device
 
         Note over CNI,BGP: Shared resources (VRF, host interface, routes,<br/>eBPF vrf_table entry, BGPAdvertisement, BGPVRFInstance) are<br/>NOT deleted by any binary's DEL — they may be in use by<br/>another pod/VM on the same (vpc, attachment).<br/>galactic-router's GC controller collects orphans periodically.
 

--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -2,7 +2,7 @@
 
 The galactic CNI plugin chain is configured through the CNI JSON conflist passed
 by Multus (or any CNI manager), plus node-local settings resolved at runtime from
-the static conflist, environment variables, and (for `galactic-cni`/`galactic-tap-cni`/
+the static conflist, environment variables, and (for `galactic-veth`/`galactic-tap`/
 `galactic-bgp`, as a last resort) the Kubernetes API.
 
 > Last verified: 2026-08-08 against the current working tree of `internal/cni/`,
@@ -21,17 +21,17 @@ inside the master plugin. A real-world attachment's conflist has this shape:
   "cniVersion": "1.0.0",
   "name": "private",
   "plugins": [
-    { "type": "galactic-cni", "...": "..." },
+    { "type": "galactic-veth", "...": "..." },
     { "type": "galactic-route", "...": "..." },
     { "type": "galactic-bgp", "...": "..." }
   ]
 }
 ```
 
-- **`galactic-cni`** (veth, containers) or **`galactic-tap-cni`** (tap, VM
+- **`galactic-veth`** (veth, containers) or **`galactic-tap`** (tap, VM
   workloads) — always first. Creates the VRF and host-side interface,
   annotates the NAD, delegates IPAM (if an `"ipam"` block is present) and
-  — `galactic-cni` only — host-device (to move the guest veth into the
+  — `galactic-veth` only — host-device (to move the guest veth into the
   container netns), configures the host gateway, and prints the CNI
   result.
 - **`galactic-route`** — optional; include only when the attachment has
@@ -61,8 +61,10 @@ variables, and a `HostConf` block parsed out of the conflist at `--conf-file`
 (default `/etc/cni/net.d/10-galactic.conflist` — this is the one *static*,
 node-level conflist every binary shares; not the per-attachment `plugins[]`
 conflist described above). `HostConf` is written by the `galactic-cni init`
-subcommand (`internal/installer.Bootstrap`), which runs as the CNI DaemonSet's
-init container — see [docs/agents/ARCHITECTURE.md](../agents/ARCHITECTURE.md#known-constraints)
+subcommand (`internal/installer.Bootstrap`) — `galactic-cni` is a separate
+installer binary, never itself a CNI plugin, whose `init`/`run` subcommands
+run as the CNI DaemonSet's init and long-running containers respectively —
+see [docs/agents/ARCHITECTURE.md](../agents/ARCHITECTURE.md#known-constraints)
 for how the DaemonSet stages it.
 
 `galactic-ipam` and `galactic-route` have no Kubernetes dependency at all, so
@@ -83,9 +85,9 @@ they resolve only `LogFile`/`LogLevel` from `HostConf` — never `NodeName` or
 
 | Setting    | Precedence (highest first)                                                                                                                                                                                                       | Default (if nothing resolves)        | Resolved by                                       |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | -------------------------------------------------- |
-| Node name  | `GALACTIC_CNI_NODE_NAME` env → `NODE_NAME` env → `HostConf.NodeName` → auto-detect via the Kubernetes API (`detectNodeNameFromAPI`: lists Nodes, matches local interface addresses against `status.addresses[].type=InternalIP`) | _(error: "node name is required")_    | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
-| Kubeconfig | `GALACTIC_CNI_KUBECONFIG` env → `HostConf.Kubeconfig`                                                                                                                                                                             | `/var/lib/galactic/kubeconfig`         | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
-| Namespace  | `namespace` field in the CNI config JSON → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace`                                                                                                                                    | `galactic-system`                     | `galactic-cni`, `galactic-tap-cni`, `galactic-bgp` |
+| Node name  | `GALACTIC_CNI_NODE_NAME` env → `NODE_NAME` env → `HostConf.NodeName` → auto-detect via the Kubernetes API (`detectNodeNameFromAPI`: lists Nodes, matches local interface addresses against `status.addresses[].type=InternalIP`) | _(error: "node name is required")_    | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
+| Kubeconfig | `GALACTIC_CNI_KUBECONFIG` env → `HostConf.Kubeconfig`                                                                                                                                                                             | `/var/lib/galactic/kubeconfig`         | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
+| Namespace  | `namespace` field in the CNI config JSON → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace`                                                                                                                                    | `galactic-system`                     | `galactic-veth`, `galactic-tap`, `galactic-bgp` |
 | Log file   | `GALACTIC_CNI_LOG_FILE` env → `HostConf.LogFile`                                                                                                                                                                                  | `/var/log/galactic/galactic-cni.log`  | every binary in the chain                          |
 | Log level  | `GALACTIC_CNI_LOG_LEVEL` env → `HostConf.LogLevel`                                                                                                                                                                                | `info`                                | every binary in the chain                          |
 
@@ -96,8 +98,8 @@ reads them (unlike `GALACTIC_IPAM_ENABLE_LOCAL_IPAM` below, which is a
 domain-specific knob belonging entirely to `galactic-ipam`).
 
 The resolved node name is re-exported as the `NODE_NAME` process environment
-variable and the resolved kubeconfig as `KUBECONFIG` (`galactic-cni`/
-`galactic-tap-cni`/`galactic-bgp` only), since other code in those packages
+variable and the resolved kubeconfig as `KUBECONFIG` (`galactic-veth`/
+`galactic-tap`/`galactic-bgp` only), since other code in those packages
 reads those directly. Auto-detection exists to tolerate environments (e.g.
 Kind-based e2e) where the conflist's hostPath mount isn't populated yet.
 
@@ -144,13 +146,13 @@ contract.
 **Type:** bool
 **Default:** `false`
 
-## Master Plugin Fields (`galactic-cni` / `galactic-tap-cni`)
+## Master Plugin Fields (`galactic-veth` / `galactic-tap`)
 
 | Field           | Required | Type     | Description                                                                                                                                                                                |
 | --------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `vpc`           | **Yes**  | `string` | Base62-encoded VPC identifier (48-bit value). Used to derive VRF names, interface names, and BGP route targets.                                                                            |
 | `vpcattachment` | **Yes**  | `string` | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming.                                                                                |
-| `mtu`           | No       | `int`    | MTU for the host-side interface. For `galactic-cni` this applies to both veth endpoints; for `galactic-tap-cni` it applies to the tap interface.                                            |
+| `mtu`           | No       | `int`    | MTU for the host-side interface. For `galactic-veth` this applies to both veth endpoints; for `galactic-tap` it applies to the tap interface.                                            |
 | `namespace`     | No       | `string` | Kubernetes namespace used for NAD lookup (and, for `galactic-bgp`'s own stanza, `BGPRouter`/BGP CRD lookup). Resolution order: this field → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace` → `galactic-system`. |
 | `ipam`          | No       | `IPAM`   | IPAM delegation block (see [IPAM Fields](#ipam-fields) below). Presence alone decides whether IPAM runs at all — no env var or sibling field can trigger or suppress it.                    |
 
@@ -170,13 +172,13 @@ uses `"1.0.0"`; keep it that way for any config authored outside these
 examples.
 
 There is no `interface_type` field anymore: which binary you invoke *is* the
-interface type. `galactic-cni` always creates a veth pair; `galactic-tap-cni`
+interface type. `galactic-veth` always creates a veth pair; `galactic-tap`
 always creates a tap device. There is likewise no `terminations` field on
 either master plugin's own stanza anymore — that field now lives entirely on
 `galactic-route`'s own stanza (see [Termination Fields](#termination-fields)
 below).
 
-### `galactic-cni` (veth)
+### `galactic-veth` (veth)
 
 Creates a veth pair: one endpoint stays in the host namespace (named
 `G<vpc, zero-padded to 9><vpcattachment, zero-padded to 3>H`, e.g. `G0000000010010H`)
@@ -185,7 +187,7 @@ and the other is moved into the container via the host-device CNI plugin
 receives an IP address from IPAM (if configured) and a default route via the
 pool gateway.
 
-### `galactic-tap-cni` (tap)
+### `galactic-tap` (tap)
 
 Creates a tap interface in the host namespace (same naming pattern as the veth
 host endpoint: `G<vpc9><vpcattachment3>H`) and enslaves it to the VRF. No
@@ -193,7 +195,7 @@ interface is moved into a container — the tap fd is managed directly by the
 guest VM hypervisor (Kata, Firecracker, kraftlet/Unikraft), so this binary
 never delegates to host-device and never configures a guest netns. It still
 runs IPAM (if `"ipam"` is present) and configures the host gateway exactly as
-`galactic-cni` does; the CNI result carries a single interface (the host tap,
+`galactic-veth` does; the CNI result carries a single interface (the host tap,
 empty sandbox) since there's no guest-side interface entry.
 
 The IPv4 gateway address on the host tap is a `/25`, not the `/32` used
@@ -285,8 +287,8 @@ Each entry in `terminations` has:
 
 Used in `cmdAdd` to install routes into the VRF table for each termination
 entry, via the host-side interface name derived from `(vpc, vpcAttachment)`
-alone — identical whether the preceding master plugin was `galactic-cni` or
-`galactic-tap-cni`. `cmdDel` is a no-op: like every other shared, per-attachment
+alone — identical whether the preceding master plugin was `galactic-veth` or
+`galactic-tap`. `cmdDel` is a no-op: like every other shared, per-attachment
 resource in the chain, termination routes may still be in use by another pod/VM
 on the same attachment, so cleanup is left to `galactic-router`'s GC controller.
 
@@ -311,7 +313,7 @@ plugin object — per [Chain structure](#chain-structure) above.
   "cniVersion": "1.0.0",
   "name": "galactic",
   "plugins": [
-    { "type": "galactic-cni", "vpc": "1", "vpcattachment": "1" },
+    { "type": "galactic-veth", "vpc": "1", "vpcattachment": "1" },
     { "type": "galactic-bgp", "vpc": "1", "vpcattachment": "1" }
   ]
 }
@@ -329,7 +331,7 @@ address is assigned to the guest interface.
   "name": "testvpc",
   "plugins": [
     {
-      "type": "galactic-cni",
+      "type": "galactic-veth",
       "vpc": "10",
       "vpcattachment": "10",
       "namespace": "galactic-system",
@@ -352,7 +354,7 @@ address is assigned to the guest interface.
   "name": "vpc21",
   "plugins": [
     {
-      "type": "galactic-cni",
+      "type": "galactic-veth",
       "vpc": "21",
       "vpcattachment": "21",
       "namespace": "galactic-system",
@@ -379,7 +381,7 @@ the IPv6 `/96` and IPv4 `/32` prefixes.
   "name": "vpc20",
   "plugins": [
     {
-      "type": "galactic-tap-cni",
+      "type": "galactic-tap",
       "vpc": "20",
       "vpcattachment": "20",
       "namespace": "galactic-system",
@@ -405,7 +407,7 @@ all; the resulting `BGPAdvertisement` carries only the IPv4 `/32` prefix.
   "name": "galactic",
   "plugins": [
     {
-      "type": "galactic-cni",
+      "type": "galactic-veth",
       "vpc": "1",
       "vpcattachment": "1",
       "ipam": { "type": "galactic-ipam", "static_ip": "fd00:1::1" }
@@ -426,7 +428,7 @@ all; the resulting `BGPAdvertisement` carries only the IPv4 `/32` prefix.
   "name": "galactic",
   "plugins": [
     {
-      "type": "galactic-cni",
+      "type": "galactic-veth",
       "vpc": "1",
       "vpcattachment": "1",
       "ipam": { "type": "galactic-ipam", "ipv6_subnet": "fd00:1:ff01::/48" }
@@ -457,7 +459,7 @@ master plugin and `galactic-bgp`.
   "name": "galactic-tap",
   "plugins": [
     {
-      "type": "galactic-tap-cni",
+      "type": "galactic-tap",
       "vpc": "1",
       "vpcattachment": "1",
       "mtu": 9000,
@@ -468,10 +470,10 @@ master plugin and `galactic-bgp`.
 }
 ```
 
-`galactic-tap-cni` creates a tap interface in the host namespace, enslaves it
+`galactic-tap` creates a tap interface in the host namespace, enslaves it
 to the VRF, and applies forwarding sysctls. It then runs IPAM (allocating the
-subnet shown above) and configures the host gateway exactly as `galactic-cni`
-does — see [`galactic-tap-cni` (tap)](#galactic-tap-cni-tap) above. Only
+subnet shown above) and configures the host gateway exactly as `galactic-veth`
+does — see [`galactic-tap` (tap)](#galactic-tap-tap) above. Only
 host-device delegation and guest-netns configuration are skipped; the guest VM
 still configures its own IP addresses independently once the hypervisor
 (Kata, Firecracker, kraftlet/Unikraft) opens the tap fd at runtime.

--- a/docs/vmtap-cni/configuration.md
+++ b/docs/vmtap-cni/configuration.md
@@ -1,6 +1,6 @@
 # vmtap-cni Configuration
 
-`vmtap-cni` is a standalone CNI plugin, separate from `galactic-cni`, that gives a
+`vmtap-cni` is a standalone CNI plugin, separate from `galactic-veth`, that gives a
 Unikraft microVM managed by `kraftlet` access to the pod's real Cilium-assigned
 identity. It has no VPC/VPCAttachment configuration and no Kubernetes API
 dependency — it never creates a `BGPAdvertisement`, never touches a VRF, and

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -292,7 +292,7 @@ func TestCmdDelIdempotent(t *testing.T) {
 func TestCmdDelIdempotentMissingResources(t *testing.T) {
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
@@ -329,7 +329,7 @@ func TestCmdDelFlushesGuestNetnsConfig(t *testing.T) {
 
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
@@ -381,7 +381,7 @@ func TestCmdCheckInvalidConfig(t *testing.T) {
 func TestCmdCheckValidConfigMissingResources(t *testing.T) {
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
@@ -402,7 +402,7 @@ func TestCmdCheckValidConfigMissingResources(t *testing.T) {
 }
 
 func TestCmdCheckMissingVPC(t *testing.T) {
-	conf := `{"cniVersion":"1.0.0","name":"test","type":"galactic-cni"}`
+	conf := `{"cniVersion":"1.0.0","name":"test","type":"galactic-veth"}`
 	args := &skel.CmdArgs{
 		ContainerID: testContainerID,
 		StdinData:   []byte(conf),
@@ -431,7 +431,7 @@ func TestCmdCheckWithPrevResultMissingResources(t *testing.T) {
 		`]}`
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s",`+
 			`"prevResult":%s}`,
 		testVPC, testAttachment, prevResult,
@@ -459,7 +459,7 @@ func TestCmdCheckWithInvalidPrevResult(t *testing.T) {
 	// prevResult that is structurally valid JSON but not a valid CNI result.
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s",`+
 			`"prevResult":{"not":"a valid cni result"}}`,
 		testVPC, testAttachment,
@@ -534,7 +534,7 @@ func TestCmdStatusValidConfigMissingResources(t *testing.T) {
 
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
@@ -558,7 +558,7 @@ func TestCmdStatusMissingVPC(t *testing.T) {
 
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpcattachment":"%s"}`,
+			`"type":"galactic-veth","vpcattachment":"%s"}`,
 		testAttachment,
 	)
 	args := &skel.CmdArgs{
@@ -581,7 +581,7 @@ func TestCmdStatusMissingVPCAttachment(t *testing.T) {
 
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s"}`,
+			`"type":"galactic-veth","vpc":"%s"}`,
 		testVPC,
 	)
 	args := &skel.CmdArgs{
@@ -603,7 +603,7 @@ func TestCmdStatusAPIProbeFailure(t *testing.T) {
 
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
@@ -625,7 +625,7 @@ func TestCmdAddPrevResultValid(t *testing.T) {
 	// validation and fail later due to missing node name.
 	conf := fmt.Sprintf(
 		`{"cniVersion":"1.0.0","name":"test",`+
-			`"type":"galactic-cni","vpc":"%s",`+
+			`"type":"galactic-veth","vpc":"%s",`+
 			`"vpcattachment":"%s",`+
 			`"prevResult":%s}`,
 		testVPC, testAttachment, testPrevResult,

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -12,7 +12,7 @@ import (
 var ConfFile = config.DefaultConfFile
 
 // cniConfig is the shared config resolver for env var resolution.
-// Initialized by InitCNIConfig() (called from cmd/galactic-cni/main.go).
+// Initialized by InitCNIConfig() (called from cmd/galactic-veth/main.go).
 var cniConfig *config.CNIConfig
 
 // InitCNIConfig initializes the shared config resolver for CNI env var
@@ -24,7 +24,7 @@ func InitCNIConfig() {
 
 // parseConf unmarshals the CNI configuration from stdin data, validates the
 // base62-encoded identifier fields, and resolves logging. The actual logic
-// is shared with galactic-tap-cni — see internal/cnimaster.ParseConf — since
+// is shared with galactic-tap — see internal/cnimaster.ParseConf — since
 // none of it is veth-specific; this is a thin wrapper binding it to this
 // binary's own cniConfig/ConfFile.
 func parseConf(data []byte) (*PluginConf, error) {

--- a/internal/cni/doc.go
+++ b/internal/cni/doc.go
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cni implements galactic-cni, the veth master plugin for wiring
+// Package cni implements galactic-veth, the veth master plugin for wiring
 // container workloads into SRv6-backed VPC networks. Tap-based workloads
-// (Kata, Firecracker, kraftlet/Unikraft) are galactic-tap-cni's own master
+// (Kata, Firecracker, kraftlet/Unikraft) are galactic-tap's own master
 // plugin (internal/cnitap) — interface kind is which binary is invoked now,
 // not a config field either binary branches on.
 //

--- a/internal/cni/hostgw/hostgw.go
+++ b/internal/cni/hostgw/hostgw.go
@@ -6,8 +6,8 @@
 // pod-subnet route for a VPC attachment's allocated IPAM addresses.
 //
 // This is kernel-interface work (netlink address/route/neighbor
-// manipulation on the interface a master plugin — galactic-cni,
-// galactic-tap-cni — itself created), not BGP/SRv6/eBPF publish, so it
+// manipulation on the interface a master plugin — galactic-veth,
+// galactic-tap — itself created), not BGP/SRv6/eBPF publish, so it
 // lives here rather than in internal/cnibgp: once galactic-bgp became its
 // own chain-invoked plugin (a separate process, invoked after the master
 // has already printed its own result), it no longer has any interface to

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -24,7 +24,7 @@ import (
 // cmdAdd uses a named return (err) so that the deferred selective rollback
 // below always observes the real failure — see the doc comment on the
 // original version of this function for why a named return matters here;
-// still true with fewer branches. galactic-cni's own ADD ends by printing
+// still true with fewer branches. galactic-veth's own ADD ends by printing
 // its own result and returning: BGP/SRv6/eBPF publish is galactic-bgp's
 // job, invoked next by the CNI runtime per conflist order, not by this
 // process.
@@ -37,7 +37,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	// Validate prevResult structure when present. The preceding plugin in the
 	// CNI chain should have produced a result with at least one interface or IP
 	// assignment. A nil or structurally broken prevResult indicates a mis-
-	// configured chain that galactic-cni should not silently ignore.
+	// configured chain that galactic-veth should not silently ignore.
 	if pluginConf.PrevResult != nil {
 		if err := cnimaster.ValidatePrevResultAdd(pluginConf.PrevResult); err != nil {
 			return &types.Error{Code: 6, Msg: fmt.Sprintf("prevResult validation in ADD: %v", err)}

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -77,7 +77,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 
 // cmdStatus implements the CNI spec STATUS operation — see
 // internal/cnimaster.RunStatus for the full reasoning, shared verbatim with
-// galactic-tap-cni.
+// galactic-tap.
 func cmdStatus(args *skel.CmdArgs) error {
 	return cnimaster.RunStatus(args.StdinData, cniConfig, ConfFile)
 }

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -42,7 +42,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Explicitly flush the address/default-route galactic-cni's IPAM step
+	// Explicitly flush the address/default-route galactic-veth's IPAM step
 	// installed on the guest interface, ahead of host-device delegation.
 	// hostDevice DEL's move of the guest veth end back out of the container
 	// netns normally flushes this as a side effect of crossing a namespace

--- a/internal/cni/resource.go
+++ b/internal/cni/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 // resourceTracker tracks resources created during cmdAdd for selective
-// rollback. galactic-cni is veth-only, and its ADD only ever creates the
+// rollback. galactic-veth is veth-only, and its ADD only ever creates the
 // VRF, the veth pair, and (if delegated) an IPAM allocation — BGP/SRv6/eBPF
 // publish is galactic-bgp's own, separately chain-invoked plugin now, with
 // its own smaller tracker (internal/cnibgp); termination routes are
@@ -61,7 +61,7 @@ func (rt *resourceTracker) cleanup() {
 	// Release the IPAM allocation first (if pluginConf carried an "ipam"
 	// block at all — see the ipamDelegated field doc comment for why this
 	// fires unconditionally on that alone, not just after a confirmed
-	// ExecAdd). Interface/VRF cleanup is shared with galactic-tap-cni's own
+	// ExecAdd). Interface/VRF cleanup is shared with galactic-tap's own
 	// tracker, so it lives in cnimaster.CleanupAttachment.
 	if rt.ipamDelegated {
 		if err := ipam.ExecDel(rt.ipamType, rt.ipamStdin); err != nil {

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -12,8 +12,8 @@ import (
 )
 
 // PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-cni, the veth master plugin. It's the same shape
-// galactic-tap-cni (internal/cnitap) uses — see internal/cnimaster's own
+// invocation of galactic-veth, the veth master plugin. It's the same shape
+// galactic-tap (internal/cnitap) uses — see internal/cnimaster's own
 // doc comment — so both packages alias the one canonical definition rather
 // than each declaring their own copy.
 type PluginConf = cnimaster.PluginConf

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -4,7 +4,7 @@
 
 // Package cnibgp implements galactic-bgp, the SRv6/BGP/eBPF publish plugin
 // in the galactic CNI chain. It is chain-invoked (per CNI conflist order)
-// after the master plugin (galactic-cni or galactic-tap-cni), not called
+// after the master plugin (galactic-veth or galactic-tap), not called
 // as a library — it has zero kernel-interface dependency: every address it
 // advertises comes from prevResult (see prevresult.go), never from a
 // runtime call into the interface it doesn't own. Host-interface gateway

--- a/internal/cniipam/types.go
+++ b/internal/cniipam/types.go
@@ -4,8 +4,8 @@
 
 // Package cniipam implements galactic-ipam, the delegated CNI IPAM plugin
 // in the galactic CNI chain (see github.com/containernetworking/cni/pkg/ipam
-// for the delegation protocol both master plugins, galactic-cni and
-// galactic-tap-cni, invoke this through via ExecAdd/ExecDel/ExecCheck).
+// for the delegation protocol both master plugins, galactic-veth and
+// galactic-tap, invoke this through via ExecAdd/ExecDel/ExecCheck).
 //
 // Explicit contract: a master plugin delegates here if and only if its own
 // "ipam" block is present at all — no environment variable or sibling

--- a/internal/cnimaster/cnimaster_test.go
+++ b/internal/cnimaster/cnimaster_test.go
@@ -84,7 +84,7 @@ func TestParseConf(t *testing.T) {
 			name: "valid config",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":"%s"}`,
 				testVPC, testAttachment,
 			),
@@ -106,7 +106,7 @@ func TestParseConf(t *testing.T) {
 			name: "missing vpc",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpcattachment":"%s"}`,
+					`"type":"galactic-veth","vpcattachment":"%s"}`,
 				testAttachment,
 			),
 			wantErr:  "vpc is required and must be a non-empty base62 string",
@@ -116,7 +116,7 @@ func TestParseConf(t *testing.T) {
 			name: "empty vpc",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"",`+
+					`"type":"galactic-veth","vpc":"",`+
 					`"vpcattachment":"%s"}`,
 				testAttachment,
 			),
@@ -127,7 +127,7 @@ func TestParseConf(t *testing.T) {
 			name: "vpc with invalid char hyphen",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":"%s"}`,
 				testInvalidBase62, testAttachment,
 			),
@@ -138,7 +138,7 @@ func TestParseConf(t *testing.T) {
 			name: "vpc with invalid char underscore",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"abc_def",`+
+					`"type":"galactic-veth","vpc":"abc_def",`+
 					`"vpcattachment":"%s"}`,
 				testAttachment,
 			),
@@ -149,7 +149,7 @@ func TestParseConf(t *testing.T) {
 			name: "missing vpcattachment",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s"}`,
+					`"type":"galactic-veth","vpc":"%s"}`,
 				testVPC,
 			),
 			wantErr:  "vpcattachment is required and must be a non-empty base62 string",
@@ -159,7 +159,7 @@ func TestParseConf(t *testing.T) {
 			name: "empty vpcattachment",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":""}`,
 				testVPC,
 			),
@@ -170,7 +170,7 @@ func TestParseConf(t *testing.T) {
 			name: "vpcattachment with invalid char space",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":"def ghi"}`,
 				testVPC,
 			),
@@ -180,7 +180,7 @@ func TestParseConf(t *testing.T) {
 		{
 			name: "valid vpc and vpcattachment with mixed case base62",
 			input: `{"cniVersion":"1.0.0","name":"test",` +
-				`"type":"galactic-cni","vpc":"Abc123XYZ",` +
+				`"type":"galactic-veth","vpc":"Abc123XYZ",` +
 				`"vpcattachment":"DeF456"}`,
 			wantVPC: "Abc123XYZ",
 		},
@@ -188,7 +188,7 @@ func TestParseConf(t *testing.T) {
 			name: "prevResult valid JSON result is accepted",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":"%s",`+
 					`"prevResult":%s}`,
 				testVPC, testAttachment, testPrevResult,
@@ -199,7 +199,7 @@ func TestParseConf(t *testing.T) {
 			name: "ipam block present is accepted, delegated per its own contract",
 			input: fmt.Sprintf(
 				`{"cniVersion":"1.0.0","name":"test",`+
-					`"type":"galactic-cni","vpc":"%s",`+
+					`"type":"galactic-veth","vpc":"%s",`+
 					`"vpcattachment":"%s","ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00:10:ff01::/48"}}`,
 				testVPC, testAttachment,
 			),
@@ -242,7 +242,7 @@ func TestIPAMBlockPresenceIsTheOnlyTrigger(t *testing.T) {
 
 	// Missing ipam block: no error, no delegation signal — conf.IPAM stays nil.
 	inputNoIPAM := fmt.Sprintf(
-		`{"cniVersion":"1.0.0","name":"test","type":"galactic-cni","vpc":"%s","vpcattachment":"%s"}`,
+		`{"cniVersion":"1.0.0","name":"test","type":"galactic-veth","vpc":"%s","vpcattachment":"%s"}`,
 		testVPC, testAttachment,
 	)
 	conf, err := ParseConf([]byte(inputNoIPAM), cniConfig, config.DefaultConfFile)
@@ -255,7 +255,7 @@ func TestIPAMBlockPresenceIsTheOnlyTrigger(t *testing.T) {
 
 	// Present ipam block: conf.IPAM is populated, ready for delegation.
 	inputWithIPAM := fmt.Sprintf(
-		`{"cniVersion":"1.0.0","name":"test","type":"galactic-cni","vpc":"%s","vpcattachment":"%s",`+
+		`{"cniVersion":"1.0.0","name":"test","type":"galactic-veth","vpc":"%s","vpcattachment":"%s",`+
 			`"ipam":{"type":"galactic-ipam"}}`,
 		testVPC, testAttachment,
 	)

--- a/internal/cnimaster/config.go
+++ b/internal/cnimaster/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 // PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of either master plugin (galactic-cni or galactic-tap-cni).
+// invocation of either master plugin (galactic-veth or galactic-tap).
 //
 // IPAM addressing fields (ipv6_subnet, ipv4_subnet, address_families,
 // static_ip) live entirely inside the "ipam" block — see

--- a/internal/cnimaster/doc.go
+++ b/internal/cnimaster/doc.go
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnimaster holds logic shared by galactic-cni (internal/cni, the
-// veth master plugin) and galactic-tap-cni (internal/cnitap, the tap master
+// Package cnimaster holds logic shared by galactic-veth (internal/cni, the
+// veth master plugin) and galactic-tap (internal/cnitap, the tap master
 // plugin). Both own the same node-level lifecycle — parse the CNI config,
 // resolve node/API settings, create a VRF, patch the pod's NAD, and answer
 // CHECK/STATUS — differing only in which kernel interface primitive they

--- a/internal/cniroute/ops_add.go
+++ b/internal/cniroute/ops_add.go
@@ -19,7 +19,7 @@ import (
 )
 
 // cmdAdd installs each of pluginConf's termination routes into the VRF
-// routing table the preceding master plugin (galactic-cni/galactic-tap-cni)
+// routing table the preceding master plugin (galactic-veth/galactic-tap)
 // already created, then passes prevResult through unchanged — galactic-
 // route adds no interfaces or IPs of its own, only kernel routes alongside
 // whatever came before it in the chain.

--- a/internal/cniroute/types.go
+++ b/internal/cniroute/types.go
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package cniroute implements galactic-route, the termination-route plugin
-// in the galactic CNI chain — chained after galactic-cni/galactic-tap-cni
+// in the galactic CNI chain — chained after galactic-veth/galactic-tap
 // and before galactic-bgp per conflist order (optional: only present when
 // an attachment has terminations to install). It installs kernel routes
 // into the VRF routing table the preceding master plugin already created,

--- a/internal/cnitap/cnitap_test.go
+++ b/internal/cnitap/cnitap_test.go
@@ -56,12 +56,12 @@ func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
 	return ipnet
 }
 
-// movedKeyConf builds an otherwise-valid galactic-tap-cni config carrying
+// movedKeyConf builds an otherwise-valid galactic-tap config carrying
 // the supplied raw JSON member(s) at the top level, for the addressing keys
 // that belong inside the "ipam" block.
 func movedKeyConf(members string) string {
 	return fmt.Sprintf(
-		`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s",%s}`,
+		`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s",%s}`,
 		testVPC, testAttachment, members,
 	)
 }
@@ -79,7 +79,7 @@ func TestParseConf(t *testing.T) {
 		{
 			name: "valid config",
 			input: fmt.Sprintf(
-				`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s"}`,
+				`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s"}`,
 				testVPC, testAttachment,
 			),
 			wantVPC: testVPC,
@@ -87,14 +87,14 @@ func TestParseConf(t *testing.T) {
 		{name: "invalid JSON", input: "not json", wantErr: "invalid CNI config", wantCode: 7},
 		{
 			name: "missing vpc",
-			input: fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpcattachment":"%s"}`,
+			input: fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpcattachment":"%s"}`,
 				testAttachment),
 			wantErr:  "vpc is required and must be a non-empty base62 string",
 			wantCode: 7,
 		},
 		{
 			name: "vpc with invalid char",
-			input: fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s"}`,
+			input: fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s"}`,
 				testInvalidBase62, testAttachment),
 			wantErr:  fmt.Sprintf("invalid base62 value for field 'vpc': %q", testInvalidBase62),
 			wantCode: 7,
@@ -285,7 +285,7 @@ func TestCmdDelIdempotent(t *testing.T) {
 }
 
 func TestCmdDelIdempotentMissingResources(t *testing.T) {
-	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s"}`,
+	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s"}`,
 		testVPC, testAttachment)
 	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte(conf)}
 	if err := cmdDel(args); err != nil {
@@ -302,7 +302,7 @@ func TestCmdCheckInvalidConfig(t *testing.T) {
 }
 
 func TestCmdCheckValidConfigMissingResources(t *testing.T) {
-	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s"}`,
+	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s"}`,
 		testVPC, testAttachment)
 	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte(conf)}
 	err := cmdCheck(args)
@@ -322,7 +322,7 @@ func TestCmdStatusAPIProbeFailure(t *testing.T) {
 	cnimaster.ProbeAPIServer = func() error { return errors.New("connection refused") }
 	defer func() { cnimaster.ProbeAPIServer = original }()
 
-	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap-cni","vpc":"%s","vpcattachment":"%s"}`,
+	conf := fmt.Sprintf(`{"cniVersion":"1.0.0","name":"test","type":"galactic-tap","vpc":"%s","vpcattachment":"%s"}`,
 		testVPC, testAttachment)
 	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte(conf)}
 	err := cmdStatus(args)

--- a/internal/cnitap/config.go
+++ b/internal/cnitap/config.go
@@ -12,7 +12,7 @@ import (
 var ConfFile = config.DefaultConfFile
 
 // cniConfig is the shared config resolver for env var resolution.
-// Initialized by InitCNIConfig() (called from cmd/galactic-tap-cni/main.go).
+// Initialized by InitCNIConfig() (called from cmd/galactic-tap/main.go).
 var cniConfig *config.CNIConfig
 
 // InitCNIConfig initializes the shared config resolver for CNI env var
@@ -24,7 +24,7 @@ func InitCNIConfig() {
 
 // parseConf unmarshals the CNI configuration from stdin data, validates the
 // base62-encoded identifier fields, and resolves logging. The actual logic
-// is shared with galactic-cni — see internal/cnimaster.ParseConf — since
+// is shared with galactic-veth — see internal/cnimaster.ParseConf — since
 // none of it is tap-specific; this is a thin wrapper binding it to this
 // binary's own cniConfig/ConfFile.
 func parseConf(data []byte) (*PluginConf, error) {

--- a/internal/cnitap/ops_check.go
+++ b/internal/cnitap/ops_check.go
@@ -65,7 +65,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 
 // cmdStatus implements the CNI spec STATUS operation — see
 // internal/cnimaster.RunStatus for the full reasoning, shared verbatim with
-// galactic-cni.
+// galactic-veth.
 func cmdStatus(args *skel.CmdArgs) error {
 	return cnimaster.RunStatus(args.StdinData, cniConfig, ConfFile)
 }

--- a/internal/cnitap/resource.go
+++ b/internal/cnitap/resource.go
@@ -14,7 +14,7 @@ import (
 )
 
 // resourceTracker tracks resources created during cmdAdd for selective
-// rollback. galactic-tap-cni's ADD only ever creates the VRF, the tap
+// rollback. galactic-tap's ADD only ever creates the VRF, the tap
 // device, and (if delegated) an IPAM allocation — BGP/SRv6/eBPF publish is
 // galactic-bgp's own, separately chain-invoked plugin now, with its own
 // smaller tracker (internal/cnibgp); termination routes are galactic-
@@ -45,7 +45,7 @@ func (rt *resourceTracker) cleanup() {
 	// Release the IPAM allocation first — see internal/cni's own
 	// resourceTracker for the full doc comment on why this fires
 	// unconditionally on ipamDelegated alone. Interface/VRF cleanup is
-	// shared with galactic-cni's own tracker, so it lives in
+	// shared with galactic-veth's own tracker, so it lives in
 	// cnimaster.CleanupAttachment.
 	if rt.ipamDelegated {
 		if err := ipam.ExecDel(rt.ipamType, rt.ipamStdin); err != nil {

--- a/internal/cnitap/types.go
+++ b/internal/cnitap/types.go
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnitap implements galactic-tap-cni, the tap master plugin for
+// Package cnitap implements galactic-tap, the tap master plugin for
 // VM-based workloads (Kata, Firecracker, kraftlet/Unikraft). It mirrors
-// internal/cni (the veth master, galactic-cni) but never delegates to
+// internal/cni (the veth master, galactic-veth) but never delegates to
 // host-device (no container netns to move anything into — the VM manages
 // its own guest interface) and never configures a guest-side netns.
 package cnitap
@@ -15,7 +15,7 @@ import (
 )
 
 // PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-tap-cni. It's the same shape galactic-cni
+// invocation of galactic-tap. It's the same shape galactic-veth
 // (internal/cni) uses — see internal/cnimaster's own doc comment — so both
 // packages alias the one canonical definition rather than each declaring
 // their own copy.

--- a/internal/hostconf/hostconf.go
+++ b/internal/hostconf/hostconf.go
@@ -42,7 +42,9 @@ import (
 )
 
 // PluginType is the "type" value Bootstrap always writes into the static
-// conflist's single plugin entry, regardless of which binary is actually
+// conflist's single plugin entry. It names galactic-cni, the installer that
+// actually authors this file, not any particular master plugin — veth, tap,
+// and bgp all read this same value regardless of which binary is actually
 // reading it. Every caller in the chain passes this to Load.
 const PluginType = "galactic-cni"
 

--- a/internal/hostconf/hostconf_test.go
+++ b/internal/hostconf/hostconf_test.go
@@ -88,44 +88,44 @@ func TestRejectMovedIPAMKeys(t *testing.T) {
 	}{
 		{
 			name:  "no addressing keys at all",
-			input: `{"cniVersion":"1.0.0","type":"galactic-cni","vpc":"abc"}`,
+			input: `{"cniVersion":"1.0.0","type":"galactic-veth","vpc":"abc"}`,
 		},
 		{
 			name:  "keys inside the ipam block",
-			input: `{"type":"galactic-cni","ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00::/48","static_ip":"fd00::1"}}`,
+			input: `{"type":"galactic-veth","ipam":{"type":"galactic-ipam","ipv6_subnet":"fd00::/48","static_ip":"fd00::1"}}`,
 		},
 		{
 			name:    "top-level ipv6_subnet",
-			input:   `{"type":"galactic-cni","ipv6_subnet":"fd00::/48"}`,
+			input:   `{"type":"galactic-veth","ipv6_subnet":"fd00::/48"}`,
 			wantErr: "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
 		},
 		{
 			name:    "top-level ipv4_subnet",
-			input:   `{"type":"galactic-cni","ipv4_subnet":"172.20.1.0/24"}`,
+			input:   `{"type":"galactic-veth","ipv4_subnet":"172.20.1.0/24"}`,
 			wantErr: "addressing field 'ipv4_subnet' belongs inside the 'ipam' block",
 		},
 		{
 			name:    "top-level address_families",
-			input:   `{"type":"galactic-cni","address_families":["ipv6"]}`,
+			input:   `{"type":"galactic-veth","address_families":["ipv6"]}`,
 			wantErr: "addressing field 'address_families' belongs inside the 'ipam' block",
 		},
 		{
 			name:    "top-level static_ip",
-			input:   `{"type":"galactic-cni","static_ip":"fd00::1234"}`,
+			input:   `{"type":"galactic-veth","static_ip":"fd00::1234"}`,
 			wantErr: "addressing field 'static_ip' belongs inside the 'ipam' block",
 		},
 		{
 			name:    "wrong-typed value is still reported as present",
-			input:   `{"type":"galactic-cni","ipv6_subnet":42}`,
+			input:   `{"type":"galactic-veth","ipv6_subnet":42}`,
 			wantErr: "addressing field 'ipv6_subnet' belongs inside the 'ipam' block",
 		},
 		{
 			name:  "explicit null carries no addressing intent",
-			input: `{"type":"galactic-cni","ipv6_subnet":null,"static_ip":null}`,
+			input: `{"type":"galactic-veth","ipv6_subnet":null,"static_ip":null}`,
 		},
 		{
 			name:    "several keys are all named",
-			input:   `{"type":"galactic-cni","ipv4_subnet":"172.20.1.0/24","static_ip":"fd00::1"}`,
+			input:   `{"type":"galactic-veth","ipv4_subnet":"172.20.1.0/24","static_ip":"fd00::1"}`,
 			wantErr: "addressing fields 'ipv4_subnet', 'static_ip' belong inside the 'ipam' block",
 		},
 		{
@@ -160,12 +160,12 @@ func TestRejectMovedIPAMKeys(t *testing.T) {
 func TestLoadAcceptsAnyOfMultipleTypes(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "10-galactic.conflist")
-	content := `{"cniVersion":"1.0.0","name":"test","plugins":[{"type":"galactic-tap-cni","node_name":"tap-node"}]}`
+	content := `{"cniVersion":"1.0.0","name":"test","plugins":[{"type":"galactic-tap","node_name":"tap-node"}]}`
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("os.WriteFile: %v", err)
 	}
 
-	conf, err := Load(path, "galactic-cni", "galactic-tap-cni")
+	conf, err := Load(path, "galactic-veth", "galactic-tap")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -65,8 +65,8 @@ var (
 	HostConflist           = "/host/etc/cni/net.d/10-galactic.conflist"
 	HostEtcDir             = "/host/var/lib/galactic"
 	SADir                  = "/var/run/secrets/kubernetes.io/serviceaccount"
-	SourceCNIBinary        = "/galactic-cni"
-	SourceTapCNIBinary     = "/galactic-tap-cni"
+	SourceVethBinary       = "/galactic-veth"
+	SourceTapBinary        = "/galactic-tap"
 	SourceIPAMBinary       = "/galactic-ipam"
 	SourceBGPBinary        = "/galactic-bgp"
 	SourceRouteBinary      = "/galactic-route"
@@ -153,7 +153,7 @@ func atomicWriteFile(destPath string, content []byte, mode os.FileMode) error {
 
 // atomicCopyFile streams a file from srcPath to destPath atomically. It
 // copies via io.Copy rather than reading the whole source into memory
-// first, since binaries copied here (e.g. galactic-cni itself) run tens of
+// first, since binaries copied here (e.g. galactic-veth itself) run tens of
 // megabytes and the installer runs under a tight memory limit.
 func atomicCopyFile(srcPath, destPath string, mode os.FileMode) error {
 	src, err := os.Open(srcPath)
@@ -265,11 +265,11 @@ func Bootstrap(ctx context.Context, nodeName string) error {
 	if err := os.MkdirAll(HostBinDir, 0755); err != nil {
 		return fmt.Errorf("create host CNI bin dir: %w", err)
 	}
-	if err := atomicCopyFile(SourceCNIBinary, filepath.Join(HostBinDir, "galactic-cni"), 0755); err != nil {
-		return fmt.Errorf("copy galactic-cni binary: %w", err)
+	if err := atomicCopyFile(SourceVethBinary, filepath.Join(HostBinDir, "galactic-veth"), 0755); err != nil {
+		return fmt.Errorf("copy galactic-veth binary: %w", err)
 	}
-	if err := atomicCopyFile(SourceTapCNIBinary, filepath.Join(HostBinDir, "galactic-tap-cni"), 0755); err != nil {
-		return fmt.Errorf("copy galactic-tap-cni binary: %w", err)
+	if err := atomicCopyFile(SourceTapBinary, filepath.Join(HostBinDir, "galactic-tap"), 0755); err != nil {
+		return fmt.Errorf("copy galactic-tap binary: %w", err)
 	}
 	if err := atomicCopyFile(SourceIPAMBinary, filepath.Join(HostBinDir, "galactic-ipam"), 0755); err != nil {
 		return fmt.Errorf("copy galactic-ipam binary: %w", err)

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -113,14 +113,14 @@ func TestBootstrap(t *testing.T) {
 	}
 
 	// Create mock CNI source binary files
-	SourceCNIBinary = filepath.Join(tmpDir, "source-galactic-cni")
-	SourceTapCNIBinary = filepath.Join(tmpDir, "source-galactic-tap-cni")
+	SourceVethBinary = filepath.Join(tmpDir, "source-galactic-veth")
+	SourceTapBinary = filepath.Join(tmpDir, "source-galactic-tap")
 	SourceIPAMBinary = filepath.Join(tmpDir, "source-galactic-ipam")
 	SourceBGPBinary = filepath.Join(tmpDir, "source-galactic-bgp")
 	SourceRouteBinary = filepath.Join(tmpDir, "source-galactic-route")
 	SourceHostDeviceBinary = filepath.Join(tmpDir, "source-host-device")
-	writeSourceBinary(t, SourceCNIBinary, "cni-content")
-	writeSourceBinary(t, SourceTapCNIBinary, "tap-cni-content")
+	writeSourceBinary(t, SourceVethBinary, "cni-content")
+	writeSourceBinary(t, SourceTapBinary, "tap-cni-content")
 	writeSourceBinary(t, SourceIPAMBinary, "ipam-content")
 	writeSourceBinary(t, SourceBGPBinary, "bgp-content")
 	writeSourceBinary(t, SourceRouteBinary, "route-content")
@@ -177,8 +177,8 @@ func TestBootstrap(t *testing.T) {
 		}
 
 		// Verify binaries copied
-		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-cni"), "cni-content")
-		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-tap-cni"), "tap-cni-content")
+		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-veth"), "cni-content")
+		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-tap"), "tap-cni-content")
 		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-ipam"), "ipam-content")
 		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-bgp"), "bgp-content")
 		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-route"), "route-content")

--- a/internal/nadpatch/nadpatch.go
+++ b/internal/nadpatch/nadpatch.go
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package nadpatch patches the NetworkAttachmentDefinition with the
-// deterministic host-side interface name a master plugin (galactic-cni,
-// galactic-tap-cni) just created — shared since NAD annotation is identical
+// deterministic host-side interface name a master plugin (galactic-veth,
+// galactic-tap) just created — shared since NAD annotation is identical
 // regardless of interface type.
 package nadpatch
 

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -87,7 +87,7 @@ func Add(vpc string) error {
 // interface for the given base62-encoded VPC. Delete is idempotent: if the
 // VRF interface does not exist, it returns nil. Callers must only invoke
 // Delete once no attachment on this VPC on this node remains live — deleting
-// out from under a still-live sibling attachment breaks it. galactic-cni's
+// out from under a still-live sibling attachment breaks it. galactic-veth's
 // own cmdDel never calls this directly for exactly that reason; only
 // galactic-router's GC controller does, after confirming via every
 // BGPAdvertisement for this VPC/node that none are still in use.

--- a/internal/vmtap/types.go
+++ b/internal/vmtap/types.go
@@ -12,7 +12,7 @@ import (
 // invocation, as a chained entry inside the pod's primary conflist (e.g.
 // appended to whatever Cilium installs at /etc/cni/net.d/05-cilium.conflist).
 // It carries no VPC/VPCAttachment identifiers — those belong exclusively to
-// galactic-cni.
+// galactic-veth.
 type PluginConf struct {
 	types.PluginConf
 

--- a/internal/vmtap/vmtap.go
+++ b/internal/vmtap/vmtap.go
@@ -18,7 +18,7 @@ const pluginName = "vmtap-cni"
 
 // RunPlugin starts the CNI plugin, handling ADD, DEL, and CHECK operations.
 // STATUS is intentionally omitted (optional per the CNI spec): unlike
-// galactic-cni, vmtap-cni has no Kubernetes API dependency or node-level
+// galactic-veth, vmtap-cni has no Kubernetes API dependency or node-level
 // bootstrap state to probe readiness against.
 func RunPlugin() {
 	skel.PluginMainFuncs(

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -69,7 +69,7 @@ func TestCNIPluginVersionReport(t *testing.T) {
 		"--restart=Never",
 		"--env=CNI_COMMAND=VERSION",
 		"--command", "--",
-		"/galactic-cni",
+		"/galactic-veth",
 	)
 	if err != nil {
 		t.Fatalf("kubectl run failed: %v", err)
@@ -158,13 +158,13 @@ func TestKernelCapabilities(t *testing.T) {
 	}
 }
 
-// TestCNITapInterface exercises galactic-tap-cni, the tap master plugin in
+// TestCNITapInterface exercises galactic-tap, the tap master plugin in
 // the galactic CNI chain (see internal/cnitap). It creates a pod that
 // invokes the plugin with CNI_COMMAND=ADD and a tap config, then validates
 // the CNI result JSON: a single host interface with an empty sandbox and
 // the host-side gateway/subnet IPAM allocated for it.
 //
-// This exercises galactic-tap-cni's own ADD (VRF + tap creation, IPAM
+// This exercises galactic-tap's own ADD (VRF + tap creation, IPAM
 // delegation to galactic-ipam) directly, then manually chains galactic-bgp
 // after it (testChainedGalacticBGP below), feeding it the tap master's own
 // CNI result as prevResult exactly as the CNI runtime would — the same
@@ -184,10 +184,10 @@ func TestCNITapInterface(t *testing.T) {
 	// Start a shell so we can later exec the CNI plugin with stdin.
 	// The galactic-cni image's entrypoint is overridden to "sh" so the pod
 	// stays running and we can pipe the CNI config via kubectl exec -i.
-	// galactic-tap-cni ships in the same image (see containers/galactic-cni/
+	// galactic-tap ships in the same image (see containers/galactic-cni/
 	// Dockerfile) alongside every other binary in the CNI chain, so no
 	// separate image is needed here. Run as the galactic-cni ServiceAccount:
-	// galactic-tap-cni's own ADD unconditionally builds an in-cluster k8s
+	// galactic-tap's own ADD unconditionally builds an in-cluster k8s
 	// client for its NAD-annotation step (config/cni/rbac.yaml grants it),
 	// even though that step itself no-ops here (no CNI_ARGS, so
 	// nadpatch.ParsePodNamespace resolves an empty namespace). hostNetwork
@@ -228,7 +228,7 @@ func TestCNITapInterface(t *testing.T) {
 	// The eBPF uSID datapath is now the only forwarding path (see
 	// internal/cnibgp/bgp.go's registerEBPFDatapath, called from
 	// galactic-bgp's own cmdAdd — a separately chain-invoked binary since
-	// the CNI plugin-chain split, not inline in galactic-tap-cni's cmdAdd
+	// the CNI plugin-chain split, not inline in galactic-tap's cmdAdd
 	// any more), so CNI ADD requires this node's locator_table/
 	// function_table/vrf_table maps to already be pinned under
 	// attach.PinDir. In production that's done ahead of time by the CNI
@@ -252,7 +252,7 @@ func TestCNITapInterface(t *testing.T) {
 	cniConf := `{
   "cniVersion": "1.0.0",
   "name": "galactic",
-  "type": "galactic-tap-cni",
+  "type": "galactic-tap",
   "vpc": "1",
   "vpcattachment": "1",
   "ipam": {
@@ -261,7 +261,7 @@ func TestCNITapInterface(t *testing.T) {
   }
 }`
 	// Step 1: write the CNI config and a wrapper script into the pod.
-	// CNI_PATH=/ lets IPAM delegation (galactic-tap-cni execs galactic-ipam
+	// CNI_PATH=/ lets IPAM delegation (galactic-tap execs galactic-ipam
 	// via github.com/containernetworking/plugins/pkg/ipam.ExecAdd) find the
 	// delegate binary: every binary in the chain is copied to the image
 	// root by containers/galactic-cni/Dockerfile (not /opt/cni/bin — that
@@ -275,7 +275,7 @@ CNI_CONTAINERID=e2e-tap-001 \
 CNI_IFNAME=eth0 \
 CNI_PATH=/ \
 NODE_NAME=` + nodeName() + ` \
-	/galactic-tap-cni < /tmp/cni.json
+	/galactic-tap < /tmp/cni.json
 `
 	_, err = kubectl(t.Context(), "exec", name, "--",
 		"sh", "-c",
@@ -340,9 +340,9 @@ NODE_NAME=` + nodeName() + ` \
 	}
 
 	// Step 3: chain galactic-bgp — the CNI runtime's next plugin in the
-	// conflist — after galactic-tap-cni, feeding it the tap master's own
+	// conflist — after galactic-tap, feeding it the tap master's own
 	// CNI result as prevResult, exactly as the runtime would. Everything
-	// up to this point only exercises galactic-tap-cni's own cmdAdd;
+	// up to this point only exercises galactic-tap's own cmdAdd;
 	// BGPVRFInstance/BGPAdvertisement CRD creation and eBPF
 	// locator_table/function_table/vrf_table registration all moved into
 	// galactic-bgp's own cmdAdd with the CNI plugin-chain split (see
@@ -386,7 +386,7 @@ func testChainedGalacticBGP(t *testing.T, podName string, tapResult map[string]a
   "prevResult": %s
 }`, vpc, vpcAttachment, prevResultJSON)
 
-	// Reuses the same netns/containerID/ifname galactic-tap-cni's own step
+	// Reuses the same netns/containerID/ifname galactic-tap's own step
 	// (above) already set up: a real chained plugin sees the identical
 	// values across every plugin invoked for one CNI ADD.
 	bgpScript := `#!/bin/sh


### PR DESCRIPTION
## Summary

Renames the two CNI master-plugin binaries for naming symmetry and pulls the DaemonSet installer logic out into its own binary:

- `galactic-cni` (veth) → `galactic-veth`
- `galactic-tap-cni` → `galactic-tap`
- `galactic-cni` is reintroduced as a dedicated installer binary: it owns only the `init`/`run` DaemonSet subcommands (`internal/installer.Bootstrap`/`Run` — binary staging, conflist/kubeconfig templating, credential refresh, eBPF datapath control) and is **never itself a CNI plugin**. No NAD ever names it in a `"type"` field and the container runtime never execs it; its only callers are the `galactic-cni` DaemonSet's own `install-cni` and `credential-refresh` containers.

`galactic-veth` and `galactic-tap` are now structurally identical: pure CNI ADD/DEL/CHECK/STATUS plugins with zero DaemonSet-lifecycle subcommands.

Also fixes `internal/hostconf.PluginType` (and the matching conflist template/check in `internal/installer`), which previously tagged the static per-node conflist's single stanza `"galactic-veth"` even though `galactic-veth`, `galactic-tap`, and `galactic-bgp` all read that exact same file identically. That tag names whoever actually authors the file, so it's now `"galactic-cni"`.

## What's deliberately unchanged

The `galactic-cni` DaemonSet/RBAC/ServiceAccount identity, the `ghcr.io/datum-cloud/galactic-cni` image, `containers/galactic-cni/`, `GALACTIC_CNI_*` env vars, and the shared default log path — those name the installer component/image that bundles every chain binary, not the veth plugin specifically.

## Related

The NAD `"type"` values driving the actual per-attachment CNI chain (`galactic-veth`/`galactic-tap` → `galactic-route` → `galactic-bgp`) in the containerlab tenant fixtures are covered by a companion PR against `deploy/containerlab/`, since that lab config needs these binary renames to already exist to make sense.

## Verification

- `task build` — pass (all binaries, including new `bin/galactic-cni`, `bin/galactic-veth`, `bin/galactic-tap`)
- `task lint` — pass, 0 issues
- `task test:unit` — pass, all 34 packages
- `task test:e2e` — pass (real Kind cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)