### PR TITLE
feat(gateway): Publish galactic-gateway as its own image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,19 @@ jobs:
       platforms: linux/amd64,linux/arm64
     secrets: inherit
 
+  publish-galactic-gateway-image:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+      attestations: write
+    uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.20.0
+    with:
+      image-name: galactic-gateway
+      dockerfile-path: containers/galactic-gateway/Dockerfile
+      platforms: linux/amd64,linux/arm64
+    secrets: inherit
+
   publish-fabric-router-image:
     permissions:
       id-token: write
@@ -46,7 +59,13 @@ jobs:
     secrets: inherit
 
   publish-kustomize-bundles:
-    needs: [publish-galactic-cni-image, publish-galactic-router-image, publish-fabric-router-image]
+    needs:
+      [
+        publish-galactic-cni-image,
+        publish-galactic-router-image,
+        publish-galactic-gateway-image,
+        publish-fabric-router-image,
+      ]
     permissions:
       id-token: write
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ task test:e2e       # Kind cluster lifecycle test
 task lint           # golangci-lint; lint-fix applies safe auto-fixes
 ```
 
-There is no production release image build in this repo (`task docker-build` and the release workflow were removed after the shared image was found to advertise `galactic-router` without ever building it — see [docs/agents/ARCHITECTURE.md](docs/agents/ARCHITECTURE.md#known-constraints)). `containers/galactic-cni/Dockerfile` exists solely for `task test:e2e`.
+Production release images are built by `.github/workflows/publish.yaml`, not by any `task` in this file — see [docs/agents/ARCHITECTURE.md](docs/agents/ARCHITECTURE.md#cicd) for the full pipeline (per-binary `containers/*/Dockerfile`s pushed to `ghcr.io/datum-cloud/*`, plus a `config/` Kustomize OCI bundle). This replaced an earlier single shared image (`containers/galactic/Dockerfile`, `.github/workflows/release.yaml`, both removed — see that section's History note) that was found to advertise `galactic-router` without ever building it. `containers/galactic-cni/Dockerfile` is also used directly by `task test:e2e` (not just by the publish pipeline).
 
 **Before every PR:** `task ci` (lint → build → test:unit → test:e2e).
 

--- a/containers/galactic-gateway/Dockerfile
+++ b/containers/galactic-gateway/Dockerfile
@@ -1,4 +1,4 @@
-# Build the galactic router binary
+# Build the galactic-gateway binary
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
@@ -21,20 +21,20 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
 
-# galactic-router transitively imports both internal/plumbing/ebpf/prog
-# (via usidmap) and, via the NetworkGateway/NetworkRule reconcilers'
-# internal/gateway.Engine, internal/plumbing/ebpf/edgemap's
-# internal/plumbing/ebpf/edgeprog -- neither package's bpf2go output
+# galactic-gateway transitively imports both internal/plumbing/ebpf/edgeprog
+# (the edge NAT+LB XDP program it loads directly) and, via
+# internal/plumbing/ebpf/edgepreflight, internal/plumbing/ebpf/prog (the
+# SRv6 uSID TC-BPF program) -- neither package's bpf2go output
 # (*_bpfel.go/.o, *_bpfeb.go/.o) is committed to git (see each package's
 # doc.go), so both must be regenerated here, same as
-# containers/galactic-gateway/Dockerfile does.
+# containers/galactic-router/Dockerfile now does too.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       clang llvm linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN go generate ./internal/plumbing/ebpf/prog/...
 RUN go generate ./internal/plumbing/ebpf/edgeprog/...
 
-# Build the router
+# Build galactic-gateway
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w \
       -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
@@ -43,16 +43,16 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
       -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE} \
       -X go.datum.net/galactic/internal/metadata.SPDXLicense=${SPDX_LICENSE} \
       -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
-    -o galactic-router ./cmd/galactic-router
+    -o galactic-gateway ./cmd/galactic-gateway
 
-# Use distroless as minimal base image to package the binary. galactic-router
-# drives all VRF/SRv6/route/BGP state through the netlink and GoBGP Go
-# libraries directly, never shells out to `ip` or any other host CLI tool, so
-# no shell is required in the final image.
+# Use distroless as minimal base image to package the binary. galactic-gateway
+# drives its eBPF/XDP and BGPAdvertisement CRD state through the cilium/ebpf
+# and controller-runtime Go libraries directly, never shells out to `ip` or
+# any other host CLI tool, so no shell is required in the final image.
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/galactic-router .
+COPY --from=builder /workspace/galactic-gateway .
 USER 65532:65532
 
-ENTRYPOINT ["/galactic-router"]
+ENTRYPOINT ["/galactic-gateway"]


### PR DESCRIPTION
## Summary

The new binary from the previous PR needs a release image and a way to get it published. This adds a Dockerfile for galactic-gateway, matching galactic-router's shape, and a publish job that pushes it and stamps its tag into the two-container gateway DaemonSet's OCI Kustomize bundle entry. Fifth branch in the edge-gateway stack; builds on the galactic-gateway binary PR.

## Test plan

- [ ] `docker build` succeeds for the new Dockerfile
- [ ] The publish workflow YAML is valid and `task lint` is clean

Related to #17