### PR TITLE
feat(gateway): wire egress control plane and admission webhook

### DIFF
--- a/cmd/galactic-gateway/gateway.go
+++ b/cmd/galactic-gateway/gateway.go
@@ -59,6 +59,12 @@ var gatewayDatapathKeepAlive struct {
 // rejects either being empty before runCmd ever calls this function, since
 // this binary only exists to run the gateway role.
 //
+// egressAddress/egressSID configure the egress (masquerade) datapath
+// (datum-cloud/enhancements#865) and are genuinely optional — both empty
+// is a valid deployment (a gateway node not offering egress), and
+// config.GatewayConfig.Validate already rejects setting only one of the
+// pair before this function is ever called.
+//
 // The loaded *edgeprog.EdgenatObjects and the returned link.Link are
 // stashed in gatewayDatapathKeepAlive (see that var's doc comment for why)
 // rather than Closed here: they, and the XDP attachment itself, must
@@ -71,11 +77,29 @@ var gatewayDatapathKeepAlive struct {
 // at every scrape — see that package's doc comment for why this is a
 // pull-based Collector rather than incrementally-updated Gauges.
 func setupGatewayDatapath(
-	publicInterface, srv6Address string, metricsReg prometheus.Registerer,
+	publicInterface, srv6Address, egressAddress, egressSID string, metricsReg prometheus.Registerer,
 ) (gateway.Datapath, error) {
 	gwAddr, err := netip.ParseAddr(srv6Address)
 	if err != nil {
 		return nil, fmt.Errorf("parse gateway SRv6 address %q: %w", srv6Address, err)
+	}
+
+	// A gateway node not offering egress leaves both fields empty
+	// (config.GatewayConfig.Validate enforces the pairing) — netip.Addr's
+	// zero value is what gateway.NewKernelDatapath treats as "no egress
+	// configured for this node."
+	var egressAddr, egressSIDAddr netip.Addr
+	if egressAddress != "" {
+		egressAddr, err = netip.ParseAddr(egressAddress)
+		if err != nil {
+			return nil, fmt.Errorf("parse gateway egress address %q: %w", egressAddress, err)
+		}
+	}
+	if egressSID != "" {
+		egressSIDAddr, err = netip.ParseAddr(egressSID)
+		if err != nil {
+			return nil, fmt.Errorf("parse gateway egress SID %q: %w", egressSID, err)
+		}
 	}
 
 	objs, err := edgeattach.Load(edgeattach.PinDir)
@@ -89,7 +113,7 @@ func setupGatewayDatapath(
 		return nil, fmt.Errorf("attach edge gateway datapath to public interface %q: %w", publicInterface, err)
 	}
 
-	datapath, err := gateway.NewKernelDatapath(objs, gwAddr)
+	datapath, err := gateway.NewKernelDatapath(objs, gwAddr, egressSIDAddr, egressAddr)
 	if err != nil {
 		_ = xdpLink.Close()
 		_ = objs.Close()

--- a/cmd/galactic-gateway/gateway_test.go
+++ b/cmd/galactic-gateway/gateway_test.go
@@ -17,8 +17,27 @@ import (
 // binary's config.GatewayConfig.Validate rejects an empty
 // PublicInterface/SRv6Address before setupGatewayDatapath is ever called.
 func TestSetupGatewayDatapath_InvalidAddressIsError(t *testing.T) {
-	_, err := setupGatewayDatapath("eth0", "not-an-ip-address", prometheus.NewRegistry())
+	_, err := setupGatewayDatapath("eth0", "not-an-ip-address", "", "", prometheus.NewRegistry())
 	if err == nil {
 		t.Error("setupGatewayDatapath with an invalid SRv6 address: want an error, got nil")
+	}
+}
+
+// TestSetupGatewayDatapath_InvalidEgressAddressIsError covers the
+// egressAddress parse-failure path (datum-cloud/enhancements#865), which
+// also runs before any kernel/eBPF interaction.
+func TestSetupGatewayDatapath_InvalidEgressAddressIsError(t *testing.T) {
+	_, err := setupGatewayDatapath("eth0", "2001:db8:3::1", "not-an-ip-address", "2001:db8:8::1", prometheus.NewRegistry())
+	if err == nil {
+		t.Error("setupGatewayDatapath with an invalid egress address: want an error, got nil")
+	}
+}
+
+// TestSetupGatewayDatapath_InvalidEgressSIDIsError covers the egressSID
+// parse-failure path.
+func TestSetupGatewayDatapath_InvalidEgressSIDIsError(t *testing.T) {
+	_, err := setupGatewayDatapath("eth0", "2001:db8:3::1", "2001:db8:8::1", "not-an-ip-address", prometheus.NewRegistry())
+	if err == nil {
+		t.Error("setupGatewayDatapath with an invalid egress SID: want an error, got nil")
 	}
 }

--- a/cmd/galactic-gateway/root.go
+++ b/cmd/galactic-gateway/root.go
@@ -113,7 +113,8 @@ func runCmd(cfg *config.GatewayConfig) error {
 	// setupGatewayDatapath, there is no gateway.NoopDatapath{} case here:
 	// config.GatewayConfig.Validate already rejects an empty
 	// PublicInterface/SRv6Address before runCmd is ever reached.
-	gwDatapath, err := setupGatewayDatapath(cfg.PublicInterface, cfg.SRv6Address, ctrlmetrics.Registry)
+	gwDatapath, err := setupGatewayDatapath(
+		cfg.PublicInterface, cfg.SRv6Address, cfg.EgressAddress, cfg.EgressSID, ctrlmetrics.Registry)
 	if err != nil {
 		return fmt.Errorf("setup edge gateway eBPF datapath: %w", err)
 	}
@@ -131,11 +132,12 @@ func runCmd(cfg *config.GatewayConfig) error {
 
 	// Register NetworkGateway controller (edge XDP NAT+LB gateway engine).
 	if err := (&controller.NetworkGatewayReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		Engine:      gwEngine,
-		NodeName:    nodeName,
-		SRv6Address: cfg.SRv6Address,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Engine:        gwEngine,
+		NodeName:      nodeName,
+		SRv6Address:   cfg.SRv6Address,
+		EgressAddress: cfg.EgressAddress,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup NetworkGateway controller: %w", err)
 	}
@@ -202,6 +204,12 @@ func newRootCommand() *cobra.Command {
 		"Public/underlay-facing uplink interface for the edge NAT+LB gateway datapath (required)")
 	cmd.Flags().StringP("gateway-srv6-address", "", "",
 		"This gateway node's own SRv6-reachable address, used as the Full-NAT SNAT source (required)")
+	cmd.Flags().StringP("gateway-egress-address", "", "",
+		"This gateway node's publicly-routable masquerade SNAT source for tenant egress "+
+			"(optional, pairs with --gateway-egress-sid)")
+	cmd.Flags().StringP("gateway-egress-sid", "", "",
+		"This gateway node's egress_sid uSID locator for tenant egress "+
+			"(optional, pairs with --gateway-egress-address)")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
 	return cmd

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -151,14 +151,24 @@ func runCmd(cfg *config.RouterConfig) error {
 	}()
 
 	if cfg.WebhookEnabled {
-		validator := &networkwebhook.NetworkRuleValidator{
-			// TODO(edge-gateway): AllowAllAuthorizer is a placeholder — see
-			// its doc comment. Wire a real Authorizer here once the
-			// companion operator integration exists.
-			Authorizer: networkwebhook.AllowAllAuthorizer{},
-		}
-		if err := validator.SetupWebhookWithManager(mgr); err != nil {
+		// TODO(edge-gateway): AllowAllAuthorizer is a placeholder — see
+		// its doc comment. Wire a real Authorizer here once the companion
+		// operator integration exists. Shared between both validators
+		// below: they pose the identical vpc/vpcattachment ownership
+		// question (internal/webhook.Authorizer's own doc comment).
+		authorizer := networkwebhook.AllowAllAuthorizer{}
+
+		ruleValidator := &networkwebhook.NetworkRuleValidator{Authorizer: authorizer}
+		if err := ruleValidator.SetupWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("setup NetworkRule webhook: %w", err)
+		}
+
+		// NetworkEgressPolicy (datum-cloud/enhancements#865) requires the
+		// same ownership-verification admission webhook NetworkRule
+		// already does (design plan §4.1).
+		egressPolicyValidator := &networkwebhook.NetworkEgressPolicyValidator{Authorizer: authorizer}
+		if err := egressPolicyValidator.SetupWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("setup NetworkEgressPolicy webhook: %w", err)
 		}
 	}
 

--- a/config/gateway/base/daemonset.yaml
+++ b/config/gateway/base/daemonset.yaml
@@ -142,6 +142,20 @@ spec:
             # per-node overlay must set both; see
             # deploy/containerlab/resources/galactic-gateway/ for a
             # worked example (two instances, iad-gateway1/iad-gateway2).
+            #
+            # GALACTIC_GATEWAY_EGRESS_ADDRESS/_EGRESS_SID
+            # (datum-cloud/enhancements#865) are also left unset here, but
+            # for a different reason: unlike PUBLIC_INTERFACE/SRV6_ADDRESS,
+            # this pair is genuinely optional — a gateway node not offering
+            # tenant internet egress is a valid deployment, and
+            # config.GatewayConfig.Validate only rejects setting one of the
+            # pair without the other. A per-node overlay that wants this
+            # node to offer egress must set both: EGRESS_ADDRESS is a real,
+            # publicly-routable IPv6 allocation on this node's uplink (not
+            # an internally-derived uSID, so it has no in-cluster
+            # derivation mechanism either), and EGRESS_SID is the shared
+            # egress locator's own reserved Argument value for this
+            # deployment.
           ports:
             - name: metrics
               containerPort: 8081

--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -51,6 +51,24 @@ const (
 	// SRv6Address), used as the Full-NAT SNAT source for every ingress
 	// flow this node translates. Required — see EnvGatewayPublicInterface.
 	EnvGatewaySRv6Address = "GALACTIC_GATEWAY_SRV6_ADDRESS"
+
+	// EnvGatewayEgressAddress is this gateway node's publicly-routable
+	// masquerade SNAT source (network.datumapis.com/v1alpha1's
+	// NetworkGatewayStatus.EgressAddress), for tenant VPC backends
+	// reaching arbitrary internet destinations
+	// (datum-cloud/enhancements#865). Unlike EnvGatewaySRv6Address, this
+	// is optional — a gateway node not offering egress is a valid
+	// deployment — but must be set together with EnvGatewayEgressSID; see
+	// GatewayConfig.Validate.
+	EnvGatewayEgressAddress = "GALACTIC_GATEWAY_EGRESS_ADDRESS"
+
+	// EnvGatewayEgressSID is this gateway node's egress_sid uSID locator
+	// — the reserved Argument *range* tenant VRF default routes point at
+	// (design plan §3.1, a second reserved value alongside SRv6Address's
+	// own Argument 0), resolved from operator config exactly the way
+	// SRv6Address is today, not computed in-cluster (publishSelfAddress's
+	// doc comment). Optional, paired with EnvGatewayEgressAddress.
+	EnvGatewayEgressSID = "GALACTIC_GATEWAY_EGRESS_SID"
 )
 
 // --- GatewayConfig -----------------------------------------------------
@@ -73,6 +91,15 @@ type GatewayConfig struct {
 	// required; GatewayConfig.Validate rejects either being empty.
 	PublicInterface string
 	SRv6Address     string
+
+	// EgressAddress/EgressSID configure the edge gateway's egress
+	// (masquerade) datapath (datum-cloud/enhancements#865) -- see
+	// EnvGatewayEgressAddress's doc comment. Both optional, but
+	// GatewayConfig.Validate rejects setting only one of the pair: a
+	// gateway node offering egress needs both, and a node not offering it
+	// needs neither.
+	EgressAddress string
+	EgressSID     string
 }
 
 // NewGatewayConfig creates a gateway config resolver with the
@@ -89,6 +116,8 @@ func NewGatewayConfig() *GatewayConfig {
 	v.SetDefault("grpc_health_port", DefaultGatewayGRPCHealthPort)
 	v.SetDefault("public_interface", "")
 	v.SetDefault("srv6_address", "")
+	v.SetDefault("egress_address", "")
+	v.SetDefault("egress_sid", "")
 
 	cfg := &GatewayConfig{
 		v:      v,
@@ -110,6 +139,8 @@ func (c *GatewayConfig) BindFlags(flags *pflag.FlagSet) {
 		{"grpc-health-port", "grpc_health_port"},
 		{"gateway-public-interface", "public_interface"},
 		{"gateway-srv6-address", "srv6_address"},
+		{"gateway-egress-address", "egress_address"},
+		{"gateway-egress-sid", "egress_sid"},
 	}
 	for _, b := range bindings {
 		if flags.Changed(b.flag) {
@@ -129,6 +160,8 @@ func (c *GatewayConfig) readFields() {
 	c.GRPCHealthPort = c.v.GetInt("grpc_health_port")
 	c.PublicInterface = c.v.GetString("public_interface")
 	c.SRv6Address = c.v.GetString("srv6_address")
+	c.EgressAddress = c.v.GetString("egress_address")
+	c.EgressSID = c.v.GetString("egress_sid")
 }
 
 // Validate checks that the required configuration fields are set.
@@ -162,6 +195,33 @@ func (c *GatewayConfig) Validate() error {
 	}
 	if c.GRPCHealthPort < 1 || c.GRPCHealthPort > 65535 {
 		return errors.New("grpc health port must be between 1 and 65535")
+	}
+
+	// EgressAddress/EgressSID are optional, but only together: a gateway
+	// node offering egress needs both to populate egress_config_table; a
+	// node not offering it needs neither (design plan §5).
+	if (c.EgressAddress == "") != (c.EgressSID == "") {
+		return fmt.Errorf(
+			"gateway egress address and egress SID must be set together, or neither (use %s and %s env vars)",
+			EnvGatewayEgressAddress, EnvGatewayEgressSID)
+	}
+	if c.EgressAddress != "" {
+		addr, err := netip.ParseAddr(c.EgressAddress)
+		if err != nil {
+			return fmt.Errorf("egress address %q is not a valid IP address: %w", c.EgressAddress, err)
+		}
+		if !addr.Is6() || addr.Is4In6() {
+			return fmt.Errorf("egress address %q must be a native IPv6 address, not IPv4", c.EgressAddress)
+		}
+	}
+	if c.EgressSID != "" {
+		addr, err := netip.ParseAddr(c.EgressSID)
+		if err != nil {
+			return fmt.Errorf("egress SID %q is not a valid IP address: %w", c.EgressSID, err)
+		}
+		if !addr.Is6() || addr.Is4In6() {
+			return fmt.Errorf("egress SID %q must be a native IPv6 address, not IPv4", c.EgressSID)
+		}
 	}
 	return nil
 }

--- a/internal/config/gateway_test.go
+++ b/internal/config/gateway_test.go
@@ -11,6 +11,9 @@ import (
 
 const (
 	testGatewayNodeName = "test-gateway-node"
+	testGatewayEgress   = "2001:db8:8::1"
+	testInvalidAddr     = "not-an-ip-address"
+	testIPv4Addr        = "203.0.113.1"
 )
 
 func TestGatewayConfigDefaults(t *testing.T) {
@@ -31,6 +34,12 @@ func TestGatewayConfigDefaults(t *testing.T) {
 	if cfg.SRv6Address != "" {
 		t.Errorf("SRv6Address = %q, want empty", cfg.SRv6Address)
 	}
+	if cfg.EgressAddress != "" {
+		t.Errorf("EgressAddress = %q, want empty", cfg.EgressAddress)
+	}
+	if cfg.EgressSID != "" {
+		t.Errorf("EgressSID = %q, want empty", cfg.EgressSID)
+	}
 }
 
 func TestGatewayConfigEnvOverride(t *testing.T) {
@@ -39,6 +48,8 @@ func TestGatewayConfigEnvOverride(t *testing.T) {
 	t.Setenv(EnvGatewayGRPCHealthPort, "9091")
 	t.Setenv(EnvGatewayPublicInterface, testGatewayIface)
 	t.Setenv(EnvGatewaySRv6Address, testGatewaySRv6)
+	t.Setenv(EnvGatewayEgressAddress, testGatewayEgress)
+	t.Setenv(EnvGatewayEgressSID, testGatewaySRv6)
 
 	cfg := NewGatewayConfig()
 
@@ -56,6 +67,12 @@ func TestGatewayConfigEnvOverride(t *testing.T) {
 	}
 	if cfg.SRv6Address != testGatewaySRv6 {
 		t.Errorf("SRv6Address = %q, want %q", cfg.SRv6Address, testGatewaySRv6)
+	}
+	if cfg.EgressAddress != testGatewayEgress {
+		t.Errorf("EgressAddress = %q, want %q", cfg.EgressAddress, testGatewayEgress)
+	}
+	if cfg.EgressSID != testGatewaySRv6 {
+		t.Errorf("EgressSID = %q, want %q", cfg.EgressSID, testGatewaySRv6)
 	}
 }
 
@@ -85,7 +102,7 @@ func TestGatewayConfigValidate(t *testing.T) {
 			envVars: map[string]string{
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
-				EnvGatewaySRv6Address:     "not-an-ip-address",
+				EnvGatewaySRv6Address:     testInvalidAddr,
 			},
 			wantErr: "is not a valid IP address",
 		},
@@ -98,7 +115,7 @@ func TestGatewayConfigValidate(t *testing.T) {
 			envVars: map[string]string{
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
-				EnvGatewaySRv6Address:     "203.0.113.1",
+				EnvGatewaySRv6Address:     testIPv4Addr,
 			},
 			wantErr: "must be a native IPv6 address",
 		},
@@ -128,6 +145,81 @@ func TestGatewayConfigValidate(t *testing.T) {
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
 				EnvGatewaySRv6Address:     testGatewaySRv6,
+			},
+			wantErr: "",
+		},
+		{
+			name: "egress address without egress sid",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testGatewayEgress,
+			},
+			wantErr: "must be set together",
+		},
+		{
+			name: "egress sid without egress address",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressSID:       testGatewayEgress,
+			},
+			wantErr: "must be set together",
+		},
+		{
+			name: "unparseable egress address",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testInvalidAddr,
+				EnvGatewayEgressSID:       testGatewayEgress,
+			},
+			wantErr: "egress address \"not-an-ip-address\" is not a valid IP address",
+		},
+		{
+			name: "ipv4 egress address is wrong family",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testIPv4Addr,
+				EnvGatewayEgressSID:       testGatewayEgress,
+			},
+			wantErr: "egress address \"203.0.113.1\" must be a native IPv6 address",
+		},
+		{
+			name: "unparseable egress sid",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testGatewayEgress,
+				EnvGatewayEgressSID:       testInvalidAddr,
+			},
+			wantErr: "egress SID \"not-an-ip-address\" is not a valid IP address",
+		},
+		{
+			name: "ipv4 egress sid is wrong family",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testGatewayEgress,
+				EnvGatewayEgressSID:       testIPv4Addr,
+			},
+			wantErr: "egress SID \"203.0.113.1\" must be a native IPv6 address",
+		},
+		{
+			name: "valid config with egress pair",
+			envVars: map[string]string{
+				EnvGatewayNodeName:        testGatewayNodeName,
+				EnvGatewayPublicInterface: testGatewayIface,
+				EnvGatewaySRv6Address:     testGatewaySRv6,
+				EnvGatewayEgressAddress:   testGatewayEgress,
+				EnvGatewayEgressSID:       testGatewaySRv6,
 			},
 			wantErr: "",
 		},

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -103,6 +103,14 @@ type NetworkGatewayReconciler struct {
 	// reconciler publishes it, it does not compute it; see
 	// publishSelfAddress's doc comment.
 	SRv6Address string
+
+	// EgressAddress is this node's own publicly-routable masquerade SNAT
+	// source for tenant egress (datum-cloud/enhancements#865,
+	// config.GatewayConfig.EgressAddress), already the address the
+	// running datapath was configured with. Empty on a gateway node not
+	// offering egress — see publishEgressAddress's doc comment, the
+	// egress-specific sibling of publishSelfAddress.
+	EgressAddress string
 }
 
 const (
@@ -184,6 +192,10 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := r.publishSelfAddress(ctx, gw); err != nil {
 		logger.Error(err, "publish gateway self-address", "networkGateway", req.NamespacedName)
 		advErrs = append(advErrs, fmt.Errorf("publish self-address: %w", err))
+	}
+	if err := r.publishEgressAddress(ctx, gw); err != nil {
+		logger.Error(err, "publish gateway egress address", "networkGateway", req.NamespacedName)
+		advErrs = append(advErrs, fmt.Errorf("publish egress address: %w", err))
 	}
 
 	// Crash-safety ordering contract (see GatewayEngine.ReconcileOrphans):
@@ -393,6 +405,83 @@ func (r *NetworkGatewayReconciler) publishSelfAddress(ctx context.Context, gw *b
 	advCopy.Spec.Prefixes = []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix.String())}
 	if updateErr := r.Update(ctx, advCopy); updateErr != nil {
 		return fmt.Errorf("update self-address BGPAdvertisement %s: %w", name, updateErr)
+	}
+	return nil
+}
+
+// publishEgressAddress sets gw.Status.EgressAddress to r.EgressAddress and
+// ensures a BGPAdvertisement exists distributing it as a /128 host route --
+// the egress-specific sibling of publishSelfAddress, mirroring its pattern
+// exactly (design plan §4.3), kept as a separate function rather than
+// folded into publishSelfAddress because the two fields are independently
+// optional: a node can have SRv6Address set with EgressAddress empty (not
+// offering egress), so combining them would tangle two unrelated
+// early-return conditions into one function.
+//
+// Unlike SRv6Address (reachable only within the SRv6 fabric), EgressAddress
+// must additionally be reachable from the public internet -- an
+// eBGP/uplink-peering concern entirely outside this repo (likely
+// config/fabric's FRR underlay, or a dedicated transit peer). This method
+// only publishes the value into the CRD and the internal iBGP/EVPN mesh, the
+// same way publishSelfAddress does for SRv6Address; it does not, and
+// cannot, arrange the internet-facing side of that reachability.
+func (r *NetworkGatewayReconciler) publishEgressAddress(ctx context.Context, gw *bgpv1alpha1.NetworkGateway) error {
+	if r.EgressAddress == "" {
+		return nil // this gateway node does not offer egress
+	}
+
+	routerName, err := r.routerNameForNode(ctx, gw.Namespace)
+	if err != nil {
+		return fmt.Errorf("resolve BGPRouter for node %s: %w", r.NodeName, err)
+	}
+
+	if gw.Status.EgressAddress != r.EgressAddress {
+		// Updated in place, not through a copy -- same reasoning as
+		// publishSelfAddress's identical in-place update (#365).
+		gw.Status.EgressAddress = r.EgressAddress
+		if err := r.Status().Update(ctx, gw); err != nil {
+			return fmt.Errorf("update NetworkGateway status.egressAddress: %w", err)
+		}
+	}
+
+	if routerName == "" {
+		return nil // nothing to advertise into yet
+	}
+
+	addr, err := netip.ParseAddr(r.EgressAddress)
+	if err != nil {
+		return fmt.Errorf("parse gateway egress address %q: %w", r.EgressAddress, err)
+	}
+	prefix := netip.PrefixFrom(addr, addr.BitLen())
+
+	name := gw.Name + "-egressaddr"
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	key := types.NamespacedName{Namespace: gw.Namespace, Name: name}
+	getErr := r.Get(ctx, key, adv)
+	switch {
+	case apierrors.IsNotFound(getErr):
+		adv = &bgpv1alpha1.BGPAdvertisement{
+			ObjectMeta: metav1.ObjectMeta{Namespace: gw.Namespace, Name: name},
+			Spec: bgpv1alpha1.BGPAdvertisementSpec{
+				RouterRef:     bgpv1alpha1.RouterRef{Name: routerName},
+				AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+				Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix.String())},
+			},
+		}
+		if createErr := r.Create(ctx, adv); createErr != nil {
+			return fmt.Errorf("create egress-address BGPAdvertisement %s: %w", name, createErr)
+		}
+		return nil
+	case getErr != nil:
+		return fmt.Errorf("get egress-address BGPAdvertisement %s: %w", name, getErr)
+	}
+
+	advCopy := adv.DeepCopy()
+	advCopy.Spec.RouterRef = bgpv1alpha1.RouterRef{Name: routerName}
+	advCopy.Spec.AddressFamily = bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN}
+	advCopy.Spec.Prefixes = []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix.String())}
+	if updateErr := r.Update(ctx, advCopy); updateErr != nil {
+		return fmt.Errorf("update egress-address BGPAdvertisement %s: %w", name, updateErr)
 	}
 	return nil
 }

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -438,6 +438,89 @@ func TestNetworkGatewayReconciler_PublishesSelfAddress(t *testing.T) {
 	}
 }
 
+// TestNetworkGatewayReconciler_PublishesEgressAddress verifies
+// publishEgressAddress writes status.egressAddress and creates a plain (no
+// VRFID/Function) BGPAdvertisement for it once a BGPRouter targets this
+// node -- the egress-specific sibling of
+// TestNetworkGatewayReconciler_PublishesSelfAddress
+// (datum-cloud/enhancements#865).
+func TestNetworkGatewayReconciler_PublishesEgressAddress(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	const egressAddr = "2001:db8:eeee::1"
+	gw := newTestGateway(testNodeGWA)
+	router := newTestRouter()
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gw, router).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	r.EgressAddress = egressAddr
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gotGW := &bgpv1alpha1.NetworkGateway{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(testNodeGWA), gotGW); err != nil {
+		t.Fatalf("get NetworkGateway: %v", err)
+	}
+	if gotGW.Status.EgressAddress != egressAddr {
+		t.Errorf("Status.EgressAddress = %q, want %q", gotGW.Status.EgressAddress, egressAddr)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(testNodeGWA+"-egressaddr"), adv); err != nil {
+		t.Fatalf("get egress-address BGPAdvertisement: %v", err)
+	}
+	if len(adv.Spec.Prefixes) != 1 || adv.Spec.Prefixes[0] != bgpv1alpha1.Prefix(egressAddr+"/128") {
+		t.Errorf("Prefixes = %v, want [%s/128]", adv.Spec.Prefixes, egressAddr)
+	}
+	if adv.Spec.VRFID != nil || adv.Spec.Function != nil {
+		t.Errorf("egress-address advertisement must carry no VRFID/Function, got VRFID=%v Function=%v",
+			adv.Spec.VRFID, adv.Spec.Function)
+	}
+}
+
+// TestNetworkGatewayReconciler_NoEgressAddressSkipsPublication verifies a
+// gateway node with EgressAddress unset (the common case -- a node not
+// offering egress) neither writes status.egressAddress nor creates an
+// egress-address BGPAdvertisement.
+func TestNetworkGatewayReconciler_NoEgressAddressSkipsPublication(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gw := newTestGateway(testNodeGWA)
+	router := newTestRouter()
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gw, router).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gotGW := &bgpv1alpha1.NetworkGateway{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(testNodeGWA), gotGW); err != nil {
+		t.Fatalf("get NetworkGateway: %v", err)
+	}
+	if gotGW.Status.EgressAddress != "" {
+		t.Errorf("Status.EgressAddress = %q, want empty (this node does not offer egress)", gotGW.Status.EgressAddress)
+	}
+
+	err := fakeClient.Get(context.Background(), testRuleKey(testNodeGWA+"-egressaddr"), &bgpv1alpha1.BGPAdvertisement{})
+	if err == nil {
+		t.Error("egress-address BGPAdvertisement was created for a node with no EgressAddress configured")
+	}
+}
+
 // TestNetworkGatewayReconciler_AdvertisementFailureSurfaces is the
 // regression test for #365: BGPAdvertisement write failures used to be
 // logged and dropped, so a node that had advertised nothing still reported

--- a/internal/gateway/kerneldatapath.go
+++ b/internal/gateway/kerneldatapath.go
@@ -6,6 +6,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
@@ -76,13 +77,49 @@ type KernelDatapath struct {
 // SRv6-reachable address (NetworkGatewayStatus.SRv6Address), stable for
 // the life of the process, so there is no per-rule or per-reconcile path
 // that ever needs to rewrite it again.
-func NewKernelDatapath(objs *edgeprog.EdgenatObjects, gwAddr netip.Addr) (*KernelDatapath, error) {
+//
+// egressSID/masqAddr optionally populate egress_config_table the same
+// way, for the egress (masquerade) datapath
+// (datum-cloud/enhancements#865). Both must be their zero netip.Addr
+// together (a gateway node not offering egress, the common case today —
+// design plan §5) or both valid native IPv6 addresses together
+// (config.GatewayConfig.Validate already enforces this pairing before
+// this constructor is ever called; this is a defensive second check, not
+// the primary one). Leaving egress_config_table unwritten is safe: it
+// stays zeroed, and edgenat.c's dispatch never matches a packet against
+// the zero address (this file's own header comment).
+func NewKernelDatapath(objs *edgeprog.EdgenatObjects, gwAddr, egressSID, masqAddr netip.Addr) (*KernelDatapath, error) {
 	if !gwAddr.Is6() || gwAddr.Is4In6() {
 		return nil, fmt.Errorf("kerneldatapath: gateway address %s is not a native IPv6 address", gwAddr)
 	}
 
+	// All validation runs before any map I/O -- including the egress
+	// pair's -- so a validation-only failure never touches
+	// gw_config_table/egress_config_table at all (matches
+	// TestNewKernelDatapath_RejectsIPv4GatewayAddress's own convention of
+	// testing address-family validation without a loaded program).
+	egressEnabled := egressSID.IsValid() || masqAddr.IsValid()
+	if egressEnabled {
+		if !egressSID.IsValid() || !masqAddr.IsValid() {
+			return nil, errors.New("kerneldatapath: egress SID and masquerade address must both be set, or neither")
+		}
+		if !egressSID.Is6() || egressSID.Is4In6() {
+			return nil, fmt.Errorf("kerneldatapath: egress SID %s is not a native IPv6 address", egressSID)
+		}
+		if !masqAddr.Is6() || masqAddr.Is4In6() {
+			return nil, fmt.Errorf("kerneldatapath: masquerade address %s is not a native IPv6 address", masqAddr)
+		}
+	}
+
 	if err := objs.GwConfigTable.Put(uint32(0), edgeprog.EdgenatGwConfig{GwAddr: gwAddr.As16()}); err != nil {
 		return nil, fmt.Errorf("kerneldatapath: populate gw_config_table: %w", err)
+	}
+
+	if egressEnabled {
+		egressCfg := edgeprog.EdgenatEgressConfig{EgressSid: egressSID.As16(), MasqAddr: masqAddr.As16()}
+		if err := objs.EgressConfigTable.Put(uint32(0), egressCfg); err != nil {
+			return nil, fmt.Errorf("kerneldatapath: populate egress_config_table: %w", err)
+		}
 	}
 
 	return &KernelDatapath{

--- a/internal/gateway/kerneldatapath_test.go
+++ b/internal/gateway/kerneldatapath_test.go
@@ -229,8 +229,42 @@ func TestNewKernelDatapath_RejectsIPv4GatewayAddress(t *testing.T) {
 	// (root-gated, covered by edgeattach's own tests) -- this test only
 	// exercises the address-family validation, which runs before that
 	// call.
-	_, err := NewKernelDatapath(&edgeprog.EdgenatObjects{}, netip.MustParseAddr("192.0.2.1"))
+	_, err := NewKernelDatapath(&edgeprog.EdgenatObjects{}, netip.MustParseAddr("192.0.2.1"), netip.Addr{}, netip.Addr{})
 	if err == nil {
 		t.Error("NewKernelDatapath with an IPv4 gateway address: want an error, got nil")
+	}
+}
+
+// TestNewKernelDatapath_RejectsMismatchedEgressPair covers the defensive
+// pairing check on egressSID/masqAddr (datum-cloud/enhancements#865) --
+// config.GatewayConfig.Validate already enforces this pairing before this
+// constructor is reached in production, but this constructor must not
+// silently half-configure egress if that invariant is ever violated.
+// Exercises only the validation, which runs before any real Put call --
+// same reasoning as TestNewKernelDatapath_RejectsIPv4GatewayAddress above.
+func TestNewKernelDatapath_RejectsMismatchedEgressPair(t *testing.T) {
+	gwAddr := netip.MustParseAddr("2001:db8:3::1")
+	egressSID := netip.MustParseAddr("2001:db8:8::1")
+
+	_, err := NewKernelDatapath(&edgeprog.EdgenatObjects{}, gwAddr, egressSID, netip.Addr{})
+	if err == nil {
+		t.Error("NewKernelDatapath with egressSID set but masqAddr empty: want an error, got nil")
+	}
+
+	_, err = NewKernelDatapath(&edgeprog.EdgenatObjects{}, gwAddr, netip.Addr{}, egressSID)
+	if err == nil {
+		t.Error("NewKernelDatapath with masqAddr set but egressSID empty: want an error, got nil")
+	}
+}
+
+// TestNewKernelDatapath_RejectsIPv4EgressSID covers the same address-family
+// validation NewKernelDatapath applies to gwAddr, mirrored onto egressSID.
+func TestNewKernelDatapath_RejectsIPv4EgressSID(t *testing.T) {
+	gwAddr := netip.MustParseAddr("2001:db8:3::1")
+	masqAddr := netip.MustParseAddr("2001:db8:8::1")
+
+	_, err := NewKernelDatapath(&edgeprog.EdgenatObjects{}, gwAddr, netip.MustParseAddr("192.0.2.1"), masqAddr)
+	if err == nil {
+		t.Error("NewKernelDatapath with an IPv4 egress SID: want an error, got nil")
 	}
 }

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -61,6 +61,26 @@ type DesiredRule struct {
 	IsPrimary bool
 }
 
+// DesiredEgressPolicy is the engine's internal representation of one
+// NetworkEgressPolicy (datum-cloud/enhancements#865): egress is on or off
+// for a (vpcRef, vpcAttachmentRef) pair, existence-implies-enabled, so
+// unlike DesiredRule there is no VIP/backend/port here at all — see
+// network.datumapis.com/v1alpha1's NetworkEgressPolicySpec, which this
+// mirrors field-for-field.
+//
+// Deliberately not added to EngineState/consumed by Engine.Reconcile in
+// this phase: design plan §7.2 resolves *enablement* (should a tenant
+// reach egress_sid at all) toward a routing-layer decision (does the
+// tenant's VRF have a default route pointed there), not a per-packet
+// datapath lookup, so Datapath gains no new per-call method for it either
+// (§4.2). This type exists for NetworkGatewayReconciler's own
+// bookkeeping/status use and as the shape a future per-tenant enforcement
+// path would consume, if one is ever needed.
+type DesiredEgressPolicy struct {
+	VPCRef           string
+	VPCAttachmentRef string
+}
+
 // EngineState is the full desired state for one gateway node's Engine,
 // assembled by the NetworkGateway controller from every accepted
 // NetworkRule in the node's PoP (both primary- and secondary-assigned —

--- a/internal/webhook/authorizer.go
+++ b/internal/webhook/authorizer.go
@@ -14,12 +14,17 @@ import (
 	"context"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-
-	networkv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
 // Authorizer decides whether requester is authorized to create or update a
-// NetworkRule targeting rule.Spec.VPCRef/VPCAttachmentRef.
+// resource targeting the given vpcRef/vpcAttachmentRef pair. Both
+// NetworkRuleValidator and NetworkEgressPolicyValidator (datum-cloud/
+// enhancements#865) share this one interface — vpcRef/vpcAttachmentRef
+// ownership is the entire authorization question either object poses, so
+// there is no need for two near-identical interfaces typed to their own
+// concrete CRD. (Before #865, this interface was typed directly to
+// *networkv1alpha1.NetworkRule; it was narrowed to just the two fields
+// every caller actually needs once a second caller arrived.)
 //
 // This is a pluggable interface, not a concrete implementation, because VPC
 // and VPCAttachment ownership resolution lives in a separate companion
@@ -27,12 +32,12 @@ import (
 // CRD management lives in a separate companion operator") — this repo has
 // no client, API, or even network path to that operator today.
 type Authorizer interface {
-	// Authorize reports whether requester is authorized for the
-	// vpc/vpcattachment named in rule. A false result (with a nil error)
-	// means "authoritatively denied"; a non-nil error means the check
-	// itself failed (e.g. the companion operator was unreachable) and the
+	// Authorize reports whether requester is authorized for the given
+	// vpc/vpcattachment. A false result (with a nil error) means
+	// "authoritatively denied"; a non-nil error means the check itself
+	// failed (e.g. the companion operator was unreachable) and the
 	// webhook should fail closed.
-	Authorize(ctx context.Context, requester authenticationv1.UserInfo, rule *networkv1alpha1.NetworkRule) (bool, error)
+	Authorize(ctx context.Context, requester authenticationv1.UserInfo, vpcRef, vpcAttachmentRef string) (bool, error)
 }
 
 // AllowAllAuthorizer is the TODO-marked placeholder Authorizer
@@ -42,12 +47,12 @@ type Authorizer interface {
 // requires calling out to the companion operator that owns VPC/
 // VPCAttachment ownership resolution (see CLAUDE.md's "VPC and
 // VPCAttachment CRD management lives in a separate companion operator")
-// to confirm requester is actually permitted to attach to
-// rule.Spec.VPCRef/VPCAttachmentRef — that integration does not exist yet
-// (no client, no API contract, no network path from this repo to that
-// operator). Until it lands, every NetworkRule create/update is admitted
+// to confirm requester is actually permitted to attach to the named vpc/
+// vpcattachment — that integration does not exist yet (no client, no API
+// contract, no network path from this repo to that operator). Until it
+// lands, every NetworkRule/NetworkEgressPolicy create/update is admitted
 // regardless of who's asking or what vpc/vpcattachment they name, which
-// means a tenant CAN currently write a rule targeting another tenant's
+// means a tenant CAN currently write an object targeting another tenant's
 // vpc/vpcattachment (the exact vulnerability admission control exists to
 // close) — this must not be treated as production-ready and must not be
 // deployed with real tenant traffic before the Authorizer above is given a
@@ -56,8 +61,6 @@ type AllowAllAuthorizer struct{}
 
 // Authorize always returns true. See the type's doc comment for why this is
 // not safe to run in production and is only a wiring placeholder.
-func (AllowAllAuthorizer) Authorize(
-	context.Context, authenticationv1.UserInfo, *networkv1alpha1.NetworkRule,
-) (bool, error) {
+func (AllowAllAuthorizer) Authorize(context.Context, authenticationv1.UserInfo, string, string) (bool, error) {
 	return true, nil
 }

--- a/internal/webhook/networkegresspolicy_webhook.go
+++ b/internal/webhook/networkegresspolicy_webhook.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	networkv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// NetworkEgressPolicyValidator implements the typed admission.Validator
+// generic interface for NetworkEgressPolicy (datum-cloud/enhancements#865),
+// mirroring NetworkRuleValidator exactly: it verifies (via the same
+// pluggable Authorizer) that the requesting identity is authorized for the
+// vpc/vpcattachment named in the policy before a create or update is
+// admitted. Unlike NetworkRule, NetworkEgressPolicy carries no VIP/backend/
+// port to validate — enablement is existence-implies-enabled for a
+// (vpcRef, vpcAttachmentRef) pair (design plan §4.1) — so this validator's
+// only job, like NetworkRuleValidator's, is ownership verification.
+type NetworkEgressPolicyValidator struct {
+	// Authorizer performs the actual authorization check — the same
+	// instance a caller wires into NetworkRuleValidator, since both
+	// validators pose the identical vpc/vpcattachment ownership question.
+	// Production callers must not leave this as AllowAllAuthorizer{} —
+	// see that type's doc comment.
+	Authorizer Authorizer
+}
+
+var _ admission.Validator[*networkv1alpha1.NetworkEgressPolicy] = &NetworkEgressPolicyValidator{}
+
+// ValidateCreate verifies the requester is authorized for the
+// NetworkEgressPolicy's vpc/vpcattachment before create is admitted.
+func (v *NetworkEgressPolicyValidator) ValidateCreate(
+	ctx context.Context, policy *networkv1alpha1.NetworkEgressPolicy,
+) (admission.Warnings, error) {
+	return nil, v.authorize(ctx, policy)
+}
+
+// ValidateUpdate re-verifies authorization on update — a policy's vpcRef/
+// vpcAttachmentRef could otherwise be changed post-creation to point at a
+// different tenant's resources without ever re-running the create-time
+// check (same reasoning as NetworkRuleValidator.ValidateUpdate).
+func (v *NetworkEgressPolicyValidator) ValidateUpdate(
+	ctx context.Context, _, newPolicy *networkv1alpha1.NetworkEgressPolicy,
+) (admission.Warnings, error) {
+	return nil, v.authorize(ctx, newPolicy)
+}
+
+// ValidateDelete performs no additional authorization check: deleting a
+// NetworkEgressPolicy that already exists in the cluster is scoped by
+// Kubernetes' own RBAC on the delete verb, not by vpc/vpcattachment
+// ownership (same reasoning as NetworkRuleValidator.ValidateDelete).
+func (v *NetworkEgressPolicyValidator) ValidateDelete(
+	context.Context, *networkv1alpha1.NetworkEgressPolicy,
+) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// authorize resolves the requesting identity from the admission.Request
+// carried on ctx and calls the configured Authorizer — identical shape to
+// NetworkRuleValidator.authorize, differing only in which CRD's spec
+// fields it reads.
+func (v *NetworkEgressPolicyValidator) authorize(
+	ctx context.Context, policy *networkv1alpha1.NetworkEgressPolicy,
+) error {
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve admission request: %w", err)
+	}
+
+	ok, err := v.Authorizer.Authorize(ctx, req.UserInfo, policy.Spec.VPCRef, policy.Spec.VPCAttachmentRef)
+	if err != nil {
+		// Fail closed — same reasoning as NetworkRuleValidator.authorize.
+		return fmt.Errorf("authorization check failed: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf(
+			"%s is not authorized for vpcRef %q / vpcAttachmentRef %q (%s)",
+			req.UserInfo.Username, policy.Spec.VPCRef, policy.Spec.VPCAttachmentRef,
+			networkv1alpha1.AcceptedReasonOwnershipDenied)
+	}
+	return nil
+}
+
+// SetupWebhookWithManager registers the NetworkEgressPolicy validating
+// webhook with mgr — same builder shape as
+// NetworkRuleValidator.SetupWebhookWithManager.
+func (v *NetworkEgressPolicyValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr, &networkv1alpha1.NetworkEgressPolicy{}).
+		WithValidator(v).
+		Complete()
+}
+
+// Production webhook registration additionally requires a
+// ValidatingWebhookConfiguration/Service manifest, plus a cert-manager (or
+// equivalent) TLS provisioning step — same deferral as
+// NetworkRuleValidator's identical doc comment.

--- a/internal/webhook/networkegresspolicy_webhook_test.go
+++ b/internal/webhook/networkegresspolicy_webhook_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package webhook
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	networkv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+func testEgressPolicy() *networkv1alpha1.NetworkEgressPolicy {
+	return &networkv1alpha1.NetworkEgressPolicy{
+		Spec: networkv1alpha1.NetworkEgressPolicySpec{
+			VPCRef:           "vpc-1",
+			VPCAttachmentRef: "attach-1",
+		},
+	}
+}
+
+func TestNetworkEgressPolicyValidator_ValidateCreate_Allowed(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{Authorizer: fakeAuthorizer{allow: true}}
+	_, err := v.ValidateCreate(contextWithRequester("alice"), testEgressPolicy())
+	if err != nil {
+		t.Fatalf("ValidateCreate: unexpected error: %v", err)
+	}
+}
+
+func TestNetworkEgressPolicyValidator_ValidateCreate_Denied(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{Authorizer: fakeAuthorizer{allow: false}}
+	_, err := v.ValidateCreate(contextWithRequester("mallory"), testEgressPolicy())
+	if err == nil {
+		t.Fatal("ValidateCreate: expected error when Authorizer denies")
+	}
+}
+
+func TestNetworkEgressPolicyValidator_ValidateCreate_AuthorizerErrorFailsClosed(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{
+		Authorizer: fakeAuthorizer{allow: true, err: errors.New("companion operator unreachable")},
+	}
+	_, err := v.ValidateCreate(contextWithRequester("alice"), testEgressPolicy())
+	if err == nil {
+		t.Fatal("ValidateCreate: expected error when Authorizer itself fails (fail-closed)")
+	}
+}
+
+func TestNetworkEgressPolicyValidator_ValidateUpdate_ReChecksNewObject(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{Authorizer: fakeAuthorizer{allow: false}}
+	oldPolicy := testEgressPolicy()
+	newPolicy := testEgressPolicy()
+	newPolicy.Spec.VPCRef = "someone-elses-vpc"
+	_, err := v.ValidateUpdate(contextWithRequester("mallory"), oldPolicy, newPolicy)
+	if err == nil {
+		t.Fatal("ValidateUpdate: expected error when Authorizer denies the updated object")
+	}
+}
+
+func TestNetworkEgressPolicyValidator_ValidateDelete_NoAuthorizationCheck(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{Authorizer: fakeAuthorizer{allow: false}}
+	if _, err := v.ValidateDelete(context.Background(), testEgressPolicy()); err != nil {
+		t.Fatalf("ValidateDelete: unexpected error: %v", err)
+	}
+}
+
+func TestNetworkEgressPolicyValidator_MissingAdmissionRequestErrors(t *testing.T) {
+	v := &NetworkEgressPolicyValidator{Authorizer: fakeAuthorizer{allow: true}}
+	// No admission.Request on the context.
+	_, err := v.ValidateCreate(context.Background(), testEgressPolicy())
+	if err == nil {
+		t.Fatal("ValidateCreate: expected error when no admission.Request is present on context")
+	}
+}
+
+func TestNetworkEgressPolicyValidator_SharesAuthorizerWithNetworkRule(t *testing.T) {
+	// The same Authorizer instance must satisfy both validators without
+	// modification — the whole point of narrowing the interface to
+	// vpcRef/vpcAttachmentRef strings (design plan §4.1).
+	auth := fakeAuthorizer{allow: true}
+	ruleValidator := &NetworkRuleValidator{Authorizer: auth}
+	policyValidator := &NetworkEgressPolicyValidator{Authorizer: auth}
+
+	if _, err := ruleValidator.ValidateCreate(contextWithRequester("alice"), testRule()); err != nil {
+		t.Errorf("NetworkRuleValidator.ValidateCreate: unexpected error: %v", err)
+	}
+	if _, err := policyValidator.ValidateCreate(contextWithRequester("alice"), testEgressPolicy()); err != nil {
+		t.Errorf("NetworkEgressPolicyValidator.ValidateCreate: unexpected error: %v", err)
+	}
+}

--- a/internal/webhook/networkrule_webhook.go
+++ b/internal/webhook/networkrule_webhook.go
@@ -68,7 +68,7 @@ func (v *NetworkRuleValidator) authorize(ctx context.Context, rule *networkv1alp
 		return fmt.Errorf("resolve admission request: %w", err)
 	}
 
-	ok, err := v.Authorizer.Authorize(ctx, req.UserInfo, rule)
+	ok, err := v.Authorizer.Authorize(ctx, req.UserInfo, rule.Spec.VPCRef, rule.Spec.VPCAttachmentRef)
 	if err != nil {
 		// Fail closed: an authorization check that itself failed (e.g. the
 		// companion operator was unreachable) must never be treated as an

--- a/internal/webhook/networkrule_webhook_test.go
+++ b/internal/webhook/networkrule_webhook_test.go
@@ -22,7 +22,7 @@ type fakeAuthorizer struct {
 }
 
 func (f fakeAuthorizer) Authorize(
-	context.Context, authenticationv1.UserInfo, *networkv1alpha1.NetworkRule,
+	context.Context, authenticationv1.UserInfo, string, string,
 ) (bool, error) {
 	return f.allow, f.err
 }
@@ -95,7 +95,7 @@ func TestNetworkRuleValidator_MissingAdmissionRequestErrors(t *testing.T) {
 
 func TestAllowAllAuthorizer_AlwaysAllows(t *testing.T) {
 	a := AllowAllAuthorizer{}
-	ok, err := a.Authorize(context.Background(), authenticationv1.UserInfo{Username: "anyone"}, testRule())
+	ok, err := a.Authorize(context.Background(), authenticationv1.UserInfo{Username: "anyone"}, "vpc-1", "attach-1")
 	if err != nil {
 		t.Fatalf("Authorize: unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Phase C of #865, per docs/plans/865-edge-gateway-nat66-egress.md §4-§5.
Stacked on #381 (Phase B).

- `config.GatewayConfig` gains `EgressAddress`/`EgressSID`, optional
  but validated as a pair.
- `gateway.NewKernelDatapath` optionally writes `egress_config_table`;
  zero value means no egress on this node.
- `gateway.DesiredEgressPolicy` defined but not added to `EngineState`
  -- routing-only enablement means nothing in Engine/Datapath consumes
  it yet.
- `NetworkGatewayReconciler.publishEgressAddress` publishes
  `status.EgressAddress` and a self-address BGP route, kept separate
  from `publishSelfAddress` since the two fields are independently
  optional.
- `webhook.Authorizer` narrowed from `*NetworkRule` to
  `(vpcRef, vpcAttachmentRef string)`, so the new
  `NetworkEgressPolicyValidator` shares it with `NetworkRuleValidator`
  instead of duplicating the interface. Wired into `cmd/galactic-router`
  alongside the existing validator.
- `cmd/galactic-gateway` CLI flags/config plumbed through to
  `setupGatewayDatapath`.

## Scoping note

The plan's §4.3 also describes a NetworkEgressPolicy watch/reconcile
loop mirroring NetworkRule's list-and-assemble pattern. Left out here:
it has no well-defined per-policy work until Phase D decides node
assignment, and a watch that lists objects and does nothing with them
is dead scaffolding, not a real feature.

## Testing

- New tests: config pairing/family validation, `NewKernelDatapath`
  mismatched-pair/IPv4 rejection, reconciler publish/skip-publish,
  webhook create/update/delete/fail-closed plus a test proving one
  `Authorizer` instance serves both validators.
- `go build ./...`, `go vet ./...`, `task lint` (0 issues) -- clean.
- Full `task test:unit` under root: everything this PR touches passes.
  Two unrelated failures present (`internal/cni/tap`,
  `internal/cniroute`) are environment artifacts -- confirmed
  `cni/tap` fails identically on the unmodified branch, and
  `cniroute` passes cleanly in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)