### PR TITLE
fix(gateway): surface swallowed NetworkGateway reconcile errors

### DIFF
--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -6,6 +6,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 
@@ -104,6 +105,19 @@ type NetworkGatewayReconciler struct {
 	SRv6Address string
 }
 
+const (
+	// reasonEngineHealthy is the Ready condition reason for a fully
+	// converged and fully advertised node.
+	reasonEngineHealthy = "EngineHealthy"
+
+	// reasonAdvertisementFailed is the Ready condition reason for a node
+	// whose engine converged but which could not publish one or more of the
+	// BGPAdvertisements that make that convergence reachable — its own
+	// self-address route, or a rule's VIP route. Such a node serves
+	// nothing, so it must not report reasonEngineHealthy (#365).
+	reasonAdvertisementFailed = "AdvertisementFailed"
+)
+
 // Reconcile reconciles a single NetworkGateway.
 func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -160,8 +174,16 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
+	// Advertisement failures are collected rather than returned on the spot:
+	// the rest of the pass still runs (one bad rule must not stop the
+	// others), then they are reported on the object as
+	// reasonAdvertisementFailed and returned, so controller-runtime retries
+	// with backoff instead of leaving a node that advertised nothing
+	// claiming EngineHealthy (#365).
+	var advErrs []error
 	if err := r.publishSelfAddress(ctx, gw); err != nil {
 		logger.Error(err, "publish gateway self-address", "networkGateway", req.NamespacedName)
+		advErrs = append(advErrs, fmt.Errorf("publish self-address: %w", err))
 	}
 
 	// Crash-safety ordering contract (see GatewayEngine.ReconcileOrphans):
@@ -240,31 +262,52 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	for _, w := range work {
 		if err := r.applyBGPAdvertisements(ctx, w.rule, w.desired, routerName); err != nil {
 			logger.Error(err, "apply BGPAdvertisements for NetworkRule", "networkRule", w.rule.Name)
+			advErrs = append(advErrs, fmt.Errorf("networkRule %s: %w", w.rule.Name, err))
 		}
 	}
+	advErr := errors.Join(advErrs...)
 
 	gwCopy := gw.DeepCopy()
 	gwCopy.Status.ObservedGeneration = gw.Generation
-	if status.Healthy {
-		setGatewayCondition(gwCopy, metav1.Condition{
-			Type: bgpv1alpha1.ConditionTypeReady, Status: metav1.ConditionTrue,
-			Reason: "EngineHealthy", Message: "gateway engine converged",
-		})
-	} else {
-		setGatewayCondition(gwCopy, metav1.Condition{
-			Type: bgpv1alpha1.ConditionTypeReady, Status: metav1.ConditionFalse,
-			Reason: "EngineDegraded", Message: "one or more NetworkRules failed to apply",
-		})
-	}
+	setGatewayCondition(gwCopy, readyConditionFor(status, advErr))
 	if updateErr := r.Status().Update(ctx, gwCopy); updateErr != nil {
 		logger.Error(updateErr, "update NetworkGateway status")
 	}
 
+	// Crash recovery (see GatewayEngine.ReconcileOrphans): a failed sweep
+	// leaves orphaned rule_table state behind until some later pass
+	// succeeds, so it is returned for retry too, after the status write
+	// above so the failure is still visible on the object.
 	if err := r.Engine.ReconcileOrphans(ctx, desired, cutoff); err != nil {
 		logger.Error(err, "reconcile orphaned rule_table state")
+		return ctrl.Result{}, errors.Join(advErr, fmt.Errorf("reconcile orphaned rule_table state: %w", err))
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, advErr
+}
+
+// readyConditionFor computes the Ready condition for a completed pass:
+// engine health first, then advertisement failures — a node whose engine
+// converged but whose routes never reached BGP serves no traffic, so it
+// must not report reasonEngineHealthy (#365).
+func readyConditionFor(status gateway.EngineStatus, advErr error) metav1.Condition {
+	switch {
+	case !status.Healthy:
+		return metav1.Condition{
+			Type: bgpv1alpha1.ConditionTypeReady, Status: metav1.ConditionFalse,
+			Reason: "EngineDegraded", Message: "one or more NetworkRules failed to apply",
+		}
+	case advErr != nil:
+		return metav1.Condition{
+			Type: bgpv1alpha1.ConditionTypeReady, Status: metav1.ConditionFalse,
+			Reason: reasonAdvertisementFailed, Message: advErr.Error(),
+		}
+	default:
+		return metav1.Condition{
+			Type: bgpv1alpha1.ConditionTypeReady, Status: metav1.ConditionTrue,
+			Reason: reasonEngineHealthy, Message: "gateway engine converged",
+		}
+	}
 }
 
 // publishSelfAddress sets gw.Status.SRv6Address to r.SRv6Address and
@@ -302,9 +345,12 @@ func (r *NetworkGatewayReconciler) publishSelfAddress(ctx context.Context, gw *b
 	}
 
 	if gw.Status.SRv6Address != r.SRv6Address {
-		gwCopy := gw.DeepCopy()
-		gwCopy.Status.SRv6Address = r.SRv6Address
-		if err := r.Status().Update(ctx, gwCopy); err != nil {
+		// Updated in place, not through a copy: Reconcile writes the Ready
+		// condition from this same object afterwards, and a copy would leave
+		// it holding a stale resourceVersion — losing that write to a
+		// conflict on exactly the pass whose outcome matters most (#365).
+		gw.Status.SRv6Address = r.SRv6Address
+		if err := r.Status().Update(ctx, gw); err != nil {
 			return fmt.Errorf("update NetworkGateway status.sRv6Address: %w", err)
 		}
 	}

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -6,7 +6,9 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"net/netip"
+	"strings"
 	"sync"
 	"testing"
 
@@ -16,9 +18,17 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"go.datum.net/galactic/internal/gateway"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// errAdvertisementWrite and errOrphanSweep are the injected failures the
+// #365 regression tests below assert are surfaced rather than swallowed.
+var (
+	errAdvertisementWrite = errors.New("simulated BGPAdvertisement write failure")
+	errOrphanSweep        = errors.New("simulated orphan sweep failure")
 )
 
 // fakeGatewayEngine records the EngineState passed to Reconcile so tests can
@@ -29,6 +39,7 @@ type fakeGatewayEngine struct {
 	lastDesired    gateway.EngineState
 	reconciled     int
 	reconcileErr   error
+	orphansErr     error
 	stopped        bool
 	generation     uint64
 	orphansCutoffs []uint64
@@ -59,7 +70,7 @@ func (f *fakeGatewayEngine) ReconcileOrphans(_ context.Context, _ gateway.Engine
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.orphansCutoffs = append(f.orphansCutoffs, cutoff)
-	return nil
+	return f.orphansErr
 }
 
 func (f *fakeGatewayEngine) Stop(context.Context) error {
@@ -99,6 +110,38 @@ func newGatewayReconciler(
 	c client.Client, scheme *runtime.Scheme, engine GatewayEngine, node string,
 ) *NetworkGatewayReconciler {
 	return &NetworkGatewayReconciler{Client: c, Scheme: scheme, Engine: engine, NodeName: node}
+}
+
+// newTestRouter returns the BGPRouter targeting testNodeGWA, resolved
+// through the
+// BGPRouterByTargetName index newIndexedClientBuilder registers. Without
+// one, routerNameForNode returns "" and Reconcile skips every
+// BGPAdvertisement it would otherwise write.
+func newTestRouter() *bgpv1alpha1.BGPRouter {
+	return &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testRouterName},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testNodeGWA},
+			LocalASN:  65000,
+			RouterID:  "1.1.1.1",
+			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
+		},
+	}
+}
+
+// gatewayReadyCondition returns node's NetworkGateway Ready condition,
+// failing the test if the object or the condition is missing.
+func gatewayReadyCondition(t *testing.T, c client.Client, node string) *metav1.Condition {
+	t.Helper()
+	gw := &bgpv1alpha1.NetworkGateway{}
+	if err := c.Get(context.Background(), testRuleKey(node), gw); err != nil {
+		t.Fatalf("get NetworkGateway %s: %v", node, err)
+	}
+	cond := meta.FindStatusCondition(gw.Status.Conditions, bgpv1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatalf("NetworkGateway %s has no %s condition", node, bgpv1alpha1.ConditionTypeReady)
+	}
+	return cond
 }
 
 func TestNetworkGatewayReconciler_SkipsNonMatchingNode(t *testing.T) {
@@ -311,15 +354,7 @@ func TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref(t
 	gwA := newTestGateway(testNodeGWA)
 	gwB := newTestGateway(testNodeGWB)
 	backendRouter, backendAdv := newBackendFixtures()
-	router := &bgpv1alpha1.BGPRouter{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testRouterName},
-		Spec: bgpv1alpha1.BGPRouterSpec{
-			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testNodeGWA},
-			LocalASN:  65000,
-			RouterID:  "1.1.1.1",
-			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
-		},
-	}
+	router := newTestRouter()
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWB // this node (gw-a) is secondary
 	acceptRule(rule)
@@ -366,15 +401,7 @@ func TestNetworkGatewayReconciler_PublishesSelfAddress(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	const selfAddr = "2001:db8:ffff::1"
 	gw := newTestGateway(testNodeGWA)
-	router := &bgpv1alpha1.BGPRouter{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testRouterName},
-		Spec: bgpv1alpha1.BGPRouterSpec{
-			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testNodeGWA},
-			LocalASN:  65000,
-			RouterID:  "1.1.1.1",
-			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
-		},
-	}
+	router := newTestRouter()
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
@@ -408,6 +435,131 @@ func TestNetworkGatewayReconciler_PublishesSelfAddress(t *testing.T) {
 	if adv.Spec.VRFID != nil || adv.Spec.Function != nil {
 		t.Errorf("self-address advertisement must carry no VRFID/Function, got VRFID=%v Function=%v",
 			adv.Spec.VRFID, adv.Spec.Function)
+	}
+}
+
+// TestNetworkGatewayReconciler_AdvertisementFailureSurfaces is the
+// regression test for #365: BGPAdvertisement write failures used to be
+// logged and dropped, so a node that had advertised nothing still reported
+// Ready=True/EngineHealthy (the condition was computed from the engine
+// result alone) and Reconcile returned nil, so nothing retried either.
+func TestNetworkGatewayReconciler_AdvertisementFailureSurfaces(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+	backendRouter, backendAdv := newBackendFixtures()
+	router := newTestRouter()
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+	rule.Status.PrimaryNode = testNodeGWA
+	acceptRule(rule)
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gwA, router, backendRouter, backendAdv, rule).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(
+				ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption,
+			) error {
+				if _, ok := obj.(*bgpv1alpha1.BGPAdvertisement); ok {
+					return errAdvertisementWrite
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	_, err := r.Reconcile(context.Background(), req)
+	if err == nil {
+		t.Fatal("Reconcile returned nil for a failed BGPAdvertisement write; the failure must be retried")
+	}
+	if !errors.Is(err, errAdvertisementWrite) {
+		t.Errorf("Reconcile error = %v, want it to wrap %v", err, errAdvertisementWrite)
+	}
+
+	cond := gatewayReadyCondition(t, fakeClient, testNodeGWA)
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready status = %s, want %s", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Reason != reasonAdvertisementFailed {
+		t.Errorf("Ready reason = %q, want %q", cond.Reason, reasonAdvertisementFailed)
+	}
+	if !strings.Contains(cond.Message, testRuleName) {
+		t.Errorf("Ready message = %q, want it to name the failing NetworkRule %q", cond.Message, testRuleName)
+	}
+}
+
+// TestNetworkGatewayReconciler_ReportsEngineHealthyOnCleanPass is the
+// other half of #365: with every advertisement written, the node still
+// reports Ready=True/EngineHealthy and Reconcile returns nil.
+func TestNetworkGatewayReconciler_ReportsEngineHealthyOnCleanPass(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+	backendRouter, backendAdv := newBackendFixtures()
+	router := newTestRouter()
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+	rule.Status.PrimaryNode = testNodeGWA
+	acceptRule(rule)
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gwA, router, backendRouter, backendAdv, rule).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(testRuleAdvV4), adv); err != nil {
+		t.Fatalf("get BGPAdvertisement %s: %v", testRuleAdvV4, err)
+	}
+
+	cond := gatewayReadyCondition(t, fakeClient, testNodeGWA)
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Ready status = %s, want %s", cond.Status, metav1.ConditionTrue)
+	}
+	if cond.Reason != reasonEngineHealthy {
+		t.Errorf("Ready reason = %q, want %q", cond.Reason, reasonEngineHealthy)
+	}
+}
+
+// TestNetworkGatewayReconciler_ReturnsOrphanSweepFailure covers the third
+// swallowed error from #365. The sweep is crash recovery, so its failure
+// must be retried -- and the status write that precedes it still has to
+// land, hence the Ready assertion.
+func TestNetworkGatewayReconciler_ReturnsOrphanSweepFailure(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gwA).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	engine.orphansErr = errOrphanSweep
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	_, err := r.Reconcile(context.Background(), req)
+	if err == nil {
+		t.Fatal("Reconcile returned nil for a failed orphan sweep; the sweep must be retried")
+	}
+	if !errors.Is(err, errOrphanSweep) {
+		t.Errorf("Reconcile error = %v, want it to wrap %v", err, errOrphanSweep)
+	}
+
+	cond := gatewayReadyCondition(t, fakeClient, testNodeGWA)
+	if cond.Reason != reasonEngineHealthy {
+		t.Errorf("Ready reason = %q, want %q (status is written before the sweep runs)",
+			cond.Reason, reasonEngineHealthy)
 	}
 }
 


### PR DESCRIPTION
## Summary

The gateway node programs its rules, then advertises the routes that steer traffic to them. Programming failures propagated. Advertisement failures were logged and dropped, and the Ready condition was computed from the engine result alone.

A node that programmed every rule and advertised none reported Ready, returned success, and never retried. The one signal an operator would check said the opposite of what was true.

Advertisement failures are now collected across the pass, so one bad rule still does not stop the others, and then reported. Ready says `AdvertisementFailed` with the rules named, and the error goes back to controller-runtime so the pass retries with backoff.

The node's own reachability address is treated the same way, since a node that cannot publish where it is reachable is in no better shape.

The orphan sweep is returned rather than logged past. It is crash recovery, and the generation cutoff is captured specifically for it. Status is still written before it runs, so a sweep failure does not hide the condition.

Engine failure keeps its precedence. If the engine is degraded, that is the root cause and the condition still says so.

## One thing found on the way

Publishing the self-address wrote status through a copy, leaving the caller holding a stale resource version. The Ready condition written later in the same pass was then lost to a conflict, logged and forgotten. It updates in place now. Without this, the fix above would report correctly and then fail to persist on exactly the passes that matter.

## Test plan

- [ ] `task lint`
- [ ] `task build`
- [ ] `task test:unit`, including three new cases: advertisement failure surfaces on the condition and returns, a clean pass still reports healthy, and an orphan sweep failure propagates with the condition already written
- [ ] `task test:e2e`

CI is the gate; this machine cannot build the module.

Note the reconcilers this touches are not registered by any binary on main yet. That arrives with #352, so there is no runtime behavior change until it lands.

Related to #365
