### PR TITLE
chore: ignore the agent worktree directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ skaffold.local.yaml
 .agents/
 .claude/scratch/
 .claude/settings.local.json
+# Agent worktrees are full git checkouts nested inside this one. Left
+# untracked, `git add -A` stages them as embedded repositories.
+.claude/worktrees/
 
 # ============================================================
 # IDEs and editors


### PR DESCRIPTION
## Summary

Agent tooling creates git worktrees under `.claude/worktrees/`, each one a full checkout nested inside this repository. The directory was untracked rather than ignored.

The result is that `git add -A` stages those nested checkouts as embedded repositories, with git warning about each one. That happened to me earlier today, and the commit had to be unpicked before it went anywhere.

Two neighbours in the same file are already ignored for the same reason, so this follows them.

## Test plan

- [ ] `task lint`
- [ ] `task build`
- [ ] `task test:unit`
- [ ] `task test:e2e`

`git status` in a working copy with agent worktrees present no longer lists them, which is the actual check.
