### PR TITLE
chore: pin go.datum.net/network to local replace for Phase A egress types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,3 +104,9 @@ require (
 )
 
 tool github.com/cilium/ebpf/cmd/bpf2go
+
+// TEMPORARY — Phase A dev-only, per docs/plans/865-edge-gateway-nat66-egress.md
+// §4.1: NetworkEgressPolicy/NetworkGatewayStatus.EgressAddress must land and
+// be tagged in datum-cloud/network before this pin can be a real pseudo-version.
+// Remove once that PR (feat/865-networkegresspolicy-crd) merges and a tag is cut.
+replace go.datum.net/network => ../network

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/vishvananda/netlink v1.3.2-0.20260803231012-156a440d85e5
 	github.com/vishvananda/netns v0.0.5
-	go.datum.net/network v0.0.0-20260812184454-6e8a6c4cbd40
+	go.datum.net/network v0.0.0-20260814001919-96677d648672
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.83.0
@@ -104,9 +104,3 @@ require (
 )
 
 tool github.com/cilium/ebpf/cmd/bpf2go
-
-// TEMPORARY — Phase A dev-only, per docs/plans/865-edge-gateway-nat66-egress.md
-// §4.1: NetworkEgressPolicy/NetworkGatewayStatus.EgressAddress must land and
-// be tagged in datum-cloud/network before this pin can be a real pseudo-version.
-// Remove once that PR (feat/865-networkegresspolicy-crd) merges and a tag is cut.
-replace go.datum.net/network => ../network

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.datum.net/network v0.0.0-20260814001919-96677d648672 h1:Kl1+MHxos5yH7tH6TqvzTmYTi39VsEX2K7zYi7/rm58=
+go.datum.net/network v0.0.0-20260814001919-96677d648672/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-go.datum.net/network v0.0.0-20260812184454-6e8a6c4cbd40 h1:83gROUl0ziuMzB4sBP3OTwpMr1A7nQPkcVFwoZoY77c=
-go.datum.net/network v0.0.0-20260812184454-6e8a6c4cbd40/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=


### PR DESCRIPTION
## Summary

Phase A of #865, per docs/plans/865-edge-gateway-nat66-egress.md §4.1.

- Temporary `replace go.datum.net/network => ../network` in go.mod, so
  this repo builds against `NetworkEgressPolicy`/
  `NetworkGatewayStatus.EgressAddress` before datum-cloud/network#15
  merges and tags.
- No consuming code — that's Phase C.

## Depends on

datum-cloud/network#15 — merge and tag that first, then drop the
replace directive here and bump the require line to the real
pseudo-version.

## Testing

- `go build ./...`, `go vet ./...` — clean.
- `task test:unit`, `task lint` — all pass, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)