### PR TITLE
fix(gateway): watch NetworkGateway from NetworkRuleReconciler

### DIFF
--- a/internal/controller/networkrule_controller.go
+++ b/internal/controller/networkrule_controller.go
@@ -17,7 +17,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"go.datum.net/galactic/internal/gateway"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
@@ -125,10 +127,9 @@ func (r *NetworkRuleReconciler) assignPrimaryNode(ctx context.Context, rule *bgp
 	if len(nodes) == 0 {
 		// No gateway nodes registered yet for this PoP. Surface this via
 		// the Accepted condition rather than silently doing nothing — the
-		// next NetworkGateway create event re-triggers this rule via
-		// ruleToGatewayRequests's inverse (NetworkGatewayReconciler watches
-		// NetworkRule, not the other way around, so this reconciler relies
-		// on this NetworkRule's own periodic resync to retry).
+		// NetworkGateway watch (see gatewayToRuleRequests) re-queues this
+		// rule as soon as a gateway node registers, so it is not parked
+		// here until the next periodic resync.
 		setRuleCondition(ruleCopy, metav1.Condition{
 			Type:    bgpv1alpha1.ConditionTypeAccepted,
 			Status:  metav1.ConditionFalse,
@@ -241,11 +242,53 @@ func (r *NetworkRuleReconciler) reconcileDelete(
 }
 
 // SetupWithManager registers the NetworkRuleReconciler with the manager.
+//
+// The NetworkGateway watch is the mirror image of
+// NetworkGatewayReconciler's NetworkRule watch: both of this reconciler's
+// jobs (isGatewayNode gating in Reconcile, primary-node assignment in
+// assignPrimaryNode) are functions of the namespace's gateway-node pool, so
+// a rule must be re-examined whenever that pool changes rather than waiting
+// on its own periodic resync.
 func (r *NetworkRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.NetworkRule{}).
+		Watches(&bgpv1alpha1.NetworkGateway{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return gatewayToRuleRequests(ctx, r.Client, obj)
+			}),
+		).
 		Named("networkrule").
 		Complete(r)
+}
+
+// gatewayToRuleRequests maps a NetworkGateway change to every NetworkRule in
+// its namespace — the inverse of ruleToGatewayRequests, and a deliberate
+// broadcast for the same reason: a NetworkRule carries no gatewayRef, and
+// every rule's Accepted condition and primary-node assignment depend on the
+// namespace's whole gateway-node pool (see assignPrimaryNode). Without this,
+// a rule created before any gateway node registered stays parked at
+// Accepted=False — and therefore excluded from NetworkGatewayReconciler's
+// rule-gathering loop — until the informer's periodic resync (10 hours by
+// default).
+func gatewayToRuleRequests(ctx context.Context, c client.Client, obj client.Object) []ctrlreconcile.Request {
+	gw, ok := obj.(*bgpv1alpha1.NetworkGateway)
+	if !ok {
+		return nil
+	}
+	logger := log.FromContext(ctx)
+
+	ruleList := &bgpv1alpha1.NetworkRuleList{}
+	if err := c.List(ctx, ruleList, client.InNamespace(gw.Namespace)); err != nil {
+		logger.Error(err, "list NetworkRules for NetworkGateway change", "networkGateway", gw.Name)
+		return nil
+	}
+	reqs := make([]ctrlreconcile.Request, 0, len(ruleList.Items))
+	for _, rule := range ruleList.Items {
+		reqs = append(reqs, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: rule.Namespace, Name: rule.Name},
+		})
+	}
+	return reqs
 }
 
 // bgpAdvertisementNamesForRule returns the deterministic BGPAdvertisement

--- a/internal/controller/networkrule_controller_test.go
+++ b/internal/controller/networkrule_controller_test.go
@@ -254,6 +254,77 @@ func TestNetworkRuleReconciler_AssignPrimaryNode_AcceptedFalseWithNoGatewayNodes
 	}
 }
 
+// TestNetworkRuleReconciler_GatewayAppearanceRequeuesParkedRule covers the
+// full recovery path for a rule created before any gateway node registered:
+// it parks at Accepted=False, and the NetworkGateway watch's mapper
+// (gatewayToRuleRequests) enqueues it as soon as a gateway registers, at
+// which point the ordinary reconcile flips it to Accepted=True. Without that
+// watch the rule waits for the informer's periodic resync (#367).
+func TestNetworkRuleReconciler_GatewayAppearanceRequeuesParkedRule(t *testing.T) {
+	ctx := context.Background()
+	scheme := newRuleTestScheme(t)
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkRule{}).
+		WithObjects(rule).
+		Build()
+
+	r := &NetworkRuleReconciler{Client: fakeClient, Scheme: scheme, NodeName: testNodeGWA}
+
+	// No NetworkGateway exists yet, so this is the zero-nodes branch (see
+	// TestNetworkRuleReconciler_AssignPrimaryNode_AcceptedFalseWithNoGatewayNodes
+	// for why it is reached directly rather than through Reconcile).
+	if err := r.assignPrimaryNode(ctx, rule); err != nil {
+		t.Fatalf("assignPrimaryNode: unexpected error: %v", err)
+	}
+	parked := &bgpv1alpha1.NetworkRule{}
+	if err := fakeClient.Get(ctx, testRuleKey(testRuleName), parked); err != nil {
+		t.Fatalf("get rule: %v", err)
+	}
+	if meta.IsStatusConditionTrue(parked.Status.Conditions, bgpv1alpha1.ConditionTypeAccepted) {
+		t.Fatal("Accepted must not be True with no gateway nodes registered")
+	}
+
+	// A gateway node registers: the mapper must enqueue the parked rule.
+	gwA := newTestGateway(testNodeGWA)
+	if err := fakeClient.Create(ctx, gwA); err != nil {
+		t.Fatalf("create gateway: %v", err)
+	}
+	reqs := gatewayToRuleRequests(ctx, fakeClient, gwA)
+	want := testRuleKey(testRuleName)
+	found := false
+	for _, req := range reqs {
+		if req.NamespacedName == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("gatewayToRuleRequests(%s) = %v, want a request for %s", gwA.Name, reqs, want)
+	}
+
+	// Non-NetworkGateway objects must map to nothing.
+	if got := gatewayToRuleRequests(ctx, fakeClient, rule); got != nil {
+		t.Fatalf("gatewayToRuleRequests on a non-NetworkGateway = %v, want nil", got)
+	}
+
+	// Reconciling that enqueued request must unpark the rule.
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: want}); err != nil {
+		t.Fatalf("Reconcile after gateway registration: unexpected error: %v", err)
+	}
+	got := &bgpv1alpha1.NetworkRule{}
+	if err := fakeClient.Get(ctx, want, got); err != nil {
+		t.Fatalf("get rule after requeue: %v", err)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, bgpv1alpha1.ConditionTypeAccepted) {
+		t.Fatal("Accepted was not flipped to True after a gateway node registered")
+	}
+	if got.Status.PrimaryNode != testNodeGWA {
+		t.Fatalf("PrimaryNode = %q, want %q", got.Status.PrimaryNode, testNodeGWA)
+	}
+}
+
 func TestNetworkRuleReconciler_NoOpOnNonGatewayNode(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)


### PR DESCRIPTION
## Summary

A rule created before any gateway node has registered is marked not accepted, correctly, and then forgotten. Nothing re-examined it when the nodes arrived, because the rule reconciler watched only rules. It waited for the informer resync, ten hours by default, and stayed out of every gateway's rule table for that whole window.

On a cluster coming up in the usual order, that reads as broken: rules exist, nodes exist, no traffic flows, nothing explains the wait.

The rule reconciler now watches gateways too, and maps a gateway change to the rules in its namespace. That is the mirror image of the watch the gateway reconciler already has in the other direction, and the same deliberate broadcast, since a rule names no gateway and every rule's acceptance depends on the namespace's whole node pool.

The comment on that path used to say a gateway event re-triggers the rule and then, in the same sentence, that it relies on the resync. It now describes what the code does.

## Not in scope

The second half of #367, where withdrawal misses advertisements belonging to nodes that have since left the namespace, is untouched. That needs owner references or a label selector rather than rebuilding names from current membership, which is a design change worth its own PR. The issue stays open for it.

## Test plan

- [ ] `task lint`
- [ ] `task build`
- [ ] `task test:unit`, including a new case: a rule parked with no gateway nodes is enqueued when a gateway appears, and then accepted with a primary node
- [ ] `task test:e2e`

CI is the gate; this machine cannot build the module.

Note this reconciler is not registered by any binary on main yet. That arrives with #352, and the RBAC that lets it watch gateways arrives with #354, so there is no runtime behavior change until both land.

Related to #367
