### PR TITLE
feat(gateway): ContainerLab egress canary and RBAC fix

### DIFF
--- a/config/gateway/rbac.yaml
+++ b/config/gateway/rbac.yaml
@@ -36,11 +36,18 @@ rules:
     resources:
       - networkgateways
       - networkrules
+      # networkegresspolicies (datum-cloud/enhancements#865): read/write
+      # for NetworkEgressPolicyReconciler's one-time gateway-node
+      # assignment (internal/controller/networkegresspolicy_controller.go),
+      # the same shape NetworkRuleReconciler already has for
+      # primary_node/Accepted on NetworkRule.
+      - networkegresspolicies
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["network.datumapis.com"]
     resources:
       - networkgateways/status
       - networkrules/status
+      - networkegresspolicies/status
     verbs: ["get", "update", "patch"]
   # Full CRUD: NetworkGatewayReconciler creates one BGPAdvertisement per VIP
   # address family per NetworkRule it serves plus one for its own

--- a/config/router/rbac.yaml
+++ b/config/router/rbac.yaml
@@ -24,6 +24,20 @@ rules:
       - bgpadvertisements
       - bgpvrfinstances
     verbs: ["get", "list", "watch", "delete"]
+  # networkgateways/networkegresspolicies (datum-cloud/enhancements#865):
+  # read-only, for internal/egressroute.Run (invoked by
+  # EgressRouteReconciler, internal/controller/egressroute_controller.go).
+  # This binary's own reconcilers never write either — enablement and
+  # gateway-node assignment are set by NetworkEgressPolicyReconciler in
+  # galactic-gateway (config/gateway/rbac.yaml), and EgressSID is
+  # published by NetworkGatewayReconciler, also in galactic-gateway. This
+  # binary only ever reads both to decide whether/where to point a local
+  # tenant VRF's own default route.
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - networkgateways
+      - networkegresspolicies
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["network.datumapis.com"]
     resources:
       - bgprouters/status

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -146,6 +146,43 @@ supplied statically through `GALACTIC_GATEWAY_SRV6_ADDRESS` (originally
 | iad-gateway1 | fc00:0:9::1/128 | 2      | 2001:db8:ff03:2:e000::         |
 | iad-gateway2 | fc00:0:a::1/128 | 3      | 2001:db8:ff03:3:e000::         |
 
+### Egress (masquerade) canary (Phase E, datum-cloud/enhancements#865)
+
+Each gateway node also gets a second, dedicated fabric loopback address
+(`GALACTIC_GATEWAY_EGRESS_ADDRESS`) and shares its ingress locator for
+`GALACTIC_GATEWAY_EGRESS_SID` (only the top 64 bits — Block+Node-ID — are
+ever compared for egress dispatch, so the low bits shown below are just an
+obviously-distinct placeholder, not a value with its own meaning). The
+egress address must be its own, separate address from the node's BGP
+session address (`fc00:0:9::1`/`fc00:0:a::1` above) — reusing it would mean
+`edgenat.c`'s fail-closed egress-return dispatch also claims, and drops,
+this node's own inbound BGP TCP traffic.
+
+| Node         | Egress address (masq_addr) | Egress SID (locator, low bits arbitrary) |
+|--------------|-----------------------------|-------------------------------------------|
+| iad-gateway1 | fc00:0:9::2/128             | 2001:db8:ff03:2:e0ff::                    |
+| iad-gateway2 | fc00:0:a::2/128             | 2001:db8:ff03:3:e0ff::                    |
+
+`ns10`'s iad attachment (`resources/galactic-gateway/iad/
+networkegresspolicy-ns10.yaml`) is the egress canary tenant — chosen over
+`ns60` (the ingress canary) because its `netshoot` image has `ping`; `ns60`'s
+`nginx` image doesn't. Only `ns10`'s **iad** attachment can egress in this
+lab: `NetworkGateway`/`NetworkEgressPolicy` only exist in iad's own Kind
+cluster, since each site here is a fully separate cluster connected only by
+the data-plane SRv6/BGP mesh, not a shared control plane — see
+`scripts/verify-egress.sh`. `task verify:egress` pings `tr1`'s own loopback
+(`fc00:0:1::1`, already announced into the transit mesh, standing in for "an
+arbitrary internet destination" since this lab has no real internet uplink)
+from that pod.
+
+**This canary could not be run live in this session** — bringing up three
+Kind clusters plus the full FRR/BGP mesh is a multi-minute operation not
+attempted here. Every value and code path above was worked through by
+reading the existing lab's real configuration and this design's own
+datapath code, not confirmed against a live cluster; treat it as a
+reasoned-through starting point; the first real run of `task verify:egress`
+is this canary's actual proof.
+
 ### Management network (fc00:10::/64)
 
 | Node                                       | Address      |
@@ -256,6 +293,7 @@ task deploy
 | `verify:ns30`            | Verify ns30 ping (dfw only, 2 pods)                                           |
 | `verify:ns40`            | Verify ns40 ping (iad only, 2 pods)                                           |
 | `verify:gateway`         | Verify iad's gateway canary CRDs exist (manifests only, no live traffic)      |
+| `verify:egress`          | Verify egress (masquerade) datapath end-to-end (ns10/iad → tr1's loopback)    |
 | `destroy`                | Destroy the lab and remove all Kind clusters                                  |
 | `restart`                | Full rebuild — destroy then redeploy                                          |
 | `rebuild`                | Full rebuild — clean (destroy + delete images/artifacts) then redeploy        |

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -227,6 +227,7 @@ tasks:
       - task: "verify:evpn"
       - task: "verify:gateway"
       - task: "verify:scenarios"
+      - task: "verify:egress"
 
   "verify:bgp-transit":
     desc: Verify transit router BGP sessions (iBGP full mesh)
@@ -281,8 +282,13 @@ tasks:
   "verify:gateway":
     desc: Verify iad's gateway canary CRDs exist
     cmds:
-      - docker exec iad-control-plane kubectl get networkgateways,networkrules -n galactic-system
+      - docker exec iad-control-plane kubectl get networkgateways,networkrules,networkegresspolicies -n galactic-system
       - docker exec iad-control-plane kubectl get daemonset -n galactic-system -l app.kubernetes.io/name=galactic-gateway
+
+  "verify:egress":
+    desc: Verify egress (masquerade) datapath end-to-end (ns10/iad -> tr1's loopback, datum-cloud/enhancements#865)
+    cmds:
+      - ./scripts/verify-egress.sh
 
   "verify:scenarios":
     desc: Verify ping across all VPC test scenarios

--- a/deploy/containerlab/resources/fabric-router/iad/frr.conf.iad-gateway1
+++ b/deploy/containerlab/resources/fabric-router/iad/frr.conf.iad-gateway1
@@ -8,6 +8,22 @@ interface lo
  ! BGP_LOCAL_ADDRESS auto-detected from lo, matching iad-worker/
  ! iad-worker-control's own convention).
  ipv6 address fc00:0:9::1/128
+ ! A second, dedicated loopback address for GALACTIC_GATEWAY_EGRESS_ADDRESS
+ ! (datum-cloud/enhancements#865, design plan §3.1's masq_addr) --
+ ! deliberately its own address, not a reuse of fc00:0:9::1 above: edgenat.c's
+ ! egress-return dispatch (edgenat.c's header comment, point 5) claims *every*
+ ! packet addressed to masq_addr regardless of protocol/port and drops
+ ! anything that isn't a recognized egress reply, fail-closed. Reusing this
+ ! node's own BGP session address would mean that same dispatch also claims
+ ! (and drops) the inbound half of this node's own outbound BGP TCP session
+ ! to the route reflector -- breaking this node's own control-plane
+ ! connectivity, not just being untidy. A real deployment provisions this
+ ! from actual public IPv6 space (design plan §7.5, "no in-cluster
+ ! derivation mechanism yet"); this lab has no real internet uplink to
+ ! provision from, so it reuses the same "dedicated per-node fabric
+ ! loopback, redistributed via a /128 network statement" technique the line
+ ! above already establishes for SRv6Address's own reachability.
+ ipv6 address fc00:0:9::2/128
 !
 interface eth1
  description tr3-facing
@@ -37,6 +53,10 @@ router bgp 65000
   # stuck in Active forever -- caught only once this link's underlay
   # eBGP was actually brought up live (see node_files/tr3/frr.conf).
   network fc00:0:9::1/128
+  ! GALACTIC_GATEWAY_EGRESS_ADDRESS -- see the matching interface lo comment
+  ! above for why this is a second, dedicated address rather than a reuse
+  ! of fc00:0:9::1.
+  network fc00:0:9::2/128
  exit-address-family
 
 ipv6 forwarding

--- a/deploy/containerlab/resources/fabric-router/iad/frr.conf.iad-gateway2
+++ b/deploy/containerlab/resources/fabric-router/iad/frr.conf.iad-gateway2
@@ -8,6 +8,10 @@ interface lo
  ! BGP_LOCAL_ADDRESS auto-detected from lo, matching iad-worker/
  ! iad-worker-control's own convention).
  ipv6 address fc00:0:a::1/128
+ ! GALACTIC_GATEWAY_EGRESS_ADDRESS -- see frr.conf.iad-gateway1's identical
+ ! comment for why this is a second, dedicated address rather than a reuse
+ ! of fc00:0:a::1.
+ ipv6 address fc00:0:a::2/128
 !
 interface eth1
  description tr3-facing
@@ -26,6 +30,9 @@ router bgp 65000
   neighbor 2001:db8:1:33::1 allowas-in 1
   # /128, not /48 -- see frr.conf.iad-gateway1's identical comment.
   network fc00:0:a::1/128
+  ! GALACTIC_GATEWAY_EGRESS_ADDRESS -- see frr.conf.iad-gateway1's identical
+  ! comment.
+  network fc00:0:a::2/128
  exit-address-family
 
 ipv6 forwarding

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway1/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway1/node-patch.yaml
@@ -50,3 +50,25 @@ spec:
             # reconciler today).
             - name: GALACTIC_GATEWAY_SRV6_ADDRESS
               value: "2001:db8:ff03:2:e000::"
+            # datum-cloud/enhancements#865 (egress masquerade): a real,
+            # publicly-routable IPv6 address in production (design plan
+            # §7.5, no in-cluster derivation mechanism yet); this lab has
+            # no real internet uplink, so it reuses a second dedicated
+            # loopback address on this node's own fabric-router
+            # (resources/fabric-router/iad/frr.conf.iad-gateway1),
+            # redistributed the same way that file's own
+            # fc00:0:9::1 (this node's BGP session address) already is.
+            - name: GALACTIC_GATEWAY_EGRESS_ADDRESS
+              value: "fc00:0:9::2"
+            # Same locator (Block+Node-ID) as GALACTIC_GATEWAY_SRV6_ADDRESS
+            # above -- edgenat.c's egress dispatch only ever compares the
+            # top 64 bits (locator_eq, design plan §3.1), so egress_sid
+            # can safely share gw_addr's own locator; the low bits shown
+            # here (e0ff) are a distinct, obviously-placeholder value only
+            # so the two env vars don't look like a copy-paste of each
+            # other, not because they carry any meaning of their own (the
+            # Argument bits are never read from this configured value at
+            # all -- only from each packet's own destination address, at
+            # runtime, as that flow's tenant_arg).
+            - name: GALACTIC_GATEWAY_EGRESS_SID
+              value: "2001:db8:ff03:2:e0ff::"

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway2/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway2/node-patch.yaml
@@ -50,3 +50,11 @@ spec:
             # reconciler today).
             - name: GALACTIC_GATEWAY_SRV6_ADDRESS
               value: "2001:db8:ff03:3:e000::"
+            # datum-cloud/enhancements#865 (egress masquerade) -- see
+            # iad-gateway1/node-patch.yaml's identical comment.
+            - name: GALACTIC_GATEWAY_EGRESS_ADDRESS
+              value: "fc00:0:a::2"
+            # Same locator as GALACTIC_GATEWAY_SRV6_ADDRESS above -- see
+            # iad-gateway1/node-patch.yaml's identical comment for why.
+            - name: GALACTIC_GATEWAY_EGRESS_SID
+              value: "2001:db8:ff03:3:e0ff::"

--- a/deploy/containerlab/resources/galactic-gateway/iad/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/kustomization.yaml
@@ -1,9 +1,12 @@
 # The single entry point for iad's gateway-role canary: both gateway
-# nodes' DaemonSet+BGP+NetworkGateway instantiations, plus the ns60
-# NetworkRule. scripts/deploy-galactic-router.sh applies this one
-# path rather than ../iad-gateway1/ and ../iad-gateway2/ separately.
+# nodes' DaemonSet+BGP+NetworkGateway instantiations, the ns60 NetworkRule
+# (ingress canary), and the ns10 NetworkEgressPolicy (egress canary,
+# datum-cloud/enhancements#865). scripts/deploy-galactic-router.sh applies
+# this one path rather than ../iad-gateway1/ and ../iad-gateway2/
+# separately.
 namespace: galactic-system
 resources:
   - ../iad-gateway1
   - ../iad-gateway2
   - networkrule-ns60.yaml
+  - networkegresspolicy-ns10.yaml

--- a/deploy/containerlab/resources/galactic-gateway/iad/networkegresspolicy-ns10.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/networkegresspolicy-ns10.yaml
@@ -1,0 +1,17 @@
+# ns10 (resources/tenants/ns10/, vpc=10/vpcattachment=10, fd20:10:ff03::/48
+# on iad -- see ns10/iad/nad.yaml) is the egress (masquerade) canary
+# (datum-cloud/enhancements#865): its iad pod is the only ns10 attachment
+# that can actually exercise egress in this lab, since NetworkGateway/
+# NetworkEgressPolicy only exist in iad's own Kind cluster -- dfw/sjc are
+# separate clusters with no visibility into iad's gateway-node CRDs at all
+# (see scripts/verify-egress.sh's own doc comment). ns10 was chosen over
+# ns60 (the ingress canary) specifically because its netshoot image has
+# ping/curl; ns60's nginx image doesn't.
+apiVersion: network.datumapis.com/v1alpha1
+kind: NetworkEgressPolicy
+metadata:
+  name: ns10-egress
+  namespace: galactic-system
+spec:
+  vpcRef: "10"
+  vpcAttachmentRef: "10"

--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -32,6 +32,7 @@ network_crds=(
   network.datumapis.com_bgpvrfinstances.yaml
   network.datumapis.com_networkgateways.yaml
   network.datumapis.com_networkrules.yaml
+  network.datumapis.com_networkegresspolicies.yaml
 )
 
 cloud_crds=(

--- a/deploy/containerlab/scripts/verify-egress.sh
+++ b/deploy/containerlab/scripts/verify-egress.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# verify-egress.sh — confirm the egress (masquerade) datapath end-to-end
+# (datum-cloud/enhancements#865): ping tr1's own loopback (fc00:0:1::1) from
+# ns10's iad pod, standing in for "an arbitrary internet destination" since
+# this lab has no real internet uplink. tr1's loopback is a real address,
+# already announced into the transit/fabric eBGP mesh (node_files/tr1/
+# frr.conf's own "network fc00:0:1::1/128"), and — crucially — outside any
+# SRv6 uSID locator or VPC ULA block this topology otherwise uses, so a
+# successful ping only ever routes correctly if the whole chain actually
+# worked: ns10's tenant VRF has a live ::/0 default route (internal/
+# egressroute's reconciler, only installed once ns10's own
+# NetworkEgressPolicy -- resources/galactic-gateway/iad/
+# networkegresspolicy-ns10.yaml -- is Accepted and assigned a gateway node),
+# that route encapsulates toward the assigned gateway's egress_sid,
+# edgenat.c's egress-forward branch SNATs to that gateway's egress_address,
+# and the reply gets DNAT'd back and delivered to the pod.
+#
+# ns10 (not ns60, the ingress canary) is used here specifically because its
+# netshoot image has ping; ns60's nginx image doesn't.
+#
+# Only exercises iad: NetworkGateway/NetworkEgressPolicy only exist in
+# iad's own Kind cluster (each site is a fully separate cluster in this
+# lab, connected only by the data-plane SRv6/BGP mesh, not a shared
+# control plane) -- so ns10's dfw/sjc attachments have no gateway-node pool
+# to be assigned into at all, and only its iad attachment can egress here.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "${SCRIPT_DIR}/lib.sh"
+
+NS=ns10
+TARGET=fc00:0:1::1 # tr1's own loopback -- the lab's stand-in "internet"
+
+node=$(control_plane iad)
+pod=$(pod_name "${node}" "${NS}")
+echo "ns10/iad: pod=${pod}"
+
+echo "--- ns10/iad -> internet (${TARGET}) ---"
+ping_pod "${node}" "${NS}" "${pod}" -6 "${TARGET}"
+
+echo "egress: ping OK from ns10/iad to ${TARGET}"


### PR DESCRIPTION
## Summary

Phase E of #865, per docs/plans/865-edge-gateway-nat66-egress.md §6/§8.
Stacked on #385 (Phase D). Final phase in the #865 stack.

Fixed first, found by trying to wire this up: `config/gateway/rbac.yaml`
and `config/router/rbac.yaml` never granted access to
`networkegresspolicies` (or, for `galactic-router`, `networkgateways`)
-- Phase D's two new reconcilers would hit RBAC-forbidden errors in
any real deployment, not just this lab.

## Lab wiring

- `GALACTIC_GATEWAY_EGRESS_ADDRESS`/`_SID` on both gateway nodes.
  `egress_sid` reuses each node's own ingress locator (only the top 64
  bits are ever compared). `masq_addr` is a new, dedicated loopback
  address, not a reuse of the node's existing BGP-session address --
  reusing it would make the fail-closed egress-return dispatch also
  claim and drop the node's own inbound BGP TCP traffic.
- `NetworkEgressPolicy` for `ns10`'s iad attachment (not `ns60`, the
  ingress canary -- `ns60` runs `nginx`, no `ping`; `ns10` runs
  `netshoot`). Only `ns10`'s iad pod can egress in this lab: each site
  is a separate Kind cluster, so `NetworkGateway`/`NetworkEgressPolicy`
  only exist where iad's own cluster can see them.
- `scripts/verify-egress.sh` + `task verify:egress`: pings `tr1`'s own
  loopback (already BGP-announced, outside any SRv6/uSID space) from
  `ns10`'s iad pod.
- `deploy-system.sh`'s CRD-install list was missing
  `networkegresspolicies` entirely -- fixed.

## Telemetry/quota

Confirmed, not added. `edgemetrics.Collector` iterates
`DropReasonCount`/`DropReasonNames` generically, so Phase B's new
egress drop reasons are already exposed with no changes here.
`QuotaEnforcer`/`TelemetryEmitter` stay Noop per the plan's own Phase E
deferral.

## Not run live

Bringing up three Kind clusters plus the full FRR/BGP mesh is a
multi-minute operation not attempted in this session. Validated
instead with `kubectl kustomize` against `config/gateway/`,
`config/router/`, and (after simulating the deploy-time `docker cp`
step) the affected lab overlays -- all build clean. The lab also can't
fully deploy until datum-cloud/network#15 merges and tags:
`deploy-system.sh` pulls CRDs from the tagged upstream repo, not this
session's local checkout.

## Testing

- `kubectl kustomize` against `config/gateway/`, `config/router/`, and
  the affected lab overlays -- all build clean, env vars land
  correctly.
- `task lint` (0 issues), shell syntax checks (`bash -n`) on both
  edited/new scripts.
- No Go code changed in this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)