### PR TITLE
chore(cni): dedupe remaining veth/tap master-plugin scaffolding

### DIFF
--- a/internal/cni/cni.go
+++ b/internal/cni/cni.go
@@ -5,15 +5,11 @@
 package cni
 
 import (
-	"time"
-
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
 
 	"go.datum.net/galactic/internal/metadata"
 )
-
-const cniTimeout = 10 * time.Second
 
 // RunPlugin starts the CNI plugin, handling ADD, DEL, CHECK, and STATUS operations.
 func RunPlugin() {

--- a/internal/cni/cni_test.go
+++ b/internal/cni/cni_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.datum.net/galactic/internal/cniipam"
 	"go.datum.net/galactic/internal/cnimaster"
+	"go.datum.net/galactic/internal/cnitestutil"
 )
 
 func TestMain(m *testing.M) {
@@ -42,29 +43,12 @@ const (
 		`"ips":[{"version":"6","address":"fd00:1::1/64"}]}`
 )
 
-// assertCNIError verifies that err is a *types.Error with the expected Code
-// and that its Msg contains wantMsg (substring match). Pass wantMsg == "" to
-// skip the message check.
-func assertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
-	t.Helper()
-	var cniErr *types.Error
-	if !errors.As(err, &cniErr) {
-		t.Fatalf("expected *types.Error, got %T: %v", err, err)
-	}
-	if cniErr.Code != wantCode {
-		t.Fatalf("expected code %d, got %d (Msg: %q)", wantCode, cniErr.Code, cniErr.Msg)
-	}
-	if wantMsg != "" && !strings.Contains(cniErr.Msg, wantMsg) {
-		t.Fatalf("expected Msg to contain %q, got %q", wantMsg, cniErr.Msg)
-	}
-}
-
 // ---- buildResult ---------------------------------------------------------
 
 func TestBuildResult(t *testing.T) {
-	subnet := mustParseCIDR(t, "fd00:10:ff01::1234/80")
+	subnet := cnitestutil.MustParseCIDR(t, "fd00:10:ff01::1234/80")
 	gateway := net.ParseIP("fd00:10:ff01::1")
-	defaultRoute := mustParseCIDR(t, "::/0")
+	defaultRoute := cnitestutil.MustParseCIDR(t, "::/0")
 	netns := "/proc/1234/ns/net"
 
 	conf := &PluginConf{
@@ -181,12 +165,12 @@ func TestBuildResult(t *testing.T) {
 // an IPv4 IPConfig, both pointing at the guest interface, plus both default
 // routes, when ipamResult carries an IPv4 allocation.
 func TestBuildResultDualStack(t *testing.T) {
-	ipv6Subnet := mustParseCIDR(t, "fd00:10:ff01::1234/96")
+	ipv6Subnet := cnitestutil.MustParseCIDR(t, "fd00:10:ff01::1234/96")
 	ipv6Gateway := net.ParseIP("fd00:10:ff01::1")
 	ipv4Address := net.ParseIP("10.128.0.5")
 	ipv4Gateway := net.ParseIP("10.128.0.1")
-	ipv6Route := mustParseCIDR(t, "::/0")
-	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+	ipv6Route := cnitestutil.MustParseCIDR(t, "::/0")
+	ipv4Route := cnitestutil.MustParseCIDR(t, "0.0.0.0/0")
 
 	conf := &PluginConf{
 		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
@@ -237,7 +221,7 @@ func TestBuildResultDualStack(t *testing.T) {
 func TestBuildResultIPv4Only(t *testing.T) {
 	ipv4Address := net.ParseIP("172.20.1.5")
 	ipv4Gateway := net.ParseIP("172.20.1.1")
-	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+	ipv4Route := cnitestutil.MustParseCIDR(t, "0.0.0.0/0")
 
 	conf := &PluginConf{
 		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
@@ -350,15 +334,6 @@ func TestCmdDelFlushesGuestNetnsConfig(t *testing.T) {
 	if gw := defaultRouteVia(t, netnsPath); gw != nil {
 		t.Fatalf("default route gateway = %v, want nil (flushed by DEL)", gw)
 	}
-}
-
-func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
-	t.Helper()
-	_, ipnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		t.Fatalf("parse CIDR %q: %v", cidr, err)
-	}
-	return ipnet
 }
 
 // ---- cmdCheck ----------------------------------------------------------
@@ -521,7 +496,7 @@ func TestCmdStatusInvalidConfig(t *testing.T) {
 	}
 
 	err := cmdStatus(args)
-	assertCNIError(t, err, 7, "invalid CNI config")
+	cnitestutil.AssertCNIError(t, err, 7, "invalid CNI config")
 }
 
 func TestCmdStatusValidConfigMissingResources(t *testing.T) {
@@ -613,7 +588,7 @@ func TestCmdStatusAPIProbeFailure(t *testing.T) {
 	}
 
 	err := cmdStatus(args)
-	assertCNIError(t, err, 50, "API server health check failed")
+	cnitestutil.AssertCNIError(t, err, 50, "API server health check failed")
 }
 
 // ---- cmdAdd prevResult validation ----------------------------------------
@@ -638,5 +613,5 @@ func TestCmdAddPrevResultValid(t *testing.T) {
 	err := cmdAdd(args)
 	// Should fail with code 4 (invalid env vars) for missing node name,
 	// not code 6 for prevResult.
-	assertCNIError(t, err, 4, "node name is required")
+	cnitestutil.AssertCNIError(t, err, 4, "node name is required")
 }

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -107,7 +107,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("create k8s client: %w", err)
 	}
 	podNamespace := nadpatch.ParsePodNamespace(args.Args)
-	nadCtx, nadCancel := context.WithTimeout(context.Background(), cniTimeout)
+	nadCtx, nadCancel := context.WithTimeout(context.Background(), cnimaster.NADPatchTimeout)
 	defer nadCancel()
 	if err := nadpatch.AnnotateNAD(nadCtx, k8sClient, pluginConf.Name, podNamespace, hostName); err != nil {
 		return fmt.Errorf("annotate NAD: %w", err)

--- a/internal/cni/result.go
+++ b/internal/cni/result.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/cniipam"
+	"go.datum.net/galactic/internal/cnimaster"
 	"go.datum.net/galactic/internal/hostgw"
 )
 
@@ -45,39 +46,8 @@ func buildResult(
 			},
 		},
 	}
-	appendIPConfigs(result, ipRes, 1, net.CIDRMask(32, 32)) // index into Interfaces (guest veth)
+	cnimaster.AppendIPConfigs(result, ipRes, 1, net.CIDRMask(32, 32)) // index into Interfaces (guest veth)
 	return result
-}
-
-// appendIPConfigs adds one IPConfig per allocated address family in ipRes
-// (IPv6, and IPv4 when present) plus any default routes, all pointing at the
-// given Interfaces index. No-op when ipRes is nil.
-func appendIPConfigs(result *type100.Result, ipRes *cniipam.IPAMResult, ifaceIndex int, ipv4Mask net.IPMask) {
-	if ipRes == nil {
-		return
-	}
-	if ipRes.IPv6Subnet != nil {
-		result.IPs = append(result.IPs, &type100.IPConfig{
-			Address:   *ipRes.IPv6Subnet,
-			Gateway:   ipRes.IPv6Gateway,
-			Interface: type100.Int(ifaceIndex),
-		})
-	}
-	if ipRes.IPv4Address != nil {
-		result.IPs = append(result.IPs, &type100.IPConfig{
-			Address:   net.IPNet{IP: ipRes.IPv4Address, Mask: ipv4Mask},
-			Gateway:   ipRes.IPv4Gateway,
-			Interface: type100.Int(ifaceIndex),
-		})
-	}
-	if len(ipRes.Routes) > 0 {
-		result.Routes = make([]*types.Route, 0, len(ipRes.Routes))
-		for _, dst := range ipRes.Routes {
-			result.Routes = append(result.Routes, &types.Route{
-				Dst: *dst,
-			})
-		}
-	}
 }
 
 // buildVethResult handles veth-specific result building: host-device

--- a/internal/cnimaster/resource.go
+++ b/internal/cnimaster/resource.go
@@ -7,6 +7,7 @@ package cnimaster
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -16,6 +17,11 @@ import (
 
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
+
+// NADPatchTimeout bounds the NAD-annotation patch call each master plugin
+// makes with the k8s client from NewK8sClient, right after creating it —
+// veth's and tap's own ADD both use the same budget.
+const NADPatchTimeout = 10 * time.Second
 
 var scheme = runtime.NewScheme()
 

--- a/internal/cnimaster/result.go
+++ b/internal/cnimaster/result.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cnimaster
+
+import (
+	"net"
+
+	"github.com/containernetworking/cni/pkg/types"
+	type100 "github.com/containernetworking/cni/pkg/types/100"
+
+	"go.datum.net/galactic/internal/cniipam"
+)
+
+// AppendIPConfigs adds one IPConfig per allocated address family in ipRes
+// (IPv6, and IPv4 when present) plus any default routes, all pointing at
+// the given Interfaces index. No-op when ipRes is nil.
+//
+// Shared verbatim between galactic-veth (internal/cni) and galactic-tap
+// (internal/cnitap): only the ifaceIndex and ipv4Mask each passes in differ
+// (veth's guest interface vs tap's own host interface, /32 vs /25), never
+// the logic itself.
+func AppendIPConfigs(result *type100.Result, ipRes *cniipam.IPAMResult, ifaceIndex int, ipv4Mask net.IPMask) {
+	if ipRes == nil {
+		return
+	}
+	if ipRes.IPv6Subnet != nil {
+		result.IPs = append(result.IPs, &type100.IPConfig{
+			Address:   *ipRes.IPv6Subnet,
+			Gateway:   ipRes.IPv6Gateway,
+			Interface: type100.Int(ifaceIndex),
+		})
+	}
+	if ipRes.IPv4Address != nil {
+		result.IPs = append(result.IPs, &type100.IPConfig{
+			Address:   net.IPNet{IP: ipRes.IPv4Address, Mask: ipv4Mask},
+			Gateway:   ipRes.IPv4Gateway,
+			Interface: type100.Int(ifaceIndex),
+		})
+	}
+	if len(ipRes.Routes) > 0 {
+		result.Routes = make([]*types.Route, 0, len(ipRes.Routes))
+		for _, dst := range ipRes.Routes {
+			result.Routes = append(result.Routes, &types.Route{
+				Dst: *dst,
+			})
+		}
+	}
+}

--- a/internal/cnitap/cnitap.go
+++ b/internal/cnitap/cnitap.go
@@ -5,15 +5,11 @@
 package cnitap
 
 import (
-	"time"
-
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
 
 	"go.datum.net/galactic/internal/metadata"
 )
-
-const cniTimeout = 10 * time.Second
 
 // RunPlugin starts the CNI plugin, handling ADD, DEL, CHECK, and STATUS operations.
 func RunPlugin() {

--- a/internal/cnitap/cnitap_test.go
+++ b/internal/cnitap/cnitap_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.datum.net/galactic/internal/cniipam"
 	"go.datum.net/galactic/internal/cnimaster"
+	"go.datum.net/galactic/internal/cnitestutil"
 )
 
 const (
@@ -31,29 +32,6 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("GALACTIC_CNI_NODE_NAME", "test-node")
 	InitCNIConfig()
 	os.Exit(m.Run())
-}
-
-func assertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
-	t.Helper()
-	var cniErr *types.Error
-	if !errors.As(err, &cniErr) {
-		t.Fatalf("expected *types.Error, got %T: %v", err, err)
-	}
-	if cniErr.Code != wantCode {
-		t.Fatalf("expected code %d, got %d (Msg: %q)", wantCode, cniErr.Code, cniErr.Msg)
-	}
-	if wantMsg != "" && !strings.Contains(cniErr.Msg, wantMsg) {
-		t.Fatalf("expected Msg to contain %q, got %q", wantMsg, cniErr.Msg)
-	}
-}
-
-func mustParseCIDR(t *testing.T, cidr string) *net.IPNet {
-	t.Helper()
-	_, ipnet, err := net.ParseCIDR(cidr)
-	if err != nil {
-		t.Fatalf("parse CIDR %q: %v", cidr, err)
-	}
-	return ipnet
 }
 
 // movedKeyConf builds an otherwise-valid galactic-tap config carrying
@@ -150,7 +128,7 @@ func TestParseConf(t *testing.T) {
 					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
 				}
 				if tt.wantCode > 0 {
-					assertCNIError(t, err, tt.wantCode, tt.wantErr)
+					cnitestutil.AssertCNIError(t, err, tt.wantCode, tt.wantErr)
 				}
 				return
 			}
@@ -167,9 +145,9 @@ func TestParseConf(t *testing.T) {
 // ---- buildTapResult ------------------------------------------------------
 
 func TestBuildTapResult(t *testing.T) {
-	subnet := mustParseCIDR(t, "fd00:10:ff01::1234/80")
+	subnet := cnitestutil.MustParseCIDR(t, "fd00:10:ff01::1234/80")
 	gateway := net.ParseIP("fd00:10:ff01::1")
-	defaultRoute := mustParseCIDR(t, "::/0")
+	defaultRoute := cnitestutil.MustParseCIDR(t, "::/0")
 
 	conf := &PluginConf{
 		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
@@ -230,7 +208,7 @@ func TestBuildTapResult(t *testing.T) {
 func TestBuildTapResultIPv4Mask(t *testing.T) {
 	ipv4Address := net.ParseIP("172.20.1.5")
 	ipv4Gateway := net.ParseIP("172.20.1.1")
-	ipv4Route := mustParseCIDR(t, "0.0.0.0/0")
+	ipv4Route := cnitestutil.MustParseCIDR(t, "0.0.0.0/0")
 
 	conf := &PluginConf{
 		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
@@ -257,9 +235,9 @@ func TestBuildTapResultIPv4Mask(t *testing.T) {
 // CNI library's same-netns rejection check. The tap result must not
 // reference a sandbox.
 func TestBuildTapResultHostNetns(t *testing.T) {
-	subnet := mustParseCIDR(t, "fd00:10:ff01::1234/80")
+	subnet := cnitestutil.MustParseCIDR(t, "fd00:10:ff01::1234/80")
 	gateway := net.ParseIP("fd00:10:ff01::1")
-	defaultRoute := mustParseCIDR(t, "::/0")
+	defaultRoute := cnitestutil.MustParseCIDR(t, "::/0")
 
 	conf := &PluginConf{
 		PluginConf:    types.PluginConf{CNIVersion: testCNIVersion},
@@ -314,7 +292,7 @@ func TestCmdCheckValidConfigMissingResources(t *testing.T) {
 func TestCmdStatusInvalidConfig(t *testing.T) {
 	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte("not valid json")}
 	err := cmdStatus(args)
-	assertCNIError(t, err, 7, "invalid CNI config")
+	cnitestutil.AssertCNIError(t, err, 7, "invalid CNI config")
 }
 
 func TestCmdStatusAPIProbeFailure(t *testing.T) {
@@ -326,7 +304,7 @@ func TestCmdStatusAPIProbeFailure(t *testing.T) {
 		testVPC, testAttachment)
 	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte(conf)}
 	err := cmdStatus(args)
-	assertCNIError(t, err, 50, "API server health check failed")
+	cnitestutil.AssertCNIError(t, err, 50, "API server health check failed")
 }
 
 // ---- resourceTracker ------------------------------------------------------

--- a/internal/cnitap/ops_add.go
+++ b/internal/cnitap/ops_add.go
@@ -96,7 +96,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("create k8s client: %w", err)
 	}
 	podNamespace := nadpatch.ParsePodNamespace(args.Args)
-	nadCtx, nadCancel := context.WithTimeout(context.Background(), cniTimeout)
+	nadCtx, nadCancel := context.WithTimeout(context.Background(), cnimaster.NADPatchTimeout)
 	defer nadCancel()
 	if err := nadpatch.AnnotateNAD(nadCtx, k8sClient, pluginConf.Name, podNamespace, hostName); err != nil {
 		return fmt.Errorf("annotate NAD: %w", err)

--- a/internal/cnitap/result.go
+++ b/internal/cnitap/result.go
@@ -7,10 +7,10 @@ package cnitap
 import (
 	"net"
 
-	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 
 	"go.datum.net/galactic/internal/cniipam"
+	"go.datum.net/galactic/internal/cnimaster"
 )
 
 // buildTapResult constructs the CNI result for tap mode: a single host
@@ -37,37 +37,6 @@ func buildTapResult(
 			},
 		},
 	}
-	appendIPConfigs(result, ipRes, 0, net.CIDRMask(25, 32)) // index into Interfaces (host tap)
+	cnimaster.AppendIPConfigs(result, ipRes, 0, net.CIDRMask(25, 32)) // index into Interfaces (host tap)
 	return result
-}
-
-// appendIPConfigs adds one IPConfig per allocated address family in ipRes
-// (IPv6, and IPv4 when present) plus any default routes, all pointing at
-// the given Interfaces index. No-op when ipRes is nil.
-func appendIPConfigs(result *type100.Result, ipRes *cniipam.IPAMResult, ifaceIndex int, ipv4Mask net.IPMask) {
-	if ipRes == nil {
-		return
-	}
-	if ipRes.IPv6Subnet != nil {
-		result.IPs = append(result.IPs, &type100.IPConfig{
-			Address:   *ipRes.IPv6Subnet,
-			Gateway:   ipRes.IPv6Gateway,
-			Interface: type100.Int(ifaceIndex),
-		})
-	}
-	if ipRes.IPv4Address != nil {
-		result.IPs = append(result.IPs, &type100.IPConfig{
-			Address:   net.IPNet{IP: ipRes.IPv4Address, Mask: ipv4Mask},
-			Gateway:   ipRes.IPv4Gateway,
-			Interface: type100.Int(ifaceIndex),
-		})
-	}
-	if len(ipRes.Routes) > 0 {
-		result.Routes = make([]*types.Route, 0, len(ipRes.Routes))
-		for _, dst := range ipRes.Routes {
-			result.Routes = append(result.Routes, &types.Route{
-				Dst: *dst,
-			})
-		}
-	}
 }

--- a/internal/cnitestutil/cnitestutil.go
+++ b/internal/cnitestutil/cnitestutil.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package cnitestutil holds test helpers shared by internal/cni's and
+// internal/cnitap's own test suites — the same reasoning as internal/
+// cnimaster, but for test-only scaffolding rather than production code:
+// neither helper is specific to veth or tap, so a fix only has to happen
+// once. Not a _test.go file, since Go doesn't let one package's _test.go
+// import another package's _test.go — this is a regular importable package
+// that happens to only ever be imported from test code.
+package cnitestutil
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// AssertCNIError verifies that err is a *types.Error with the expected Code
+// and that its Msg contains wantMsg (substring match). Pass wantMsg == "" to
+// skip the message check.
+func AssertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
+	t.Helper()
+	var cniErr *types.Error
+	if !errors.As(err, &cniErr) {
+		t.Fatalf("expected *types.Error, got %T: %v", err, err)
+	}
+	if cniErr.Code != wantCode {
+		t.Fatalf("expected code %d, got %d (Msg: %q)", wantCode, cniErr.Code, cniErr.Msg)
+	}
+	if wantMsg != "" && !strings.Contains(cniErr.Msg, wantMsg) {
+		t.Fatalf("expected Msg to contain %q, got %q", wantMsg, cniErr.Msg)
+	}
+}
+
+// MustParseCIDR parses cidr and fails the test immediately if it's invalid.
+func MustParseCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse CIDR %q: %v", cidr, err)
+	}
+	return ipnet
+}


### PR DESCRIPTION
## Summary

Closes the residual duplication #325 flags. Most of its scope was already fixed by the `internal/cnimaster` extraction from the #303-306 stack; this covers what's left, verified byte-identical by diff:

- `appendIPConfigs` (`internal/cni` and `internal/cnitap` `result.go`) → `cnimaster.AppendIPConfigs`
- `cniTimeout` const → `cnimaster.NADPatchTimeout`, next to `NewK8sClient`
- `assertCNIError`/`mustParseCIDR` test helpers → new `internal/cnitestutil` package

`checkPrevResult` and the per-binary `cmdAdd`/`cmdCheck`/`cmdDel`/`parseConf`/`RunPlugin` entrypoints are left alone — they genuinely differ or are already documented as intentionally thin.

## Testing

`task build`, `task lint` (0 issues), `task test:unit` — all pass.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)