### PR TITLE
feat(gateway): Add edge XDP NAT+LB eBPF datapath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ internal/plumbing/ebpf/prog/usid_bpfel.go
 internal/plumbing/ebpf/prog/usid_bpfel.o
 internal/plumbing/ebpf/prog/usid_bpfeb.go
 internal/plumbing/ebpf/prog/usid_bpfeb.o
+internal/plumbing/ebpf/edgeprog/edgenat_bpfel.go
+internal/plumbing/ebpf/edgeprog/edgenat_bpfel.o
+internal/plumbing/ebpf/edgeprog/edgenat_bpfeb.go
+internal/plumbing/ebpf/edgeprog/edgenat_bpfeb.o
 
 # ============================================================
 # Kubernetes / controller-runtime / kubebuilder

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -88,11 +88,12 @@ tasks:
       - task: build:binaries
 
   build:ebpf:
-    desc: Regenerate the eBPF uSID datapath from usid.c (requires clang)
+    desc: Regenerate the eBPF uSID and edge gateway NAT/LB datapaths (requires clang)
     run: once
     deps: [require-clang]
     cmds:
       - go generate ./internal/plumbing/ebpf/prog/...
+      - go generate ./internal/plumbing/ebpf/edgeprog/...
 
   require-clang:
     internal: true

--- a/internal/plumbing/ebpf/edgeattach/attach.go
+++ b/internal/plumbing/ebpf/edgeattach/attach.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgeattach
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgepreflight"
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// PinDir is the default bpffs directory every edgeprog map is pinned
+// under -- deliberately distinct from internal/plumbing/ebpf/attach.PinDir
+// and internal/plumbing/ebpf/gwattach's own PinDir, so every datapath in
+// this codebase is fully independent under bpffs even where map names
+// don't actually collide.
+const PinDir = "/sys/fs/bpf/galactic-edge"
+
+// preflightCheckFn is a package-level override point so tests can force
+// the preflight failure path without touching the real kernel -- same
+// pattern as internal/plumbing/ebpf/attach's identical var.
+var preflightCheckFn = edgepreflight.Check
+
+// Load runs the kernel preflight check and, only if it passes, loads
+// edgeprog's compiled object with every map pinned under pinDir. A map
+// already pinned there from a previous process is reused as-is; see
+// internal/plumbing/ebpf/attach.Load's identical doc comment for the full
+// rationale (schema-mismatch recreation, pin-by-name semantics) -- not
+// repeated here, since it applies unchanged.
+func Load(pinDir string) (*edgeprog.EdgenatObjects, error) {
+	if err := preflightCheckFn(); err != nil {
+		return nil, fmt.Errorf(
+			"edgeattach: kernel preflight check failed, refusing to load the edge gateway datapath: %w", err)
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("edgeattach: remove memlock rlimit: %w", err)
+	}
+	if err := os.MkdirAll(pinDir, 0o755); err != nil {
+		return nil, fmt.Errorf("edgeattach: create bpf map pin directory %q: %w", pinDir, err)
+	}
+
+	spec, err := edgeprog.LoadEdgenat()
+	if err != nil {
+		return nil, fmt.Errorf("edgeattach: load compiled edgenat collection spec: %w", err)
+	}
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinByName
+	}
+
+	var loaded edgeprog.EdgenatObjects
+	opts := &ebpf.CollectionOptions{Maps: ebpf.MapOptions{PinPath: pinDir}}
+	loadErr := spec.LoadAndAssign(&loaded, opts)
+	if loadErr != nil && errors.Is(loadErr, ebpf.ErrMapIncompatible) {
+		// Every map here is control-plane-owned and reconstructable
+		// (edgemap.RuleTable.Register repopulates rule_table from live
+		// NetworkRule CRDs; conn_table is a pure cache the datapath
+		// itself repopulates from live traffic; gw_config_table is a
+		// single entry the caller rewrites on every Engine reconcile) --
+		// a stale pin from an older, incompatible map layout is safe to
+		// recreate rather than fatal.
+		slog.Warn("edgeattach: pinned eBPF map incompatible with the newly compiled map spec, recreating "+
+			"(control-plane state will repopulate on the next NetworkRule reconcile)", "pinDir", pinDir, "err", loadErr)
+		if unpinErr := unpinIncompatibleMaps(spec, pinDir); unpinErr != nil {
+			return nil, fmt.Errorf("edgeattach: recreate incompatible pinned maps: %w", unpinErr)
+		}
+		loadErr = spec.LoadAndAssign(&loaded, opts)
+	}
+	if loadErr != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(loadErr, &ve) {
+			return nil, fmt.Errorf("edgeattach: verifier rejected edge_nat program:\n%w", ve)
+		}
+		return nil, fmt.Errorf("edgeattach: load and pin edgenat objects: %w", loadErr)
+	}
+	return &loaded, nil
+}
+
+// unpinIncompatibleMaps mirrors internal/plumbing/ebpf/attach's identical
+// helper -- see that function's doc comment.
+func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
+	var errs []error
+	for name := range spec.Maps {
+		path := filepath.Join(pinDir, name)
+		m, err := ebpf.LoadPinnedMap(path, nil)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("load pinned map %q for recreation: %w", name, err))
+			continue
+		}
+		if err := m.Unpin(); err != nil {
+			errs = append(errs, fmt.Errorf("unpin stale map %q: %w", name, err))
+		}
+		_ = m.Close()
+	}
+	return errors.Join(errs...)
+}
+
+// Attach attaches program (edgeprog.EdgenatObjects.EdgeNat) to ifaceName's
+// XDP hook in native (driver) mode, returning the resulting link.Link for
+// the caller to hold open and Close on shutdown -- see doc.go for why
+// native mode is required, not merely preferred, and why no pinning or
+// Watch-style re-attachment is needed here.
+func Attach(program *ebpf.Program, ifaceName string) (link.Link, error) {
+	if program == nil {
+		return nil, errors.New("edgeattach: program is nil")
+	}
+
+	iface, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		return nil, fmt.Errorf("edgeattach: find link %q: %w", ifaceName, err)
+	}
+
+	xdpLink, err := link.AttachXDP(link.XDPOptions{
+		Program:   program,
+		Interface: iface.Attrs().Index,
+		Flags:     link.XDPDriverMode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"edgeattach: attach XDP program to %q in native/driver mode: %w "+
+				"(this program requires native XDP support -- generic/SKB mode is not attempted, "+
+				"see this package's doc comment)",
+			ifaceName, err,
+		)
+	}
+	return xdpLink, nil
+}

--- a/internal/plumbing/ebpf/edgeattach/attach_test.go
+++ b/internal/plumbing/ebpf/edgeattach/attach_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgeattach
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN/CAP_SYS_ADMIN) to load/attach BPF programs " +
+			"and create a test network namespace; re-run via sudo")
+	}
+}
+
+// TestLoad_PreflightBlocksLoad mirrors internal/plumbing/ebpf/attach's
+// identical test.
+func TestLoad_PreflightBlocksLoad(t *testing.T) {
+	origPreflight := preflightCheckFn
+	t.Cleanup(func() { preflightCheckFn = origPreflight })
+
+	wantErr := errors.New("simulated missing kernel capability")
+	preflightCheckFn = func() error { return wantErr }
+
+	pinDir := filepath.Join(t.TempDir(), "does-not-exist", "galactic-edge")
+
+	objs, err := Load(pinDir)
+	if err == nil {
+		t.Fatal("Load() error = nil, want a preflight failure")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Load() error = %v, want it to wrap the preflight error %v", err, wantErr)
+	}
+	if objs != nil {
+		t.Errorf("Load() objs = %v, want nil on preflight failure", objs)
+	}
+	if _, statErr := os.Stat(pinDir); statErr == nil {
+		t.Error("Load() created the pin directory despite failing preflight")
+	}
+}
+
+// TestAttach_NilProgramIsError covers Attach's defensive nil-program
+// guard directly, without needing root.
+func TestAttach_NilProgramIsError(t *testing.T) {
+	if _, err := Attach(nil, "eth0"); err == nil {
+		t.Error("Attach(nil program, ...) error = nil, want an error")
+	}
+}
+
+// TestLoadAttach_SurvivesRestartWithMapsIntact is the real, root-gated
+// exit criterion: program load/attach survives a simulated process
+// restart with pinned maps intact. Unlike a TC-BPF filter (which persists
+// in the kernel independent of any process), an unpinned XDP bpf_link
+// detaches when its owning process's file descriptor closes -- so
+// simulating "restart" here means explicitly Close()ing the first
+// attach's link before re-attaching, not just calling Attach twice in a
+// row (see doc.go).
+//
+// Uses a veth pair, not a dummy interface: dummy's driver, like geneve's
+// (this design's own earlier rejected finding), does not implement
+// ndo_bpf, so it cannot accept a native-mode XDP attach at all --
+// confirmed during this design's Phase 0 spike that veth genuinely does.
+func TestLoadAttach_SurvivesRestartWithMapsIntact(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-edge-test-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	const ifaceName = "edgetest0"
+	const peerName = "edgetest1"
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		handle, err := netlink.NewHandle()
+		if err != nil {
+			return err
+		}
+		defer handle.Close() //nolint:errcheck // best-effort cleanup
+
+		veth := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}, PeerName: peerName}
+		if err := handle.LinkAdd(veth); err != nil {
+			return fmt.Errorf("add veth pair: %w", err)
+		}
+		link, err := handle.LinkByName(ifaceName)
+		if err != nil {
+			return err
+		}
+		return handle.LinkSetUp(link)
+	})
+	if err != nil {
+		t.Fatalf("setup veth interface: %v", err)
+	}
+
+	ruleKey := edgeprog.EdgenatRuleKey{Proto: 6, Port: 80}
+	ruleValue := edgeprog.EdgenatRuleValue{BackendCount: 1, Generation: 42}
+
+	// --- pre-restart: first load, attach, and populate a map entry. ---
+	var firstLink interface{ Close() error }
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("load: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		l, err := Attach(objs.EdgeNat, ifaceName)
+		if err != nil {
+			return fmt.Errorf("attach: %w", err)
+		}
+		firstLink = l
+
+		if err := objs.RuleTable.Put(ruleKey, ruleValue); err != nil {
+			return fmt.Errorf("populate rule_table: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("pre-restart load/attach/populate: %v", err)
+	}
+
+	// Simulate the old process exiting: close its XDP link so the
+	// interface has no attached program, exactly like a real process
+	// restart would leave it.
+	if err := firstLink.Close(); err != nil {
+		t.Fatalf("close pre-restart link: %v", err)
+	}
+
+	// --- simulate a container restart: fresh Load+Attach against the
+	// same pinDir/interface, as a brand new process would do. ---
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("reload after restart: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		l, err := Attach(objs.EdgeNat, ifaceName)
+		if err != nil {
+			return fmt.Errorf("re-attach after restart: %w", err)
+		}
+		defer func() { _ = l.Close() }()
+
+		var got edgeprog.EdgenatRuleValue
+		if err := objs.RuleTable.Lookup(ruleKey, &got); err != nil {
+			return fmt.Errorf("lookup rule_table entry after restart: %w", err)
+		}
+		if got.BackendCount != 1 || got.Generation != 42 {
+			return fmt.Errorf("rule_table entry after restart = %+v, want BackendCount=1 Generation=42", got)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("post-restart verification: %v", err)
+	}
+}

--- a/internal/plumbing/ebpf/edgeattach/doc.go
+++ b/internal/plumbing/ebpf/edgeattach/doc.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package edgeattach loads internal/plumbing/ebpf/edgeprog's compiled XDP
+// program and attaches it to one interface -- the gateway node's single
+// public/underlay-facing uplink. Load mirrors
+// internal/plumbing/ebpf/attach.Load's mechanics (pinned maps, verifier-
+// error unwrapping, incompatible-map recreation on a schema change) almost
+// verbatim, since none of that is attach-mechanism-specific; Attach itself
+// is genuinely new, not a port of internal/plumbing/ebpf/gwattach's TC-BPF
+// clsact+filter mechanics (the earlier, rejected Geneve-based design) --
+// XDP attaches via a kernel bpf_link (github.com/cilium/ebpf/link.
+// AttachXDP), a different netlink/bpf-link surface than TC's
+// netlink.BpfFilter entirely.
+//
+// Like gwattach before it, there is no Watch-style netlink-driven
+// re-attachment here: this program has exactly one attach target (a
+// fixed, operator-configured interface name,
+// config.GatewayConfig.PublicInterface), attached once at process startup
+// -- there is no external network event (a Geneve device appearing, a NIC
+// renumbering) this package would ever need to notice on its own, unlike
+// internal/plumbing/ebpf/attach's SRv6 underlay-facing interface set.
+//
+// Native XDP support is required, not merely preferred: Attach always
+// requests link.XDPDriverMode and returns an error rather than silently
+// retrying in link.XDPGenericMode (SKB mode) if the interface's driver
+// doesn't support it. Generic mode has materially different performance
+// characteristics -- accepting it silently would defeat the reason this
+// design chose XDP over TC-BPF in the first place, and violates the same
+// "no partial/unsafe fallback" invariant
+// internal/plumbing/ebpf/preflight/edgepreflight already hold the rest of
+// this datapath to.
+//
+// Unlike a TC-BPF filter (which persists in the kernel's qdisc structure
+// independent of any process holding a reference), an unpinned bpf_link
+// detaches automatically when the last file descriptor referencing it is
+// closed. This package does not pin the returned link: the owning process
+// (galactic-gateway) is expected to hold it open for its own lifetime and
+// Close it on shutdown, the same "keep the fd, don't pin" simplification
+// gwattach's own AttachPublic used for its single fixed interface. A
+// process restart therefore has a genuinely clean slate -- no existing
+// attach to conflict with -- so there is no TC-FilterReplace-style
+// "replace what's already there" case to handle.
+package edgeattach

--- a/internal/plumbing/ebpf/edgemap/doc.go
+++ b/internal/plumbing/ebpf/edgemap/doc.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package edgemap implements the read/write API that populates
+// internal/plumbing/ebpf/edgeprog's control-plane maps -- rule_table and
+// gw_config_table. conn_table is not wrapped here: it is written and read
+// exclusively by the compiled program itself (edgenat.c's forward branch
+// writes it, the return branch reads it); nothing in the Go control plane
+// ever touches it directly, the same boundary the earlier, rejected
+// gwprog/gwnatmap design drew for its own conn_table.
+//
+// This package does not itself decide *when* to register anything, load
+// the program, or attach it to an interface -- that is
+// internal/gateway.Engine's job (via its Datapath interface) and
+// internal/plumbing/ebpf/edgeattach's, analogous to
+// internal/plumbing/ebpf/attach but for this program.
+//
+// # Why RuleTable carries a Generation field
+//
+// internal/gateway.Engine is a single long-lived process, but it can still
+// crash mid-reconcile and leave rule_table entries behind with no
+// corresponding NetworkRule left to reconcile them against.
+// RuleTable.Reconcile's cutoff/Generation mechanism guards exactly that
+// crash-restart window -- the same register-after-snapshot-is-safe
+// guarantee internal/plumbing/ebpf/usidmap.VRFTable's identical mechanism
+// already documents.
+//
+// # Testability
+//
+// RuleTable is built against the Table interface (table.go), not directly
+// against *ebpf.Map -- KernelTable adapts a real, loaded map (e.g.
+// edgeprog.EdgenatObjects.RuleTable) for production use, while this
+// package's own tests substitute an in-memory fake implementation to
+// exercise register/unregister/reconcile logic without a kernel or root
+// privileges. Table/Iterator/KernelTable are a deliberate duplicate of
+// usidmap's identical types, not an import of them -- this package and
+// usidmap serve two unrelated datapaths (edge ingress NAT/LB vs. SRv6 uSID
+// decap) with no shared map/key layout, so importing usidmap would gain
+// nothing but coupling.
+package edgemap

--- a/internal/plumbing/ebpf/edgemap/ruletable.go
+++ b/internal/plumbing/ebpf/edgemap/ruletable.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgemap
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// MaxBackends is edgenat.c's EDGE_MAX_BACKENDS, hand-kept in sync --
+// bpf2go's -type flag generates a Go struct matching struct rule_value's
+// fixed-size Backends array, but the #define itself has no BTF
+// representation to generate a Go constant from (same reason
+// internal/plumbing/ebpf/prog/dropreason.go's constants are hand-kept, not
+// generated). Register rejects more backends than this before ever
+// writing to the map, rather than letting a silently-truncated Put
+// succeed.
+const MaxBackends = 8
+
+// MaxRuleTableEntries is rule_table's own __uint(max_entries, ...) in
+// edgenat.c, hand-kept in sync for the same reason as MaxBackends (a map's
+// max_entries has no BTF representation bpf2go could generate a Go
+// constant from). internal/gateway's QuotaEnforcer (Phase E) uses this as
+// the hard ceiling protecting the shared map's fixed capacity across every
+// tenant on the node -- rule_table itself has no notion of "full,"
+// bpf_map_update_elem simply starts failing once it is, so this quota
+// exists to fail closed at the control-plane admission point instead.
+const MaxRuleTableEntries = 4096
+
+// beU16 converts v between host and big-endian ("network") representation
+// by a full 2-byte swap -- its own inverse, so this same function is used
+// for both directions. Required because edgeprog's generated Go structs
+// store a C __be16 field as a plain uint16, and cilium/ebpf's BTF-based
+// marshalling writes it using the host's native (little-endian, on every
+// architecture this repo targets) byte order with no swap of its own.
+func beU16(v uint16) uint16 {
+	return v<<8 | v>>8
+}
+
+// RuleKey identifies one rule_table row: (proto, VIP port, VIP address).
+// No tenant dimension here -- a VIP is globally unique by construction
+// (it's a public address), so this key never needs one; see edgenat.c's
+// struct rule_key doc comment.
+type RuleKey struct {
+	Proto uint8
+	VPort uint16
+	VIP   netip.Addr
+}
+
+// Backend is one RuleEntry load-balancing target: the backend Pod's own
+// address/port, plus the SRv6 uSID of the worker node it's reachable
+// through -- resolved by the caller (internal/gateway's control plane) the
+// same way any other cross-node SRv6 destination is, never parsed from a
+// packet. This is the field that replaces the earlier, rejected gwprog
+// design's shared per-rule VNI/GeneveIfindex: each backend here can be
+// reached through a genuinely different worker node, so the uSID has to
+// live per-backend, not per-rule.
+type Backend struct {
+	Addr netip.Addr
+	Port uint16
+	USID netip.Addr
+}
+
+// RuleEntry is one fully decoded rule_table row.
+type RuleEntry struct {
+	RuleKey
+	Backends []Backend
+
+	// Generation is this table's monotonic-clock reading at the time this
+	// entry was last written by Register -- see doc.go's "why RuleTable
+	// carries a Generation field" section.
+	Generation uint64
+
+	// Packets/Bytes/DroppedPackets/LastSeenNs are per-rule hit counters
+	// maintained by the datapath itself (edgenat.c's rule_value, Phase E),
+	// backing internal/gateway's QuotaEnforcer/TelemetryEmitter. Packets
+	// counts every packet that matched this rule's VIP+port+protocol,
+	// regardless of outcome; DroppedPackets is the subset of those the
+	// datapath then dropped (count_claimed_drop) -- so DroppedPackets is
+	// always <= Packets. LastSeenNs is a CLOCK_MONOTONIC nanosecond
+	// timestamp of the most recent matching packet, 0 if none yet.
+	//
+	// Register preserves these across re-registration (read-modify-write)
+	// -- see that method's doc comment for why a naive overwrite would
+	// zero them on every controller reconcile pass.
+	Packets        uint64
+	Bytes          uint64
+	DroppedPackets uint64
+	LastSeenNs     uint64
+}
+
+// RuleTable is the read/write API for rule_table.
+type RuleTable struct {
+	table Table
+	clock func() uint64
+}
+
+// NewRuleTable wraps table as a RuleTable. Production callers pass a
+// KernelTable wrapping a loaded *edgeprog.EdgenatObjects's RuleTable map;
+// tests pass a fake Table.
+func NewRuleTable(table Table) *RuleTable {
+	return &RuleTable{table: table, clock: clockFn}
+}
+
+// Generation returns a snapshot of this table's monotonic clock. A caller
+// intending to call Reconcile must capture this immediately *before*
+// listing the NetworkRule CRDs that will become Reconcile's live set.
+func (t *RuleTable) Generation() uint64 {
+	return t.clock()
+}
+
+func toWireKey(key RuleKey) (edgeprog.EdgenatRuleKey, error) {
+	if !key.VIP.Is6() || key.VIP.Is4In6() {
+		return edgeprog.EdgenatRuleKey{}, fmt.Errorf("VIP %s is not a native IPv6 address (phase 1 is IPv6-only)", key.VIP)
+	}
+	return edgeprog.EdgenatRuleKey{Proto: key.Proto, Port: beU16(key.VPort), Vip: key.VIP.As16()}, nil
+}
+
+func toWireBackends(backends []Backend) ([MaxBackends]edgeprog.EdgenatBackend, error) {
+	var out [MaxBackends]edgeprog.EdgenatBackend
+	for i, b := range backends {
+		if !b.Addr.Is6() || b.Addr.Is4In6() {
+			return out, fmt.Errorf("backend %d address %s is not a native IPv6 address (phase 1 is IPv6-only)", i, b.Addr)
+		}
+		if !b.USID.Is6() || b.USID.Is4In6() {
+			return out, fmt.Errorf("backend %d uSID %s is not a native IPv6 address", i, b.USID)
+		}
+		out[i] = edgeprog.EdgenatBackend{Addr: b.Addr.As16(), Port: beU16(b.Port), Usid: b.USID.As16()}
+	}
+	return out, nil
+}
+
+// Register writes (or overwrites) the rule_table entry for key, mapping
+// it to backends and stamping it with this table's current Generation.
+// Rejects an empty or over-capacity backend list before ever writing to
+// the map, per MaxBackends' doc comment.
+//
+// This is a read-modify-write, not a blind overwrite: it looks up any
+// existing entry first and carries its Packets/Bytes/DroppedPackets/
+// LastSeenNs counters forward into the new value. Those counters are
+// maintained by the datapath itself on every packet (edgenat.c), not by
+// this method -- internal/gateway.Engine.Reconcile calls ApplyRule (and
+// therefore this method) for every desired rule on *every* reconcile
+// pass, not just changed ones (see that method's own doc comment), so a
+// naive overwrite would zero a long-lived, healthy rule's counters on
+// every controller resync. Same fix as an earlier, rejected design's
+// equivalent register method.
+func (t *RuleTable) Register(key RuleKey, backends []Backend) error {
+	if len(backends) == 0 {
+		return fmt.Errorf("edgemap: rule_table: register %+v: at least one backend is required", key)
+	}
+	if len(backends) > MaxBackends {
+		return fmt.Errorf("edgemap: rule_table: register %+v: %d backends exceeds MaxBackends (%d)",
+			key, len(backends), MaxBackends)
+	}
+
+	wireKey, err := toWireKey(key)
+	if err != nil {
+		return fmt.Errorf("edgemap: rule_table: register %+v: %w", key, err)
+	}
+	wireBackends, err := toWireBackends(backends)
+	if err != nil {
+		return fmt.Errorf("edgemap: rule_table: register %+v: %w", key, err)
+	}
+
+	var existing edgeprog.EdgenatRuleValue
+	if err := t.table.Lookup(wireKey, &existing); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		return fmt.Errorf("edgemap: rule_table: register %+v: look up existing entry: %w", key, err)
+	}
+
+	value := edgeprog.EdgenatRuleValue{
+		BackendCount:   uint32(len(backends)),
+		Backends:       wireBackends,
+		Generation:     t.clock(),
+		Packets:        existing.Packets,
+		Bytes:          existing.Bytes,
+		DroppedPackets: existing.DroppedPackets,
+		LastSeenNs:     existing.LastSeenNs,
+	}
+	if err := t.table.Put(wireKey, value); err != nil {
+		return fmt.Errorf("edgemap: rule_table: register %+v: %w", key, err)
+	}
+	return nil
+}
+
+// Unregister removes the rule_table entry for key, if present. Not an
+// error if already absent.
+func (t *RuleTable) Unregister(key RuleKey) error {
+	wireKey, err := toWireKey(key)
+	if err != nil {
+		return fmt.Errorf("edgemap: rule_table: unregister %+v: %w", key, err)
+	}
+	if err := t.table.Delete(wireKey); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("edgemap: rule_table: unregister %+v: %w", key, err)
+	}
+	return nil
+}
+
+func fromWireValue(key RuleKey, value edgeprog.EdgenatRuleValue) RuleEntry {
+	backends := make([]Backend, value.BackendCount)
+	for i := range backends {
+		wb := value.Backends[i]
+		backends[i] = Backend{
+			Addr: netip.AddrFrom16(wb.Addr),
+			Port: beU16(wb.Port),
+			USID: netip.AddrFrom16(wb.Usid),
+		}
+	}
+	return RuleEntry{
+		RuleKey:        key,
+		Backends:       backends,
+		Generation:     value.Generation,
+		Packets:        value.Packets,
+		Bytes:          value.Bytes,
+		DroppedPackets: value.DroppedPackets,
+		LastSeenNs:     value.LastSeenNs,
+	}
+}
+
+// Get reads the rule_table entry for key, reporting whether it exists.
+func (t *RuleTable) Get(key RuleKey) (RuleEntry, bool, error) {
+	wireKey, err := toWireKey(key)
+	if err != nil {
+		return RuleEntry{}, false, fmt.Errorf("edgemap: rule_table: get %+v: %w", key, err)
+	}
+
+	var value edgeprog.EdgenatRuleValue
+	if err := t.table.Lookup(wireKey, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return RuleEntry{}, false, nil
+		}
+		return RuleEntry{}, false, fmt.Errorf("edgemap: rule_table: get %+v: %w", key, err)
+	}
+	return fromWireValue(key, value), true, nil
+}
+
+// List returns every entry currently in rule_table, in unspecified order.
+func (t *RuleTable) List() ([]RuleEntry, error) {
+	var (
+		entries []RuleEntry
+		rawKey  edgeprog.EdgenatRuleKey
+		value   edgeprog.EdgenatRuleValue
+	)
+	it := t.table.Iterate()
+	for it.Next(&rawKey, &value) {
+		key := RuleKey{Proto: rawKey.Proto, VPort: beU16(rawKey.Port), VIP: netip.AddrFrom16(rawKey.Vip)}
+		entries = append(entries, fromWireValue(key, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("edgemap: rule_table: list: %w", err)
+	}
+	return entries, nil
+}
+
+// Reconcile brings rule_table into agreement with live -- the caller's
+// current set of RuleKeys that have a live NetworkRule CRD -- removing
+// every rule_table entry whose key is absent from live, *except* an entry
+// whose Generation is >= cutoff (it was written after the caller's live
+// snapshot was taken, so deleting it could race a fresh Register). See
+// doc.go's "why RuleTable carries a Generation field."
+func (t *RuleTable) Reconcile(live map[RuleKey]struct{}, cutoff uint64) (removed []RuleEntry, err error) {
+	entries, err := t.List()
+	if err != nil {
+		return nil, fmt.Errorf("edgemap: rule_table: reconcile: %w", err)
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, ok := live[e.RuleKey]; ok {
+			continue
+		}
+		if e.Generation >= cutoff {
+			continue
+		}
+		if err := t.Unregister(e.RuleKey); err != nil {
+			errs = append(errs, fmt.Errorf("edgemap: rule_table: reconcile: delete stale entry %+v: %w", e.RuleKey, err))
+			continue
+		}
+		removed = append(removed, e)
+	}
+	return removed, errors.Join(errs...)
+}

--- a/internal/plumbing/ebpf/edgemap/ruletable_test.go
+++ b/internal/plumbing/ebpf/edgemap/ruletable_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgemap
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// fakeTable is an in-memory Table, letting RuleTable's register/
+// unregister/reconcile logic be exercised without a kernel or root
+// privileges -- same pattern as internal/plumbing/ebpf/usidmap's identical
+// fake table.
+type fakeTable struct {
+	entries map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue)}
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	f.entries[key.(edgeprog.EdgenatRuleKey)] = value.(edgeprog.EdgenatRuleValue)
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key.(edgeprog.EdgenatRuleKey)]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	*valueOut.(*edgeprog.EdgenatRuleValue) = v
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	k := key.(edgeprog.EdgenatRuleKey)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	return nil
+}
+
+func (f *fakeTable) Iterate() Iterator {
+	keys := make([]edgeprog.EdgenatRuleKey, 0, len(f.entries))
+	for k := range f.entries {
+		keys = append(keys, k)
+	}
+	return &fakeIterator{table: f, keys: keys}
+}
+
+type fakeIterator struct {
+	table *fakeTable
+	keys  []edgeprog.EdgenatRuleKey
+	i     int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	if it.i >= len(it.keys) {
+		return false
+	}
+	k := it.keys[it.i]
+	it.i++
+	*keyOut.(*edgeprog.EdgenatRuleKey) = k
+	*valueOut.(*edgeprog.EdgenatRuleValue) = it.table.entries[k]
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }
+
+var _ Table = (*fakeTable)(nil)
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("netip.ParseAddr(%q): %v", s, err)
+	}
+	return a
+}
+
+func testKey(t *testing.T) RuleKey {
+	return RuleKey{Proto: 6, VPort: 443, VIP: mustAddr(t, "2001:db8:1::10")}
+}
+
+func testBackend(t *testing.T) Backend {
+	return Backend{
+		Addr: mustAddr(t, "fd00:10:1::20"),
+		Port: 8443,
+		USID: mustAddr(t, "2001:db8:2::1"),
+	}
+}
+
+func TestRuleTable_RegisterGetRoundTrip(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	key, backend := testKey(t), testBackend(t)
+
+	if err := rt.Register(key, []Backend{backend}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got, ok, err := rt.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: entry not found after Register")
+	}
+	if len(got.Backends) != 1 || got.Backends[0] != backend {
+		t.Errorf("Get: backends = %+v, want [%+v]", got.Backends, backend)
+	}
+}
+
+func TestRuleTable_RegisterRejectsEmptyBackends(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	if err := rt.Register(testKey(t), nil); err == nil {
+		t.Error("Register with no backends: want error, got nil")
+	}
+}
+
+func TestRuleTable_RegisterRejectsTooManyBackends(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	backends := make([]Backend, MaxBackends+1)
+	for i := range backends {
+		backends[i] = testBackend(t)
+	}
+	if err := rt.Register(testKey(t), backends); err == nil {
+		t.Error("Register with MaxBackends+1 backends: want error, got nil")
+	}
+}
+
+func TestRuleTable_RegisterRejectsIPv4Backend(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	backend := testBackend(t)
+	backend.Addr = netip.MustParseAddr("192.0.2.1")
+	if err := rt.Register(testKey(t), []Backend{backend}); err == nil {
+		t.Error("Register with an IPv4 backend address: want error, got nil")
+	}
+}
+
+func TestRuleTable_UnregisterIsIdempotent(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	key := testKey(t)
+	if err := rt.Unregister(key); err != nil {
+		t.Fatalf("Unregister on an absent key: %v, want nil", err)
+	}
+	if err := rt.Register(key, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := rt.Unregister(key); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+	if err := rt.Unregister(key); err != nil {
+		t.Fatalf("second Unregister on an already-absent key: %v, want nil", err)
+	}
+	if _, ok, _ := rt.Get(key); ok {
+		t.Error("entry still present after Unregister")
+	}
+}
+
+func TestRuleTable_GetMissingReturnsFalseNotError(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	_, ok, err := rt.Get(testKey(t))
+	if err != nil {
+		t.Fatalf("Get on an absent key: %v, want nil error", err)
+	}
+	if ok {
+		t.Error("Get on an absent key: ok = true, want false")
+	}
+}
+
+func TestRuleTable_List(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	key1 := testKey(t)
+	key2 := RuleKey{Proto: 17, VPort: 53, VIP: mustAddr(t, "2001:db8:1::11")}
+
+	if err := rt.Register(key1, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register key1: %v", err)
+	}
+	if err := rt.Register(key2, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register key2: %v", err)
+	}
+
+	entries, err := rt.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List: len = %d, want 2", len(entries))
+	}
+}
+
+func TestRuleTable_ReconcileRemovesStaleNotLive(t *testing.T) {
+	var fakeClock uint64
+	rt := NewRuleTable(newFakeTable())
+	rt.clock = func() uint64 { return fakeClock }
+
+	liveKey := testKey(t)
+	staleKey := RuleKey{Proto: 17, VPort: 53, VIP: mustAddr(t, "2001:db8:1::11")}
+
+	fakeClock = 100
+	if err := rt.Register(liveKey, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register liveKey: %v", err)
+	}
+	if err := rt.Register(staleKey, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register staleKey: %v", err)
+	}
+
+	// The cutoff snapshot is taken strictly after both entries were
+	// written (generation 100 < cutoff 150), matching the real ordering
+	// contract: capture Generation() immediately before listing the live
+	// NetworkRule CRDs, i.e. after whatever already-registered state
+	// exists, not before it.
+	fakeClock = 150
+	cutoff := rt.Generation()
+	fakeClock = 200
+
+	removed, err := rt.Reconcile(map[RuleKey]struct{}{liveKey: {}}, cutoff)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(removed) != 1 || removed[0].RuleKey != staleKey {
+		t.Errorf("Reconcile removed = %+v, want exactly [staleKey]", removed)
+	}
+	if _, ok, _ := rt.Get(liveKey); !ok {
+		t.Error("Reconcile removed the live entry")
+	}
+	if _, ok, _ := rt.Get(staleKey); ok {
+		t.Error("Reconcile left the stale entry in place")
+	}
+}
+
+// TestRuleTable_ReconcileSparesRecentGeneration covers the crash-safety
+// case doc.go describes: an entry written *after* the caller's live
+// snapshot's cutoff must survive even though it's absent from live --
+// deleting it would race a fresh Register that just hasn't made it into
+// the caller's live set yet.
+func TestRuleTable_ReconcileSparesRecentGeneration(t *testing.T) {
+	var fakeClock uint64
+	rt := NewRuleTable(newFakeTable())
+	rt.clock = func() uint64 { return fakeClock }
+
+	cutoff := rt.Generation() // 0
+
+	fakeClock = 50 // written AFTER the cutoff snapshot was taken
+	recentKey := testKey(t)
+	if err := rt.Register(recentKey, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	removed, err := rt.Reconcile(map[RuleKey]struct{}{}, cutoff)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("Reconcile removed = %+v, want none (generation %d >= cutoff %d)", removed, fakeClock, cutoff)
+	}
+	if _, ok, _ := rt.Get(recentKey); !ok {
+		t.Error("Reconcile removed a recently-written entry it should have spared")
+	}
+}
+
+func TestRuleTable_RegisterOverwritesExistingKey(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	key := testKey(t)
+	b1 := testBackend(t)
+	b2 := Backend{Addr: mustAddr(t, "fd00:10:1::99"), Port: 9999, USID: mustAddr(t, "2001:db8:2::2")}
+
+	if err := rt.Register(key, []Backend{b1}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := rt.Register(key, []Backend{b2}); err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+
+	got, ok, err := rt.Get(key)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if len(got.Backends) != 1 || got.Backends[0] != b2 {
+		t.Errorf("Get after overwrite: backends = %+v, want [%+v]", got.Backends, b2)
+	}
+}
+
+// TestRuleTable_RegisterPreservesHitCounters verifies Register's
+// read-modify-write behavior (Phase E): re-registering an existing key
+// (e.g. every controller reconcile pass, per Engine.Reconcile's "apply
+// everything in desired" convention) must not zero the datapath-maintained
+// Packets/Bytes/DroppedPackets/LastSeenNs counters, only Backends/
+// Generation.
+func TestRuleTable_RegisterPreservesHitCounters(t *testing.T) {
+	table := newFakeTable()
+	rt := NewRuleTable(table)
+	key := testKey(t)
+
+	if err := rt.Register(key, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+
+	// Simulate the datapath having handled traffic between reconciles by
+	// writing counters directly into the fake table's backing map, the
+	// same way edgenat.c's __sync_fetch_and_add calls would in the real
+	// kernel map.
+	wireKey, err := toWireKey(key)
+	if err != nil {
+		t.Fatalf("toWireKey: %v", err)
+	}
+	entry := table.entries[wireKey]
+	entry.Packets = 42
+	entry.Bytes = 4096
+	entry.DroppedPackets = 3
+	entry.LastSeenNs = 123456789
+	table.entries[wireKey] = entry
+
+	// Re-register with a different backend, exactly as a later
+	// convergence pass would (e.g. a backend Pod rescheduled).
+	b2 := Backend{Addr: mustAddr(t, "fd00:10:1::99"), Port: 9999, USID: mustAddr(t, "2001:db8:2::2")}
+	if err := rt.Register(key, []Backend{b2}); err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+
+	got, ok, err := rt.Get(key)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.Packets != 42 {
+		t.Errorf("Packets after re-register = %d, want 42 (preserved)", got.Packets)
+	}
+	if got.Bytes != 4096 {
+		t.Errorf("Bytes after re-register = %d, want 4096 (preserved)", got.Bytes)
+	}
+	if got.DroppedPackets != 3 {
+		t.Errorf("DroppedPackets after re-register = %d, want 3 (preserved)", got.DroppedPackets)
+	}
+	if got.LastSeenNs != 123456789 {
+		t.Errorf("LastSeenNs after re-register = %d, want 123456789 (preserved)", got.LastSeenNs)
+	}
+	if len(got.Backends) != 1 || got.Backends[0] != b2 {
+		t.Errorf("Backends after re-register = %+v, want [%+v] (updated)", got.Backends, b2)
+	}
+}
+
+// TestRuleTable_RegisterOnFreshKeyStartsCountersAtZero verifies a brand
+// new key's counters start at zero, not garbage from an unrelated
+// previous lookup failure.
+func TestRuleTable_RegisterOnFreshKeyStartsCountersAtZero(t *testing.T) {
+	rt := NewRuleTable(newFakeTable())
+	key := testKey(t)
+
+	if err := rt.Register(key, []Backend{testBackend(t)}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got, ok, err := rt.Get(key)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.Packets != 0 || got.Bytes != 0 || got.DroppedPackets != 0 || got.LastSeenNs != 0 {
+		t.Errorf("fresh key counters = %+v, want all zero", got)
+	}
+}
+
+func TestBeU16_IsItsOwnInverse(t *testing.T) {
+	for _, v := range []uint16{0, 1, 443, 8443, 65535} {
+		if got := beU16(beU16(v)); got != v {
+			t.Errorf("beU16(beU16(%d)) = %d, want %d", v, got, v)
+		}
+	}
+}
+
+func TestFakeTable_LookupMissingReturnsErrKeyNotExist(t *testing.T) {
+	f := newFakeTable()
+	var v edgeprog.EdgenatRuleValue
+	err := f.Lookup(edgeprog.EdgenatRuleKey{}, &v)
+	if !errors.Is(err, ebpf.ErrKeyNotExist) {
+		t.Errorf("Lookup on empty fakeTable: err = %v, want ebpf.ErrKeyNotExist", err)
+	}
+}

--- a/internal/plumbing/ebpf/edgemap/table.go
+++ b/internal/plumbing/ebpf/edgemap/table.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgemap
+
+import (
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+)
+
+// Table is the minimal map-operation surface every table type in this
+// package is written against, instead of directly against *ebpf.Map. Its
+// method set matches *ebpf.Map's own Put/Lookup/Delete/Iterate closely
+// enough that KernelTable (below) is a one-line adapter; this package's
+// own tests substitute a fake, in-memory implementation to exercise
+// register/unregister/reconcile logic without a kernel or root
+// privileges -- see internal/plumbing/ebpf/usidmap's identical Table
+// interface, which this one deliberately duplicates rather than imports
+// (see doc.go).
+type Table interface {
+	// Put creates or overwrites the map entry at key with value.
+	Put(key, value any) error
+
+	// Lookup reads the map entry at key into valueOut. It returns
+	// ebpf.ErrKeyNotExist (or, for a fake Table, an error satisfying
+	// errors.Is(err, ebpf.ErrKeyNotExist)) if key is absent.
+	Lookup(key, valueOut any) error
+
+	// Delete removes the map entry at key. It returns ebpf.ErrKeyNotExist
+	// (see Lookup) if key is already absent.
+	Delete(key any) error
+
+	// Iterate returns an Iterator walking every entry currently in the
+	// map, in unspecified order -- matching *ebpf.Map.Iterate's own
+	// documented behavior.
+	Iterate() Iterator
+}
+
+// Iterator matches *ebpf.MapIterator's own Next/Err method set.
+type Iterator interface {
+	// Next decodes the next key/value pair into keyOut/valueOut and
+	// reports whether one was available. Callers must check Err after
+	// Next returns false to distinguish "iteration finished" from "an
+	// error interrupted iteration."
+	Next(keyOut, valueOut any) bool
+
+	// Err returns the first error encountered during iteration, if any.
+	Err() error
+}
+
+// KernelTable adapts a real, loaded *ebpf.Map -- e.g.
+// edgeprog.EdgenatObjects.RuleTable, once loaded by
+// internal/plumbing/ebpf/edgeattach -- to the Table interface every table
+// type in this package is written against.
+type KernelTable struct {
+	Map *ebpf.Map
+}
+
+func (k KernelTable) Put(key, value any) error       { return k.Map.Put(key, value) }
+func (k KernelTable) Lookup(key, valueOut any) error { return k.Map.Lookup(key, valueOut) }
+func (k KernelTable) Delete(key any) error           { return k.Map.Delete(key) }
+func (k KernelTable) Iterate() Iterator              { return k.Map.Iterate() }
+
+// clockFn is a package-level override point so tests can control the
+// generation values Register/Generation observe deterministically, instead
+// of racing against a real, always-advancing clock. Production code always
+// leaves this at its default, monotonicNow -- same CLOCK_MONOTONIC choice,
+// for the same wall-clock-can-jump-backwards reason, as
+// internal/plumbing/ebpf/usidmap/table.go's identical function.
+var clockFn = monotonicNow
+
+func monotonicNow() uint64 {
+	var ts unix.Timespec
+	// A clock_gettime failure is left to fail toward "never reaped" (0 >=
+	// 0 in Reconcile's cutoff comparison) rather than toward misdelivery.
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/internal/plumbing/ebpf/edgemetrics/collector.go
+++ b/internal/plumbing/ebpf/edgemetrics/collector.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgemetrics
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+const namespace = "galactic_edgenat"
+
+// DropReasonsReader abstracts drop_reasons's per-CPU lookup (a
+// BPF_MAP_TYPE_PERCPU_ARRAY keyed by drop reason index) down to the one
+// operation Collector needs, so tests can substitute an in-memory fake
+// instead of a real, kernel-loaded map -- same interface shape as
+// internal/plumbing/ebpf/metrics's identical type. *ebpf.Map already
+// satisfies this interface structurally.
+type DropReasonsReader interface {
+	Lookup(key, valueOut any) error
+}
+
+// ConnCounter abstracts conn_table down to the one operation Collector
+// needs: counting live entries. Deliberately not edgemap.Table's full
+// interface -- Collector never needs Put/Lookup/Delete on conn_table,
+// only a live count for utilization reporting (per-flow labels would be
+// an unbounded-cardinality Prometheus anti-pattern; see collectConn's doc
+// comment).
+type ConnCounter interface {
+	Iterate() edgemap.Iterator
+}
+
+// Collector is a prometheus.Collector reading the edge gateway's live eBPF
+// map state at every scrape: per-rule hit counters from rule_table,
+// conn_table utilization, and drops by reason (package doc comment).
+type Collector struct {
+	ruleTable   *edgemap.RuleTable
+	connTable   ConnCounter
+	connMax     uint32
+	dropReasons DropReasonsReader
+}
+
+// NewCollector builds a Collector from already-constructed values, so
+// tests can pass fakes (a fake edgemap.Table wrapped in
+// edgemap.NewRuleTable, and any ConnCounter/DropReasonsReader) without a
+// kernel. Production callers normally use NewCollectorFromObjects.
+func NewCollector(
+	ruleTable *edgemap.RuleTable, connTable ConnCounter, connMax uint32, dropReasons DropReasonsReader,
+) *Collector {
+	return &Collector{ruleTable: ruleTable, connTable: connTable, connMax: connMax, dropReasons: dropReasons}
+}
+
+// NewCollectorFromObjects builds a Collector reading directly from a
+// loaded *edgeprog.EdgenatObjects's rule_table/conn_table/drop_reasons
+// maps -- e.g. the object internal/plumbing/ebpf/edgeattach.Load returns.
+func NewCollectorFromObjects(objs *edgeprog.EdgenatObjects) *Collector {
+	return NewCollector(
+		edgemap.NewRuleTable(edgemap.KernelTable{Map: objs.RuleTable}),
+		edgemap.KernelTable{Map: objs.ConnTable},
+		objs.ConnTable.MaxEntries(),
+		objs.DropReasons,
+	)
+}
+
+const (
+	labelProto = "proto"
+	labelPort  = "port"
+	labelVIP   = "vip"
+)
+
+var (
+	rulePacketsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "rule", "packets_total"),
+		"Packets that matched this rule_table entry's VIP+port+protocol, regardless of outcome, "+
+			"since it was last (re-)registered.",
+		[]string{labelProto, labelPort, labelVIP}, nil,
+	)
+	ruleBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "rule", "bytes_total"),
+		"Bytes that matched this rule_table entry's VIP+port+protocol, regardless of outcome, "+
+			"since it was last (re-)registered.",
+		[]string{labelProto, labelPort, labelVIP}, nil,
+	)
+	ruleDroppedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "rule", "dropped_packets_total"),
+		"Packets that matched this rule but were then dropped by the datapath (e.g. no backends, "+
+			"PAT-port exhaustion) -- a subset of rule_packets_total, not an additional count.",
+		[]string{labelProto, labelPort, labelVIP}, nil,
+	)
+	ruleBackendsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "rule", "backends"),
+		"Current number of load-balancing backends registered for this rule.",
+		[]string{labelProto, labelPort, labelVIP}, nil,
+	)
+	ruleSecondsSinceLastPacketDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "rule", "seconds_since_last_packet"),
+		"Seconds since the most recent packet matched this rule, per rule_table's LastSeenNs "+
+			"(CLOCK_MONOTONIC). Absent for a rule that has never seen a matching packet.",
+		[]string{labelProto, labelPort, labelVIP}, nil,
+	)
+	dropsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "drops_total"),
+		"Packets dropped by the edge_nat program, by reason (drop_reasons map).",
+		[]string{"reason"}, nil,
+	)
+	connTableEntriesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "conn_table", "entries"),
+		"Current number of live conn_table entries (both forward and reverse rows).",
+		nil, nil,
+	)
+	connTableUtilizationDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "conn_table", "utilization_ratio"),
+		"galactic_edgenat_conn_table_entries divided by conn_table's configured capacity -- "+
+			"an exhaustion-alerting input; conn_table is BPF_MAP_TYPE_LRU_HASH, so exhaustion causes "+
+			"self-eviction of the least-recently-used flow rather than a hard failure, but sustained "+
+			"high utilization still means shorter flow lifetimes than intended.",
+		nil, nil,
+	)
+)
+
+// Describe implements prometheus.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- rulePacketsDesc
+	ch <- ruleBytesDesc
+	ch <- ruleDroppedDesc
+	ch <- ruleBackendsDesc
+	ch <- ruleSecondsSinceLastPacketDesc
+	ch <- dropsDesc
+	ch <- connTableEntriesDesc
+	ch <- connTableUtilizationDesc
+}
+
+// Collect implements prometheus.Collector.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.collectRules(ch)
+	c.collectDrops(ch)
+	c.collectConn(ch)
+}
+
+// protoLabel renders a rule_key.proto value as a metric label -- the
+// IANA-numeric value's name where this package knows it (tcp/udp, the
+// only two protocols NetworkRuleSpec.Protocol accepts), the raw number
+// otherwise, so an unrecognized value is still visible rather than
+// silently dropped.
+func protoLabel(proto uint8) string {
+	switch proto {
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	default:
+		return strconv.Itoa(int(proto))
+	}
+}
+
+func (c *Collector) collectRules(ch chan<- prometheus.Metric) {
+	entries, err := c.ruleTable.List()
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(rulePacketsDesc, fmt.Errorf("list rule_table: %w", err))
+		return
+	}
+
+	now := c.ruleTable.Generation() // same CLOCK_MONOTONIC domain as LastSeenNs
+	for _, e := range entries {
+		proto := protoLabel(e.Proto)
+		port := strconv.Itoa(int(e.VPort))
+		vip := e.VIP.String()
+
+		ch <- prometheus.MustNewConstMetric(rulePacketsDesc, prometheus.CounterValue, float64(e.Packets), proto, port, vip)
+		ch <- prometheus.MustNewConstMetric(ruleBytesDesc, prometheus.CounterValue, float64(e.Bytes), proto, port, vip)
+		ch <- prometheus.MustNewConstMetric(
+			ruleDroppedDesc, prometheus.CounterValue, float64(e.DroppedPackets), proto, port, vip)
+		ch <- prometheus.MustNewConstMetric(
+			ruleBackendsDesc, prometheus.GaugeValue, float64(len(e.Backends)), proto, port, vip)
+		if e.LastSeenNs != 0 && now >= e.LastSeenNs {
+			secondsSince := float64(now-e.LastSeenNs) / 1e9
+			ch <- prometheus.MustNewConstMetric(
+				ruleSecondsSinceLastPacketDesc, prometheus.GaugeValue, secondsSince, proto, port, vip)
+		}
+	}
+}
+
+func (c *Collector) collectDrops(ch chan<- prometheus.Metric) {
+	if c.dropReasons == nil {
+		return
+	}
+	for i := range edgeprog.DropReasonCount {
+		var perCPU []uint64
+		if err := c.dropReasons.Lookup(i, &perCPU); err != nil {
+			ch <- prometheus.NewInvalidMetric(dropsDesc, fmt.Errorf("lookup drop_reasons[%d]: %w", i, err))
+			continue
+		}
+		var total uint64
+		for _, v := range perCPU {
+			total += v
+		}
+		name := edgeprog.DropReasonNames[i]
+		if name == "" {
+			name = fmt.Sprintf("unknown_%d", i)
+		}
+		ch <- prometheus.MustNewConstMetric(dropsDesc, prometheus.CounterValue, float64(total), name)
+	}
+}
+
+// collectConn reports only an aggregate live entry count and utilization
+// ratio, never a per-entry metric: conn_table's key is a client-facing
+// 5-tuple, so a per-entry label set would mean one Prometheus series per
+// active connection -- unbounded cardinality driven directly by end-user
+// traffic, exactly the anti-pattern Prometheus's own labeling best
+// practices warn against. The aggregate count is still directly useful
+// for exhaustion alerting (connTableUtilizationDesc's doc comment).
+func (c *Collector) collectConn(ch chan<- prometheus.Metric) {
+	if c.connTable == nil {
+		return
+	}
+	var (
+		count  uint64
+		rawKey edgeprog.EdgenatConnKey
+		value  edgeprog.EdgenatConnValue
+	)
+	it := c.connTable.Iterate()
+	for it.Next(&rawKey, &value) {
+		count++
+	}
+	if err := it.Err(); err != nil {
+		ch <- prometheus.NewInvalidMetric(connTableEntriesDesc, fmt.Errorf("iterate conn_table: %w", err))
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(connTableEntriesDesc, prometheus.GaugeValue, float64(count))
+	if c.connMax > 0 {
+		ch <- prometheus.MustNewConstMetric(
+			connTableUtilizationDesc, prometheus.GaugeValue, float64(count)/float64(c.connMax))
+	}
+}

--- a/internal/plumbing/ebpf/edgemetrics/collector_test.go
+++ b/internal/plumbing/ebpf/edgemetrics/collector_test.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgemetrics
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// fakeRuleTable is an in-memory edgemap.Table, the same technique
+// internal/plumbing/ebpf/edgemap/ruletable_test.go's identical fake uses
+// (unexported there, so not reusable across package boundaries --
+// reimplemented here rather than promoted, to keep that package's own
+// test surface unchanged; same convention
+// internal/plumbing/ebpf/metrics/faketable_test.go documents for its own
+// duplicate).
+type fakeRuleTable struct {
+	entries map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue
+}
+
+func newFakeRuleTable() *fakeRuleTable {
+	return &fakeRuleTable{entries: make(map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue)}
+}
+
+func (f *fakeRuleTable) Put(key, value any) error {
+	f.entries[key.(edgeprog.EdgenatRuleKey)] = value.(edgeprog.EdgenatRuleValue)
+	return nil
+}
+
+func (f *fakeRuleTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key.(edgeprog.EdgenatRuleKey)]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	*valueOut.(*edgeprog.EdgenatRuleValue) = v
+	return nil
+}
+
+func (f *fakeRuleTable) Delete(key any) error {
+	k := key.(edgeprog.EdgenatRuleKey)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	return nil
+}
+
+func (f *fakeRuleTable) Iterate() edgemap.Iterator {
+	keys := make([]edgeprog.EdgenatRuleKey, 0, len(f.entries))
+	for k := range f.entries {
+		keys = append(keys, k)
+	}
+	return &fakeRuleIterator{table: f, keys: keys}
+}
+
+type fakeRuleIterator struct {
+	table *fakeRuleTable
+	keys  []edgeprog.EdgenatRuleKey
+	i     int
+}
+
+func (it *fakeRuleIterator) Next(keyOut, valueOut any) bool {
+	if it.i >= len(it.keys) {
+		return false
+	}
+	k := it.keys[it.i]
+	it.i++
+	*keyOut.(*edgeprog.EdgenatRuleKey) = k
+	*valueOut.(*edgeprog.EdgenatRuleValue) = it.table.entries[k]
+	return true
+}
+
+func (it *fakeRuleIterator) Err() error { return nil }
+
+var _ edgemap.Table = (*fakeRuleTable)(nil)
+
+// fakeConnTable is an in-memory ConnCounter for tests -- Collector only
+// ever needs to count entries, so this just yields count zero-value rows.
+type fakeConnTable struct {
+	count int
+}
+
+func (f fakeConnTable) Iterate() edgemap.Iterator {
+	return &fakeConnIterator{remaining: f.count}
+}
+
+type fakeConnIterator struct {
+	remaining int
+}
+
+func (it *fakeConnIterator) Next(keyOut, valueOut any) bool {
+	if it.remaining <= 0 {
+		return false
+	}
+	it.remaining--
+	*keyOut.(*edgeprog.EdgenatConnKey) = edgeprog.EdgenatConnKey{}
+	*valueOut.(*edgeprog.EdgenatConnValue) = edgeprog.EdgenatConnValue{}
+	return true
+}
+
+func (it *fakeConnIterator) Err() error { return nil }
+
+var _ ConnCounter = fakeConnTable{}
+
+// fakeDropReasons is an in-memory DropReasonsReader for tests -- same
+// shape as internal/plumbing/ebpf/metrics's identical fake.
+type fakeDropReasons map[uint32]uint64
+
+func (f fakeDropReasons) Lookup(key, valueOut any) error {
+	k := key.(uint32)
+	out := valueOut.(*[]uint64)
+	*out = []uint64{f[k]}
+	return nil
+}
+
+var _ DropReasonsReader = fakeDropReasons{}
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("netip.ParseAddr(%q): %v", s, err)
+	}
+	return a
+}
+
+// collectedMetric pairs a prometheus.Metric with its decoded protobuf
+// form, so tests can filter by Desc() identity (distinguishing e.g.
+// rulePacketsDesc from ruleBytesDesc even though both share the same
+// label set) and then assert on the decoded value/labels.
+type collectedMetric struct {
+	desc *prometheus.Desc
+	pb   *dto.Metric
+}
+
+// collect runs c's Collect method to completion and returns every emitted
+// metric, decoded to its protobuf form alongside its Desc -- extends
+// internal/plumbing/ebpf/metrics/collector_test.go's identical helper
+// (which returns only the decoded form) with the Desc, since this
+// package's per-rule metrics all share one label set (proto/port/vip)
+// across five different Descs, unlike usid's Collector where every Desc
+// carries visibly different values in these tests.
+func collect(t *testing.T, c prometheus.Collector) []collectedMetric {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 256)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	var out []collectedMetric
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		out = append(out, collectedMetric{desc: m.Desc(), pb: &pb})
+	}
+	return out
+}
+
+func labelValue(m *dto.Metric, name string) string {
+	for _, lp := range m.GetLabel() {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func metricValue(m *dto.Metric) float64 {
+	switch {
+	case m.Counter != nil:
+		return m.Counter.GetValue()
+	case m.Gauge != nil:
+		return m.Gauge.GetValue()
+	default:
+		return 0
+	}
+}
+
+// findMetric returns the single metric matching desc and, if labelName is
+// non-empty, carrying labelVal for labelName. Fails the test if none or
+// more than one match, so a broken disambiguation never silently passes.
+func findMetric(
+	t *testing.T, metrics []collectedMetric, desc *prometheus.Desc, labelName, labelVal string,
+) *dto.Metric {
+	t.Helper()
+	var found *dto.Metric
+	for _, m := range metrics {
+		if m.desc != desc {
+			continue
+		}
+		if labelName != "" && labelValue(m.pb, labelName) != labelVal {
+			continue
+		}
+		if found != nil {
+			t.Fatalf("multiple metrics matched desc %v with %s=%q", desc, labelName, labelVal)
+		}
+		found = m.pb
+	}
+	if found == nil {
+		t.Fatalf("no metric found matching desc %v with %s=%q", desc, labelName, labelVal)
+	}
+	return found
+}
+
+func TestCollector_CollectsRuleCounters(t *testing.T) {
+	table := newFakeRuleTable()
+	rt := edgemap.NewRuleTable(table)
+	key := edgemap.RuleKey{Proto: 6, VPort: 443, VIP: mustAddr(t, "2001:db8:1::10")}
+	backend := edgemap.Backend{
+		Addr: mustAddr(t, "fd00:10:1::20"),
+		Port: 8443,
+		USID: mustAddr(t, "2001:db8:2::1"),
+	}
+	if err := rt.Register(key, []edgemap.Backend{backend}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Simulate datapath-accumulated counters directly on the fake's
+	// backing map, the way edgenat.c's __sync_fetch_and_add calls would
+	// in the real kernel map. LastSeenNs is set behind "now" (the fake
+	// table's own clock, read via rt.Generation() below) by exactly 5s.
+	now := rt.Generation()
+	for k, v := range table.entries {
+		v.Packets = 10
+		v.Bytes = 2000
+		v.DroppedPackets = 1
+		v.LastSeenNs = now - 5_000_000_000
+		table.entries[k] = v
+	}
+
+	c := NewCollector(rt, fakeConnTable{count: 3}, 100, fakeDropReasons{})
+	metrics := collect(t, c)
+
+	packets := findMetric(t, metrics, rulePacketsDesc, "vip", "2001:db8:1::10")
+	if got := metricValue(packets); got != 10 {
+		t.Errorf("rule_packets_total = %v, want 10", got)
+	}
+	if got := labelValue(packets, "proto"); got != "tcp" {
+		t.Errorf("proto label = %q, want tcp", got)
+	}
+	if got := labelValue(packets, "port"); got != "443" {
+		t.Errorf("port label = %q, want 443", got)
+	}
+
+	bytes := findMetric(t, metrics, ruleBytesDesc, "vip", "2001:db8:1::10")
+	if got := metricValue(bytes); got != 2000 {
+		t.Errorf("rule_bytes_total = %v, want 2000", got)
+	}
+
+	dropped := findMetric(t, metrics, ruleDroppedDesc, "vip", "2001:db8:1::10")
+	if got := metricValue(dropped); got != 1 {
+		t.Errorf("rule_dropped_packets_total = %v, want 1", got)
+	}
+
+	backends := findMetric(t, metrics, ruleBackendsDesc, "vip", "2001:db8:1::10")
+	if got := metricValue(backends); got != 1 {
+		t.Errorf("rule_backends = %v, want 1", got)
+	}
+
+	staleness := findMetric(t, metrics, ruleSecondsSinceLastPacketDesc, "vip", "2001:db8:1::10")
+	if got := metricValue(staleness); got < 4.9 || got > 5.1 {
+		t.Errorf("rule_seconds_since_last_packet = %v, want ~5", got)
+	}
+}
+
+func TestCollector_OmitsSecondsSinceLastPacketWhenNeverSeen(t *testing.T) {
+	table := newFakeRuleTable()
+	rt := edgemap.NewRuleTable(table)
+	key := edgemap.RuleKey{Proto: 6, VPort: 443, VIP: mustAddr(t, "2001:db8:1::10")}
+	if err := rt.Register(key, []edgemap.Backend{{
+		Addr: mustAddr(t, "fd00:10:1::20"), Port: 8443, USID: mustAddr(t, "2001:db8:2::1"),
+	}}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	c := NewCollector(rt, fakeConnTable{count: 0}, 100, fakeDropReasons{})
+	metrics := collect(t, c)
+
+	// 4 metrics per rule (packets/bytes/dropped/backends) when
+	// LastSeenNs == 0, not 5 -- the staleness gauge must be absent.
+	count := 0
+	for _, m := range metrics {
+		if labelValue(m.pb, "vip") == "2001:db8:1::10" {
+			count++
+		}
+	}
+	if count != 4 {
+		t.Errorf("metrics with vip label = %d, want 4 (staleness gauge must be omitted when never seen)", count)
+	}
+}
+
+func TestCollector_CollectsDropsByReason(t *testing.T) {
+	drops := fakeDropReasons{
+		edgeprog.DropReasonNoBackends:   3,
+		edgeprog.DropReasonPATExhausted: 7,
+	}
+	c := NewCollector(edgemap.NewRuleTable(newFakeRuleTable()), fakeConnTable{}, 100, drops)
+	metrics := collect(t, c)
+
+	noBackends := findMetric(t, metrics, dropsDesc, "reason", "no_backends")
+	if got := metricValue(noBackends); got != 3 {
+		t.Errorf("drops_total{reason=no_backends} = %v, want 3", got)
+	}
+	patExhausted := findMetric(t, metrics, dropsDesc, "reason", "pat_exhausted")
+	if got := metricValue(patExhausted); got != 7 {
+		t.Errorf("drops_total{reason=pat_exhausted} = %v, want 7", got)
+	}
+}
+
+func TestCollector_ConnTableEntriesAndUtilization(t *testing.T) {
+	c := NewCollector(edgemap.NewRuleTable(newFakeRuleTable()), fakeConnTable{count: 25}, 100, fakeDropReasons{})
+	metrics := collect(t, c)
+
+	entries := findMetric(t, metrics, connTableEntriesDesc, "", "")
+	if got := metricValue(entries); got != 25 {
+		t.Errorf("conn_table_entries = %v, want 25", got)
+	}
+
+	util := findMetric(t, metrics, connTableUtilizationDesc, "", "")
+	if got := metricValue(util); got != 0.25 {
+		t.Errorf("conn_table_utilization_ratio = %v, want 0.25 (25/100)", got)
+	}
+}
+
+// TestCollector_ZeroConnMaxOmitsUtilization verifies connMax == 0 (e.g. a
+// caller that never set it) skips the utilization gauge entirely rather
+// than emitting a divide-by-zero NaN/Inf series -- conn_table_entries
+// itself is still reported.
+func TestCollector_ZeroConnMaxOmitsUtilization(t *testing.T) {
+	c := NewCollector(edgemap.NewRuleTable(newFakeRuleTable()), fakeConnTable{count: 5}, 0, fakeDropReasons{})
+	metrics := collect(t, c)
+
+	entries := findMetric(t, metrics, connTableEntriesDesc, "", "")
+	if got := metricValue(entries); got != 5 {
+		t.Errorf("conn_table_entries = %v, want 5", got)
+	}
+
+	for _, m := range metrics {
+		if m.desc == connTableUtilizationDesc {
+			t.Errorf("conn_table_utilization_ratio must be entirely absent when connMax is 0, got %v",
+				metricValue(m.pb))
+		}
+	}
+}

--- a/internal/plumbing/ebpf/edgemetrics/doc.go
+++ b/internal/plumbing/ebpf/edgemetrics/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package edgemetrics implements the edge XDP NAT+LB gateway's Prometheus
+// instrumentation (design plan Phase E), following the same split
+// internal/plumbing/ebpf/metrics already established for the SRv6 uSID
+// datapath:
+//
+//   - Per-rule hit counters (Packets/Bytes/DroppedPackets, current
+//     backend count) and aggregate drop/conn_table-utilization state are
+//     all *state currently held in a BPF map* -- rule_table, conn_table,
+//     drop_reasons. Collector (collector.go) reads these live, directly
+//     from the map, at every Prometheus scrape via a custom
+//     prometheus.Collector, rather than mirroring them into
+//     incrementally-Set() Gauges: a rule_table entry
+//     internal/gateway.Engine.ReconcileOrphans removes simply stops being
+//     emitted on the *next* scrape this way, instead of leaking a stale
+//     label combination forever (a Gauge/GaugeVec has no way to "expire" a
+//     label combination on its own; only a Collector that re-derives its
+//     label set from the live source of truth at every Collect() call
+//     gets that for free).
+//   - Which gateway node is primary/secondary for a rule, and rule
+//     applications rejected before ever reaching the datapath (e.g.
+//     QuotaEnforcer denials), are control-plane-only facts with no BPF
+//     map to read them back from -- those are
+//     internal/gateway.PrometheusTelemetryEmitter's ordinary
+//     GaugeVec/CounterVec, incremented in place at Engine's own call
+//     sites, not this package's concern.
+package edgemetrics

--- a/internal/plumbing/ebpf/edgepreflight/kernel_prober.go
+++ b/internal/plumbing/ebpf/edgepreflight/kernel_prober.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgepreflight
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/rlimit"
+)
+
+// bpfFuncXDPAdjustHead and bpfFuncCsumDiff are the raw BPF_FUNC_* helper IDs
+// from the kernel UAPI's enum bpf_func_id (include/uapi/linux/bpf.h). These
+// numeric IDs are stable ABI once a helper is introduced -- unlike
+// preflight's tbid check, no BTF struct-field probe is possible for "does
+// this helper exist," so features.HaveProgramHelper (the same
+// creation-attempt technique preflight's own SchedCLS/HashMap checks use,
+// just applied to a specific helper rather than a program/map type) is the
+// house convention here instead of a version-string heuristic.
+//
+// github.com/cilium/ebpf v0.22.0's asm package does not export named
+// constants for every helper (BuiltinFunc constants are resolved per
+// platform via BuiltinFuncForPlatform for helpers the library hasn't
+// special-cased) -- these two are cited directly against the raw enum
+// values confirmed empirically on this repo's target kernel
+// (7.1.3-200.fc44.x86_64) during this design's Phase 0 spike.
+const (
+	bpfFuncXDPAdjustHead asm.BuiltinFunc = 44
+	bpfFuncCsumDiff      asm.BuiltinFunc = 28
+)
+
+// KernelProber is the real, kernel-backed [Prober] implementation used in
+// production. It probes the actual running kernel via
+// github.com/cilium/ebpf's features package (which detects support by
+// actually attempting the create/load syscall) and via kernel BTF
+// introspection for BTF presence.
+//
+// The zero value is not ready to use; construct with [NewKernelProber]. A
+// *KernelProber may be reused across multiple Check/CheckWith calls -- its
+// one piece of internal state (the loaded kernel BTF spec) is cached after
+// the first probe that needs it.
+type KernelProber struct {
+	specOnce sync.Once
+	spec     *btf.Spec
+	specErr  error
+}
+
+// NewKernelProber returns a ready-to-use [KernelProber].
+func NewKernelProber() *KernelProber {
+	return &KernelProber{}
+}
+
+// XDP implements [Prober] by attempting to create a minimal
+// BPF_PROG_TYPE_XDP program and reporting whether the kernel accepted the
+// program type.
+func (k *KernelProber) XDP() error {
+	if err := ensureMemlockRemoved(); err != nil {
+		return err
+	}
+	if err := features.HaveProgramType(ebpf.XDP); err != nil {
+		return fmt.Errorf("kernel rejects BPF_PROG_TYPE_XDP: %w", err)
+	}
+	return nil
+}
+
+// HashMap implements [Prober] by attempting to create a minimal
+// BPF_MAP_TYPE_HASH map.
+func (k *KernelProber) HashMap() error {
+	if err := ensureMemlockRemoved(); err != nil {
+		return err
+	}
+	if err := features.HaveMapType(ebpf.Hash); err != nil {
+		return fmt.Errorf("kernel rejects BPF_MAP_TYPE_HASH: %w", err)
+	}
+	return nil
+}
+
+// LRUHashMap implements [Prober] by attempting to create a minimal
+// BPF_MAP_TYPE_LRU_HASH map.
+func (k *KernelProber) LRUHashMap() error {
+	if err := ensureMemlockRemoved(); err != nil {
+		return err
+	}
+	if err := features.HaveMapType(ebpf.LRUHash); err != nil {
+		return fmt.Errorf("kernel rejects BPF_MAP_TYPE_LRU_HASH: %w", err)
+	}
+	return nil
+}
+
+// BTF implements [Prober] by attempting to load the running kernel's own
+// BTF (typically /sys/kernel/btf/vmlinux).
+func (k *KernelProber) BTF() error {
+	if _, err := k.kernelSpec(); err != nil {
+		return fmt.Errorf("kernel BTF unavailable: %w", err)
+	}
+	return nil
+}
+
+// XDPAdjustHead implements [Prober] by attempting to load a minimal XDP
+// program that calls bpf_xdp_adjust_head.
+func (k *KernelProber) XDPAdjustHead() error {
+	if err := ensureMemlockRemoved(); err != nil {
+		return err
+	}
+	if err := features.HaveProgramHelper(ebpf.XDP, bpfFuncXDPAdjustHead); err != nil {
+		return fmt.Errorf("kernel's XDP programs reject bpf_xdp_adjust_head: %w", err)
+	}
+	return nil
+}
+
+// XDPCsumDiff implements [Prober] by attempting to load a minimal XDP
+// program that calls bpf_csum_diff.
+func (k *KernelProber) XDPCsumDiff() error {
+	if err := ensureMemlockRemoved(); err != nil {
+		return err
+	}
+	if err := features.HaveProgramHelper(ebpf.XDP, bpfFuncCsumDiff); err != nil {
+		return fmt.Errorf("kernel's XDP programs reject bpf_csum_diff: %w", err)
+	}
+	return nil
+}
+
+// kernelSpec loads and caches the running kernel's BTF spec, parsing it at
+// most once per *KernelProber.
+func (k *KernelProber) kernelSpec() (*btf.Spec, error) {
+	k.specOnce.Do(func() {
+		k.spec, k.specErr = btf.LoadKernelSpec()
+	})
+	return k.spec, k.specErr
+}
+
+// ensureMemlockRemoved lifts the memlock rlimit that older kernels enforce
+// against BPF map/program creation. Safe and cheap to call repeatedly.
+func ensureMemlockRemoved() error {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return fmt.Errorf("remove memlock rlimit: %w", err)
+	}
+	return nil
+}
+
+var _ Prober = (*KernelProber)(nil)

--- a/internal/plumbing/ebpf/edgepreflight/kernel_prober_test.go
+++ b/internal/plumbing/ebpf/edgepreflight/kernel_prober_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgepreflight
+
+import (
+	"os"
+	"testing"
+)
+
+// requireRoot skips the calling test unless running as root, matching
+// internal/plumbing/ebpf/preflight's own convention for tests that need
+// CAP_BPF to touch the real kernel.
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF) to probe real kernel capabilities; re-run via sudo")
+	}
+}
+
+// TestKernelProber_BTF exercises [KernelProber.BTF] against the real
+// running kernel.
+func TestKernelProber_BTF(t *testing.T) {
+	k := NewKernelProber()
+	if err := k.BTF(); err != nil {
+		t.Errorf("KernelProber.BTF() = %v, want nil (this sandbox is documented to have kernel BTF)", err)
+	}
+}
+
+// TestKernelProber_XDP exercises [KernelProber.XDP] against the real
+// running kernel. Requires root: creating even a throwaway
+// BPF_PROG_TYPE_XDP program needs CAP_BPF.
+func TestKernelProber_XDP(t *testing.T) {
+	requireRoot(t)
+	k := NewKernelProber()
+	if err := k.XDP(); err != nil {
+		t.Errorf("KernelProber.XDP() = %v, want nil", err)
+	}
+}
+
+// TestKernelProber_HashMap exercises [KernelProber.HashMap].
+func TestKernelProber_HashMap(t *testing.T) {
+	requireRoot(t)
+	k := NewKernelProber()
+	if err := k.HashMap(); err != nil {
+		t.Errorf("KernelProber.HashMap() = %v, want nil", err)
+	}
+}
+
+// TestKernelProber_LRUHashMap exercises [KernelProber.LRUHashMap].
+func TestKernelProber_LRUHashMap(t *testing.T) {
+	requireRoot(t)
+	k := NewKernelProber()
+	if err := k.LRUHashMap(); err != nil {
+		t.Errorf("KernelProber.LRUHashMap() = %v, want nil", err)
+	}
+}
+
+// TestKernelProber_XDPAdjustHead exercises [KernelProber.XDPAdjustHead]
+// against the real running kernel -- this is the same helper the Phase 0
+// spike confirmed by hand (compiling a minimal program and attaching it to
+// a live veth); this test confirms the same fact via the feature-probe path
+// the real preflight check uses.
+func TestKernelProber_XDPAdjustHead(t *testing.T) {
+	requireRoot(t)
+	k := NewKernelProber()
+	if err := k.XDPAdjustHead(); err != nil {
+		t.Errorf("KernelProber.XDPAdjustHead() = %v, want nil (confirmed working via a live spike on this kernel)", err)
+	}
+}
+
+// TestKernelProber_XDPCsumDiff exercises [KernelProber.XDPCsumDiff]
+// against the real running kernel.
+func TestKernelProber_XDPCsumDiff(t *testing.T) {
+	requireRoot(t)
+	k := NewKernelProber()
+	if err := k.XDPCsumDiff(); err != nil {
+		t.Errorf("KernelProber.XDPCsumDiff() = %v, want nil (confirmed working via a live spike on this kernel)", err)
+	}
+}
+
+// TestCheck_RealKernel runs the full, real Check() against this sandbox's
+// actual kernel -- the end-to-end exit criterion: report what the real
+// kernel supports, not an assumption.
+func TestCheck_RealKernel(t *testing.T) {
+	requireRoot(t)
+	err := Check()
+	t.Logf("Check() on this sandbox kernel: %v", err)
+	if err != nil {
+		t.Errorf("Check() = %v, want nil (every capability was individually confirmed present during Phase 0)", err)
+	}
+}

--- a/internal/plumbing/ebpf/edgepreflight/preflight.go
+++ b/internal/plumbing/ebpf/edgepreflight/preflight.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package edgepreflight implements the startup kernel-capability check for
+// internal/plumbing/ebpf/edgeprog's XDP ingress NAT+LB gateway datapath.
+//
+// This is a sibling of internal/plumbing/ebpf/preflight, not an extension
+// of it: that package's Prober interface is scoped specifically to the
+// SRv6 uSID TC-BPF datapath's own capability list (SCHED_CLS, plain
+// BPF_MAP_TYPE_HASH, bpf_fib_lookup's tbid parameter) and forcing every
+// caller of either datapath to satisfy the union of both lists would be
+// worse interface hygiene than two small, focused ones (CONVENTIONS.md:
+// "prefer creating a focused sub-package over adding to an existing large
+// one"). The two datapaths' checks are structurally identical (a Prober
+// interface + KernelProber + capabilityChecks + Check/CheckWith) but list
+// genuinely different capabilities:
+//
+//   - BPF_PROG_TYPE_XDP itself.
+//   - bpf_xdp_adjust_head -- edgenat.c grows the packet by 40 bytes on the
+//     forward/DNAT path (room for the pushed outer IPv6 header) and shrinks
+//     it back by 40 on the return/decap path. This helper has no
+//     __sk_buff-based equivalent usid.c's preflight needed to check for.
+//   - bpf_csum_diff -- edgenat.c's checksum fixups after mutating an
+//     address/port covered by the L4 pseudo-header. gwprog's earlier,
+//     rejected Geneve-based design used bpf_l4_csum_replace/
+//     bpf_l3_csum_replace instead, but those are __sk_buff-only helpers,
+//     unavailable to an XDP program's xdp_md context -- bpf_csum_diff is
+//     the XDP-safe replacement, and its availability is not implied by
+//     BPF_PROG_TYPE_XDP support alone.
+//   - BPF_MAP_TYPE_LRU_HASH -- conn_table is this type (self-evicting
+//     under pressure, matching gwprog's own conn_table convention); rule_table
+//     is plain BPF_MAP_TYPE_HASH, already covered by preflight's HashMap
+//     check conceptually but probed again here independently so this
+//     package has no runtime dependency on the other one.
+//   - Kernel BTF, for the same CO-RE-adjacent reason usid.c's preflight
+//     requires it: edgenat.c is compiled with -g and bpf2go's generated
+//     Go bindings for rule_value/conn_value/backend depend on the running
+//     kernel accepting BTF-annotated map value types.
+//
+// Deliberately NOT checked here: whether a specific interface's driver
+// supports *native* (driver-mode) XDP attach, as opposed to generic
+// (SKB-mode) attach. That is a per-interface, per-driver property (the
+// design's own spike found the geneve driver lacks it entirely, while a
+// veth or a real NIC's driver normally has it) -- it cannot be answered in
+// the abstract the way "does this kernel support BPF_PROG_TYPE_XDP at all"
+// can, so it is checked at attach time, against the actual interface being
+// attached to, by internal/plumbing/ebpf/edgeattach, not here.
+//
+// Every check below follows preflight's own hard invariant: no partial
+// pass, and no unsafe/degraded fallback on failure -- a node missing any
+// one of these capabilities must not run the edge gateway datapath at all.
+package edgepreflight
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Prober is the kernel-capability probe interface this package's checks run
+// against. [NewKernelProber] returns the real, kernel-backed implementation
+// used in production; tests substitute a stubbed implementation to exercise
+// the pass case and each individual failure case in [CheckWith] without
+// touching the real kernel.
+type Prober interface {
+	// XDP reports whether the running kernel supports BPF_PROG_TYPE_XDP.
+	XDP() error
+
+	// LRUHashMap reports whether the running kernel supports
+	// BPF_MAP_TYPE_LRU_HASH (edgenat.c's conn_table).
+	LRUHashMap() error
+
+	// HashMap reports whether the running kernel supports
+	// BPF_MAP_TYPE_HASH (edgenat.c's rule_table).
+	HashMap() error
+
+	// BTF reports whether the running kernel exposes BTF type information,
+	// required for edgenat.c's bpf2go-generated map value types to load.
+	BTF() error
+
+	// XDPAdjustHead reports whether this kernel's XDP programs can call
+	// bpf_xdp_adjust_head -- required to grow/shrink the packet for the
+	// pushed/stripped outer SRv6 header.
+	XDPAdjustHead() error
+
+	// XDPCsumDiff reports whether this kernel's XDP programs can call
+	// bpf_csum_diff -- the XDP-safe checksum-fixup helper (unlike
+	// bpf_l4_csum_replace/bpf_l3_csum_replace, which require __sk_buff and
+	// are unavailable to an XDP program).
+	XDPCsumDiff() error
+}
+
+// capabilityCheck names one required capability, binds it to its probe
+// function, and carries a one-line "why this matters" note used to build
+// [CheckWith]'s aggregate error.
+type capabilityCheck struct {
+	name string
+	fn   func() error
+	why  string
+}
+
+func capabilityChecks(p Prober) []capabilityCheck {
+	return []capabilityCheck{
+		{
+			name: "BPF_PROG_TYPE_XDP",
+			fn:   p.XDP,
+			why:  "the edge gateway's ingress NAT+LB program attaches as an XDP program, not TC-BPF",
+		},
+		{
+			name: "BPF_MAP_TYPE_HASH",
+			fn:   p.HashMap,
+			why:  "rule_table (VIP+port -> backend) is BPF_MAP_TYPE_HASH",
+		},
+		{
+			name: "BPF_MAP_TYPE_LRU_HASH",
+			fn:   p.LRUHashMap,
+			why:  "conn_table is BPF_MAP_TYPE_LRU_HASH so it self-evicts under pressure instead of failing closed",
+		},
+		{
+			name: "kernel BTF",
+			fn:   p.BTF,
+			why:  "edgenat.c is compiled with -g and its generated map value types require kernel BTF to load",
+		},
+		{
+			name: "bpf_xdp_adjust_head",
+			fn:   p.XDPAdjustHead,
+			why: "the forward path grows the packet by 40 bytes for the pushed outer SRv6 header, and the " +
+				"return path shrinks it back by 40 to strip it",
+		},
+		{
+			name: "bpf_csum_diff",
+			fn:   p.XDPCsumDiff,
+			why: "checksum fixups after DNAT/SNAT must use this XDP-safe helper -- bpf_l4_csum_replace and " +
+				"bpf_l3_csum_replace require __sk_buff and are unavailable to an XDP program",
+		},
+	}
+}
+
+// Check runs every capability probe this datapath depends on against the
+// real running kernel (via [NewKernelProber]) and returns a clear,
+// actionable error if any is missing.
+func Check() error {
+	return CheckWith(NewKernelProber())
+}
+
+// CheckWith runs the same checks as [Check] against an arbitrary [Prober].
+// Every check always runs, even after an earlier one fails, so a caller
+// sees every missing capability at once. If nothing is missing, CheckWith
+// returns nil; otherwise it returns a single non-nil error (built with
+// [errors.Join]) describing every failure. There is no partial-pass return
+// value: callers must treat any non-nil error as "do not load the edge
+// gateway datapath on this node," never as a signal to fall back to a
+// degraded or unsafe mode.
+func CheckWith(p Prober) error {
+	checks := capabilityChecks(p)
+
+	var errs []error
+	for _, c := range checks {
+		if err := c.fn(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %s: %w", c.name, c.why, err))
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"edge gateway XDP datapath preflight check failed (%d/%d required kernel capabilities missing) -- "+
+			"refusing to load the datapath on this node; there is no partial or unsafe fallback: %w",
+		len(errs), len(checks), errors.Join(errs...),
+	)
+}

--- a/internal/plumbing/ebpf/edgepreflight/preflight_test.go
+++ b/internal/plumbing/ebpf/edgepreflight/preflight_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgepreflight
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubProber is a mocked/stubbed [Prober] letting the pass case and each
+// individual failure case be exercised without touching the real kernel.
+type stubProber struct {
+	xdp           error
+	lruHashMap    error
+	hashMap       error
+	btf           error
+	xdpAdjustHead error
+	xdpCsumDiff   error
+}
+
+func (s stubProber) XDP() error           { return s.xdp }
+func (s stubProber) LRUHashMap() error    { return s.lruHashMap }
+func (s stubProber) HashMap() error       { return s.hashMap }
+func (s stubProber) BTF() error           { return s.btf }
+func (s stubProber) XDPAdjustHead() error { return s.xdpAdjustHead }
+func (s stubProber) XDPCsumDiff() error   { return s.xdpCsumDiff }
+
+var _ Prober = stubProber{}
+
+// TestCheckWith_AllCapabilitiesPresent covers the pass case.
+func TestCheckWith_AllCapabilitiesPresent(t *testing.T) {
+	if err := CheckWith(stubProber{}); err != nil {
+		t.Fatalf("CheckWith() = %v, want nil", err)
+	}
+}
+
+// failureCase exercises one capability failing in isolation and asserts the
+// aggregate error wraps the underlying cause and names the capability.
+func failureCase(t *testing.T, name string, p Prober, want error) {
+	t.Helper()
+	err := CheckWith(p)
+	if err == nil {
+		t.Fatal("CheckWith() = nil, want an error")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("CheckWith() = %v, want it to wrap %v", err, want)
+	}
+	if !strings.Contains(err.Error(), name) {
+		t.Errorf("CheckWith() = %q, want it to name %q", err.Error(), name)
+	}
+}
+
+func TestCheckWith_XDPMissing(t *testing.T) {
+	want := errors.New("no XDP on this kernel")
+	failureCase(t, "BPF_PROG_TYPE_XDP", stubProber{xdp: want}, want)
+}
+
+func TestCheckWith_HashMapMissing(t *testing.T) {
+	want := errors.New("no BPF_MAP_TYPE_HASH on this kernel")
+	failureCase(t, "BPF_MAP_TYPE_HASH", stubProber{hashMap: want}, want)
+}
+
+func TestCheckWith_LRUHashMapMissing(t *testing.T) {
+	want := errors.New("no BPF_MAP_TYPE_LRU_HASH on this kernel")
+	failureCase(t, "BPF_MAP_TYPE_LRU_HASH", stubProber{lruHashMap: want}, want)
+}
+
+func TestCheckWith_BTFMissing(t *testing.T) {
+	want := errors.New("no BTF on this kernel")
+	failureCase(t, "kernel BTF", stubProber{btf: want}, want)
+}
+
+func TestCheckWith_XDPAdjustHeadMissing(t *testing.T) {
+	want := errors.New("no bpf_xdp_adjust_head on this kernel")
+	failureCase(t, "bpf_xdp_adjust_head", stubProber{xdpAdjustHead: want}, want)
+}
+
+func TestCheckWith_XDPCsumDiffMissing(t *testing.T) {
+	want := errors.New("no bpf_csum_diff on this kernel")
+	failureCase(t, "bpf_csum_diff", stubProber{xdpCsumDiff: want}, want)
+}
+
+// TestCheckWith_EveryCapabilityMissing covers every probe failing at once:
+// the aggregate error must name all six, and no early return may skip any.
+func TestCheckWith_EveryCapabilityMissing(t *testing.T) {
+	err := CheckWith(stubProber{
+		xdp:           errors.New("a"),
+		hashMap:       errors.New("b"),
+		lruHashMap:    errors.New("c"),
+		btf:           errors.New("d"),
+		xdpAdjustHead: errors.New("e"),
+		xdpCsumDiff:   errors.New("f"),
+	})
+	if err == nil {
+		t.Fatal("CheckWith() = nil, want an error")
+	}
+	for _, name := range []string{
+		"BPF_PROG_TYPE_XDP", "BPF_MAP_TYPE_HASH", "BPF_MAP_TYPE_LRU_HASH",
+		"kernel BTF", "bpf_xdp_adjust_head", "bpf_csum_diff",
+	} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("CheckWith() = %q, want it to name %q", err.Error(), name)
+		}
+	}
+	if !strings.Contains(err.Error(), "6/6") {
+		t.Errorf("CheckWith() = %q, want it to report 6/6 missing", err.Error())
+	}
+}

--- a/internal/plumbing/ebpf/edgeprog/doc.go
+++ b/internal/plumbing/ebpf/edgeprog/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package edgeprog holds the compiled XDP program that implements the edge
+// gateway's ingress Full-NAT (DNAT+SNAT) load-balancing and reverse un-NAT
+// datapath, plus a direct SRv6 uSID push/strip -- no Geneve overlay, no
+// separate gateway-tier decap step, no kernel VRF/FIB dependency for the
+// encap itself (see the design plan at
+// /home/sprygada/.claude/datum/plans/merry-percolating-tulip.md for the
+// full rationale versus the earlier, rejected gwprog/Geneve approach).
+//
+// edgenat.c is the single source of truth for the packet path; see its
+// header comment for the full walkthrough. `go generate` (via bpf2go,
+// github.com/cilium/ebpf's code generator) compiles it with clang into a
+// CO-RE-portable BPF object and generates matching Go bindings
+// (EdgenatObjects, LoadEdgenat, LoadEdgenatObjects, plus per-map/
+// per-program fields) in this package -- run `go generate ./...` from the
+// repo root, or `go generate` from this directory, after editing
+// edgenat.c.
+//
+// Same not-committed-generated-artifacts convention as
+// internal/plumbing/ebpf/prog (see that package's doc.go): *_bpfel.go/
+// *_bpfel.o and *_bpfeb.go/*_bpfeb.o are gitignored, regenerated fresh by
+// `task build:ebpf` at every build site.
+//
+// Placement: sibling of internal/plumbing/ebpf/prog under the shared
+// internal/plumbing/ebpf/ umbrella, kept as its own package rather than a
+// second program in prog itself -- this is a different datapath domain
+// (edge ingress NAT/LB vs. SRv6 uSID decap) with no shared map/key layout,
+// so folding it into prog would couple two things that change for
+// unrelated reasons (CONVENTIONS.md: "prefer creating a focused
+// sub-package over adding to an existing large one").
+//
+// This package does not itself load or attach the compiled program to any
+// interface -- that is internal/plumbing/ebpf/edgeattach's job, and
+// ultimately internal/gateway's KernelDatapath, which calls into
+// edgeattach/edgemap from Engine's convergence loop.
+package edgeprog
+
+// See internal/plumbing/ebpf/prog/doc.go for why -idirafter lists both
+// multiarch directories and why -cc is omitted (same clang/bpf2go
+// environment, same rationale, not repeated here).
+//
+// -Wno-address-of-packed-member suppresses a known clang false positive
+// for this file's l4_view.{sport,dport,check}_ptr fields: taking the
+// address of a __be16 member inside a packed struct warns generically
+// (packed structs can place a field at any byte offset), but every field
+// edgenat.c takes the address of sits at a compile-time-fixed *even*
+// offset (edge_tcphdr's source/dest/check are 0/2/16; edge_udphdr's are
+// 0/2/6) -- genuinely 2-byte aligned despite the struct's packed
+// attribute, so there is no real unaligned-access risk to suppress
+// unsafely here.
+//
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -Wno-address-of-packed-member -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type rule_key -type backend -type rule_value -type conn_key -type conn_value -type gw_config Edgenat edgenat.c

--- a/internal/plumbing/ebpf/edgeprog/dropreason.go
+++ b/internal/plumbing/ebpf/edgeprog/dropreason.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgeprog
+
+// Drop reason indices into the drop_reasons map (edgenat.c's `enum
+// edge_drop_reason`), exported for callers outside this package --
+// notably internal/plumbing/ebpf/edgemetrics's Prometheus collector
+// (Phase E), which needs a stable, human-readable label per index.
+// Hand-kept in sync with edgenat.c for the same reason
+// internal/plumbing/ebpf/prog's identical DropReason* constants are:
+// bpf2go's -type flag cannot generate a Go type for a C enum that is only
+// ever used as a literal constant, never as a typed variable/field the
+// compiler retains distinct BTF for.
+const (
+	DropReasonNoBackends       uint32 = 0
+	DropReasonNoConnNotSyn     uint32 = 1
+	DropReasonPATExhausted     uint32 = 2
+	DropReasonMalformedReturn  uint32 = 3
+	DropReasonNoReturnConn     uint32 = 4
+	DropReasonFibNoNeigh       uint32 = 5
+	DropReasonFibUnreachable   uint32 = 6
+	DropReasonFibFragNeeded    uint32 = 7
+	DropReasonFibLookupFailed  uint32 = 8
+	DropReasonAdjustHeadFailed uint32 = 9
+	DropReasonCount            uint32 = 10
+)
+
+// DropReasonNames maps each DropReason* index to a short, stable,
+// metrics/log-friendly name, decoupling Prometheus label values and any
+// other external representation from edgenat.c's C identifier spelling.
+var DropReasonNames = map[uint32]string{
+	DropReasonNoBackends:       "no_backends",
+	DropReasonNoConnNotSyn:     "no_conn_not_syn",
+	DropReasonPATExhausted:     "pat_exhausted",
+	DropReasonMalformedReturn:  "malformed_return",
+	DropReasonNoReturnConn:     "no_return_conn",
+	DropReasonFibNoNeigh:       "fib_no_neigh",
+	DropReasonFibUnreachable:   "fib_unreachable",
+	DropReasonFibFragNeeded:    "fib_frag_needed",
+	DropReasonFibLookupFailed:  "fib_lookup_failed",
+	DropReasonAdjustHeadFailed: "adjust_head_failed",
+}

--- a/internal/plumbing/ebpf/edgeprog/edgenat.c
+++ b/internal/plumbing/ebpf/edgeprog/edgenat.c
@@ -1,0 +1,910 @@
+//go:build ignore
+
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// edgenat.c implements the XDP ingress datapath for the edge gateway's
+// Full-NAT (DNAT+SNAT) load-balancing engine, IPv6-only, phase 1 scope
+// (plain TCP/UDP, no extension headers, deterministic FNV-1a-hash-of-flow
+// backend selection, no active conn_table GC -- conn_table is
+// BPF_MAP_TYPE_LRU_HASH, self-evicting under pressure, same convention
+// gwprog's earlier, rejected Geneve-based conn_table used).
+//
+// One program, one attach point per gateway node (the node's single
+// public/underlay-facing uplink interface -- there is no separate
+// "public" vs "fabric" NIC in this topology, and no Geneve device to demux
+// direction by ifindex the way the rejected gwprog design did). Direction
+// is decided by matching the packet's outer IPv6 destination against this
+// node's own configured gw_addr (gw_config_table), exactly the way
+// internal/plumbing/ebpf/prog/usid.c already decides "is this mine" by
+// locator match, just against a single address instead of a locator
+// block/function/argument hierarchy -- this program has no VRF concept at
+// all (see the design plan's decision #4: because the outer SRv6 header is
+// written directly from this program's own rule_table/conn_table, there is
+// no kernel VRF/FIB route this program depends on for the encap itself).
+//
+// Packet path:
+//
+//  1. Parse the outer Ethernet + IPv6 header (bounds-checked). Not IPv6,
+//     or too short to parse -- XDP_PASS (this program only ever claims
+//     traffic it can fully parse and match; anything else falls through
+//     to the normal kernel stack, e.g. BGP/SSH to the node itself).
+//
+//  2. RETURN/DECAP BRANCH: if the outer destination matches this node's
+//     own gw_addr (gw_config_table), this is a reply this node SNAT'd on
+//     the way out -- see handle_return(). The outer next header must be
+//     41 (IPv6-in-IPv6, the same ENCAP_RED wire format
+//     internal/plumbing/srv6/egress.go's RouteEgressAdd already uses for
+//     every other cross-node SRv6 packet in this codebase -- no SRH, the
+//     single segment is fully expressed by the outer destination address)
+//     -- anything else is a malformed/unexpected packet claimed by this
+//     address and is dropped, not passed through (once claimed, silent
+//     pass-through would misdeliver it, same fail-closed reasoning as
+//     usid.c's own claimed-packet drops).
+//
+//     Strip the outer header (two bpf_xdp_adjust_head calls -- see the
+//     comment at handle_return's strip_outer_header call site for why one
+//     flat +40 does not work), look up conn_table by the revealed inner
+//     packet's own 5-tuple (this is the *reverse* row: (proto,
+//     backend_addr:backend_port -> gw_addr:snat_port)), and if found,
+//     rewrite the inner packet's addresses/ports back to the client's
+//     original view (saddr=VIP, sport=VIP port; daddr/dport = the
+//     original client's own address/port) -- un-SNAT and un-DNAT in one
+//     step, since Full-NAT changed both on the way in. Fix the L4
+//     checksum via bpf_csum_diff (bpf_l4_csum_replace/
+//     bpf_l3_csum_replace require __sk_buff and are unavailable to an XDP
+//     program -- see edgepreflight's doc comment). Resolve the new L2
+//     next-hop toward the client via bpf_fib_lookup and XDP_TX back out
+//     this same interface. No conn_table hit -- this address is claimed,
+//     so drop rather than pass through.
+//
+//  3. FORWARD/INGRESS BRANCH: otherwise, parse the L4 header (TCP or UDP
+//     only; anything else -- XDP_PASS) and match (proto, dst port, dst
+//     addr) against rule_table, keyed by VIP+port only, no tenant
+//     dimension needed -- a VIP is globally unique by construction, the
+//     same invariant gwprog's own gw_pub_ingress relied on. No match --
+//     XDP_PASS (not one of this gateway's VIPs).
+//
+//     Look up conn_table by the *forward* row key
+//     (proto, client_addr:client_port -> VIP:VIP port). A hit reuses the
+//     already-assigned backend and SNAT port (so a flow's translation
+//     never changes mid-connection even if rule_table's backend list
+//     changes later). A miss allocates fresh state -- but only for a TCP
+//     SYN or any UDP packet (there is no other correct point to start a
+//     new translated flow); anything else with no existing state is
+//     dropped, not passed through (this address is claimed).
+//
+//     New-flow allocation: pick a backend by
+//     hash(client_addr,client_port) % rule->backend_count (deterministic
+//     per-flow, same technique gwprog used), then claim a SNAT port for
+//     (backend_addr,backend_port) by probing a small, bounded number of
+//     candidate ports (starting from a hash of the client's own tuple) and
+//     inserting the *reverse* conn_table row with BPF_NOEXIST -- this is
+//     the actual atomic claim, and it is also the sole liveness mechanism
+//     for port reuse: once a flow's conn_table rows are LRU-evicted, the
+//     same reverse-row insert simply succeeds again for a new flow,
+//     without any separate GC or explicit free needed. Note this design
+//     only needs to avoid a same-(SNAT port, backend) collision -- two
+//     different flows sharing a SNAT port but going to *different*
+//     backends never collide, because backend_addr/backend_port are part
+//     of the reverse key. Every probe attempt failing -- drop
+//     (PAT_EXHAUSTED), not pass through.
+//
+//     DNAT the destination to the chosen backend, SNAT the source to this
+//     node's own gw_addr:allocated-port, fix the L4 checksum, then push a
+//     fresh 40-byte outer IPv6 header addressed to the backend's own
+//     worker-node SRv6 uSID (rule_table's per-backend field, resolved by
+//     the Go control plane the same way any other cross-node SRv6
+//     destination is -- srv6.ComputeSID over the backend's BGPRouter/
+//     BGPAdvertisement, see internal/gateway's doc comment) via a single
+//     bpf_xdp_adjust_head(-40) call (see push_outer_header's comment for
+//     why one call suffices here, unlike the two-call strip). Resolve the
+//     new L2 next-hop via bpf_fib_lookup and XDP_TX back out this same
+//     interface.
+//
+// A real eBPF verifier gotcha carried over from gwprog's own header
+// comment: the backend-selection index (hash % backend_count, then
+// rule->backends[idx]) needs an explicit bounds-narrowing op for the
+// *verifier* specifically -- it does not propagate a range bound from %'s
+// divisor onto the result. clang can independently prove the bound and
+// eliminate a naive narrowing op as dead code, so this file uses the same
+// EDGE_BARRIER_VAR macro gwprog used (an opaquing asm volatile no-op) to
+// force the mask to survive as a real instruction the verifier can see.
+#include <linux/bpf.h>
+
+// __u8/__u16/__u32/__u64/__s16/__s32/__be16/__be32 all come transitively
+// from <linux/bpf.h> -> <linux/types.h> -> <asm-generic/int-ll64.h>.
+
+#define SEC(name) __attribute__((section(name), used))
+#define __uint(name, val) int (*name)[val]
+#define __type(name, val) typeof(val) *name
+#define EDGE_ALWAYS_INLINE inline __attribute__((always_inline))
+
+// EDGE_BARRIER_VAR forces the compiler to treat var as opaque immediately
+// before a bounds-narrowing operation on it, so that operation survives
+// dead-code elimination even when clang can otherwise prove the narrowing
+// is redundant -- see the header comment above and gwprog/gwnat.c's
+// identical gotcha.
+#define EDGE_BARRIER_VAR(var) asm volatile("" : "=r"(var) : "0"(var))
+
+// ---------------------------------------------------------------------
+// BPF helper function declarations, using the enum bpf_func_id constants
+// from <linux/bpf.h> rather than hardcoded helper IDs.
+// ---------------------------------------------------------------------
+
+static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) BPF_FUNC_map_lookup_elem;
+static long (*bpf_map_update_elem)(void *map, const void *key, const void *value,
+				    __u64 flags) = (void *) BPF_FUNC_map_update_elem;
+
+// Growing/shrinking the packet for the pushed/stripped outer SRv6 header.
+// Unlike TC-BPF's bpf_skb_adjust_room(..., BPF_ADJ_ROOM_MAC, ...), this
+// helper has no mode that automatically relocates the Ethernet header for
+// us -- see push_outer_header/strip_outer_header for the manual technique
+// this program uses instead.
+static long (*bpf_xdp_adjust_head)(void *ctx, int delta) = (void *) BPF_FUNC_xdp_adjust_head;
+
+// The XDP-safe checksum-fixup helper -- bpf_l4_csum_replace/
+// bpf_l3_csum_replace require __sk_buff and are unavailable here.
+static __s64 (*bpf_csum_diff)(__be32 *from, __u32 from_size, __be32 *to, __u32 to_size,
+			       __wsum seed) = (void *) BPF_FUNC_csum_diff;
+
+static long (*bpf_fib_lookup)(void *ctx, struct bpf_fib_lookup *params, __s32 plen,
+			       __u32 flags) = (void *) BPF_FUNC_fib_lookup;
+
+// Timestamps rule_value.last_seen_ns (Phase E hit counters) -- CLOCK_MONOTONIC
+// nanoseconds since boot, same clock source usid.c's vrf_value.last_seen_ns
+// and gwnat.c's identical field already use.
+static __u64 (*bpf_ktime_get_ns)(void) = (void *) BPF_FUNC_ktime_get_ns;
+
+// ---------------------------------------------------------------------
+// Address-family / protocol constants (fixed kernel ABI, never change).
+// ---------------------------------------------------------------------
+
+#define EDGE_AF_INET6 10
+#define EDGE_ETH_P_IPV6 0x86DD
+#define EDGE_IPPROTO_TCP 6
+#define EDGE_IPPROTO_UDP 17
+
+// EDGE_IPPROTO_IPV6 (41) is the outer Next Header value this program's own
+// pushed header always uses, and the only one its return branch accepts --
+// the same plain IPv6-in-IPv6, no-SRH wire format
+// internal/plumbing/srv6/egress.go's RouteEgressAdd already installs for
+// every other cross-node SRv6 packet in this codebase (SEG6_IPTUN_MODE_
+// ENCAP_RED). Using the same format means the destination worker node's
+// existing internal/plumbing/ebpf/prog/usid.c decaps this program's own
+// pushed packets with zero changes on that end.
+#define EDGE_IPPROTO_IPV6 41
+
+#define EDGE_TCP_FLAG_SYN 0x02
+
+// ---------------------------------------------------------------------
+// Minimal, self-contained header structs -- byte-exact to the wire
+// formats, hand-rolled so this file has exactly one external header
+// dependency (<linux/bpf.h>), matching usid.c's own convention.
+// ---------------------------------------------------------------------
+
+struct edge_ethhdr {
+	__u8 h_dest[6];
+	__u8 h_source[6];
+	__be16 h_proto;
+} __attribute__((packed));
+
+// Deliberately not the kernel's bitfield-based struct ipv6hdr (endian
+// dependent) -- this program never reads version/traffic-class/flow
+// label, so vtc_flow is left as an opaque 4-byte blob, matching usid.c's
+// usid_ip6hdr.
+struct edge_ip6hdr {
+	__u8 vtc_flow[4];
+	__be16 payload_len;
+	__u8 nexthdr;
+	__u8 hop_limit;
+	__u8 saddr[16];
+	__u8 daddr[16];
+} __attribute__((packed));
+
+// Only the fields this program reads/writes: source/dest port and the
+// SYN flag. TCP options (anything past byte 20) are never inspected --
+// phase 1 scope excludes extension/option parsing, matching gwprog's own
+// "plain TCP/UDP" precedent.
+struct edge_tcphdr {
+	__be16 source;
+	__be16 dest;
+	__be32 seq;
+	__be32 ack_seq;
+	__u8 doff_reserved;
+	__u8 flags;
+	__be16 window;
+	__be16 check;
+	__be16 urg_ptr;
+} __attribute__((packed));
+
+struct edge_udphdr {
+	__be16 source;
+	__be16 dest;
+	__be16 len;
+	__be16 check;
+} __attribute__((packed));
+
+// ---------------------------------------------------------------------
+// Map key/value types.
+// ---------------------------------------------------------------------
+
+#define EDGE_MAX_BACKENDS 8
+
+// struct backend is one load-balancing target: the Pod's own address, the
+// port traffic is forwarded to, and the SRv6 uSID of the worker node that
+// address is reachable through -- resolved by the Go control plane via
+// the same srv6.ComputeSID path any other cross-node destination uses
+// (internal/gateway's doc comment), never parsed from a packet.
+struct backend {
+	__u8 addr[16];
+	__be16 port;
+	__u8 usid[16];
+};
+
+// struct rule_key is rule_table's key: an ingress VIP+port+protocol. No
+// tenant dimension -- a VIP is globally unique by construction (design
+// plan decision #1), so (proto, port, vip) alone disambiguates every rule
+// on this node.
+struct rule_key {
+	__u8 proto;
+	__u8 pad[1];
+	__be16 port;
+	__u8 vip[16];
+};
+
+// struct rule_value is rule_table's value: the load-balancing target set
+// for one VIP+port+protocol, plus per-rule hit counters (Phase E) backing
+// internal/gateway's QuotaEnforcer/TelemetryEmitter -- same
+// packets/bytes/dropped_packets/last_seen_ns convention as an earlier,
+// rejected design's equivalent rule_value, deliberately deferred out
+// of Phase B/C's scope (see internal/gateway/datapath.go's QuotaEnforcer
+// doc comment for why) rather than spread across two phases' worth of
+// speculative fields. generation is a __u64 monotonic-clock reading
+// stamped by the Go control plane's edgemap.RuleTable.Register on every
+// write, backing its crash-safe Reconcile cutoff (same pattern as
+// internal/plumbing/ebpf/usidmap's locator_value.generation and gwprog's
+// identical rule_value.generation) -- this program never reads this field
+// itself, so widening or repurposing it has no effect on the packet path.
+//
+// Deliberately NOT __attribute__((packed)) -- a map value has no
+// on-the-wire byte-layout requirement (bpf2go derives the matching Go
+// struct from BTF, padding included, regardless), and packing this one
+// specifically would misalign the u64 counter fields below out of natural
+// 8-byte alignment, which __sync_fetch_and_add requires (clang warns
+// -Wsync-alignment; some architectures fault outright on a misaligned
+// atomic op). Same unpacked choice as gwnat.c's identical struct, for the
+// same reason.
+struct rule_value {
+	__u32 backend_count;
+	struct backend backends[EDGE_MAX_BACKENDS];
+	__u64 packets;
+	__u64 bytes;
+	__u64 dropped_packets;
+	__u64 last_seen_ns;
+	__u64 generation;
+};
+
+// struct conn_key is conn_table's key: a plain 5-tuple, oriented however
+// the packet being looked up actually appears on the wire -- the forward
+// row is keyed by the client-facing tuple (saddr/sport = client,
+// daddr/dport = VIP); the reverse row is keyed by the backend-facing
+// tuple (saddr/sport = backend, daddr/dport = this node's own
+// gw_addr:allocated SNAT port). Both rows are written with the *same*
+// conn_value (see below), so either lookup direction yields everything
+// needed to rewrite the packet.
+struct conn_key {
+	__u8 proto;
+	__u8 pad[1];
+	__be16 sport;
+	__be16 dport;
+	__u8 saddr[16];
+	__u8 daddr[16];
+};
+
+// struct conn_value carries the full picture of one translated flow.
+struct conn_value {
+	__u8 client_addr[16];
+	__be16 client_port;
+	__u8 vip_addr[16];
+	__be16 vip_port;
+	__u8 backend_addr[16];
+	__be16 backend_port;
+	__u8 backend_usid[16];
+	__u8 gw_addr[16];
+	__be16 gw_port;
+	__u8 proto;
+	__u8 pad[1];
+};
+
+// struct gw_config is gw_config_table's single-entry value: this gateway
+// node's own SRv6-reachable address, used both as the Full-NAT SNAT
+// source and as the return-branch match address (design plan's
+// NetworkGatewayStatus.SRv6Address).
+struct gw_config {
+	__u8 gw_addr[16];
+};
+
+// Drop reason indices into the drop_reasons map -- see dropreason.go for
+// the exported Go constants any caller outside this package should use
+// instead of a hand-kept copy of this enum (bpf2go's -type flag cannot
+// generate a Go type for a C enum that is only ever used as a literal
+// constant, same rationale as prog/dropreason.go's identical note).
+enum edge_drop_reason {
+	DROP_REASON_NO_BACKENDS       = 0,
+	DROP_REASON_NO_CONN_NOT_SYN   = 1,
+	DROP_REASON_PAT_EXHAUSTED     = 2,
+	DROP_REASON_MALFORMED_RETURN  = 3,
+	DROP_REASON_NO_RETURN_CONN    = 4,
+	DROP_REASON_FIB_NO_NEIGH      = 5,
+	DROP_REASON_FIB_UNREACHABLE   = 6,
+	DROP_REASON_FIB_FRAG_NEEDED   = 7,
+	DROP_REASON_FIB_LOOKUP_FAILED = 8,
+	// push_outer_header's own bpf_xdp_adjust_head(-40) growing the packet
+	// for the pushed outer header, or the bounds check immediately after
+	// it, failed -- distinct from the FIB failures above (which run
+	// *inside* push_outer_header too, just further along, once the outer
+	// header has already been written): this reason means the header
+	// itself was never written at all.
+	DROP_REASON_ADJUST_HEAD_FAILED = 9,
+	DROP_REASON_COUNT              = 10,
+};
+
+// ---------------------------------------------------------------------
+// Maps.
+// ---------------------------------------------------------------------
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 4096);
+	__type(key, struct rule_key);
+	__type(value, struct rule_value);
+} rule_table SEC(".maps");
+
+// BPF_MAP_TYPE_LRU_HASH: self-evicting under pressure rather than failing
+// closed once full -- see edgepreflight's doc comment on why this map
+// type specifically is a required kernel capability, and this file's
+// header comment on why eviction alone (no separate GC pass) is a
+// sufficient port-reclaim mechanism.
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 65536);
+	__type(key, struct conn_key);
+	__type(value, struct conn_value);
+} conn_table SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, struct gw_config);
+} gw_config_table SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, DROP_REASON_COUNT);
+	__type(key, __u32);
+	__type(value, __u64);
+} drop_reasons SEC(".maps");
+
+static EDGE_ALWAYS_INLINE void count_drop(__u32 reason)
+{
+	__u64 *counter = bpf_map_lookup_elem(&drop_reasons, &reason);
+	if (counter)
+		*counter += 1;
+}
+
+// count_claimed_drop records a drop that happened after rule was already
+// matched against rule_table -- i.e. this gateway definitely owns this
+// VIP+port+protocol, so the drop counts against that rule's own
+// dropped_packets in addition to the global drop_reasons counter (same
+// convention as an earlier, rejected design's equivalent). Unlike
+// drop_reasons (BPF_MAP_TYPE_PERCPU_ARRAY, so count_drop's plain
+// increment is race-free), rule_table is a plain HASH shared across CPUs,
+// so this uses __sync_fetch_and_add.
+static EDGE_ALWAYS_INLINE void count_claimed_drop(__u32 reason, struct rule_value *rule)
+{
+	count_drop(reason);
+	__sync_fetch_and_add(&rule->dropped_packets, 1);
+}
+
+// ---------------------------------------------------------------------
+// Small helpers.
+// ---------------------------------------------------------------------
+
+static EDGE_ALWAYS_INLINE int addr6_eq(const __u8 a[16], const __u8 b[16])
+{
+	for (int i = 0; i < 16; i++) {
+		if (a[i] != b[i])
+			return 0;
+	}
+	return 1;
+}
+
+// fnv1a_flow is a deterministic, stateless hash of a flow's client-facing
+// tuple, used both for backend selection (hash % backend_count) and as the
+// starting point for SNAT port probing. Same technique gwprog's own
+// gw_pub_ingress used for backend selection.
+static EDGE_ALWAYS_INLINE __u32 fnv1a_flow(const __u8 addr[16], __be16 port)
+{
+	__u32 h = 2166136261u;
+	for (int i = 0; i < 16; i++) {
+		h ^= addr[i];
+		h *= 16777619u;
+	}
+	h ^= (__u8) (port & 0xff);
+	h *= 16777619u;
+	h ^= (__u8) (port >> 8);
+	h *= 16777619u;
+	return h;
+}
+
+// csum_fold_add applies diff (as returned by bpf_csum_diff) to an existing
+// ones'-complement checksum field, folding carries -- the standard
+// incremental-checksum-update technique (RFC 1624), used here because
+// bpf_l3_csum_replace/bpf_l4_csum_replace (which fold this automatically)
+// require __sk_buff and are unavailable to an XDP program.
+static EDGE_ALWAYS_INLINE __be16 csum_fold_add(__be16 check, __s64 diff)
+{
+	__s64 sum = (__u16) ~check;
+	sum += diff;
+	sum = (sum & 0xffff) + (sum >> 16);
+	sum = (sum & 0xffff) + (sum >> 16);
+	return (__be16) ~((__u16) sum);
+}
+
+// EDGE_PAT_PROBE_LIMIT bounds the linear probe below at compile time (a
+// verifier-friendly, fully unrolled loop rather than relying on
+// kernel-version-dependent bounded-loop support).
+#define EDGE_PAT_PROBE_LIMIT 8
+#define EDGE_PAT_PORT_BASE 32768
+#define EDGE_PAT_PORT_RANGE 28000
+
+// ---------------------------------------------------------------------
+// Forward/ingress branch.
+// ---------------------------------------------------------------------
+
+// struct l4_view carries out sport/dport/is_syn plus DIRECT, already-typed
+// pointers to the fields a later rewrite needs to touch (source port, dest
+// port, checksum) -- resolved once, at parse_l4's own bounds-checked call
+// site, and never re-derived from a type-erased void* cast on a
+// proto-based branch taken again later. An earlier version of this
+// program stored a single `void *l4hdr` here and re-cast it to
+// struct edge_tcphdr*/edge_udphdr* at the point of use based on a
+// re-evaluated proto comparison -- the verifier rejected that (a
+// pointer's proven safe-range, tracked per register/stack-slot, did not
+// survive being read back and reinterpreted at a different program point
+// than its own bounds check): "invalid access to packet ... R2 min value
+// is outside of the allowed memory range". Resolving typed field pointers
+// exactly once, adjacent to the one bounds check that proves them safe,
+// removes that whole class of problem.
+struct l4_view {
+	__be16 sport;
+	__be16 dport;
+	__u8 is_syn;
+	__be16 *sport_ptr;
+	__be16 *dport_ptr;
+	__be16 *check_ptr;
+};
+
+static EDGE_ALWAYS_INLINE int parse_l4(__u8 proto, void *l4, void *data_end, struct l4_view *out)
+{
+	if (proto == EDGE_IPPROTO_TCP) {
+		struct edge_tcphdr *tcp = l4;
+		if ((void *) (tcp + 1) > data_end)
+			return -1;
+		out->sport = tcp->source;
+		out->dport = tcp->dest;
+		out->is_syn = (tcp->flags & EDGE_TCP_FLAG_SYN) != 0;
+		out->sport_ptr = &tcp->source;
+		out->dport_ptr = &tcp->dest;
+		out->check_ptr = &tcp->check;
+		return 0;
+	}
+	if (proto == EDGE_IPPROTO_UDP) {
+		struct edge_udphdr *udp = l4;
+		if ((void *) (udp + 1) > data_end)
+			return -1;
+		out->sport = udp->source;
+		out->dport = udp->dest;
+		out->is_syn = 1; // any UDP packet may start a new flow
+		out->sport_ptr = &udp->source;
+		out->dport_ptr = &udp->dest;
+		out->check_ptr = &udp->check;
+		return 0;
+	}
+	return -1;
+}
+
+// fix_l4_checksum applies the combined address+port checksum delta for a
+// Full-NAT rewrite (both addresses and both ports changed) to *check_ptr
+// -- already resolved to the correct field by parse_l4, so this function
+// needs no proto parameter of its own.
+static EDGE_ALWAYS_INLINE void fix_l4_checksum(__be16 *check_ptr,
+						const __u8 old_saddr[16], const __u8 old_daddr[16],
+						__be16 old_sport, __be16 old_dport,
+						const __u8 new_saddr[16], const __u8 new_daddr[16],
+						__be16 new_sport, __be16 new_dport)
+{
+	__be32 old_words[9];
+	__be32 new_words[9];
+
+	__builtin_memcpy(&old_words[0], old_saddr, 16);
+	__builtin_memcpy(&old_words[4], old_daddr, 16);
+	old_words[8] = ((__be32) old_sport << 16) | (__be32) old_dport;
+
+	__builtin_memcpy(&new_words[0], new_saddr, 16);
+	__builtin_memcpy(&new_words[4], new_daddr, 16);
+	new_words[8] = ((__be32) new_sport << 16) | (__be32) new_dport;
+
+	__s64 diff = bpf_csum_diff(old_words, sizeof(old_words), new_words, sizeof(new_words), 0);
+	*check_ptr = csum_fold_add(*check_ptr, diff);
+}
+
+// resolve_fib_and_write_eth resolves the L2 next-hop for dst via
+// bpf_fib_lookup and writes it into eth's dest/source fields, setting
+// h_proto to IPv6. ifindex is the interface this program is attached to
+// (ctx->ingress_ifindex) -- the resolved egress interface for
+// BPF_FIB_LOOKUP_DIRECT is expected to be the same interface XDP_TX
+// retransmits out of; this program has no VRF/tbid scoping (design plan
+// decision #4), unlike usid.c's own FIB lookup.
+static EDGE_ALWAYS_INLINE long resolve_fib_and_write_eth(void *ctx, __u32 ifindex,
+							  const __u8 src[16], const __u8 dst[16],
+							  __u16 tot_len, struct edge_ethhdr *eth)
+{
+	struct bpf_fib_lookup fib_params;
+	__builtin_memset(&fib_params, 0, sizeof(fib_params));
+	fib_params.family = EDGE_AF_INET6;
+	__builtin_memcpy(&fib_params.ipv6_src, src, 16);
+	__builtin_memcpy(&fib_params.ipv6_dst, dst, 16);
+	fib_params.ifindex = ifindex;
+	fib_params.tot_len = tot_len;
+
+	long fib_rc = bpf_fib_lookup(ctx, &fib_params, sizeof(fib_params), BPF_FIB_LOOKUP_DIRECT);
+	if (fib_rc != BPF_FIB_LKUP_RET_SUCCESS)
+		return fib_rc;
+
+	__builtin_memcpy(eth->h_dest, fib_params.dmac, sizeof(eth->h_dest));
+	__builtin_memcpy(eth->h_source, fib_params.smac, sizeof(eth->h_source));
+	eth->h_proto = __builtin_bswap16(EDGE_ETH_P_IPV6);
+	return BPF_FIB_LKUP_RET_SUCCESS;
+}
+
+static EDGE_ALWAYS_INLINE void count_fib_drop(long fib_rc)
+{
+	if (fib_rc == BPF_FIB_LKUP_RET_NO_NEIGH)
+		count_drop(DROP_REASON_FIB_NO_NEIGH);
+	else if (fib_rc == BPF_FIB_LKUP_RET_UNREACHABLE || fib_rc == BPF_FIB_LKUP_RET_BLACKHOLE ||
+		 fib_rc == BPF_FIB_LKUP_RET_PROHIBIT)
+		count_drop(DROP_REASON_FIB_UNREACHABLE);
+	else if (fib_rc == BPF_FIB_LKUP_RET_FRAG_NEEDED)
+		// No ICMPv6 Packet Too Big is generated here -- the same
+		// accepted PMTUD gap usid.c's own FIB lookup has (see
+		// docs/agents/ARCHITECTURE.md's Known Constraints).
+		count_drop(DROP_REASON_FIB_FRAG_NEEDED);
+	else
+		count_drop(DROP_REASON_FIB_LOOKUP_FAILED);
+}
+
+// push_outer_header grows the packet by exactly 40 bytes and writes a
+// fresh 54-byte block (14-byte Ethernet + 40-byte outer IPv6 header) at
+// the new front. This single bpf_xdp_adjust_head(-40) call is sufficient
+// -- unlike strip_outer_header's two-call technique below -- because the
+// 14 bytes of the *old* Ethernet header, after the grow, land squarely
+// inside the 54-byte region this function overwrites anyway (grow-by-40
+// shifts all old content 40 bytes later; the old Ethernet header, 14
+// bytes, was already immediately followed by where the old IPv6 header
+// starts, so old-Ethernet-plus-new-outer-header together occupy exactly
+// the first 54 bytes post-grow, and the untouched old IPv6 header +
+// payload already sits correctly positioned as the "inner packet"
+// starting at byte 54). Returns 0 on success.
+static EDGE_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 src[16],
+						 const __u8 dst[16], __be16 inner_payload_len_plus_ip6hdr)
+{
+	if (bpf_xdp_adjust_head(ctx, -40) != 0) {
+		count_drop(DROP_REASON_ADJUST_HEAD_FAILED);
+		return -1;
+	}
+
+	void *data = (void *) (long) ctx->data;
+	void *data_end = (void *) (long) ctx->data_end;
+	if (data + sizeof(struct edge_ethhdr) + sizeof(struct edge_ip6hdr) > data_end) {
+		count_drop(DROP_REASON_ADJUST_HEAD_FAILED);
+		return -1;
+	}
+
+	struct edge_ethhdr *eth = data;
+	struct edge_ip6hdr *outer = (void *) (eth + 1);
+
+	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
+	outer->payload_len = inner_payload_len_plus_ip6hdr;
+	outer->nexthdr = EDGE_IPPROTO_IPV6;
+	outer->hop_limit = 64;
+	__builtin_memcpy(outer->saddr, src, 16);
+	__builtin_memcpy(outer->daddr, dst, 16);
+
+	long fib_rc = resolve_fib_and_write_eth(ctx, ctx->ingress_ifindex, src, dst,
+						 (__u16) (sizeof(*outer) + __builtin_bswap16(inner_payload_len_plus_ip6hdr)),
+						 eth);
+	if (fib_rc != BPF_FIB_LKUP_RET_SUCCESS) {
+		count_fib_drop(fib_rc);
+		return -1;
+	}
+	return 0;
+}
+
+static EDGE_ALWAYS_INLINE int handle_forward(struct xdp_md *ctx, struct edge_ip6hdr *ip6, void *l4,
+					      __u8 proto, void *data_end)
+{
+	struct l4_view l4v;
+	if (parse_l4(proto, l4, data_end, &l4v) != 0)
+		return XDP_PASS;
+
+	struct rule_key rk;
+	__builtin_memset(&rk, 0, sizeof(rk));
+	rk.proto = proto;
+	rk.port = l4v.dport;
+	__builtin_memcpy(rk.vip, ip6->daddr, 16);
+
+	struct rule_value *rule = bpf_map_lookup_elem(&rule_table, &rk);
+	if (!rule)
+		return XDP_PASS; // not one of this gateway's VIPs
+
+	// Claimed past this point: this gateway owns this VIP+port+protocol,
+	// so every packet reaching here counts toward the rule's hit
+	// counters regardless of what happens next -- a PAT-exhausted or
+	// no-backends drop still legitimately consumed this rule's capacity
+	// (same convention as an earlier, rejected design's equivalent).
+	__sync_fetch_and_add(&rule->packets, 1);
+	__sync_fetch_and_add(&rule->bytes,
+			      (__u64) ((char *) data_end - (char *) (long) ctx->data));
+	rule->last_seen_ns = bpf_ktime_get_ns();
+
+	struct conn_key fwd_key;
+	__builtin_memset(&fwd_key, 0, sizeof(fwd_key));
+	fwd_key.proto = proto;
+	__builtin_memcpy(fwd_key.saddr, ip6->saddr, 16);
+	fwd_key.sport = l4v.sport;
+	__builtin_memcpy(fwd_key.daddr, ip6->daddr, 16);
+	fwd_key.dport = l4v.dport;
+
+	struct conn_value *existing = bpf_map_lookup_elem(&conn_table, &fwd_key);
+	struct conn_value cv;
+
+	if (existing) {
+		__builtin_memcpy(&cv, existing, sizeof(cv));
+	} else {
+		if (!l4v.is_syn) {
+			count_claimed_drop(DROP_REASON_NO_CONN_NOT_SYN, rule);
+			return XDP_DROP;
+		}
+		if (rule->backend_count == 0 || rule->backend_count > EDGE_MAX_BACKENDS) {
+			count_claimed_drop(DROP_REASON_NO_BACKENDS, rule);
+			return XDP_DROP;
+		}
+
+		// EDGE_MAX_BACKENDS must stay a power of two -- the mask below
+		// is what makes the bounds-narrowing survive as a real
+		// instruction (see this file's header comment and
+		// EDGE_BARRIER_VAR's doc comment): clang can independently
+		// prove idx < backend_count <= EDGE_MAX_BACKENDS from the
+		// %-divisor's own already-checked [1,EDGE_MAX_BACKENDS] range
+		// above, and eliminates a naive `if (idx >= MAX) idx = 0;` (or
+		// an unbarriered mask) as dead code -- which then fails to
+		// load, because the *verifier* does not propagate a range
+		// bound from %'s divisor onto its result the way clang's own
+		// optimizer does. A single EDGE_BARRIER_VAR call immediately
+		// before the mask forces clang to treat idx as opaque, so the
+		// mask survives as a real instruction the verifier can see and
+		// use to bound the following array index.
+		__u32 idx = fnv1a_flow(ip6->saddr, l4v.sport) % rule->backend_count;
+		EDGE_BARRIER_VAR(idx);
+		idx &= (EDGE_MAX_BACKENDS - 1);
+		struct backend *b = &rule->backends[idx];
+
+		__u32 cfg_key = 0;
+		struct gw_config *cfg = bpf_map_lookup_elem(&gw_config_table, &cfg_key);
+		if (!cfg) {
+			count_claimed_drop(DROP_REASON_NO_BACKENDS, rule);
+			return XDP_DROP;
+		}
+
+		__builtin_memset(&cv, 0, sizeof(cv));
+		__builtin_memcpy(cv.client_addr, ip6->saddr, 16);
+		cv.client_port = l4v.sport;
+		__builtin_memcpy(cv.vip_addr, ip6->daddr, 16);
+		cv.vip_port = l4v.dport;
+		__builtin_memcpy(cv.backend_addr, b->addr, 16);
+		cv.backend_port = b->port;
+		__builtin_memcpy(cv.backend_usid, b->usid, 16);
+		__builtin_memcpy(cv.gw_addr, cfg->gw_addr, 16);
+		cv.proto = proto;
+
+		__u32 base = fnv1a_flow(ip6->saddr, l4v.sport) ^ (__u32) l4v.dport;
+		int claimed = 0;
+
+		#pragma unroll
+		for (int i = 0; i < EDGE_PAT_PROBE_LIMIT; i++) {
+			__u16 candidate = EDGE_PAT_PORT_BASE + ((base + (__u32) i) % EDGE_PAT_PORT_RANGE);
+			cv.gw_port = __builtin_bswap16(candidate);
+
+			struct conn_key rev_key;
+			__builtin_memset(&rev_key, 0, sizeof(rev_key));
+			rev_key.proto = proto;
+			__builtin_memcpy(rev_key.saddr, b->addr, 16);
+			rev_key.sport = b->port;
+			__builtin_memcpy(rev_key.daddr, cfg->gw_addr, 16);
+			rev_key.dport = cv.gw_port;
+
+			if (bpf_map_update_elem(&conn_table, &rev_key, &cv, BPF_NOEXIST) == 0) {
+				claimed = 1;
+				break;
+			}
+		}
+
+		if (!claimed) {
+			count_claimed_drop(DROP_REASON_PAT_EXHAUSTED, rule);
+			return XDP_DROP;
+		}
+
+		bpf_map_update_elem(&conn_table, &fwd_key, &cv, BPF_ANY);
+	}
+
+	__u8 old_saddr[16], old_daddr[16];
+	__builtin_memcpy(old_saddr, ip6->saddr, 16);
+	__builtin_memcpy(old_daddr, ip6->daddr, 16);
+	__be16 old_sport = l4v.sport;
+	__be16 old_dport = l4v.dport;
+
+	fix_l4_checksum(l4v.check_ptr, old_saddr, old_daddr, old_sport, old_dport,
+			cv.gw_addr, cv.backend_addr, cv.gw_port, cv.backend_port);
+
+	__builtin_memcpy(ip6->saddr, cv.gw_addr, 16);
+	__builtin_memcpy(ip6->daddr, cv.backend_addr, 16);
+	*l4v.sport_ptr = cv.gw_port;
+	*l4v.dport_ptr = cv.backend_port;
+
+	__be16 inner_payload_len = ip6->payload_len;
+
+	if (push_outer_header(ctx, cv.gw_addr, cv.backend_usid, inner_payload_len) != 0)
+		return XDP_DROP;
+
+	return XDP_TX;
+}
+
+// ---------------------------------------------------------------------
+// Return/decap branch.
+// ---------------------------------------------------------------------
+
+// strip_outer_header removes the outer Ethernet+IPv6 header (54 bytes)
+// entirely and then regrows exactly 14 bytes for a fresh Ethernet header
+// -- two bpf_xdp_adjust_head calls, unlike push_outer_header's one. A
+// single flat +40 would remove "the old Ethernet header plus the first 26
+// bytes of the outer IPv6 header," which is not the region that needs to
+// disappear (the Ethernet header must be *preserved*, just relocated to
+// sit immediately before the inner packet, not discarded) -- bpf_skb_
+// adjust_room's BPF_ADJ_ROOM_MAC mode handles this automatically for
+// TC-BPF; bpf_xdp_adjust_head has no equivalent, so this program does the
+// two-step remove-then-regrow by hand. Returns 0 on success, with *eth_out
+// pointing at the (uninitialized) fresh Ethernet header slot to fill in.
+static EDGE_ALWAYS_INLINE int strip_outer_header(struct xdp_md *ctx, struct edge_ethhdr **eth_out)
+{
+	if (bpf_xdp_adjust_head(ctx, (int) (sizeof(struct edge_ethhdr) + sizeof(struct edge_ip6hdr))) != 0)
+		return -1;
+	if (bpf_xdp_adjust_head(ctx, -(int) sizeof(struct edge_ethhdr)) != 0)
+		return -1;
+
+	void *data = (void *) (long) ctx->data;
+	void *data_end = (void *) (long) ctx->data_end;
+	if (data + sizeof(struct edge_ethhdr) > data_end)
+		return -1;
+
+	*eth_out = data;
+	return 0;
+}
+
+static EDGE_ALWAYS_INLINE int handle_return(struct xdp_md *ctx, struct edge_ip6hdr *outer, void *data_end)
+{
+	if (outer->nexthdr != EDGE_IPPROTO_IPV6) {
+		count_drop(DROP_REASON_MALFORMED_RETURN);
+		return XDP_DROP;
+	}
+
+	__u8 gw_addr[16];
+	__builtin_memcpy(gw_addr, outer->daddr, 16);
+
+	struct edge_ethhdr *eth;
+	if (strip_outer_header(ctx, &eth) != 0) {
+		count_drop(DROP_REASON_MALFORMED_RETURN);
+		return XDP_DROP;
+	}
+
+	data_end = (void *) (long) ctx->data_end;
+
+	struct edge_ip6hdr *inner = (void *) (eth + 1);
+	if ((void *) (inner + 1) > data_end) {
+		count_drop(DROP_REASON_MALFORMED_RETURN);
+		return XDP_DROP;
+	}
+	if (inner->nexthdr != EDGE_IPPROTO_TCP && inner->nexthdr != EDGE_IPPROTO_UDP) {
+		count_drop(DROP_REASON_MALFORMED_RETURN);
+		return XDP_DROP;
+	}
+
+	struct l4_view l4v;
+	if (parse_l4(inner->nexthdr, (void *) (inner + 1), data_end, &l4v) != 0) {
+		count_drop(DROP_REASON_MALFORMED_RETURN);
+		return XDP_DROP;
+	}
+
+	struct conn_key rev_key;
+	__builtin_memset(&rev_key, 0, sizeof(rev_key));
+	rev_key.proto = inner->nexthdr;
+	__builtin_memcpy(rev_key.saddr, inner->saddr, 16);
+	rev_key.sport = l4v.sport;
+	__builtin_memcpy(rev_key.daddr, inner->daddr, 16);
+	rev_key.dport = l4v.dport;
+
+	struct conn_value *cv = bpf_map_lookup_elem(&conn_table, &rev_key);
+	if (!cv) {
+		count_drop(DROP_REASON_NO_RETURN_CONN);
+		return XDP_DROP;
+	}
+
+	__u8 old_saddr[16], old_daddr[16];
+	__builtin_memcpy(old_saddr, inner->saddr, 16);
+	__builtin_memcpy(old_daddr, inner->daddr, 16);
+	__be16 old_sport = l4v.sport;
+	__be16 old_dport = l4v.dport;
+
+	fix_l4_checksum(l4v.check_ptr, old_saddr, old_daddr, old_sport, old_dport,
+			cv->vip_addr, cv->client_addr, cv->vip_port, cv->client_port);
+
+	__builtin_memcpy(inner->saddr, cv->vip_addr, 16);
+	__builtin_memcpy(inner->daddr, cv->client_addr, 16);
+	*l4v.sport_ptr = cv->vip_port;
+	*l4v.dport_ptr = cv->client_port;
+
+	long fib_rc = resolve_fib_and_write_eth(ctx, ctx->ingress_ifindex, cv->vip_addr, cv->client_addr,
+						 __builtin_bswap16(inner->payload_len) + (__u16) sizeof(*inner), eth);
+	if (fib_rc != BPF_FIB_LKUP_RET_SUCCESS) {
+		count_fib_drop(fib_rc);
+		return XDP_DROP;
+	}
+
+	return XDP_TX;
+}
+
+// ---------------------------------------------------------------------
+// Entry point.
+// ---------------------------------------------------------------------
+
+SEC("xdp")
+int edge_nat(struct xdp_md *ctx)
+{
+	void *data = (void *) (long) ctx->data;
+	void *data_end = (void *) (long) ctx->data_end;
+
+	struct edge_ethhdr *eth = data;
+	if ((void *) (eth + 1) > data_end)
+		return XDP_PASS;
+	if (eth->h_proto != __builtin_bswap16(EDGE_ETH_P_IPV6))
+		return XDP_PASS;
+
+	struct edge_ip6hdr *ip6 = (void *) (eth + 1);
+	if ((void *) (ip6 + 1) > data_end)
+		return XDP_PASS;
+
+	__u32 cfg_key = 0;
+	struct gw_config *cfg = bpf_map_lookup_elem(&gw_config_table, &cfg_key);
+	if (cfg && addr6_eq(ip6->daddr, cfg->gw_addr))
+		return handle_return(ctx, ip6, data_end);
+
+	if (ip6->nexthdr != EDGE_IPPROTO_TCP && ip6->nexthdr != EDGE_IPPROTO_UDP)
+		return XDP_PASS;
+
+	return handle_forward(ctx, ip6, (void *) (ip6 + 1), ip6->nexthdr, data_end);
+}
+
+char _license[] SEC("license") = "GPL";

--- a/internal/plumbing/ebpf/edgeprog/edgenat_test.go
+++ b/internal/plumbing/ebpf/edgeprog/edgenat_test.go
@@ -1,0 +1,773 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package edgeprog
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	xdpPass = 2
+	xdpDrop = 1
+	xdpTx   = 3
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN/CAP_SYS_ADMIN) to load BPF programs, create a test " +
+			"network namespace, and run BPF_PROG_TEST_RUN against real FIB state; re-run via sudo")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatalf("rlimit.RemoveMemlock: %v", err)
+	}
+}
+
+// loadObjects loads a fresh copy of the compiled program and its maps into
+// the kernel, returning a cleanup-registered *EdgenatObjects.
+func loadObjects(t *testing.T) *EdgenatObjects {
+	t.Helper()
+
+	var objs EdgenatObjects
+	if err := LoadEdgenatObjects(&objs, nil); err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("load objects: verifier rejected program:\n%+v", ve)
+		}
+		t.Fatalf("load objects: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := objs.Close(); err != nil {
+			t.Errorf("close objects: %v", err)
+		}
+	})
+	return &objs
+}
+
+// htons converts a host-order port value into the big-endian byte pattern
+// edgenat.c's __be16 fields carry verbatim (the program never byte-swaps a
+// port -- every comparison/store is between two equally-unswapped wire
+// values) -- so any Go-side value written into a rule_key/conn_key/
+// conn_value/backend field mirroring one of those C fields must go through
+// this first, on this little-endian test host, or the map key/value the
+// program reads will not match what a real client's TCP/IP stack put on
+// the wire.
+func htons(v uint16) uint16 { return v<<8 | v>>8 }
+
+// xdpMDCtx mirrors the kernel UAPI's struct xdp_md field layout (six
+// uint32s: data, data_end, data_meta, ingress_ifindex, rx_queue_index,
+// egress_ifindex) so it can be passed as ebpf.RunOptions.Context.
+// cilium/ebpf's own equivalent (internal/sys.XdpMd) is unexported outside
+// its module -- encoding/binary.Append (which Program.Run uses to
+// serialize RunOptions.Context) only cares about field layout, not the
+// Go type's name, so a local mirror struct with identical field
+// order/widths serializes identically.
+type xdpMDCtx struct {
+	Data           uint32
+	DataEnd        uint32
+	DataMeta       uint32
+	IngressIfindex uint32
+	RxQueueIndex   uint32
+	EgressIfindex  uint32
+}
+
+// runXDP runs prog against pkt with ctx.IngressIfindex set to ifindex, and
+// returns the verdict plus whatever this program left in the packet
+// buffer -- populated regardless of verdict, so a dropped packet's
+// in-progress mutations (e.g. an already-pushed outer header, ahead of a
+// FIB lookup failure) can still be inspected.
+func runXDP(t *testing.T, prog *ebpf.Program, pkt []byte, ifindex int) (uint32, []byte) {
+	t.Helper()
+	out := make([]byte, len(pkt)+256) // headroom for adjust_head(-40) growth
+	// ctx_in.DataEnd must be set to len(pkt) explicitly -- for
+	// BPF_PROG_TEST_RUN, data/data_end in the supplied xdp_md context are
+	// offsets into the Data buffer the kernel populates real pointers
+	// from, not raw pointers themselves; leaving DataEnd at its zero
+	// value gives the program a zero-length packet (confirmed via
+	// bpf_trace_printk during development: "entry len=0"), matching
+	// cilium/ebpf's own examples/xdp_live_frame, which sets this
+	// explicitly for the same reason.
+	ret, err := prog.Run(&ebpf.RunOptions{
+		Data:    pkt,
+		DataOut: out,
+		Context: &xdpMDCtx{DataEnd: uint32(len(pkt)), IngressIfindex: uint32(ifindex)},
+		Repeat:  1,
+	})
+	if err != nil {
+		t.Fatalf("program run: %v", err)
+	}
+	return ret, out
+}
+
+// testEnv is an isolated network namespace carrying a veth pair with a
+// real on-link IPv6 route + static (permanent) neighbor entry for every
+// destination address the tests below hand to bpf_fib_lookup, so the
+// program's forward/return paths can be proven end-to-end (a real XDP_TX
+// with a correctly resolved L2 header), not merely "reached the FIB
+// lookup" -- unlike internal/plumbing/ebpf/prog's own tests, which
+// explicitly punt on live routing state as a "ContainerLab/e2e concern";
+// this package's tests go further because root/kernel access is available
+// in this environment and the extra assurance is worth it for the
+// centerpiece of this design.
+type testEnv struct {
+	ifindex int
+}
+
+// dummyMAC is an arbitrary, locally-administered MAC address used for
+// every static neighbor entry setupTestEnv installs -- its exact value is
+// never asserted on by any test (only that *some* resolved dmac/smac made
+// it into the rewritten packet, proving bpf_fib_lookup succeeded), so one
+// fixed value for every destination is sufficient.
+var dummyMAC = []byte{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+
+// setupTestEnv creates a fresh netns, enters it on the calling goroutine's
+// OS thread (which is locked for the lifetime of the returned *testEnv --
+// call the returned cleanup to unlock and restore the original netns), and
+// installs an on-link route + static neighbor entry for every address in
+// destinations.
+func setupTestEnv(t *testing.T, destinations []netip.Addr) (*testEnv, func()) {
+	t.Helper()
+	requireRoot(t)
+
+	runtime.LockOSThread()
+
+	origNS, err := netns.Get()
+	if err != nil {
+		runtime.UnlockOSThread()
+		t.Fatalf("netns.Get: %v", err)
+	}
+
+	newNS, err := netns.New()
+	if err != nil {
+		_ = netns.Set(origNS)
+		_ = origNS.Close()
+		runtime.UnlockOSThread()
+		t.Fatalf("netns.New: %v", err)
+	}
+
+	cleanup := func() {
+		_ = netns.Set(origNS)
+		_ = newNS.Close()
+		_ = origNS.Close()
+		runtime.UnlockOSThread()
+	}
+
+	// bpf_fib_lookup returns BPF_FIB_LKUP_RET_FWD_DISABLED unless IPv6
+	// forwarding is enabled on the (soon-to-be) ingress device's stack --
+	// a fresh network namespace starts with forwarding off, matching the
+	// kernel's own default, so this test environment must turn it on
+	// explicitly, the same way a real gateway node's sysctl configuration
+	// would (see internal/plumbing/sysctl's ConfigureInterfaceSysctls
+	// convention for VRF interfaces -- this is the same class of setup).
+	if err := os.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding", []byte("1"), 0o644); err != nil {
+		cleanup()
+		t.Fatalf("enable ipv6 forwarding in test netns: %v", err)
+	}
+
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: "edgenat0"},
+		PeerName:  "edgenat1",
+	}
+	if err := netlink.LinkAdd(veth); err != nil {
+		cleanup()
+		t.Fatalf("create veth pair: %v", err)
+	}
+	link, err := netlink.LinkByName("edgenat0")
+	if err != nil {
+		cleanup()
+		t.Fatalf("find veth: %v", err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		cleanup()
+		t.Fatalf("set veth up: %v", err)
+	}
+	if peer, err := netlink.LinkByName("edgenat1"); err == nil {
+		_ = netlink.LinkSetUp(peer)
+	}
+
+	// A real address on the link (not itself used as a test destination)
+	// so the link has a usable IPv6 scope/source for the routes below.
+	addr, err := netlink.ParseAddr("fd00:eda::1/64")
+	if err != nil {
+		cleanup()
+		t.Fatalf("parse veth address: %v", err)
+	}
+	if err := netlink.AddrAdd(link, addr); err != nil {
+		cleanup()
+		t.Fatalf("assign veth address: %v", err)
+	}
+
+	for _, dst := range destinations {
+		route := &netlink.Route{
+			LinkIndex: link.Attrs().Index,
+			Dst:       &net.IPNet{IP: dst.AsSlice(), Mask: net.CIDRMask(128, 128)},
+		}
+		if err := netlink.RouteAdd(route); err != nil {
+			cleanup()
+			t.Fatalf("add on-link route to %s: %v", dst, err)
+		}
+		neigh := &netlink.Neigh{
+			LinkIndex:    link.Attrs().Index,
+			Family:       unix.AF_INET6,
+			State:        netlink.NUD_PERMANENT,
+			IP:           dst.AsSlice(),
+			HardwareAddr: dummyMAC,
+		}
+		if err := netlink.NeighAdd(neigh); err != nil {
+			cleanup()
+			t.Fatalf("add static neighbor for %s: %v", dst, err)
+		}
+	}
+
+	return &testEnv{ifindex: link.Attrs().Index}, cleanup
+}
+
+// ---------------------------------------------------------------------
+// Packet construction and checksum verification. edgenat.c's own
+// checksum fixups are exercised by these tests via bpf_csum_diff -- this
+// section independently recomputes the expected TCP/UDP checksum in Go
+// from the rewritten packet's own bytes and compares, the same
+// "recompute independently, don't just eyeball it" standard gwprog's
+// gwnat_test.go held itself to.
+// ---------------------------------------------------------------------
+
+const (
+	ethHdrLen = 14
+	ip6HdrLen = 40
+	tcpHdrLen = 20
+	udpHdrLen = 8
+)
+
+func sum16(b []byte) uint32 {
+	var sum uint32
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(b[i])<<8 | uint32(b[i+1])
+	}
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+	return sum
+}
+
+func foldChecksum(sum uint32) uint16 {
+	for sum > 0xffff {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// ipv6L4Checksum computes the RFC 8200 §8.1 pseudo-header + payload
+// checksum for an IPv6 TCP/UDP segment. l4 must have its own checksum
+// field already zeroed.
+func ipv6L4Checksum(src, dst netip.Addr, protocol uint8, l4 []byte) uint16 {
+	s, d := src.As16(), dst.As16()
+	sum := sum16(s[:]) + sum16(d[:])
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(l4)))
+	sum += sum16(lenBuf[:])
+	sum += uint32(protocol)
+	sum += sum16(l4)
+	return foldChecksum(sum)
+}
+
+// buildTCPPacket returns a full Ethernet+IPv6+TCP frame (no payload) with
+// a correct checksum.
+func buildTCPPacket(src, dst netip.Addr, sport, dport uint16, synFlag bool) []byte {
+	pkt := make([]byte, ethHdrLen+ip6HdrLen+tcpHdrLen)
+
+	binary.BigEndian.PutUint16(pkt[12:14], 0x86DD) // ethertype IPv6
+
+	ip6 := pkt[ethHdrLen:]
+	ip6[0] = 0x60 // version 6, rest of vtc_flow zero
+	binary.BigEndian.PutUint16(ip6[4:6], tcpHdrLen)
+	ip6[6] = 6 // TCP
+	ip6[7] = 64
+	sb, db := src.As16(), dst.As16()
+	copy(ip6[8:24], sb[:])
+	copy(ip6[24:40], db[:])
+
+	tcp := ip6[ip6HdrLen:]
+	binary.BigEndian.PutUint16(tcp[0:2], sport)
+	binary.BigEndian.PutUint16(tcp[2:4], dport)
+	tcp[13] = 0x10 // ACK
+	if synFlag {
+		tcp[13] = 0x02 // SYN
+	}
+	binary.BigEndian.PutUint16(tcp[16:18], 0) // checksum placeholder
+
+	csum := ipv6L4Checksum(src, dst, 6, tcp)
+	binary.BigEndian.PutUint16(tcp[16:18], csum)
+
+	return pkt
+}
+
+// buildUDPPacket returns a full Ethernet+IPv6+UDP frame (no payload) with
+// a correct checksum.
+func buildUDPPacket(src, dst netip.Addr, sport, dport uint16) []byte {
+	pkt := make([]byte, ethHdrLen+ip6HdrLen+udpHdrLen)
+
+	binary.BigEndian.PutUint16(pkt[12:14], 0x86DD)
+
+	ip6 := pkt[ethHdrLen:]
+	ip6[0] = 0x60
+	binary.BigEndian.PutUint16(ip6[4:6], udpHdrLen)
+	ip6[6] = 17 // UDP
+	ip6[7] = 64
+	sb, db := src.As16(), dst.As16()
+	copy(ip6[8:24], sb[:])
+	copy(ip6[24:40], db[:])
+
+	udp := ip6[ip6HdrLen:]
+	binary.BigEndian.PutUint16(udp[0:2], sport)
+	binary.BigEndian.PutUint16(udp[2:4], dport)
+	binary.BigEndian.PutUint16(udp[4:6], udpHdrLen)
+	binary.BigEndian.PutUint16(udp[6:8], 0)
+
+	csum := ipv6L4Checksum(src, dst, 17, udp)
+	binary.BigEndian.PutUint16(udp[6:8], csum)
+
+	return pkt
+}
+
+// buildEncappedTCPPacket returns an Ethernet+outer-IPv6(NH=41)+inner-IPv6+
+// TCP frame -- the wire shape of a return packet arriving at the
+// gateway's own SRv6-reachable address, addressed from a backend to the
+// gateway's SNAT address:port.
+func buildEncappedTCPPacket(
+	outerSrc, outerDst, innerSrc, innerDst netip.Addr, sport, dport uint16, synFlag bool,
+) []byte {
+	inner := buildTCPPacket(innerSrc, innerDst, sport, dport, synFlag)[ethHdrLen:] // strip the throwaway inner eth
+
+	pkt := make([]byte, ethHdrLen+ip6HdrLen+len(inner))
+	binary.BigEndian.PutUint16(pkt[12:14], 0x86DD)
+
+	outer := pkt[ethHdrLen:]
+	outer[0] = 0x60
+	binary.BigEndian.PutUint16(outer[4:6], uint16(len(inner)))
+	outer[6] = 41 // IPv6-in-IPv6
+	outer[7] = 64
+	sb, db := outerSrc.As16(), outerDst.As16()
+	copy(outer[8:24], sb[:])
+	copy(outer[24:40], db[:])
+
+	copy(pkt[ethHdrLen+ip6HdrLen:], inner)
+	return pkt
+}
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("netip.ParseAddr(%q): %v", s, err)
+	}
+	return a
+}
+
+// Fixed addresses/ports shared across the tests below.
+var (
+	testVIP        = "2001:db8:1::10"
+	testClient     = "2001:db8:99::5"
+	testBackendIP  = "fd00:10:1::20"
+	testBackendSID = "2001:db8:2::1" // the backend's worker-node SRv6 uSID
+	testGWAddr     = "2001:db8:3::1" // this gateway's own SRv6-reachable SNAT address
+)
+
+const (
+	testVIPPort     = uint16(443)
+	testClientPort  = uint16(51234)
+	testBackendPort = uint16(8443)
+)
+
+// installRule populates rule_table with one VIP/port/protocol rule
+// pointing at a single backend, and gw_config_table with this gateway's
+// own SRv6 address.
+func installRule(t *testing.T, objs *EdgenatObjects) {
+	t.Helper()
+
+	vip := mustAddr(t, testVIP).As16()
+	backendAddr := mustAddr(t, testBackendIP).As16()
+	backendUSID := mustAddr(t, testBackendSID).As16()
+	gwAddr := mustAddr(t, testGWAddr).As16()
+
+	rk := EdgenatRuleKey{Proto: 6, Port: htons(testVIPPort), Vip: vip}
+	rv := EdgenatRuleValue{BackendCount: 1}
+	rv.Backends[0] = EdgenatBackend{Addr: backendAddr, Port: htons(testBackendPort), Usid: backendUSID}
+	if err := objs.RuleTable.Put(rk, rv); err != nil {
+		t.Fatalf("populate rule_table: %v", err)
+	}
+
+	if err := objs.GwConfigTable.Put(uint32(0), EdgenatGwConfig{GwAddr: gwAddr}); err != nil {
+		t.Fatalf("populate gw_config_table: %v", err)
+	}
+}
+
+func parseEth(t *testing.T, pkt []byte) {
+	t.Helper()
+	if len(pkt) < ethHdrLen {
+		t.Fatalf("packet too short for an Ethernet header: %d bytes", len(pkt))
+	}
+	if got := binary.BigEndian.Uint16(pkt[12:14]); got != 0x86DD {
+		t.Errorf("ethertype = %#04x, want 0x86dd (IPv6)", got)
+	}
+}
+
+// TestEdgeNat_NoRuleMatchPassesThrough covers a TCP packet to an address
+// with no rule_table entry at all -- must XDP_PASS untouched, so ordinary
+// traffic to the node itself (SSH, BGP) is never affected.
+func TestEdgeNat_NoRuleMatchPassesThrough(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	pkt := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, "2001:db8:1::99"), testClientPort, 22, true)
+	ret, out := runXDP(t, objs.EdgeNat, pkt, 1)
+	if ret != xdpPass {
+		t.Fatalf("verdict = %d, want XDP_PASS (%d)", ret, xdpPass)
+	}
+	if string(out[:len(pkt)]) != string(pkt) {
+		t.Error("XDP_PASS packet was modified, want byte-for-byte untouched")
+	}
+}
+
+// TestEdgeNat_ForwardSYNAllocatesRewritesAndEncapsulates covers the full
+// forward path end-to-end: a fresh SYN to a known VIP must be DNAT'd to
+// the backend, SNAT'd to this gateway's own address, checksum-fixed, and
+// wrapped in a correctly addressed outer SRv6 header, with a real
+// bpf_fib_lookup-resolved L2 header (proven via the on-link route/neighbor
+// this test's testEnv installs) -- ending in XDP_TX, not just "reached
+// the FIB lookup."
+func TestEdgeNat_ForwardSYNAllocatesRewritesAndEncapsulates(t *testing.T) {
+	env, cleanup := setupTestEnv(t, []netip.Addr{mustAddr(t, testBackendSID)})
+	defer cleanup()
+
+	objs := loadObjects(t)
+	installRule(t, objs)
+
+	pkt := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, testVIPPort, true)
+	ret, out := runXDP(t, objs.EdgeNat, pkt, env.ifindex)
+	if ret != xdpTx {
+		t.Fatalf("verdict = %d, want XDP_TX (%d)", ret, xdpTx)
+	}
+
+	wantLen := ethHdrLen + ip6HdrLen + ip6HdrLen + tcpHdrLen
+	out = out[:wantLen]
+	parseEth(t, out)
+
+	outer := out[ethHdrLen:]
+	if got := outer[6]; got != 41 {
+		t.Errorf("outer nexthdr = %d, want 41 (IPv6-in-IPv6)", got)
+	}
+	if got := netip.AddrFrom16([16]byte(outer[8:24])); got != mustAddr(t, testGWAddr) {
+		t.Errorf("outer saddr = %s, want this gateway's own address %s", got, testGWAddr)
+	}
+	if got := netip.AddrFrom16([16]byte(outer[24:40])); got != mustAddr(t, testBackendSID) {
+		t.Errorf("outer daddr = %s, want the backend's worker-node uSID %s", got, testBackendSID)
+	}
+
+	inner := outer[ip6HdrLen:]
+	if got := netip.AddrFrom16([16]byte(inner[8:24])); got != mustAddr(t, testGWAddr) {
+		t.Errorf("inner saddr (SNAT) = %s, want gateway address %s", got, testGWAddr)
+	}
+	if got := netip.AddrFrom16([16]byte(inner[24:40])); got != mustAddr(t, testBackendIP) {
+		t.Errorf("inner daddr (DNAT) = %s, want backend address %s", got, testBackendIP)
+	}
+
+	tcp := inner[ip6HdrLen:]
+	if got := binary.BigEndian.Uint16(tcp[2:4]); got != testBackendPort {
+		t.Errorf("inner dest port = %d, want backend port %d", got, testBackendPort)
+	}
+	gotSNATPort := binary.BigEndian.Uint16(tcp[0:2])
+
+	wantCsum := ipv6L4ChecksumZeroed(t, mustAddr(t, testGWAddr), mustAddr(t, testBackendIP), 6, tcp)
+	if gotCsum := binary.BigEndian.Uint16(tcp[16:18]); gotCsum != wantCsum {
+		t.Errorf("inner TCP checksum = %#04x, want %#04x (independently recomputed)", gotCsum, wantCsum)
+	}
+
+	// A second packet on the same 5-tuple (even a plain ACK, not a SYN)
+	// must reuse the exact same backend/SNAT-port assignment via
+	// conn_table, not drop or re-allocate.
+	pkt2 := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, testVIPPort, false)
+	ret2, out2 := runXDP(t, objs.EdgeNat, pkt2, env.ifindex)
+	if ret2 != xdpTx {
+		t.Fatalf("second packet verdict = %d, want XDP_TX (%d)", ret2, xdpTx)
+	}
+	out2 = out2[:wantLen]
+	inner2 := out2[ethHdrLen+ip6HdrLen+ip6HdrLen:]
+	if got := binary.BigEndian.Uint16(inner2[0:2]); got != gotSNATPort {
+		t.Errorf("second packet SNAT port = %d, want the same allocated port %d (reused from conn_table)",
+			got, gotSNATPort)
+	}
+}
+
+// TestEdgeNat_ForwardIncrementsRuleHitCounters covers the design plan's
+// Phase E hit counters: a successfully forwarded packet must bump
+// rule_table's Packets/Bytes/LastSeenNs (backing internal/gateway's
+// QuotaEnforcer/TelemetryEmitter), with DroppedPackets left at zero since
+// nothing was dropped.
+func TestEdgeNat_ForwardIncrementsRuleHitCounters(t *testing.T) {
+	env, cleanup := setupTestEnv(t, []netip.Addr{mustAddr(t, testBackendSID)})
+	defer cleanup()
+
+	objs := loadObjects(t)
+	installRule(t, objs)
+
+	pkt := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, testVIPPort, true)
+	ret, _ := runXDP(t, objs.EdgeNat, pkt, env.ifindex)
+	if ret != xdpTx {
+		t.Fatalf("verdict = %d, want XDP_TX (%d)", ret, xdpTx)
+	}
+
+	rk := EdgenatRuleKey{Proto: 6, Port: htons(testVIPPort), Vip: mustAddr(t, testVIP).As16()}
+	var rv EdgenatRuleValue
+	if err := objs.RuleTable.Lookup(rk, &rv); err != nil {
+		t.Fatalf("read back rule_table entry: %v", err)
+	}
+	if rv.Packets != 1 {
+		t.Errorf("rule_table Packets = %d, want 1", rv.Packets)
+	}
+	if rv.Bytes != uint64(len(pkt)) {
+		t.Errorf("rule_table Bytes = %d, want %d (the ingress packet's own length)", rv.Bytes, len(pkt))
+	}
+	if rv.DroppedPackets != 0 {
+		t.Errorf("rule_table DroppedPackets = %d, want 0 (nothing was dropped)", rv.DroppedPackets)
+	}
+	if rv.LastSeenNs == 0 {
+		t.Error("rule_table LastSeenNs was never stamped")
+	}
+
+	// A second packet on the same flow must add to Packets/Bytes, not
+	// reset them -- edgemap.RuleTable.Register's read-modify-write must
+	// preserve these across re-registration too (see ruletable_test.go),
+	// but this confirms the datapath side accumulates correctly first.
+	pkt2 := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, testVIPPort, false)
+	if ret2, _ := runXDP(t, objs.EdgeNat, pkt2, env.ifindex); ret2 != xdpTx {
+		t.Fatalf("second packet verdict = %d, want XDP_TX (%d)", ret2, xdpTx)
+	}
+	var rv2 EdgenatRuleValue
+	if err := objs.RuleTable.Lookup(rk, &rv2); err != nil {
+		t.Fatalf("read back rule_table entry after second packet: %v", err)
+	}
+	if rv2.Packets != 2 {
+		t.Errorf("rule_table Packets after second packet = %d, want 2 (accumulated, not reset)", rv2.Packets)
+	}
+	if rv2.Bytes != rv.Bytes+uint64(len(pkt2)) {
+		t.Errorf("rule_table Bytes after second packet = %d, want %d (accumulated)", rv2.Bytes, rv.Bytes+uint64(len(pkt2)))
+	}
+}
+
+// TestEdgeNat_ForwardNonSYNWithNoConnDrops covers a non-SYN TCP packet
+// (an ACK, say) to a known VIP with no existing conn_table state -- there
+// is no correct point to start a brand-new translated flow except a SYN
+// (or, for UDP, any first packet), so this must drop, not pass through
+// (the VIP is claimed).
+func TestEdgeNat_ForwardNonSYNWithNoConnDrops(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+	installRule(t, objs)
+
+	pkt := buildTCPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, testVIPPort, false)
+	ret, _ := runXDP(t, objs.EdgeNat, pkt, 1)
+	if ret != xdpDrop {
+		t.Fatalf("verdict = %d, want XDP_DROP (%d)", ret, xdpDrop)
+	}
+
+	got := sumPerCPU(t, objs.DropReasons, DropReasonNoConnNotSyn)
+	if got != 1 {
+		t.Errorf("drop_reasons[no_conn_not_syn] = %d, want 1", got)
+	}
+
+	// The drop happened after this packet's VIP+port+protocol matched
+	// rule_table (design plan Phase E), so it counts against both the
+	// rule's own Packets (every packet that matched, regardless of
+	// outcome) and DroppedPackets (the claimed-drop subset) -- see
+	// edgenat.c's count_claimed_drop.
+	rk := EdgenatRuleKey{Proto: 6, Port: htons(testVIPPort), Vip: mustAddr(t, testVIP).As16()}
+	var rv EdgenatRuleValue
+	if err := objs.RuleTable.Lookup(rk, &rv); err != nil {
+		t.Fatalf("read back rule_table entry: %v", err)
+	}
+	if rv.Packets != 1 {
+		t.Errorf("rule_table Packets = %d, want 1", rv.Packets)
+	}
+	if rv.DroppedPackets != 1 {
+		t.Errorf("rule_table DroppedPackets = %d, want 1", rv.DroppedPackets)
+	}
+	if rv.LastSeenNs == 0 {
+		t.Error("rule_table LastSeenNs was never stamped")
+	}
+}
+
+// TestEdgeNat_ForwardUDPFirstPacketAllocates covers the UDP path: unlike
+// TCP, any first packet (no SYN concept) may start a new flow.
+func TestEdgeNat_ForwardUDPFirstPacketAllocates(t *testing.T) {
+	env, cleanup := setupTestEnv(t, []netip.Addr{mustAddr(t, testBackendSID)})
+	defer cleanup()
+
+	objs := loadObjects(t)
+	vip := mustAddr(t, testVIP).As16()
+	backendAddr := mustAddr(t, testBackendIP).As16()
+	backendUSID := mustAddr(t, testBackendSID).As16()
+	gwAddr := mustAddr(t, testGWAddr).As16()
+
+	rk := EdgenatRuleKey{Proto: 17, Port: htons(53), Vip: vip}
+	rv := EdgenatRuleValue{BackendCount: 1}
+	rv.Backends[0] = EdgenatBackend{Addr: backendAddr, Port: htons(testBackendPort), Usid: backendUSID}
+	if err := objs.RuleTable.Put(rk, rv); err != nil {
+		t.Fatalf("populate rule_table: %v", err)
+	}
+	if err := objs.GwConfigTable.Put(uint32(0), EdgenatGwConfig{GwAddr: gwAddr}); err != nil {
+		t.Fatalf("populate gw_config_table: %v", err)
+	}
+
+	pkt := buildUDPPacket(mustAddr(t, testClient), mustAddr(t, testVIP), testClientPort, 53)
+	ret, _ := runXDP(t, objs.EdgeNat, pkt, env.ifindex)
+	if ret != xdpTx {
+		t.Fatalf("verdict = %d, want XDP_TX (%d)", ret, xdpTx)
+	}
+}
+
+// TestEdgeNat_ReturnPacketUnNATsEndToEnd covers the return/decap branch:
+// a reply from the backend, encapsulated and addressed to this gateway's
+// own SRv6 address, must be decapsulated, un-SNAT'd/un-DNAT'd back to the
+// client's original view, checksum-fixed, and transmitted toward the
+// client with a real FIB-resolved L2 header.
+func TestEdgeNat_ReturnPacketUnNATsEndToEnd(t *testing.T) {
+	env, cleanup := setupTestEnv(t, []netip.Addr{mustAddr(t, testClient)})
+	defer cleanup()
+
+	objs := loadObjects(t)
+
+	gwAddr := mustAddr(t, testGWAddr)
+	if err := objs.GwConfigTable.Put(uint32(0), EdgenatGwConfig{GwAddr: gwAddr.As16()}); err != nil {
+		t.Fatalf("populate gw_config_table: %v", err)
+	}
+
+	const snatPort = uint16(40000)
+	rev := EdgenatConnKey{
+		Proto: 6,
+		Saddr: mustAddr(t, testBackendIP).As16(),
+		Sport: htons(testBackendPort),
+		Daddr: gwAddr.As16(),
+		Dport: htons(snatPort),
+	}
+	cv := EdgenatConnValue{
+		ClientAddr:  mustAddr(t, testClient).As16(),
+		ClientPort:  htons(testClientPort),
+		VipAddr:     mustAddr(t, testVIP).As16(),
+		VipPort:     htons(testVIPPort),
+		BackendAddr: mustAddr(t, testBackendIP).As16(),
+		BackendPort: htons(testBackendPort),
+		BackendUsid: mustAddr(t, testBackendSID).As16(),
+		GwAddr:      gwAddr.As16(),
+		GwPort:      htons(snatPort),
+		Proto:       6,
+	}
+	if err := objs.ConnTable.Put(rev, cv); err != nil {
+		t.Fatalf("populate conn_table reverse row: %v", err)
+	}
+
+	// buildEncappedTCPPacket (like buildTCPPacket, which it wraps) takes
+	// host-order port arguments and does its own big-endian encoding --
+	// snatPort is already a plain host-order value, matching testBackendPort.
+	pkt := buildEncappedTCPPacket(
+		mustAddr(t, testBackendSID), gwAddr,
+		mustAddr(t, testBackendIP), gwAddr,
+		testBackendPort, snatPort, false,
+	)
+
+	ret, out := runXDP(t, objs.EdgeNat, pkt, env.ifindex)
+	if ret != xdpTx {
+		t.Fatalf("verdict = %d, want XDP_TX (%d)", ret, xdpTx)
+	}
+
+	wantLen := ethHdrLen + ip6HdrLen + tcpHdrLen
+	out = out[:wantLen]
+	parseEth(t, out)
+
+	ip6 := out[ethHdrLen:]
+	if got := netip.AddrFrom16([16]byte(ip6[8:24])); got != mustAddr(t, testVIP) {
+		t.Errorf("saddr (un-DNAT) = %s, want VIP %s", got, testVIP)
+	}
+	if got := netip.AddrFrom16([16]byte(ip6[24:40])); got != mustAddr(t, testClient) {
+		t.Errorf("daddr (un-SNAT) = %s, want client %s", got, testClient)
+	}
+
+	tcp := ip6[ip6HdrLen:]
+	if got := binary.BigEndian.Uint16(tcp[0:2]); got != testVIPPort {
+		t.Errorf("source port = %d, want VIP port %d", got, testVIPPort)
+	}
+	if got := binary.BigEndian.Uint16(tcp[2:4]); got != testClientPort {
+		t.Errorf("dest port = %d, want client port %d", got, testClientPort)
+	}
+
+	wantCsum := ipv6L4ChecksumZeroed(t, mustAddr(t, testVIP), mustAddr(t, testClient), 6, tcp)
+	if gotCsum := binary.BigEndian.Uint16(tcp[16:18]); gotCsum != wantCsum {
+		t.Errorf("TCP checksum = %#04x, want %#04x (independently recomputed)", gotCsum, wantCsum)
+	}
+}
+
+// TestEdgeNat_ReturnWithNoConnDrops covers a packet addressed to this
+// gateway's own SRv6 address with no matching conn_table row -- the
+// address is claimed, so this must drop, not pass through.
+func TestEdgeNat_ReturnWithNoConnDrops(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	gwAddr := mustAddr(t, testGWAddr)
+	if err := objs.GwConfigTable.Put(uint32(0), EdgenatGwConfig{GwAddr: gwAddr.As16()}); err != nil {
+		t.Fatalf("populate gw_config_table: %v", err)
+	}
+
+	pkt := buildEncappedTCPPacket(
+		mustAddr(t, testBackendSID), gwAddr,
+		mustAddr(t, testBackendIP), gwAddr,
+		testBackendPort, 40000, false,
+	)
+	ret, _ := runXDP(t, objs.EdgeNat, pkt, 1)
+	if ret != xdpDrop {
+		t.Fatalf("verdict = %d, want XDP_DROP (%d)", ret, xdpDrop)
+	}
+
+	got := sumPerCPU(t, objs.DropReasons, DropReasonNoReturnConn)
+	if got != 1 {
+		t.Errorf("drop_reasons[no_return_conn] = %d, want 1", got)
+	}
+}
+
+// ipv6L4ChecksumZeroed recomputes the expected checksum for l4 (whose own
+// checksum field is NOT already zero) by zeroing a copy of that field
+// first, matching how a real TCP/IP stack computes it.
+func ipv6L4ChecksumZeroed(t *testing.T, src, dst netip.Addr, protocol uint8, l4 []byte) uint16 {
+	t.Helper()
+	cp := make([]byte, len(l4))
+	copy(cp, l4)
+	binary.BigEndian.PutUint16(cp[16:18], 0)
+	return ipv6L4Checksum(src, dst, protocol, cp)
+}
+
+// sumPerCPU sums a BPF_MAP_TYPE_PERCPU_ARRAY counter across every CPU.
+func sumPerCPU(t *testing.T, m *ebpf.Map, index uint32) uint64 {
+	t.Helper()
+	var perCPU []uint64
+	if err := m.Lookup(index, &perCPU); err != nil {
+		t.Fatalf("lookup drop_reasons[%d]: %v", index, err)
+	}
+	var total uint64
+	for _, v := range perCPU {
+		total += v
+	}
+	return total
+}


### PR DESCRIPTION
## Summary

The edge gateway needs a kernel-level datapath that DNATs a public VIP:port to a backend's SRv6 uSID and forwards it into the fabric, without a userspace hop per packet. This adds that datapath as a self-contained package tree with no Kubernetes or CRD dependency: the XDP program itself, load/attach/pin logic, a Go-side rule table wrapper, kernel feature preflight checks, and a Prometheus collector over its drop-reason counters. First branch in an 8-part stack splitting the edge NAT+LB gateway feature into reviewable, independently buildable PRs — later branches (control-plane engine, CRD reconcilers, the new binary, manifests, lab canary, docs) build on this one.

## Test plan

- [ ] Unit tests pass for the new eBPF plumbing packages (`task test:unit`)
- [ ] `task lint` and `task build` are clean

Related to #17