### PR TITLE
chore(containerlab): update NAD type fields for galactic-veth/galactic-tap rename

### DIFF
--- a/deploy/containerlab/docs/tenants.md
+++ b/deploy/containerlab/docs/tenants.md
@@ -10,7 +10,7 @@ attaches each `netshoot` pod to its VPC's `private` NetworkAttachmentDefinition
 (via the `v1.multus-cni.io/default-network` annotation, which makes the VPC
 interface the pod's `eth0` rather than an additional `net1` — there is no
 `k8s.v1.cni.cncf.io/networks` annotation in play here), which invokes the
-galactic CNI plugin chain: `galactic-cni` creates a VRF and veth pair, then
+galactic CNI plugin chain: `galactic-veth` creates a VRF and veth pair, then
 `galactic-bgp` registers the attachment against the eBPF uSID datapath and
 writes a `BGPAdvertisement` CRD (see [docs/cni-cmd-sequence.md](../../../docs/cni-cmd-sequence.md)
 for the full per-binary ADD sequence). The `galactic-router` controller then
@@ -40,7 +40,7 @@ below for why `ns30`/`ns40` deliberately use two attachments instead of one.
 `ns30` and `ns40` each define **two** NADs (`private` and `private-b`) with
 the same `vpc` but different `vpcattachment` values, each backing its own
 single-replica Deployment — not one NAD scaled to `replicas: 2`. This is
-required, not a style choice: `galactic-cni` derives its host/guest veth
+required, not a style choice: `galactic-veth` derives its host/guest veth
 interface names from `(vpc, vpcAttachment)` alone, so two pods sharing one
 `vpcattachment` on the same node would collide on that name, and
 `internal/cni/veth`'s "stale veth" self-heal would delete whichever pod's

--- a/deploy/containerlab/resources/tenants/ns10/dfw/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns10/dfw/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "10",
           "vpcattachment": "10",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns10/iad/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns10/iad/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "10",
           "vpcattachment": "10",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns10/sjc/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns10/sjc/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "10",
           "vpcattachment": "10",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns20/dfw/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns20/dfw/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "20",
           "vpcattachment": "20",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns20/iad/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns20/iad/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "20",
           "vpcattachment": "20",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns20/sjc/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns20/sjc/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "20",
           "vpcattachment": "20",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns30/base/kustomization.yaml
+++ b/deploy/containerlab/resources/tenants/ns30/base/kustomization.yaml
@@ -1,7 +1,7 @@
 # ns30 is single-site (dfw only, see ../dfw/). This is the first of its two
 # attachments — ../dfw/pod-b.yaml is the second, on its own NAD
 # (ns30/private-b). They deliberately use two distinct vpcattachment values
-# under the same vpc rather than one NAD scaled to replicas: 2: galactic-cni
+# under the same vpc rather than one NAD scaled to replicas: 2: galactic-veth
 # derives its host/guest veth interface names from (vpc, vpcAttachment)
 # alone (internal/plumbing/intf), so two pods sharing one vpcAttachment on
 # the same node collide on that name — internal/cni/veth's "stale veth"

--- a/deploy/containerlab/resources/tenants/ns30/dfw/nad-b.yaml
+++ b/deploy/containerlab/resources/tenants/ns30/dfw/nad-b.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private-b",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "30",
           "vpcattachment": "31",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns30/dfw/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns30/dfw/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "30",
           "vpcattachment": "30",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns40/base/kustomization.yaml
+++ b/deploy/containerlab/resources/tenants/ns40/base/kustomization.yaml
@@ -3,7 +3,7 @@
 # attachments — ../iad/pod-b.yaml is the second, on its own NAD
 # (ns40/private-b). They deliberately use two distinct vpcattachment values
 # under the same vpc rather than one NAD scaled to replicas: 2 — see
-# ../../ns30/base/kustomization.yaml's doc comment for why (galactic-cni's
+# ../../ns30/base/kustomization.yaml's doc comment for why (galactic-veth's
 # host/guest veth naming collides when two pods share one vpcattachment on
 # the same node). Two distinct vpcattachments avoids that collision and
 # lands both pods in one shared VRF for same-node, same-VPC pod-to-pod

--- a/deploy/containerlab/resources/tenants/ns40/iad/nad-b.yaml
+++ b/deploy/containerlab/resources/tenants/ns40/iad/nad-b.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private-b",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "40",
           "vpcattachment": "41",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns40/iad/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns40/iad/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "40",
           "vpcattachment": "40",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns50/dfw/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns50/dfw/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "50",
           "vpcattachment": "50",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns50/iad/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns50/iad/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "50",
           "vpcattachment": "50",
           "namespace": "galactic-system",

--- a/deploy/containerlab/resources/tenants/ns50/sjc/nad.yaml
+++ b/deploy/containerlab/resources/tenants/ns50/sjc/nad.yaml
@@ -11,7 +11,7 @@ spec:
       "name": "private",
       "plugins": [
         {
-          "type": "galactic-cni",
+          "type": "galactic-veth",
           "vpc": "50",
           "vpcattachment": "50",
           "namespace": "galactic-system",


### PR DESCRIPTION
## Summary

Updates every tenant NAD fixture's plugin `"type"` to match #346:

- `galactic-cni` → `galactic-veth`
- `galactic-tap-cni` → `galactic-tap`

## Depends on

#346. The lab stages the old binary names until that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)