### PR TITLE
feat(gateway): Add gateway control-plane engine

### DIFF
--- a/internal/gateway/datapath.go
+++ b/internal/gateway/datapath.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import "context"
+
+// Datapath is the engine's interface onto the actual NAT/load-balancing
+// dataplane for one DesiredRule. GoBGP, via galactic-router's existing
+// embedding, owns all BGP speaking (the design plan's Active-Active BGP
+// model); no BGP speaker lives in this interface's implementations at
+// all.
+//
+// KernelDatapath (kerneldatapath.go) is the real implementation, backed by
+// internal/plumbing/ebpf/edgemap's RuleTable API onto a loaded
+// internal/plumbing/ebpf/edgeprog.EdgenatObjects. Unlike an earlier,
+// rejected design's identically-named interface, there is no
+// lpmOverrides parameter here at all: that existed solely to work around a
+// LoxiLB-internal routing-engine self-collision bug, and this design has
+// no internal routing engine of its own for a return packet to collide
+// with (see doc.go). NoopDatapath remains available for tests and any
+// caller not yet wired to a loaded, attached edgeprog program.
+type Datapath interface {
+	// ApplyRule programs (or reprograms) rule's ingress DNAT/LB state.
+	ApplyRule(ctx context.Context, rule DesiredRule) error
+
+	// RemoveRule tears down rule_table state for the rule identified by
+	// key. The caller (the future NetworkRule controller) must withdraw
+	// the rule's BGP route before calling this, never after — removing
+	// NAT state first while the route is still advertised risks
+	// blackholing in-flight flows through a translation that no longer
+	// exists.
+	RemoveRule(ctx context.Context, key string) error
+
+	// Generation returns a snapshot of the datapath's own monotonic
+	// clock, for crash-recovery purposes. Callers intending to call
+	// ReconcileOrphans must capture this immediately *before* listing the
+	// NetworkRule CRDs that become that call's live set — see
+	// internal/plumbing/ebpf/edgemap's RuleTable.Generation doc comment
+	// for why the ordering matters.
+	Generation() uint64
+
+	// ReconcileOrphans removes rule_table state whose owning rule is
+	// absent from live and was written before cutoff — the datapath-level
+	// half of Engine.ReconcileOrphans (recovery.go).
+	ReconcileOrphans(ctx context.Context, live []DesiredRule, cutoff uint64) error
+}
+
+// QuotaEnforcer is the engine's interface onto per-tenant conntrack/NAT
+// table quota enforcement, called once per rule per convergence pass so a
+// misbehaving tenant's traffic can be capped before it exhausts shared
+// conntrack/eBPF map capacity on its assigned gateway node.
+//
+// NodeQuotaEnforcer (quota.go) is the real (Phase E) implementation: a
+// coarse, node-level admission cap (max rules per tenant, max total
+// rule_table entries), not per-flow/conntrack rate limiting — see that
+// type's doc comment for why the latter needs live traffic data to
+// calibrate sensible thresholds against, which this repo does not have
+// yet (the design plan's Phase D was authored as manifests only, not
+// exercised against a live cluster). NoopQuotaEnforcer remains available
+// for tests and always reports quota as available.
+type QuotaEnforcer interface {
+	// CheckAndReserve reports whether rule is within its per-tenant quota
+	// and, if so, reserves the resources ApplyRule is about to consume.
+	CheckAndReserve(ctx context.Context, rule DesiredRule) (bool, error)
+
+	// Release frees any quota reservation held for key, called during
+	// teardown, alongside Datapath.RemoveRule.
+	Release(ctx context.Context, key string) error
+}
+
+// TelemetryEmitter is the engine's interface onto telemetry for
+// conntrack/NAT entry counts, drop counters, and primary/secondary BGP
+// advertisement state per VIP.
+//
+// PrometheusTelemetryEmitter (telemetry.go) is the real (Phase E)
+// implementation, covering only what these call sites uniquely know
+// (primary/secondary placement, control-plane-level rejections) --
+// rule_table's own per-packet counters are exposed separately by
+// internal/plumbing/ebpf/edgemetrics's pull-based Collector; see both
+// types' doc comments for the full split. NoopTelemetryEmitter remains
+// available for tests and drops every call on the floor.
+type TelemetryEmitter interface {
+	// RuleApplied is called after a successful Datapath.ApplyRule, so a
+	// caller can emit primary/secondary advertisement state and NAT/
+	// conntrack counters for the rule.
+	RuleApplied(ctx context.Context, rule DesiredRule)
+
+	// RuleRemoved is called after a successful teardown of key.
+	RuleRemoved(ctx context.Context, key string)
+
+	// DropObserved records a dropped packet/flow for key, distinguishing
+	// quota-enforcement drops from genuine failures via reason.
+	DropObserved(ctx context.Context, key string, reason string)
+}
+
+// NoopDatapath is a placeholder Datapath implementation for tests and any
+// caller not yet wired to a loaded, attached edgeprog program —
+// KernelDatapath (kerneldatapath.go) is the real implementation; see
+// Datapath's doc comment.
+type NoopDatapath struct{}
+
+func (NoopDatapath) ApplyRule(context.Context, DesiredRule) error { return nil }
+func (NoopDatapath) RemoveRule(context.Context, string) error     { return nil }
+func (NoopDatapath) Generation() uint64                           { return 0 }
+func (NoopDatapath) ReconcileOrphans(context.Context, []DesiredRule, uint64) error {
+	return nil
+}
+
+// NoopQuotaEnforcer is the TODO-marked placeholder QuotaEnforcer
+// implementation. It always reports quota as available — see
+// QuotaEnforcer's doc comment for why real enforcement is deferred.
+type NoopQuotaEnforcer struct{}
+
+// CheckAndReserve always allows the rule.
+func (NoopQuotaEnforcer) CheckAndReserve(context.Context, DesiredRule) (bool, error) {
+	return true, nil
+}
+
+// Release is a no-op.
+func (NoopQuotaEnforcer) Release(context.Context, string) error {
+	return nil
+}
+
+// NoopTelemetryEmitter is the TODO-marked placeholder TelemetryEmitter
+// implementation. It drops every call — see TelemetryEmitter's doc
+// comment for why the real implementation is deferred.
+type NoopTelemetryEmitter struct{}
+
+// RuleApplied is a no-op.
+func (NoopTelemetryEmitter) RuleApplied(context.Context, DesiredRule) {}
+
+// RuleRemoved is a no-op.
+func (NoopTelemetryEmitter) RuleRemoved(context.Context, string) {}
+
+// DropObserved is a no-op.
+func (NoopTelemetryEmitter) DropObserved(context.Context, string, string) {}

--- a/internal/gateway/diff.go
+++ b/internal/gateway/diff.go
@@ -1,0 +1,32 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import "sort"
+
+// diffRuleKeys compares the currently-active rule keys against the desired
+// EngineState and returns which keys need to be (re)applied and which need
+// to be removed. A key present in both sets is always returned in toApply
+// (Engine.Reconcile applies unconditionally rather than trying to diff
+// individual field changes — matching GoBGPRuntime's own "re-apply the
+// whole desired set" convergence style) — toApply/toRemove partition the
+// *key space*, not "changed vs. unchanged".
+//
+// Both returned slices are sorted for deterministic iteration order (log
+// output, test assertions) — desired/active are Go maps, whose iteration
+// order is intentionally randomized.
+func diffRuleKeys(active map[string]DesiredRule, desired map[string]DesiredRule) (toApply, toRemove []string) {
+	for key := range desired {
+		toApply = append(toApply, key)
+	}
+	for key := range active {
+		if _, ok := desired[key]; !ok {
+			toRemove = append(toRemove, key)
+		}
+	}
+	sort.Strings(toApply)
+	sort.Strings(toRemove)
+	return toApply, toRemove
+}

--- a/internal/gateway/diff_test.go
+++ b/internal/gateway/diff_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	testKeyA    = "ns/a"
+	testKeyB    = "ns/b"
+	testKeyKeep = "ns/keep"
+)
+
+func TestDiffRuleKeys_ApplyAndRemove(t *testing.T) {
+	active := map[string]DesiredRule{
+		testKeyKeep: {Key: testKeyKeep},
+		testKeyA:    {Key: testKeyA},
+	}
+	desired := map[string]DesiredRule{
+		testKeyKeep: {Key: testKeyKeep},
+		testKeyB:    {Key: testKeyB},
+	}
+
+	toApply, toRemove := diffRuleKeys(active, desired)
+
+	if want := []string{testKeyB, testKeyKeep}; !reflect.DeepEqual(toApply, want) {
+		t.Errorf("toApply = %v, want %v", toApply, want)
+	}
+	if want := []string{testKeyA}; !reflect.DeepEqual(toRemove, want) {
+		t.Errorf("toRemove = %v, want %v", toRemove, want)
+	}
+}
+
+func TestDiffRuleKeys_EmptyInputs(t *testing.T) {
+	toApply, toRemove := diffRuleKeys(nil, nil)
+	if len(toApply) != 0 || len(toRemove) != 0 {
+		t.Errorf("diffRuleKeys(nil, nil) = (%v, %v), want both empty", toApply, toRemove)
+	}
+}
+
+func TestDiffRuleKeys_AllNewNoActive(t *testing.T) {
+	desired := map[string]DesiredRule{testKeyA: {Key: testKeyA}, testKeyB: {Key: testKeyB}}
+	toApply, toRemove := diffRuleKeys(nil, desired)
+	if want := []string{testKeyA, testKeyB}; !reflect.DeepEqual(toApply, want) {
+		t.Errorf("toApply = %v, want %v", toApply, want)
+	}
+	if len(toRemove) != 0 {
+		t.Errorf("toRemove = %v, want empty", toRemove)
+	}
+}
+
+func TestDiffRuleKeys_AllRemovedNoDesired(t *testing.T) {
+	active := map[string]DesiredRule{testKeyA: {Key: testKeyA}, testKeyB: {Key: testKeyB}}
+	toApply, toRemove := diffRuleKeys(active, nil)
+	if len(toApply) != 0 {
+		t.Errorf("toApply = %v, want empty", toApply)
+	}
+	if want := []string{testKeyA, testKeyB}; !reflect.DeepEqual(toRemove, want) {
+		t.Errorf("toRemove = %v, want %v", toRemove, want)
+	}
+}

--- a/internal/gateway/doc.go
+++ b/internal/gateway/doc.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package gateway implements the in-process edge NAT+LB gateway engine
+// described in the design plan
+// (.claude/plans/merry-percolating-tulip.md). One Engine runs per
+// gateway-role node (one process, one NetworkGateway object), converging
+// the set of accepted network.datumapis.com/v1alpha1 NetworkRule resources
+// for that node into calls against a pluggable Datapath (datapath.go).
+//
+// This is a deliberate pivot away from an earlier, rejected design that
+// tunneled tenant traffic to gateway nodes over Geneve and drove a TC-BPF
+// program keyed by (VNI, 5-tuple), after three rounds of live spikes ruled
+// out driving LoxiLB directly and found native XDP unavailable
+// specifically on Geneve tunnel devices. This package instead backs onto
+// internal/plumbing/ebpf/edgeprog's XDP program directly: no tunnel, no
+// per-tenant Geneve provisioning, and — because the outer SRv6 header is
+// pushed straight from the program's own rule_table (resolved via
+// internal/plumbing/ebpf/edgemap) rather than a kernel VRF route — no VRF
+// dependency and no exposure to the two GoBGP bugs
+// ([[project_vpc20_siit_gateway_design]] in the operator's memory; see
+// internal/runtime/gobgp/monitor.go's processEVPNPath and runtime.go's
+// rtIndex) that forced every earlier per-VPC gateway design to colocate
+// with the workload's own VRF.
+//
+//   - engine.go: Engine, the mutex-guarded convergence loop, mirroring
+//     internal/runtime/gobgp's GoBGPRuntime shape ("apply everything in
+//     desired, remove everything not in desired" rather than a
+//     field-level diff, so a partial previous failure self-heals on the
+//     next Reconcile).
+//   - types.go: DesiredRule/DesiredBackend/EngineState/EngineStatus, the
+//     engine's own representation of a NetworkRule, assembled by the
+//     future NetworkGateway/NetworkRule controllers.
+//   - datapath.go: the Datapath/QuotaEnforcer/TelemetryEmitter interfaces
+//     Engine calls through. KernelDatapath (kerneldatapath.go) is the
+//     real Datapath implementation, backed by
+//     internal/plumbing/ebpf/edgemap's RuleTable and a loaded
+//     internal/plumbing/ebpf/edgeprog.EdgenatObjects (loading/attaching
+//     that object to an interface is internal/plumbing/ebpf/edgeattach's
+//     job, called from cmd/galactic-router's own startup, not from
+//     anywhere in this package). QuotaEnforcer/TelemetryEmitter remain
+//     Noop-stubbed (deferred to the design plan's Phase E).
+//   - placement.go/localpref.go: the Active-Active BGP model's pure,
+//     dependency-free primary-node hashing and local-preference lookup —
+//     unaffected by the datapath pivot above, since they never touched
+//     Geneve/TC-BPF/VRF state in the first place.
+//   - recovery.go: Engine.ReconcileOrphans, the crash-recovery pass for a
+//     process that died mid-reconcile — unlike the earlier design's
+//     Geneve-interface scan, this delegates directly to
+//     edgemap.RuleTable.Reconcile's own Generation-cutoff mechanism (see
+//     that package's doc comment), since rule_table state (not a kernel
+//     interface) is the only thing this design can leak on a crash.
+//   - diff.go: diffRuleKeys, the pure key-set diff both Reconcile and
+//     ReconcileOrphans build on.
+package gateway

--- a/internal/gateway/engine.go
+++ b/internal/gateway/engine.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Engine is the in-process gateway engine running on one gateway node,
+// mirroring internal/runtime/gobgp's GoBGPRuntime shape: a mutex-protected
+// map of currently-active state, converged towards a desired state on each
+// Reconcile call.
+//
+// Unlike an earlier, rejected design's identically-named type,
+// Engine holds no VRF/Geneve state at all — no vrfLinkNames map, no
+// SetVRFLink method — because this datapath has no VRF dependency (see
+// doc.go).
+type Engine struct {
+	mu     sync.Mutex
+	active map[string]DesiredRule
+
+	datapath  Datapath
+	quota     QuotaEnforcer
+	telemetry TelemetryEmitter
+}
+
+// NewEngine returns an Engine wired to the given Datapath, QuotaEnforcer,
+// and TelemetryEmitter implementations. Production callers pass
+// KernelDatapath (kerneldatapath.go), NoopQuotaEnforcer{}, and
+// NoopTelemetryEmitter{} until those interfaces' real implementations
+// land; tests pass fakes.
+func NewEngine(datapath Datapath, quota QuotaEnforcer, telemetry TelemetryEmitter) *Engine {
+	return &Engine{
+		active:    make(map[string]DesiredRule),
+		datapath:  datapath,
+		quota:     quota,
+		telemetry: telemetry,
+	}
+}
+
+// Reconcile converges the engine's live state toward desired: every rule in
+// desired.Rules is (re-)applied via Datapath.ApplyRule, and every rule no
+// longer present in desired.Rules but still active is torn down via
+// Datapath.RemoveRule (the caller must already have withdrawn its BGP
+// route before it ever disappears from desired — see Datapath.RemoveRule's
+// doc comment).
+//
+// Reconcile is intentionally "apply everything in desired, remove
+// everything not in desired" rather than a fine-grained field-level diff —
+// matching GoBGPRuntime.Apply's own convergence style — so a partial
+// previous failure (e.g. the process crashed between two rules) always
+// self-heals on the next call rather than requiring the caller to track
+// what succeeded.
+func (e *Engine) Reconcile(ctx context.Context, desired EngineState) (EngineStatus, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	toApply, toRemove := diffRuleKeys(e.active, desired.Rules)
+
+	var statuses []RuleStatus
+	for _, key := range toApply {
+		rule := desired.Rules[key]
+		if err := e.applyRuleLocked(ctx, rule); err != nil {
+			statuses = append(statuses, RuleStatus{Key: key, Applied: false, Error: err.Error()})
+			continue
+		}
+		e.active[key] = rule
+		statuses = append(statuses, RuleStatus{Key: key, Applied: true})
+	}
+
+	for _, key := range toRemove {
+		if err := e.removeRuleLocked(ctx, key); err != nil {
+			statuses = append(statuses, RuleStatus{Key: key, Applied: true, Error: err.Error()})
+			continue
+		}
+		delete(e.active, key)
+	}
+
+	healthy := true
+	for _, s := range statuses {
+		if s.Error != "" {
+			healthy = false
+			break
+		}
+	}
+	return EngineStatus{Healthy: healthy, Rules: statuses}, nil
+}
+
+// Status returns the current observed state without performing a
+// convergence pass, mirroring RouterRuntime.Status.
+func (e *Engine) Status(context.Context) (EngineStatus, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	statuses := make([]RuleStatus, 0, len(e.active))
+	for key := range e.active {
+		statuses = append(statuses, RuleStatus{Key: key, Applied: true})
+	}
+	return EngineStatus{Healthy: true, Rules: statuses}, nil
+}
+
+// Stop tears down every currently-active rule. The caller must already
+// have withdrawn BGP routes for every rule before calling this, exactly as
+// for an individual rule removal via Reconcile.
+func (e *Engine) Stop(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var firstErr error
+	for key := range e.active {
+		if err := e.removeRuleLocked(ctx, key); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("stop: remove rule %s: %w", key, err)
+			continue
+		}
+		delete(e.active, key)
+	}
+	return firstErr
+}
+
+// DatapathGeneration returns a snapshot of the underlying Datapath's
+// monotonic clock. Callers intending to call ReconcileOrphans must invoke
+// this *before* listing the NetworkRule CRDs that will become that call's
+// live set — see Datapath.Generation's doc comment for why the ordering
+// matters, and recovery.go for the full crash-recovery contract.
+func (e *Engine) DatapathGeneration() uint64 {
+	return e.datapath.Generation()
+}
+
+// applyRuleLocked performs the real (quota-gated Datapath.ApplyRule) work
+// for a single rule. Caller must hold e.mu.
+func (e *Engine) applyRuleLocked(ctx context.Context, rule DesiredRule) error {
+	ok, err := e.quota.CheckAndReserve(ctx, rule)
+	if err != nil {
+		return fmt.Errorf("quota check for %s: %w", rule.Key, err)
+	}
+	if !ok {
+		e.telemetry.DropObserved(ctx, rule.Key, "quota_exceeded")
+		return fmt.Errorf("rule %s exceeds its per-tenant quota", rule.Key)
+	}
+
+	if err := e.datapath.ApplyRule(ctx, rule); err != nil {
+		return fmt.Errorf("apply datapath rule %s: %w", rule.Key, err)
+	}
+
+	e.telemetry.RuleApplied(ctx, rule)
+	return nil
+}
+
+// removeRuleLocked tears down a single rule's datapath and quota state.
+// Caller must hold e.mu.
+func (e *Engine) removeRuleLocked(ctx context.Context, key string) error {
+	if err := e.datapath.RemoveRule(ctx, key); err != nil {
+		return fmt.Errorf("remove datapath rule %s: %w", key, err)
+	}
+	if err := e.quota.Release(ctx, key); err != nil {
+		return fmt.Errorf("release quota for %s: %w", key, err)
+	}
+
+	e.telemetry.RuleRemoved(ctx, key)
+	return nil
+}

--- a/internal/gateway/engine_test.go
+++ b/internal/gateway/engine_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeDatapath is an in-memory Datapath for exercising Engine's
+// convergence logic without a kernel or root privileges.
+type fakeDatapath struct {
+	applied            map[string]DesiredRule
+	removed            []string
+	applyErr           error
+	removeErr          error
+	generation         uint64
+	reconcileOrphansFn func(context.Context, []DesiredRule, uint64) error
+}
+
+func newFakeDatapath() *fakeDatapath {
+	return &fakeDatapath{applied: make(map[string]DesiredRule)}
+}
+
+func (f *fakeDatapath) ApplyRule(_ context.Context, rule DesiredRule) error {
+	if f.applyErr != nil {
+		return f.applyErr
+	}
+	f.applied[rule.Key] = rule
+	return nil
+}
+
+func (f *fakeDatapath) RemoveRule(_ context.Context, key string) error {
+	if f.removeErr != nil {
+		return f.removeErr
+	}
+	delete(f.applied, key)
+	f.removed = append(f.removed, key)
+	return nil
+}
+
+func (f *fakeDatapath) Generation() uint64 { return f.generation }
+
+func (f *fakeDatapath) ReconcileOrphans(ctx context.Context, live []DesiredRule, cutoff uint64) error {
+	if f.reconcileOrphansFn != nil {
+		return f.reconcileOrphansFn(ctx, live, cutoff)
+	}
+	return nil
+}
+
+var _ Datapath = (*fakeDatapath)(nil)
+
+// fakeQuota is a controllable QuotaEnforcer.
+type fakeQuota struct {
+	deny       bool
+	checkErr   error
+	releaseErr error
+	released   []string
+}
+
+func (f *fakeQuota) CheckAndReserve(context.Context, DesiredRule) (bool, error) {
+	if f.checkErr != nil {
+		return false, f.checkErr
+	}
+	return !f.deny, nil
+}
+
+func (f *fakeQuota) Release(_ context.Context, key string) error {
+	if f.releaseErr != nil {
+		return f.releaseErr
+	}
+	f.released = append(f.released, key)
+	return nil
+}
+
+var _ QuotaEnforcer = (*fakeQuota)(nil)
+
+// fakeTelemetry records every call for assertion.
+type fakeTelemetry struct {
+	applied []string
+	removed []string
+	dropped []string
+}
+
+func (f *fakeTelemetry) RuleApplied(_ context.Context, rule DesiredRule) {
+	f.applied = append(f.applied, rule.Key)
+}
+func (f *fakeTelemetry) RuleRemoved(_ context.Context, key string) {
+	f.removed = append(f.removed, key)
+}
+func (f *fakeTelemetry) DropObserved(_ context.Context, key, _ string) {
+	f.dropped = append(f.dropped, key)
+}
+
+var _ TelemetryEmitter = (*fakeTelemetry)(nil)
+
+func TestEngine_ReconcileAppliesNewRules(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+
+	desired := EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}
+	status, err := e.Reconcile(context.Background(), desired)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !status.Healthy {
+		t.Errorf("status.Healthy = false, want true; rules=%+v", status.Rules)
+	}
+	if _, ok := dp.applied[testKeyA]; !ok {
+		t.Error("rule was not applied to the datapath")
+	}
+}
+
+func TestEngine_ReconcileRemovesDroppedRules(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+	ctx := context.Background()
+
+	if _, err := e.Reconcile(ctx, EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}); err != nil {
+		t.Fatalf("first Reconcile: %v", err)
+	}
+	if _, err := e.Reconcile(ctx, EngineState{Rules: map[string]DesiredRule{}}); err != nil {
+		t.Fatalf("second Reconcile: %v", err)
+	}
+
+	if _, ok := dp.applied[testKeyA]; ok {
+		t.Error("rule still applied after being dropped from desired state")
+	}
+	if len(dp.removed) != 1 || dp.removed[0] != testKeyA {
+		t.Errorf("dp.removed = %v, want [%s]", dp.removed, testKeyA)
+	}
+}
+
+func TestEngine_ReconcileIsIdempotentAcrossRepeatedCalls(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+	ctx := context.Background()
+	desired := EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}
+
+	for range 3 {
+		if _, err := e.Reconcile(ctx, desired); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+	}
+	if len(dp.applied) != 1 {
+		t.Errorf("applied = %v, want exactly one entry after repeated identical reconciles", dp.applied)
+	}
+}
+
+func TestEngine_ReconcileQuotaDeniedSkipsApply(t *testing.T) {
+	dp := newFakeDatapath()
+	telem := &fakeTelemetry{}
+	e := NewEngine(dp, &fakeQuota{deny: true}, telem)
+
+	status, err := e.Reconcile(context.Background(), EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if status.Healthy {
+		t.Error("status.Healthy = true, want false (quota denied)")
+	}
+	if _, ok := dp.applied[testKeyA]; ok {
+		t.Error("rule was applied to the datapath despite quota denial")
+	}
+	if len(telem.dropped) != 1 || telem.dropped[0] != testKeyA {
+		t.Errorf("telemetry.dropped = %v, want [%s]", telem.dropped, testKeyA)
+	}
+}
+
+func TestEngine_ReconcileApplyErrorReportsUnhealthyKeepsGoing(t *testing.T) {
+	dp := newFakeDatapath()
+	dp.applyErr = errors.New("simulated datapath failure")
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+
+	status, err := e.Reconcile(context.Background(), EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if status.Healthy {
+		t.Error("status.Healthy = true, want false")
+	}
+	if len(status.Rules) != 1 || status.Rules[0].Error == "" {
+		t.Errorf("status.Rules = %+v, want one entry with a non-empty Error", status.Rules)
+	}
+}
+
+func TestEngine_StatusReflectsActiveRulesWithoutReconciling(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+	ctx := context.Background()
+
+	if _, err := e.Reconcile(ctx, EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	status, err := e.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !status.Healthy || len(status.Rules) != 1 || status.Rules[0].Key != testKeyA {
+		t.Errorf("Status() = %+v, want one healthy rule %q", status, testKeyA)
+	}
+}
+
+func TestEngine_StopTearsDownEveryActiveRule(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+	ctx := context.Background()
+
+	desired := EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}, testKeyB: {Key: testKeyB}}}
+	if _, err := e.Reconcile(ctx, desired); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if err := e.Stop(ctx); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if len(dp.applied) != 0 {
+		t.Errorf("dp.applied = %v, want empty after Stop", dp.applied)
+	}
+
+	status, err := e.Status(ctx)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if len(status.Rules) != 0 {
+		t.Errorf("Status() after Stop = %+v, want no active rules", status)
+	}
+}
+
+func TestEngine_DatapathGenerationDelegates(t *testing.T) {
+	dp := newFakeDatapath()
+	dp.generation = 12345
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+
+	if got := e.DatapathGeneration(); got != 12345 {
+		t.Errorf("DatapathGeneration() = %d, want 12345", got)
+	}
+}

--- a/internal/gateway/kerneldatapath.go
+++ b/internal/gateway/kerneldatapath.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// protoNumber maps a NetworkRuleSpec.Protocol string ("tcp"/"udp") to the
+// IANA protocol number edgenat.c's rule_key.proto expects. There is no
+// generated/shared constant for this: network.datumapis.com/v1alpha1's
+// NetworkRuleProtocol enum is a string type for CRD readability, and
+// edgeprog's wire format is the numeric IPPROTO_* value edgenat.c already
+// reads directly off the packet — this is the one place those two
+// representations need to be reconciled.
+func protoNumber(protocol string) (uint8, error) {
+	switch protocol {
+	case "tcp":
+		return 6, nil
+	case "udp":
+		return 17, nil
+	default:
+		return 0, fmt.Errorf("kerneldatapath: unsupported protocol %q (want \"tcp\" or \"udp\")", protocol)
+	}
+}
+
+// ruleKeysForRule returns the rule_table keys ApplyRule registers for
+// rule -- one per VIPAddress, since edgenat.c's rule_table is keyed by
+// (proto, VIP port, VIP address) with the backend list identical across
+// every VIP a rule owns.
+func ruleKeysForRule(rule DesiredRule) ([]edgemap.RuleKey, error) {
+	proto, err := protoNumber(rule.Protocol)
+	if err != nil {
+		return nil, fmt.Errorf("rule %s: %w", rule.Key, err)
+	}
+	keys := make([]edgemap.RuleKey, len(rule.VIPAddresses))
+	for i, vip := range rule.VIPAddresses {
+		keys[i] = edgemap.RuleKey{Proto: proto, VPort: rule.Port, VIP: vip}
+	}
+	return keys, nil
+}
+
+// KernelDatapath is the real Datapath implementation, backed by
+// internal/plumbing/ebpf/edgemap's RuleTable API onto a loaded
+// internal/plumbing/ebpf/edgeprog.EdgenatObjects. It assumes the compiled
+// program is already loaded and attached to the gateway node's public
+// interface by the time ApplyRule is first called — that attach lifecycle
+// is internal/plumbing/ebpf/edgeattach's job and cmd/galactic-router's own
+// startup sequence's, not this package's. NoopDatapath remains available
+// for tests and any caller not yet wired to a loaded program.
+type KernelDatapath struct {
+	mu        sync.Mutex
+	ruleTable *edgemap.RuleTable
+
+	// ruleKeysByName maps a DesiredRule.Key to the rule_table keys
+	// currently registered for it, so RemoveRule (which the Datapath
+	// interface only passes a bare key string, not the full DesiredRule)
+	// knows what to unregister, and so ApplyRule can prune a key a rule
+	// dropped since its last apply (e.g. a VIP removed from
+	// spec.vipAddresses) without needing the caller to have tracked that
+	// itself.
+	ruleKeysByName map[string][]edgemap.RuleKey
+}
+
+// NewKernelDatapath constructs a KernelDatapath and writes gwAddr into
+// gw_config_table once, immediately -- gwAddr is this gateway node's own
+// SRv6-reachable address (NetworkGatewayStatus.SRv6Address), stable for
+// the life of the process, so there is no per-rule or per-reconcile path
+// that ever needs to rewrite it again.
+func NewKernelDatapath(objs *edgeprog.EdgenatObjects, gwAddr netip.Addr) (*KernelDatapath, error) {
+	if !gwAddr.Is6() || gwAddr.Is4In6() {
+		return nil, fmt.Errorf("kerneldatapath: gateway address %s is not a native IPv6 address", gwAddr)
+	}
+
+	if err := objs.GwConfigTable.Put(uint32(0), edgeprog.EdgenatGwConfig{GwAddr: gwAddr.As16()}); err != nil {
+		return nil, fmt.Errorf("kerneldatapath: populate gw_config_table: %w", err)
+	}
+
+	return &KernelDatapath{
+		ruleTable:      edgemap.NewRuleTable(edgemap.KernelTable{Map: objs.RuleTable}),
+		ruleKeysByName: make(map[string][]edgemap.RuleKey),
+	}, nil
+}
+
+// ApplyRule registers rule_table entries for rule (one per VIPAddress,
+// sharing rule.Backends), replacing whatever this rule had registered
+// previously and pruning any key it no longer owns.
+func (d *KernelDatapath) ApplyRule(_ context.Context, rule DesiredRule) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	keys, err := ruleKeysForRule(rule)
+	if err != nil {
+		return err
+	}
+
+	backends := make([]edgemap.Backend, len(rule.Backends))
+	for i, b := range rule.Backends {
+		backends[i] = edgemap.Backend{Addr: b.Address, Port: b.Port, USID: b.USID}
+	}
+
+	for _, key := range keys {
+		if err := d.ruleTable.Register(key, backends); err != nil {
+			return fmt.Errorf("kerneldatapath: apply rule %s: %w", rule.Key, err)
+		}
+	}
+
+	// Prune keys this rule owned before but no longer does (e.g. a VIP
+	// removed from spec.vipAddresses on this reconcile).
+	stillOwned := make(map[edgemap.RuleKey]struct{}, len(keys))
+	for _, k := range keys {
+		stillOwned[k] = struct{}{}
+	}
+	for _, old := range d.ruleKeysByName[rule.Key] {
+		if _, ok := stillOwned[old]; ok {
+			continue
+		}
+		if err := d.ruleTable.Unregister(old); err != nil {
+			return fmt.Errorf("kerneldatapath: apply rule %s: prune dropped key %+v: %w", rule.Key, old, err)
+		}
+	}
+
+	d.ruleKeysByName[rule.Key] = keys
+	return nil
+}
+
+// RemoveRule unregisters every rule_table entry key previously owned.
+func (d *KernelDatapath) RemoveRule(_ context.Context, key string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for _, k := range d.ruleKeysByName[key] {
+		if err := d.ruleTable.Unregister(k); err != nil {
+			return fmt.Errorf("kerneldatapath: remove rule %s: %w", key, err)
+		}
+	}
+	delete(d.ruleKeysByName, key)
+	return nil
+}
+
+// Generation returns rule_table's own monotonic-clock snapshot.
+func (d *KernelDatapath) Generation() uint64 {
+	return d.ruleTable.Generation()
+}
+
+// ReconcileOrphans removes rule_table entries whose key is not implied by
+// any rule in live and was written before cutoff -- see
+// edgemap.RuleTable.Reconcile's identical contract, which this delegates
+// to directly.
+func (d *KernelDatapath) ReconcileOrphans(_ context.Context, live []DesiredRule, cutoff uint64) error {
+	liveKeys := make(map[edgemap.RuleKey]struct{})
+	for _, rule := range live {
+		keys, err := ruleKeysForRule(rule)
+		if err != nil {
+			// A rule with an unsupported protocol never got registered
+			// by ApplyRule in the first place, so it can't own any
+			// rule_table entry to spare here either; skip rather than
+			// fail the whole orphan sweep over one bad rule.
+			continue
+		}
+		for _, k := range keys {
+			liveKeys[k] = struct{}{}
+		}
+	}
+
+	if _, err := d.ruleTable.Reconcile(liveKeys, cutoff); err != nil {
+		return fmt.Errorf("kerneldatapath: reconcile orphans: %w", err)
+	}
+	return nil
+}
+
+var _ Datapath = (*KernelDatapath)(nil)

--- a/internal/gateway/kerneldatapath_test.go
+++ b/internal/gateway/kerneldatapath_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// fakeRuleTable is an in-memory edgemap.Table, letting KernelDatapath's
+// key-management logic (apply/prune/remove/reconcile) be exercised without
+// a kernel or root privileges -- same pattern as edgemap's own tests.
+type fakeRuleTable struct {
+	entries map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue
+}
+
+func newFakeRuleTable() *fakeRuleTable {
+	return &fakeRuleTable{entries: make(map[edgeprog.EdgenatRuleKey]edgeprog.EdgenatRuleValue)}
+}
+
+func (f *fakeRuleTable) Put(key, value any) error {
+	f.entries[key.(edgeprog.EdgenatRuleKey)] = value.(edgeprog.EdgenatRuleValue)
+	return nil
+}
+
+func (f *fakeRuleTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key.(edgeprog.EdgenatRuleKey)]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	*valueOut.(*edgeprog.EdgenatRuleValue) = v
+	return nil
+}
+
+func (f *fakeRuleTable) Delete(key any) error {
+	k := key.(edgeprog.EdgenatRuleKey)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	return nil
+}
+
+func (f *fakeRuleTable) Iterate() edgemap.Iterator {
+	keys := make([]edgeprog.EdgenatRuleKey, 0, len(f.entries))
+	for k := range f.entries {
+		keys = append(keys, k)
+	}
+	return &fakeRuleIterator{table: f, keys: keys}
+}
+
+type fakeRuleIterator struct {
+	table *fakeRuleTable
+	keys  []edgeprog.EdgenatRuleKey
+	i     int
+}
+
+func (it *fakeRuleIterator) Next(keyOut, valueOut any) bool {
+	if it.i >= len(it.keys) {
+		return false
+	}
+	k := it.keys[it.i]
+	it.i++
+	*keyOut.(*edgeprog.EdgenatRuleKey) = k
+	*valueOut.(*edgeprog.EdgenatRuleValue) = it.table.entries[k]
+	return true
+}
+
+func (it *fakeRuleIterator) Err() error { return nil }
+
+var _ edgemap.Table = (*fakeRuleTable)(nil)
+
+func newTestKernelDatapath() *KernelDatapath {
+	return &KernelDatapath{
+		ruleTable:      edgemap.NewRuleTable(newFakeRuleTable()),
+		ruleKeysByName: make(map[string][]edgemap.RuleKey),
+	}
+}
+
+func testDesiredRule(t *testing.T, key string, vips ...string) DesiredRule {
+	t.Helper()
+	addrs := make([]netip.Addr, len(vips))
+	for i, v := range vips {
+		addrs[i] = netip.MustParseAddr(v)
+	}
+	return DesiredRule{
+		Key:          key,
+		Protocol:     "tcp",
+		Port:         443,
+		VIPAddresses: addrs,
+		Backends: []DesiredBackend{
+			{
+				Address: netip.MustParseAddr("fd00:10:1::20"),
+				Port:    8443,
+				USID:    netip.MustParseAddr("2001:db8:2::1"),
+			},
+		},
+	}
+}
+
+func TestKernelDatapath_ApplyRuleRegistersOneKeyPerVIP(t *testing.T) {
+	d := newTestKernelDatapath()
+	rule := testDesiredRule(t, testKeyA, "2001:db8:1::10", "2001:db8:1::11")
+
+	if err := d.ApplyRule(context.Background(), rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
+	}
+
+	if len(d.ruleKeysByName[testKeyA]) != 2 {
+		t.Fatalf("ruleKeysByName[%s] = %v, want 2 keys", testKeyA, d.ruleKeysByName[testKeyA])
+	}
+	for _, key := range d.ruleKeysByName[testKeyA] {
+		entry, ok, err := d.ruleTable.Get(key)
+		if err != nil || !ok {
+			t.Fatalf("Get(%+v): ok=%v err=%v", key, ok, err)
+		}
+		if len(entry.Backends) != 1 || entry.Backends[0].USID != rule.Backends[0].USID {
+			t.Errorf("Get(%+v).Backends = %+v, want backend with USID %s", key, entry.Backends, rule.Backends[0].USID)
+		}
+	}
+}
+
+func TestKernelDatapath_ApplyRulePrunesDroppedVIP(t *testing.T) {
+	d := newTestKernelDatapath()
+	ctx := context.Background()
+
+	first := testDesiredRule(t, testKeyA, "2001:db8:1::10", "2001:db8:1::11")
+	if err := d.ApplyRule(ctx, first); err != nil {
+		t.Fatalf("first ApplyRule: %v", err)
+	}
+
+	second := testDesiredRule(t, testKeyA, "2001:db8:1::10") // dropped ::11
+	if err := d.ApplyRule(ctx, second); err != nil {
+		t.Fatalf("second ApplyRule: %v", err)
+	}
+
+	if len(d.ruleKeysByName[testKeyA]) != 1 {
+		t.Fatalf("ruleKeysByName[%s] = %v, want exactly 1 key after dropping a VIP", testKeyA, d.ruleKeysByName[testKeyA])
+	}
+
+	droppedKey := edgemap.RuleKey{Proto: 6, VPort: 443, VIP: netip.MustParseAddr("2001:db8:1::11")}
+	if _, ok, _ := d.ruleTable.Get(droppedKey); ok {
+		t.Error("dropped VIP's rule_table entry is still present")
+	}
+}
+
+func TestKernelDatapath_RemoveRuleUnregistersAllOwnedKeys(t *testing.T) {
+	d := newTestKernelDatapath()
+	ctx := context.Background()
+	rule := testDesiredRule(t, testKeyA, "2001:db8:1::10", "2001:db8:1::11")
+
+	if err := d.ApplyRule(ctx, rule); err != nil {
+		t.Fatalf("ApplyRule: %v", err)
+	}
+	if err := d.RemoveRule(ctx, testKeyA); err != nil {
+		t.Fatalf("RemoveRule: %v", err)
+	}
+
+	if len(d.ruleKeysByName[testKeyA]) != 0 {
+		t.Errorf("ruleKeysByName[%s] = %v, want empty after RemoveRule", testKeyA, d.ruleKeysByName[testKeyA])
+	}
+	entries, err := d.ruleTable.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("rule_table has %d entries after RemoveRule, want 0", len(entries))
+	}
+}
+
+func TestKernelDatapath_ApplyRuleRejectsUnsupportedProtocol(t *testing.T) {
+	d := newTestKernelDatapath()
+	rule := testDesiredRule(t, testKeyA, "2001:db8:1::10")
+	rule.Protocol = "sctp"
+
+	if err := d.ApplyRule(context.Background(), rule); err == nil {
+		t.Error("ApplyRule with an unsupported protocol: want an error, got nil")
+	}
+}
+
+func TestKernelDatapath_ReconcileOrphansRemovesUnownedKeys(t *testing.T) {
+	d := newTestKernelDatapath()
+	ctx := context.Background()
+
+	liveRule := testDesiredRule(t, testKeyA, "2001:db8:1::10")
+	staleRule := testDesiredRule(t, testKeyB, "2001:db8:1::99")
+
+	if err := d.ApplyRule(ctx, liveRule); err != nil {
+		t.Fatalf("apply liveRule: %v", err)
+	}
+	if err := d.ApplyRule(ctx, staleRule); err != nil {
+		t.Fatalf("apply staleRule: %v", err)
+	}
+
+	// cutoff greater than both entries' Generation (a fake clock defaulting
+	// to monotonicNow would make this flaky across different real
+	// timestamps — capture Generation() after both applies instead, then
+	// bump it via a fresh table generation call is not available here, so
+	// just use the datapath's own current Generation as a safe upper bound
+	// for entries already written).
+	cutoff := d.Generation() + 1
+
+	if err := d.ReconcileOrphans(ctx, []DesiredRule{liveRule}, cutoff); err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+
+	liveKey := edgemap.RuleKey{Proto: 6, VPort: 443, VIP: netip.MustParseAddr("2001:db8:1::10")}
+	staleKey := edgemap.RuleKey{Proto: 6, VPort: 443, VIP: netip.MustParseAddr("2001:db8:1::99")}
+
+	if _, ok, _ := d.ruleTable.Get(liveKey); !ok {
+		t.Error("ReconcileOrphans removed a live rule's entry")
+	}
+	if _, ok, _ := d.ruleTable.Get(staleKey); ok {
+		t.Error("ReconcileOrphans left a stale entry in place")
+	}
+}
+
+func TestNewKernelDatapath_RejectsIPv4GatewayAddress(t *testing.T) {
+	// NewKernelDatapath itself needs a real *edgeprog.EdgenatObjects to
+	// call Put against gw_config_table, which requires a loaded program
+	// (root-gated, covered by edgeattach's own tests) -- this test only
+	// exercises the address-family validation, which runs before that
+	// call.
+	_, err := NewKernelDatapath(&edgeprog.EdgenatObjects{}, netip.MustParseAddr("192.0.2.1"))
+	if err == nil {
+		t.Error("NewKernelDatapath with an IPv4 gateway address: want an error, got nil")
+	}
+}

--- a/internal/gateway/localpref.go
+++ b/internal/gateway/localpref.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+// Local-preference values for the design plan's Active-Active BGP model.
+// Both gateway nodes in a PoP always advertise every rule they hold — these
+// values only decide which path upstream routers prefer, never which node
+// is allowed to advertise at all. See LocalPreference below.
+const (
+	// PrimaryLocalPref is advertised by the node that is a rule's
+	// status.primaryNode.
+	PrimaryLocalPref uint32 = 100
+
+	// SecondaryLocalPref is advertised by the other gateway node(s) serving
+	// the same rule. It must be lower than PrimaryLocalPref but non-zero
+	// (a live, less-preferred path, not a withdrawn one) so that BGP
+	// reconvergence — not a controller-driven health check — is what
+	// fails traffic over if the primary's session or route withdraws.
+	SecondaryLocalPref uint32 = 50
+)
+
+// LocalPreference returns the local-preference this gateway node should
+// advertise a rule's VIPs at, given the rule's assigned primaryNode. This
+// is a pure lookup, not a decision GoBGP makes independently — see
+// internal/runtime/gobgp/paths.go's buildEVPNPaths, which already applies
+// whatever value ends up on BGPAdvertisement.Spec.LocalPreference. The
+// caller (the future NetworkGateway controller) is responsible for
+// invoking this once per rule per reconcile and setting the result onto
+// the BGPAdvertisement(s) it manages for that rule.
+func LocalPreference(nodeName, primaryNode string) uint32 {
+	if nodeName != "" && nodeName == primaryNode {
+		return PrimaryLocalPref
+	}
+	return SecondaryLocalPref
+}

--- a/internal/gateway/localpref_test.go
+++ b/internal/gateway/localpref_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import "testing"
+
+func TestLocalPreference_Primary(t *testing.T) {
+	got := LocalPreference(testNodeA, testNodeA)
+	if got != PrimaryLocalPref {
+		t.Fatalf("LocalPreference(primary match) = %d, want %d", got, PrimaryLocalPref)
+	}
+}
+
+func TestLocalPreference_Secondary(t *testing.T) {
+	got := LocalPreference(testNodeB, testNodeA)
+	if got != SecondaryLocalPref {
+		t.Fatalf("LocalPreference(no match) = %d, want %d", got, SecondaryLocalPref)
+	}
+}
+
+func TestLocalPreference_EmptyPrimaryNode(t *testing.T) {
+	// A rule that hasn't been assigned a primaryNode yet must never be
+	// treated as "primary" by an empty-string coincidence.
+	got := LocalPreference("", "")
+	if got != SecondaryLocalPref {
+		t.Fatalf("LocalPreference(\"\", \"\") = %d, want %d (secondary, not accidentally primary)",
+			got, SecondaryLocalPref)
+	}
+}
+
+func TestLocalPreference_ValuesOrdered(t *testing.T) {
+	if PrimaryLocalPref <= SecondaryLocalPref {
+		t.Fatalf("PrimaryLocalPref (%d) must be greater than SecondaryLocalPref (%d)",
+			PrimaryLocalPref, SecondaryLocalPref)
+	}
+}

--- a/internal/gateway/placement.go
+++ b/internal/gateway/placement.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"errors"
+	"hash/fnv"
+	"sort"
+)
+
+// ErrNoGatewayNodes is returned by AssignPrimaryNode when given an empty
+// gateway node set.
+var ErrNoGatewayNodes = errors.New("gateway: no gateway nodes available for placement")
+
+// AssignPrimaryNode deterministically selects one of gatewayNodes as the
+// primary_node for vpcRef, implementing the design plan's Active-Active BGP
+// model:
+//
+//	primary_node = hash(vpc_id) % <gateway node count>
+//
+// gatewayNodes is sorted internally before indexing so the result does not
+// depend on the caller's (e.g. a Kubernetes List's) iteration order — only
+// on the *set* of gateway node names and vpcRef. This must be called
+// exactly once per NetworkRule, at creation (the NetworkRule controller
+// enforces the immutability guard on status.primaryNode); calling it again
+// with a different gatewayNodes set (e.g. after a node is added or
+// removed) will generally produce a different assignment for the same
+// vpcRef, which is why the caller must never invoke this a second time for
+// an already-assigned rule.
+func AssignPrimaryNode(vpcRef string, gatewayNodes []string) (string, error) {
+	if len(gatewayNodes) == 0 {
+		return "", ErrNoGatewayNodes
+	}
+
+	sorted := make([]string, len(gatewayNodes))
+	copy(sorted, gatewayNodes)
+	sort.Strings(sorted)
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(vpcRef)) // hash.Hash32.Write never returns an error
+	idx := int(h.Sum32() % uint32(len(sorted)))
+	return sorted[idx], nil
+}

--- a/internal/gateway/placement_test.go
+++ b/internal/gateway/placement_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"errors"
+	"testing"
+)
+
+// Shared fixture identifiers reused across this package's test files.
+const (
+	testNodeA = "gw-a"
+	testNodeB = "gw-b"
+)
+
+func TestAssignPrimaryNode_NoNodes(t *testing.T) {
+	if _, err := AssignPrimaryNode("vpc-1", nil); !errors.Is(err, ErrNoGatewayNodes) {
+		t.Fatalf("AssignPrimaryNode with no nodes: got err %v, want ErrNoGatewayNodes", err)
+	}
+	if _, err := AssignPrimaryNode("vpc-1", []string{}); !errors.Is(err, ErrNoGatewayNodes) {
+		t.Fatalf("AssignPrimaryNode with empty slice: got err %v, want ErrNoGatewayNodes", err)
+	}
+}
+
+func TestAssignPrimaryNode_Deterministic(t *testing.T) {
+	nodes := []string{testNodeA, testNodeB}
+	first, err := AssignPrimaryNode("vpc-123", nodes)
+	if err != nil {
+		t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+	}
+	for range 100 {
+		got, err := AssignPrimaryNode("vpc-123", nodes)
+		if err != nil {
+			t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+		}
+		if got != first {
+			t.Fatalf("AssignPrimaryNode not deterministic: got %q, want %q", got, first)
+		}
+	}
+}
+
+func TestAssignPrimaryNode_OrderIndependent(t *testing.T) {
+	got1, err := AssignPrimaryNode("vpc-abc", []string{testNodeA, testNodeB})
+	if err != nil {
+		t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+	}
+	got2, err := AssignPrimaryNode("vpc-abc", []string{testNodeB, testNodeA})
+	if err != nil {
+		t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+	}
+	if got1 != got2 {
+		t.Fatalf("AssignPrimaryNode depends on input order: %q vs %q", got1, got2)
+	}
+}
+
+func TestAssignPrimaryNode_ReturnsGivenNode(t *testing.T) {
+	nodes := []string{testNodeA, testNodeB}
+	got, err := AssignPrimaryNode("vpc-xyz", nodes)
+	if err != nil {
+		t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+	}
+	if got != testNodeA && got != testNodeB {
+		t.Fatalf("AssignPrimaryNode returned unknown node %q", got)
+	}
+}
+
+// TestAssignPrimaryNode_RoughlyEvenSplit is not a correctness requirement
+// (the design plan explicitly disclaims capacity-aware or perfectly-even
+// placement) but guards against a degenerate hash that always picks the
+// same index regardless of input.
+func TestAssignPrimaryNode_RoughlyEvenSplit(t *testing.T) {
+	nodes := []string{testNodeA, testNodeB}
+	counts := map[string]int{}
+	const n = 2000
+	for i := range n {
+		vpc := "vpc-" + string(rune('a'+i%26)) + string(rune('0'+i%10)) + string(rune(i))
+		node, err := AssignPrimaryNode(vpc, nodes)
+		if err != nil {
+			t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+		}
+		counts[node]++
+	}
+	if len(counts) != 2 {
+		t.Fatalf("AssignPrimaryNode only ever selected %d distinct node(s): %v", len(counts), counts)
+	}
+	for node, c := range counts {
+		if c < n/10 {
+			t.Fatalf("AssignPrimaryNode split too skewed: node %q got %d/%d", node, c, n)
+		}
+	}
+}
+
+func TestAssignPrimaryNode_SingleNode(t *testing.T) {
+	got, err := AssignPrimaryNode("vpc-1", []string{"gw-only"})
+	if err != nil {
+		t.Fatalf("AssignPrimaryNode: unexpected error: %v", err)
+	}
+	if got != "gw-only" {
+		t.Fatalf("AssignPrimaryNode with single node: got %q, want %q", got, "gw-only")
+	}
+}

--- a/internal/gateway/quota.go
+++ b/internal/gateway/quota.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"sync"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
+)
+
+// Default limits for NodeQuotaEnforcer. Both are coarse, node-level
+// admission caps, not bandwidth or conntrack rate limits -- see that
+// type's doc comment for why the latter is deliberately out of scope
+// here.
+const (
+	// DefaultMaxRulesPerTenant bounds how many NetworkRules a single
+	// VPCRef may have registered on one gateway node at once. A
+	// NetworkRule may carry up to 8 VIPAddresses (network.datumapis.com/
+	// v1alpha1's NetworkRuleSpec.VIPAddresses MaxItems), so this also
+	// bounds one tenant's worst-case rule_table footprint to
+	// DefaultMaxRulesPerTenant*8 entries.
+	DefaultMaxRulesPerTenant = 64
+
+	// DefaultMaxRuleTableEntries is the node-wide ceiling across every
+	// tenant, defaulting to edgemap.MaxRuleTableEntries (rule_table's own
+	// map capacity) -- once desired state would fill the map,
+	// bpf_map_update_elem starts failing mid-reconcile with no clean way
+	// to roll back a partial apply, so this must be enforced before
+	// ApplyRule is ever called, at CheckAndReserve time.
+	DefaultMaxRuleTableEntries = edgemap.MaxRuleTableEntries
+)
+
+// NodeQuotaEnforcer is a real (not stubbed) QuotaEnforcer implementation,
+// enforcing two coarse, node-level admission caps entirely from
+// control-plane state Engine already holds — no eBPF map read required:
+//
+//  1. MaxRulesPerTenant: no single VPCRef may register more than this many
+//     NetworkRules on this gateway node at once.
+//  2. MaxRuleTableEntries: the total rule_table rows every tenant's rules
+//     would occupy together (one row per VIPAddress, see
+//     kerneldatapath.go's ruleKeysForRule) may not exceed rule_table's own
+//     fixed map capacity.
+//
+// What this deliberately does NOT do: per-flow or per-tenant conntrack
+// (conn_table) rate limiting. conn_table's key carries no tenant
+// dimension (design plan decision #1 — a VIP is globally unique, so
+// conn_table doesn't need one either), so there is no cheap way to
+// attribute an individual flow back to a tenant without adding a field
+// that changes the packet-path key layout; and a meaningful bandwidth/
+// packet-rate quota needs a time-windowed rate, not the cumulative,
+// never-reset Packets/Bytes counters rule_table carries (a long-lived,
+// healthy, popular rule will always eventually cross any static
+// cumulative threshold — that isn't misbehavior, that's success). Real
+// rate-based enforcement needs live traffic data to calibrate sensible
+// thresholds against, which is exactly what the design plan's Phase D
+// (validated live, not just manifests) was meant to provide before this
+// phase built on top of it — see docs/agents/ARCHITECTURE.md and the
+// design plan's own Phase E note. This type is the enforceable subset
+// buildable without that data.
+type NodeQuotaEnforcer struct {
+	mu sync.Mutex
+
+	maxRulesPerTenant   int
+	maxRuleTableEntries int
+
+	// tenantRuleCount/totalEntries are the enforcer's own bookkeeping of
+	// what it has reserved — not read back from rule_table itself, so
+	// CheckAndReserve/Release stay correct even before ApplyRule has run
+	// (a new rule has no rule_table row yet to read counters from).
+	tenantRuleCount map[string]int
+	ruleTenant      map[string]string
+	ruleEntries     map[string]int
+	totalEntries    int
+}
+
+// NewNodeQuotaEnforcer returns a NodeQuotaEnforcer with the given limits.
+// Use DefaultMaxRulesPerTenant/DefaultMaxRuleTableEntries for production
+// defaults.
+func NewNodeQuotaEnforcer(maxRulesPerTenant, maxRuleTableEntries int) *NodeQuotaEnforcer {
+	return &NodeQuotaEnforcer{
+		maxRulesPerTenant:   maxRulesPerTenant,
+		maxRuleTableEntries: maxRuleTableEntries,
+		tenantRuleCount:     make(map[string]int),
+		ruleTenant:          make(map[string]string),
+		ruleEntries:         make(map[string]int),
+	}
+}
+
+// CheckAndReserve reports whether rule fits within both limits and, if so,
+// reserves its rule_table footprint. Idempotent for a rule.Key already
+// reserved: re-checking (or changing) an already-active rule's VIP count
+// never double-counts it against either limit — required because
+// Engine.Reconcile calls this for every desired rule on every reconcile
+// pass, not just new ones (see Engine.Reconcile's own doc comment).
+func (e *NodeQuotaEnforcer) CheckAndReserve(_ context.Context, rule DesiredRule) (bool, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	entries := len(rule.VIPAddresses)
+	if entries == 0 {
+		entries = 1 // defensive: a rule always occupies at least one row
+	}
+
+	prevEntries, alreadyReserved := e.ruleEntries[rule.Key]
+	prevTenant := e.ruleTenant[rule.Key]
+
+	// Compute what the tenant's rule count and the node total would be if
+	// this reservation is accepted, without mutating state yet.
+	tenantCount := e.tenantRuleCount[rule.VPCRef]
+	if !alreadyReserved {
+		tenantCount++
+	} else if prevTenant != rule.VPCRef {
+		// VPCRef changed for an existing rule.Key -- shouldn't happen in
+		// practice (NetworkRuleSpec.VPCRef is not mutated in place by any
+		// caller in this codebase), but guard against under/over-counting
+		// either tenant bucket if it ever does.
+		tenantCount++
+	}
+	if tenantCount > e.maxRulesPerTenant {
+		return false, nil
+	}
+
+	projectedTotal := e.totalEntries - prevEntries + entries
+	if projectedTotal > e.maxRuleTableEntries {
+		return false, nil
+	}
+
+	// Accepted: commit the reservation.
+	if alreadyReserved && prevTenant != rule.VPCRef {
+		e.tenantRuleCount[prevTenant]--
+		if e.tenantRuleCount[prevTenant] <= 0 {
+			delete(e.tenantRuleCount, prevTenant)
+		}
+	}
+	if !alreadyReserved || prevTenant != rule.VPCRef {
+		e.tenantRuleCount[rule.VPCRef] = tenantCount
+	}
+	e.ruleTenant[rule.Key] = rule.VPCRef
+	e.ruleEntries[rule.Key] = entries
+	e.totalEntries = projectedTotal
+	return true, nil
+}
+
+// Release frees the reservation held for key, if any. Not an error if key
+// was never reserved (e.g. CheckAndReserve denied it, or it was never
+// called for this key at all).
+func (e *NodeQuotaEnforcer) Release(_ context.Context, key string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	entries, ok := e.ruleEntries[key]
+	if !ok {
+		return nil
+	}
+	tenant := e.ruleTenant[key]
+
+	e.totalEntries -= entries
+	if e.totalEntries < 0 {
+		e.totalEntries = 0 // defensive: must never go negative
+	}
+	e.tenantRuleCount[tenant]--
+	if e.tenantRuleCount[tenant] <= 0 {
+		delete(e.tenantRuleCount, tenant)
+	}
+	delete(e.ruleEntries, key)
+	delete(e.ruleTenant, key)
+	return nil
+}
+
+// Stats returns a snapshot of current reservations, for
+// TelemetryEmitter/diagnostics use.
+func (e *NodeQuotaEnforcer) Stats() (totalEntries int, tenantRuleCounts map[string]int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	out := make(map[string]int, len(e.tenantRuleCount))
+	for k, v := range e.tenantRuleCount {
+		out[k] = v
+	}
+	return e.totalEntries, out
+}
+
+var _ QuotaEnforcer = (*NodeQuotaEnforcer)(nil)

--- a/internal/gateway/quota_test.go
+++ b/internal/gateway/quota_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+)
+
+// Shared test rule keys, used across this file and telemetry_test.go.
+const (
+	testRuleKeyR1 = "ns/r1"
+	testRuleKeyR2 = "ns/r2"
+)
+
+func testRuleWithVIPs(key, vpcRef string, vipCount int) DesiredRule {
+	vips := make([]netip.Addr, vipCount)
+	for i := range vips {
+		vips[i] = netip.MustParseAddr("2001:db8:1::" + string(rune('1'+i)))
+	}
+	return DesiredRule{Key: key, VPCRef: vpcRef, VIPAddresses: vips}
+}
+
+func TestNodeQuotaEnforcer_AllowsWithinLimits(t *testing.T) {
+	e := NewNodeQuotaEnforcer(10, 100)
+	ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs(testRuleKeyR1, "vpc-1", 1))
+	if err != nil {
+		t.Fatalf("CheckAndReserve: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("CheckAndReserve: want true, well within limits")
+	}
+}
+
+func TestNodeQuotaEnforcer_DeniesOverTenantLimit(t *testing.T) {
+	e := NewNodeQuotaEnforcer(2, 100)
+	for i, name := range []string{testRuleKeyR1, testRuleKeyR2} {
+		ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs(name, "vpc-1", 1))
+		if err != nil || !ok {
+			t.Fatalf("CheckAndReserve rule %d: ok=%v err=%v, want true", i, ok, err)
+		}
+	}
+
+	ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs("ns/r3", "vpc-1", 1))
+	if err != nil {
+		t.Fatalf("CheckAndReserve: unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("CheckAndReserve: want false, third rule exceeds per-tenant limit of 2")
+	}
+}
+
+func TestNodeQuotaEnforcer_DifferentTenantsDoNotShareLimit(t *testing.T) {
+	e := NewNodeQuotaEnforcer(1, 100)
+	if ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs("ns/a", "vpc-1", 1)); err != nil || !ok {
+		t.Fatalf("vpc-1 rule: ok=%v err=%v, want true", ok, err)
+	}
+	if ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs("ns/b", "vpc-2", 1)); err != nil || !ok {
+		t.Fatalf("vpc-2 rule: ok=%v err=%v, want true (different tenant, own limit)", ok, err)
+	}
+}
+
+func TestNodeQuotaEnforcer_DeniesOverNodeWideEntryLimit(t *testing.T) {
+	e := NewNodeQuotaEnforcer(100, 3)
+	// A dual-stack rule with 3 VIPs fills the node-wide 3-entry budget
+	// exactly.
+	if ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs(testRuleKeyR1, "vpc-1", 3)); err != nil || !ok {
+		t.Fatalf("first rule: ok=%v err=%v, want true", ok, err)
+	}
+
+	ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs(testRuleKeyR2, "vpc-2", 1))
+	if err != nil {
+		t.Fatalf("CheckAndReserve: unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("CheckAndReserve: want false, node-wide rule_table capacity is exhausted")
+	}
+}
+
+func TestNodeQuotaEnforcer_ReapplyIsIdempotent(t *testing.T) {
+	e := NewNodeQuotaEnforcer(1, 100)
+	rule := testRuleWithVIPs(testRuleKeyR1, "vpc-1", 1)
+
+	if ok, err := e.CheckAndReserve(context.Background(), rule); err != nil || !ok {
+		t.Fatalf("first CheckAndReserve: ok=%v err=%v, want true", ok, err)
+	}
+	// Re-checking the SAME rule.Key on a later reconcile pass must not
+	// double-count it against its own tenant's limit of 1 (see
+	// Engine.Reconcile's "apply everything in desired" convention).
+	if ok, err := e.CheckAndReserve(context.Background(), rule); err != nil || !ok {
+		t.Fatalf("second CheckAndReserve (re-apply): ok=%v err=%v, want true (idempotent)", ok, err)
+	}
+
+	total, tenants := e.Stats()
+	if total != 1 {
+		t.Errorf("totalEntries = %d, want 1 (re-apply must not double-reserve)", total)
+	}
+	if tenants["vpc-1"] != 1 {
+		t.Errorf("tenantRuleCounts[vpc-1] = %d, want 1", tenants["vpc-1"])
+	}
+}
+
+func TestNodeQuotaEnforcer_ReleaseFreesReservation(t *testing.T) {
+	e := NewNodeQuotaEnforcer(1, 100)
+	rule := testRuleWithVIPs(testRuleKeyR1, "vpc-1", 2)
+
+	if ok, err := e.CheckAndReserve(context.Background(), rule); err != nil || !ok {
+		t.Fatalf("CheckAndReserve: ok=%v err=%v, want true", ok, err)
+	}
+	if err := e.Release(context.Background(), rule.Key); err != nil {
+		t.Fatalf("Release: unexpected error: %v", err)
+	}
+
+	total, tenants := e.Stats()
+	if total != 0 {
+		t.Errorf("totalEntries after Release = %d, want 0", total)
+	}
+	if _, ok := tenants["vpc-1"]; ok {
+		t.Errorf("tenantRuleCounts still contains vpc-1 after Release: %+v", tenants)
+	}
+
+	// Capacity freed by Release must be usable by a new rule.
+	if ok, err := e.CheckAndReserve(context.Background(), testRuleWithVIPs(testRuleKeyR2, "vpc-1", 1)); err != nil || !ok {
+		t.Fatalf("CheckAndReserve after Release: ok=%v err=%v, want true (capacity freed)", ok, err)
+	}
+}
+
+func TestNodeQuotaEnforcer_ReleaseUnknownKeyIsNoop(t *testing.T) {
+	e := NewNodeQuotaEnforcer(10, 100)
+	if err := e.Release(context.Background(), "never-reserved"); err != nil {
+		t.Fatalf("Release of unreserved key: unexpected error: %v", err)
+	}
+}
+
+func TestNodeQuotaEnforcer_ReapplyWithChangedVIPCountAdjustsTotal(t *testing.T) {
+	e := NewNodeQuotaEnforcer(10, 100)
+	rule := testRuleWithVIPs(testRuleKeyR1, "vpc-1", 1)
+	if ok, err := e.CheckAndReserve(context.Background(), rule); err != nil || !ok {
+		t.Fatalf("first CheckAndReserve: ok=%v err=%v, want true", ok, err)
+	}
+
+	// Same rule.Key, now dual-stack (2 VIPs instead of 1).
+	rule2 := testRuleWithVIPs(testRuleKeyR1, "vpc-1", 2)
+	if ok, err := e.CheckAndReserve(context.Background(), rule2); err != nil || !ok {
+		t.Fatalf("second CheckAndReserve: ok=%v err=%v, want true", ok, err)
+	}
+
+	total, _ := e.Stats()
+	if total != 2 {
+		t.Errorf("totalEntries after VIP count change = %d, want 2 (not 3 -- must replace, not add)", total)
+	}
+}

--- a/internal/gateway/recovery.go
+++ b/internal/gateway/recovery.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReconcileOrphans identifies and cleans up rule_table state left behind
+// by a gateway engine process that crashed mid-reconcile.
+//
+// Unlike an earlier, rejected design's identically-named method
+// (which scanned live Geneve interfaces against a desired VNI set), this
+// design has no kernel interface state of its own to leak — the only
+// thing a crashed process can leave behind is a rule_table row with no
+// corresponding NetworkRule left to reconcile it against. That is exactly
+// what internal/plumbing/ebpf/edgemap.RuleTable.Reconcile's own
+// Generation-cutoff mechanism already handles, so this method is a thin,
+// correctly-ordered wrapper around Datapath.ReconcileOrphans rather than a
+// second, independent orphan-detection mechanism.
+//
+// cutoff must have been captured via Engine.DatapathGeneration *before*
+// desired's NetworkRule CRDs were listed — an entry written after that
+// snapshot but before this call runs is a legitimate fresh Register this
+// method must not race, not an orphan (see
+// internal/plumbing/ebpf/edgemap's RuleTable.Generation doc comment for
+// the same ordering contract at the map layer).
+//
+// Unlike Reconcile, ReconcileOrphans does not rely on Engine's in-memory
+// active map — that map is empty immediately after a crash/restart, which
+// is exactly the situation this method exists to recover from.
+func (e *Engine) ReconcileOrphans(ctx context.Context, desired EngineState, cutoff uint64) error {
+	live := make([]DesiredRule, 0, len(desired.Rules))
+	for _, rule := range desired.Rules {
+		live = append(live, rule)
+	}
+
+	if err := e.datapath.ReconcileOrphans(ctx, live, cutoff); err != nil {
+		return fmt.Errorf("reconcile orphaned datapath state: %w", err)
+	}
+	return nil
+}

--- a/internal/gateway/recovery_test.go
+++ b/internal/gateway/recovery_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestEngine_ReconcileOrphansDelegatesToDatapath(t *testing.T) {
+	dp := newFakeDatapath()
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+
+	var gotLive []DesiredRule
+	var gotCutoff uint64
+	dp.reconcileOrphansFn = func(_ context.Context, live []DesiredRule, cutoff uint64) error {
+		gotLive = live
+		gotCutoff = cutoff
+		return nil
+	}
+
+	desired := EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}
+	if err := e.ReconcileOrphans(context.Background(), desired, 99); err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+
+	if gotCutoff != 99 {
+		t.Errorf("cutoff passed to Datapath.ReconcileOrphans = %d, want 99", gotCutoff)
+	}
+	if len(gotLive) != 1 || gotLive[0].Key != testKeyA {
+		t.Errorf("live passed to Datapath.ReconcileOrphans = %+v, want one rule %q", gotLive, testKeyA)
+	}
+}
+
+func TestEngine_ReconcileOrphansPropagatesDatapathError(t *testing.T) {
+	dp := newFakeDatapath()
+	wantErr := errors.New("simulated reconcile failure")
+	dp.reconcileOrphansFn = func(context.Context, []DesiredRule, uint64) error { return wantErr }
+
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+	err := e.ReconcileOrphans(context.Background(), EngineState{}, 0)
+	if !errors.Is(err, wantErr) {
+		t.Errorf("ReconcileOrphans error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+// TestEngine_ReconcileOrphansDoesNotConsultActiveMap confirms
+// ReconcileOrphans works from desired alone (not e.active), matching its
+// crash-recovery contract: e.active is empty immediately after a
+// crash/restart, exactly when this method is needed.
+func TestEngine_ReconcileOrphansDoesNotConsultActiveMap(t *testing.T) {
+	dp := newFakeDatapath()
+	var gotLive []DesiredRule
+	dp.reconcileOrphansFn = func(_ context.Context, live []DesiredRule, _ uint64) error {
+		gotLive = live
+		return nil
+	}
+
+	// A fresh Engine: e.active is empty, never populated by Reconcile.
+	e := NewEngine(dp, &fakeQuota{}, &fakeTelemetry{})
+
+	desired := EngineState{Rules: map[string]DesiredRule{testKeyA: {Key: testKeyA}}}
+	if err := e.ReconcileOrphans(context.Background(), desired, 0); err != nil {
+		t.Fatalf("ReconcileOrphans: %v", err)
+	}
+	if len(gotLive) != 1 {
+		t.Errorf("live = %+v, want the rule from desired regardless of e.active", gotLive)
+	}
+}

--- a/internal/gateway/telemetry.go
+++ b/internal/gateway/telemetry.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const telemetryNamespace = "galactic_edge"
+
+// labelRule is the Prometheus label name for a DesiredRule.Key value,
+// shared across every metric below that carries one.
+const labelRule = "rule"
+
+// PrometheusTelemetryEmitter is a real (not stubbed) TelemetryEmitter,
+// covering exactly the two things only knowable at Engine's own call
+// sites -- not re-derivable from a live scrape of rule_table/conn_table
+// state, which internal/plumbing/ebpf/edgemetrics's Collector already
+// exposes separately (packets/bytes/dropped_packets/last_seen_ns per
+// rule, same pull-at-scrape-time pattern as
+// internal/plumbing/ebpf/metrics's Collector for the SRv6 uSID datapath):
+//
+//  1. Which gateway node is currently primary vs. secondary for a rule's
+//     VIPs (DesiredRule.IsPrimary) -- an Active-Active BGP placement
+//     decision this engine's own control plane made, not something the
+//     datapath's own counters carry.
+//  2. Rule applications rejected before ever reaching the datapath (e.g.
+//     QuotaEnforcer denials) -- these never touch rule_table at all, so
+//     rule_table's own DroppedPackets counter (a strictly datapath-level,
+//     per-packet count) cannot see them.
+type PrometheusTelemetryEmitter struct {
+	rulePrimary       *prometheus.GaugeVec
+	controlPlaneDrops *prometheus.CounterVec
+}
+
+// NewPrometheusTelemetryEmitter builds a fresh, unregistered
+// PrometheusTelemetryEmitter. Call MustRegister once at process startup.
+func NewPrometheusTelemetryEmitter() *PrometheusTelemetryEmitter {
+	return &PrometheusTelemetryEmitter{
+		rulePrimary: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: telemetryNamespace,
+			Subsystem: labelRule,
+			Name:      "is_primary",
+			Help: "1 if this gateway node is the active-active primary (higher BGP local-pref) for " +
+				"this rule's VIPs, 0 if secondary. Absent entirely once the rule is removed.",
+		}, []string{labelRule}),
+		controlPlaneDrops: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: telemetryNamespace,
+			Name:      "control_plane_drops_total",
+			Help: "Rule applications rejected before ever reaching the datapath (e.g. quota_exceeded), " +
+				"by rule and reason. Datapath-level packet drops (a rule that WAS applied, then dropped " +
+				"traffic) are exposed separately by internal/plumbing/ebpf/edgemetrics's Collector.",
+		}, []string{labelRule, "reason"}),
+	}
+}
+
+// MustRegister registers every metric this type owns against reg. Panics
+// on a duplicate registration, matching prometheus.Registerer.MustRegister's
+// own documented behavior -- callers only ever do this once per process,
+// at startup, same convention as internal/plumbing/ebpf/metrics's
+// EventCounters.MustRegister.
+func (e *PrometheusTelemetryEmitter) MustRegister(reg prometheus.Registerer) {
+	reg.MustRegister(e.rulePrimary, e.controlPlaneDrops)
+}
+
+// RuleApplied records rule's current primary/secondary placement.
+func (e *PrometheusTelemetryEmitter) RuleApplied(_ context.Context, rule DesiredRule) {
+	v := 0.0
+	if rule.IsPrimary {
+		v = 1
+	}
+	e.rulePrimary.WithLabelValues(rule.Key).Set(v)
+}
+
+// RuleRemoved deletes key's is_primary series -- a removed rule has no
+// primary/secondary state to report, and leaving a stale series behind
+// would misreport it as still (say) secondary forever.
+func (e *PrometheusTelemetryEmitter) RuleRemoved(_ context.Context, key string) {
+	e.rulePrimary.DeleteLabelValues(key)
+}
+
+// DropObserved records a control-plane-level rejection for key, labeled by
+// reason (e.g. "quota_exceeded" -- see Engine.applyRuleLocked).
+func (e *PrometheusTelemetryEmitter) DropObserved(_ context.Context, key, reason string) {
+	e.controlPlaneDrops.WithLabelValues(key, reason).Inc()
+}
+
+var _ TelemetryEmitter = (*PrometheusTelemetryEmitter)(nil)

--- a/internal/gateway/telemetry_test.go
+++ b/internal/gateway/telemetry_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// collect runs c's Collect method to completion and returns every emitted
+// metric decoded to its protobuf form -- same convention as
+// internal/plumbing/ebpf/metrics/collector_test.go's identical helper,
+// duplicated rather than imported (unexported, different package).
+func collect(t *testing.T, c prometheus.Collector) []*dto.Metric {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 256)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	var out []*dto.Metric
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("write metric: %v", err)
+		}
+		out = append(out, &pb)
+	}
+	return out
+}
+
+func labelValue(m *dto.Metric, name string) string {
+	for _, lp := range m.GetLabel() {
+		if lp.GetName() == name {
+			return lp.GetValue()
+		}
+	}
+	return ""
+}
+
+func TestPrometheusTelemetryEmitter_RuleAppliedRecordsPrimary(t *testing.T) {
+	e := NewPrometheusTelemetryEmitter()
+	e.RuleApplied(context.Background(), DesiredRule{Key: testRuleKeyR1, IsPrimary: true})
+	e.RuleApplied(context.Background(), DesiredRule{Key: testRuleKeyR2, IsPrimary: false})
+
+	metrics := collect(t, e.rulePrimary)
+	if len(metrics) != 2 {
+		t.Fatalf("got %d metrics, want 2", len(metrics))
+	}
+	for _, m := range metrics {
+		switch labelValue(m, "rule") {
+		case testRuleKeyR1:
+			if m.GetGauge().GetValue() != 1 {
+				t.Errorf("ns/r1 is_primary = %v, want 1", m.GetGauge().GetValue())
+			}
+		case testRuleKeyR2:
+			if m.GetGauge().GetValue() != 0 {
+				t.Errorf("ns/r2 is_primary = %v, want 0", m.GetGauge().GetValue())
+			}
+		default:
+			t.Errorf("unexpected rule label %q", labelValue(m, "rule"))
+		}
+	}
+}
+
+func TestPrometheusTelemetryEmitter_RuleRemovedDeletesSeries(t *testing.T) {
+	e := NewPrometheusTelemetryEmitter()
+	e.RuleApplied(context.Background(), DesiredRule{Key: testRuleKeyR1, IsPrimary: true})
+	e.RuleRemoved(context.Background(), testRuleKeyR1)
+
+	if metrics := collect(t, e.rulePrimary); len(metrics) != 0 {
+		t.Errorf("got %d metrics after RuleRemoved, want 0", len(metrics))
+	}
+}
+
+func TestPrometheusTelemetryEmitter_DropObservedIncrementsCounter(t *testing.T) {
+	e := NewPrometheusTelemetryEmitter()
+	e.DropObserved(context.Background(), testRuleKeyR1, "quota_exceeded")
+	e.DropObserved(context.Background(), testRuleKeyR1, "quota_exceeded")
+
+	metrics := collect(t, e.controlPlaneDrops)
+	if len(metrics) != 1 {
+		t.Fatalf("got %d metrics, want 1", len(metrics))
+	}
+	m := metrics[0]
+	if labelValue(m, "rule") != testRuleKeyR1 || labelValue(m, "reason") != "quota_exceeded" {
+		t.Errorf("labels = rule=%q reason=%q, want rule=ns/r1 reason=quota_exceeded",
+			labelValue(m, "rule"), labelValue(m, "reason"))
+	}
+	if m.GetCounter().GetValue() != 2 {
+		t.Errorf("counter value = %v, want 2", m.GetCounter().GetValue())
+	}
+}
+
+func TestPrometheusTelemetryEmitter_MustRegisterIsIdempotentPerInstance(t *testing.T) {
+	e := NewPrometheusTelemetryEmitter()
+	reg := prometheus.NewRegistry()
+	e.MustRegister(reg) // must not panic
+}

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gateway
+
+import "net/netip"
+
+// DesiredBackend is a single backend endpoint a rule load-balances to,
+// mirroring network.datumapis.com/v1alpha1's NetworkRuleBackend plus one
+// field the CRD does not itself carry: USID, the SRv6 uSID of the worker
+// node this backend is reachable through. The controller building
+// DesiredRule resolves USID the same way any other cross-node SRv6
+// destination is resolved (srv6.ComputeSID over the backend's BGPRouter/
+// BGPAdvertisement — see internal/reconcile/reconcile.go's
+// resolveSRv6SID), never by parsing it out of a packet.
+type DesiredBackend struct {
+	Address netip.Addr
+	Port    uint16
+	USID    netip.Addr
+}
+
+// DesiredRule is the engine's internal representation of one NetworkRule,
+// assembled by the future NetworkGateway/NetworkRule controllers from the
+// NetworkRule CRD plus the node's own primary/secondary role for it.
+// Unlike an earlier, rejected design's identically-named type,
+// there is no VNI or VRFTableID here at all: this engine has no VRF/
+// Geneve dependency (see doc.go).
+type DesiredRule struct {
+	// Key uniquely identifies the rule (namespace/name of the source
+	// NetworkRule), used as the map key in Engine's convergence pass.
+	Key string
+
+	// VPCRef/VPCAttachmentRef are opaque tenant identifiers, carried
+	// through for telemetry labeling and admission-webhook auditing —
+	// this engine's datapath itself never needs them (a VIP is globally
+	// unique by construction, so no tenant dimension is needed to
+	// disambiguate ingress traffic; see edgeprog's doc comment).
+	VPCRef           string
+	VPCAttachmentRef string
+
+	// VIPAddresses are the ingress VIP addresses this rule provisions.
+	VIPAddresses []netip.Addr
+
+	// Protocol is "tcp" or "udp", matching
+	// network.datumapis.com/v1alpha1's NetworkRuleProtocol enum values.
+	Protocol string
+	Port     uint16
+	Backends []DesiredBackend
+
+	// LocalPreference is the BGP local-preference this node should
+	// advertise this rule's VIPs at: PrimaryLocalPref if this node is the
+	// rule's primary_node, SecondaryLocalPref otherwise (localpref.go).
+	// Both nodes always advertise — this field only affects preference,
+	// never presence.
+	LocalPref uint32
+
+	// IsPrimary mirrors LocalPref == PrimaryLocalPref, kept as a separate
+	// bool for callers (e.g. status reporting, telemetry) that want the
+	// role without re-deriving it from the numeric preference.
+	IsPrimary bool
+}
+
+// EngineState is the full desired state for one gateway node's Engine,
+// assembled by the NetworkGateway controller from every accepted
+// NetworkRule in the node's PoP (both primary- and secondary-assigned —
+// active-active means both gateway nodes serve every rule, see
+// localpref.go).
+type EngineState struct {
+	// Rules is keyed by DesiredRule.Key.
+	Rules map[string]DesiredRule
+}
+
+// RuleStatus is the observed state of a single rule after a convergence
+// pass, analogous to model.AdvertisementStatus for the BGP runtime.
+type RuleStatus struct {
+	Key     string
+	Applied bool
+	Error   string
+}
+
+// EngineStatus is the observed state returned by Engine.Status, analogous
+// to model.RuntimeStatus for the BGP runtime.
+type EngineStatus struct {
+	Healthy bool
+	Rules   []RuleStatus
+}


### PR DESCRIPTION
## Summary

The eBPF datapath from the previous PR needs a control-plane layer that decides what belongs in the rule table and keeps it converged as backends and quotas change. This adds that engine: desired-vs-active rule diffing, a kernel-backed datapath implementation, primary/secondary local-pref and placement logic, per-VPC quota enforcement, and telemetry. It defines its own types rather than reusing the CRD API, so this package has no Kubernetes dependency at all. Second branch in the edge-gateway stack; builds on the eBPF datapath PR.

## Test plan

- [ ] Unit tests pass for the engine package (`task test:unit`)
- [ ] `task lint` and `task build` are clean

Related to #17