### PR TITLE
fix(cni): mount cni-net-dir into credential-refresh container

### DIFF
--- a/config/cni/daemonset.yaml
+++ b/config/cni/daemonset.yaml
@@ -100,6 +100,9 @@ spec:
             limits:
               memory: 32Mi
           volumeMounts:
+            - name: cni-net-dir
+              mountPath: /host/etc/cni/net.d
+              readOnly: true
             - name: galactic-etc
               mountPath: /host/var/lib/galactic
             - name: galactic-log

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -100,7 +101,6 @@ require (
 	sigs.k8s.io/knftables v0.0.18 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.3 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 tool github.com/cilium/ebpf/cmd/bpf2go

--- a/internal/installer/manifest_test.go
+++ b/internal/installer/manifest_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// TestDaemonsetManifest_RunContainerMountsHostConflistDir is a regression
+// test for a manifest/code mismatch that shipped silently: startEBPFDatapath
+// (and getLogFileHostPath) call loadHostConf(HostConflist) from inside
+// whichever container runs the installer's "run" command
+// (credential-refresh in config/cni/daemonset.yaml). If that container's
+// volumeMounts don't cover the host directory HostConflist lives under,
+// loadHostConf fails on every node, and the eBPF vrf_table GC sweep (and
+// log-rotation's host-path lookup) permanently disables itself with only a
+// slog.Warn("eBPF vrf_table GC sweep disabled: ...") to show for it --
+// config/cni/daemonset.yaml previously mounted cni-net-dir into the
+// install-cni init container only, never into credential-refresh, so this
+// went unnoticed until it was confirmed live on production infra.
+//
+// This test parses the real manifest rather than a copy, so it can't drift
+// from what actually gets applied to a cluster.
+//
+// hostConflistDefault captures HostConflist's production default at
+// package-variable-initialization time -- before any test body runs. Other
+// tests in this package (e.g. TestRun) repoint the HostConflist package var
+// at a t.TempDir() path for the duration of the test and never restore it,
+// so reading the live HostConflist var here would make this test's outcome
+// depend on test execution order within the package.
+var hostConflistDefault = HostConflist
+
+func TestDaemonsetManifest_RunContainerMountsHostConflistDir(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "config", "cni", "daemonset.yaml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifestPath, err)
+	}
+
+	var ds appsv1.DaemonSet
+	if err := yaml.Unmarshal(data, &ds); err != nil {
+		t.Fatalf("unmarshal %s: %v", manifestPath, err)
+	}
+
+	// Find the container that invokes `/galactic-cni run` -- that's the one
+	// that calls loadHostConf(HostConflist) at runtime.
+	var runContainerName string
+	var mountPaths []string
+	found := false
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		for _, arg := range c.Command {
+			if arg != "run" {
+				continue
+			}
+			runContainerName = c.Name
+			for _, vm := range c.VolumeMounts {
+				mountPaths = append(mountPaths, vm.MountPath)
+			}
+			found = true
+		}
+		if found {
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no container in %s runs the installer's \"run\" command", manifestPath)
+	}
+
+	hostConflistDir := filepath.Dir(hostConflistDefault)
+	if !slices.Contains(mountPaths, hostConflistDir) {
+		t.Errorf("container %q in %s does not mount %s (needed to read HostConflist=%s via "+
+			"loadHostConf; without it the eBPF vrf_table GC sweep and log-rotation host-path "+
+			"lookup silently disable themselves on every node); mounted paths: %v",
+			runContainerName, manifestPath, hostConflistDir, hostConflistDefault, mountPaths)
+	}
+}


### PR DESCRIPTION
## Problem

`internal/installer/installer.go`'s `startEBPFDatapath` (and `getLogFileHostPath`) call `loadHostConf(HostConflist)` from inside whichever container runs `/galactic-cni run` -- `credential-refresh` in `config/cni/daemonset.yaml`. `HostConflist` points at `/host/etc/cni/net.d/10-galactic.conflist`, the conflist the `install-cni` init container writes.

But `daemonset.yaml` only mounted the `cni-net-dir` hostPath into `install-cni`, not into `credential-refresh`, so `credential-refresh` could never read the conflist `install-cni` just wrote. `loadHostConf` failed on every node, every time, and the eBPF `vrf_table` GC sweep (Milestone 7.3) silently disabled itself with only a `slog.Warn` to show for it:

```
WARN eBPF vrf_table GC sweep disabled: failed to load host conf
err="open /host/etc/cni/net.d/10-galactic.conflist: no such file or directory"
```

Confirmed live on datum-cloud infra's `us-central-1-lab` edge cluster running the current published image.

## Fix

Add the same `cni-net-dir` volumeMount to `credential-refresh`, read-only since that container only reads the conflist and never writes it.

`config/vmtap/daemonset.yaml` is a different binary and unaffected. The containerlab overlay at `deploy/containerlab/resources/galactic-cni/` is a strategic-merge patch that only touches `image`/env and inherits this fix from the base -- no other `config/cni` overlay exists.

## Regression coverage

`task test:e2e`'s `TestCNITapInterface` doesn't exercise this path: it hand-builds its own pod spec instead of applying `config/cni/daemonset.yaml`, so it never had a way to catch a missing volume mount in that manifest.

Added `internal/installer/manifest_test.go` instead: a unit test (runs under `task test:unit`) that parses the real `config/cni/daemonset.yaml`, finds the container running the installer's `"run"` command, and asserts it mounts the host directory `HostConflist` lives under. Verified it fails against the pre-fix manifest and passes against the fix, so a future manifest/code drift on this path gets caught automatically instead of shipping silently again.

## Testing

`task ci` (lint → build → test:unit → test:e2e) passes clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)