### PR TITLE
fix(router): treat a dead gRPC health server as fatal

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -116,7 +117,12 @@ func runCmd(cfg *config.RouterConfig) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	ctx := ctrl.SetupSignalHandler()
+	// ctx carries a cause so that an ordinary signal-triggered shutdown can
+	// be told apart from the health server's own Serve failure below (#372),
+	// which cmd/galactic-gateway already treats as fatal -- see the cause
+	// check after mgr.Start.
+	ctx, cancel := context.WithCancelCause(ctrl.SetupSignalHandler())
+	defer cancel(nil)
 
 	// Start gRPC health server.
 	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcHealthPort))
@@ -128,8 +134,15 @@ func runCmd(cfg *config.RouterConfig) error {
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	go func() {
+		// Serve returning non-nil means this node has lost its health
+		// signal for good: logging it and continuing would leave the
+		// router running unprobeable, with nothing to restart it and
+		// nothing to report it. Cancelling ctx with the failure as its
+		// cause routes it out through mgr.Start below, so it surfaces
+		// like any other fatal startup error. The GracefulStop path
+		// below is unaffected: Serve returns nil there.
 		if serveErr := grpcSrv.Serve(lis); serveErr != nil {
-			log.Printf("gRPC health server: %v", serveErr)
+			cancel(fmt.Errorf("gRPC health server: %w", serveErr))
 		}
 	}()
 	go func() {
@@ -261,6 +274,13 @@ func runCmd(cfg *config.RouterConfig) error {
 
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("manager exited: %w", err)
+	}
+	// A nil return from mgr.Start means ctx is Done, so it always has a
+	// cause by now: context.Canceled for a signal-triggered shutdown, or
+	// the health server's fatal Serve error from above. Only the second
+	// should fail the process.
+	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
+		return cause
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

The gateway binary treats a dead health server as fatal. The router, which had the same code first, logged the failure and carried on with no health signal and nothing to restart it.

This ports the gateway's mechanism across: the run context carries a cause, the serving goroutine cancels with the failure as that cause, and it surfaces after the manager exits like any other fatal startup error. Ordinary signal-driven shutdown stays quiet, since serving returns cleanly there.

The router runs on every node rather than only edge nodes, so this was the wider blind spot of the two.

## Not in scope

The router also reports serving before its BGP runtime is up, which is the same shape as the gateway issue that prompted this. Router readiness means something different, so that stays parked in #372 for a separate decision rather than being folded in here.

## No test

The health server is built inline inside the run function, past a live cluster config and a manager start, so there is no seam to drive a serving failure through without extracting one purely for the test. The gateway's equivalent change shipped without a test for the same reason. Said plainly rather than contrived around.

## Test plan

- [ ] `task lint`
- [ ] `task build`
- [ ] `task test:unit`
- [ ] `task test:e2e`

Related to #372
