### PR TITLE
chore(ci): extract the eBPF toolchain install into a composite action

### DIFF
--- a/.github/actions/install-ebpf-deps/action.yaml
+++ b/.github/actions/install-ebpf-deps/action.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Datum Cloud, Inc.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Install eBPF build dependencies
+description: >-
+  Installs the pinned clang/llvm/linux-libc-dev toolchain every job needs to
+  regenerate internal/plumbing/ebpf/prog's bpf2go output, which is gitignored
+  (see that package's doc.go).
+
+runs:
+  using: composite
+  steps:
+    # Pinned to an explicit versioned package (clang-18/llvm-18) rather than
+    # the unversioned clang/llvm meta-packages, matching ci.yaml's
+    # workflow-level BPF2GO_CC pin -- keeps the BPF object bytes (BTF, debug
+    # info, section layout) produced by one job identical to every other
+    # job's regeneration instead of drifting with whatever clang a future
+    # runner-image bump resolves to. Bumping the version here means bumping
+    # BPF2GO_CC with it.
+    #
+    # linux-libc-dev is listed explicitly too -- prog/doc.go's -idirafter
+    # workaround exists specifically to find its headers, so no job should
+    # rely on it merely happening to be preinstalled.
+    - name: Install clang/llvm/linux-libc-dev
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-18 llvm-18 linux-libc-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,8 @@ jobs:
 
       - name: Install eBPF build dependencies
         # `task lint` type-checks the whole module, which needs
-        # internal/plumbing/ebpf/prog's bpf2go output regenerated first
-        # (see build job's identical step below for the package pins).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # internal/plumbing/ebpf/prog's bpf2go output regenerated first.
+        uses: ./.github/actions/install-ebpf-deps
 
       - name: Run lint
         run: task lint
@@ -67,11 +64,8 @@ jobs:
 
       - name: Install eBPF build dependencies
         # `task test:unit` builds internal/plumbing/ebpf/prog, which needs
-        # its bpf2go output regenerated first (see build job's identical
-        # step below for the package pins).
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # its bpf2go output regenerated first.
+        uses: ./.github/actions/install-ebpf-deps
 
       - name: Run unit tests
         run: task test:unit
@@ -140,15 +134,12 @@ jobs:
 
       - name: Install eBPF build dependencies
         # `task test:unit-root` builds internal/plumbing/ebpf/prog, which
-        # needs its bpf2go output regenerated first (see build job's
-        # identical step below for the package pins). This runs as the
+        # needs its bpf2go output regenerated first. This runs as the
         # unprivileged runner user -- it's the regeneration below, run as
         # root via `sudo -E task test:unit-root`, that needs clang on
         # root's PATH, which -E's preserved PATH (asserted explicitly via
         # `env "PATH=$PATH"`) already covers.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        uses: ./.github/actions/install-ebpf-deps
 
       - name: Run root-gated unit tests as root
         # sudo's secure_path policy overrides -E's preserved PATH for
@@ -175,18 +166,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install eBPF build dependencies
-        # Pinned to an explicit versioned package (clang-18/llvm-18) rather
-        # than the unversioned clang/llvm meta-packages, matching the
-        # workflow-level BPF2GO_CC pin above -- keeps the BPF object bytes
-        # (BTF, debug info, section layout) produced by this job identical
-        # to every other job's regeneration instead of drifting with
-        # whatever clang a future runner-image bump resolves to.
-        # linux-libc-dev is listed explicitly too -- doc.go's -idirafter
-        # workaround exists specifically to find its headers, so this job
-        # shouldn't rely on it merely happening to be preinstalled.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # `task build`'s build:ebpf step regenerates
+        # internal/plumbing/ebpf/prog's bpf2go output before it builds any
+        # binary -- see the composite action for the package pins.
+        uses: ./.github/actions/install-ebpf-deps
 
       - name: Build binary
         # task build's build:ebpf step regenerates
@@ -219,11 +202,8 @@ jobs:
         # galactic-cni image it builds separately regenerates its own copy
         # inside containers/galactic-cni/Dockerfile's builder stage), which
         # needs internal/plumbing/ebpf/prog's bpf2go output regenerated
-        # first -- see build job's identical step above for the package
-        # pins.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # first.
+        uses: ./.github/actions/install-ebpf-deps
 
       - name: Run E2E tests
         run: task test:e2e


### PR DESCRIPTION
## Summary

Five CI jobs each installed the same pinned eBPF toolchain, with the reasoning for the pins written out in one job and cross-referenced from the other four.

The pins are the point. They keep the compiled BPF object bytes identical across every job that regenerates them, and they have to move in step with the workflow-level compiler pin. Five copies means five chances to bump one and miss the rest.

Now there is one copy, in a composite action, with the reasoning next to the packages it explains. Each job keeps its own one-line note about why it needs the toolchain, since that part genuinely differs per job.

No behavior change. Same packages, same order, same jobs.

## Test plan

- [ ] `task lint`, including the yamlfmt pass over the new action
- [ ] `task build`
- [ ] `task test:unit`
- [ ] `task test:e2e`

CI is the check here, since all five call sites are CI jobs.

Related to #314
