### PR TITLE
fix(cnibgp): dedupe advertised prefixes and prune dead sibling annotations

### DIFF
--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -31,6 +31,7 @@ import (
 
 	"go.datum.net/galactic/internal/cniipam"
 	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/gc"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/vrf"
@@ -299,18 +300,77 @@ func ipamAdvertisementPrefixes(ipamResult *cniipam.IPAMResult) (prefixes []strin
 // it, rather than from just the container currently being processed — see
 // crdnames' doc comment for why a single BGPAdvertisement can be shared by
 // more than one container.
+//
+// The result is deduplicated by CIDR value. spec.Prefixes is
+// x-kubernetes-list-type=set, so a duplicate value is rejected outright by
+// the API server: when a replaced pod's IPAM allocation lands on the same
+// subnet its predecessor held (the common case — IPAM re-allocates the same
+// subnet for the same vpcAttachment identity), the predecessor's own
+// per-containerID annotation is often still present (see
+// pruneDeadContainerAnnotations's doc comment for why that can outlast the
+// pod), and without this dedup the two identical-value annotations would
+// both land in Prefixes and permanently fail every CNI ADD retry for this
+// attachment. Deduplicating here is a hard backstop independent of whether
+// pruning above has run yet.
 func allAdvertisedPrefixes(annotations map[string]string) []string {
+	seen := make(map[string]struct{})
 	var prefixes []string
+	addUnique := func(p string) {
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		prefixes = append(prefixes, p)
+	}
 	for key, value := range annotations {
 		switch {
 		case strings.HasPrefix(key, crdnames.AnnotationAllocatedSubnetIPv6+"."):
-			prefixes = append(prefixes, value)
+			addUnique(value)
 		case strings.HasPrefix(key, crdnames.AnnotationAllocatedSubnetIPv4+"."):
-			prefixes = append(prefixes, value+"/32")
+			addUnique(value + "/32")
 		}
 	}
 	sort.Strings(prefixes)
 	return prefixes
+}
+
+// netNSExistsFn is a variable so tests can override it without needing a
+// real netns bind-mount under /var/run/netns.
+var netNSExistsFn = gc.NetNSExists
+
+// pruneDeadContainerAnnotations removes every per-container annotation
+// (netns plus allocated-subnet-ipv6/ipv4) belonging to a containerID whose
+// recorded netns path no longer exists on this node.
+//
+// Without this, a replaced pod's dead sibling containerID's annotations
+// survive on the shared BGPAdvertisement forever: galactic-router's GC
+// controller (internal/gc.CollectOrphanedCRDs) only ever deletes the whole
+// CRD, and only once every container that has ever referenced it is dead —
+// which never happens while the vpcAttachment has any live pod, i.e.
+// exactly the pod-replacement case this exists to handle. So the set of
+// per-container annotations on a long-lived, frequently-churned
+// vpcAttachment (e.g. a Deployment) grows without bound, and whenever a
+// replacement pod's IPAM allocation reuses a dead sibling's subnet (the
+// common case), allAdvertisedPrefixes' dedup is the only thing standing
+// between that and a rejected update. Pruning here, on the write path that
+// already holds this attachment's current annotation set, is what actually
+// keeps it bounded and self-heals the moment a new container attaches —
+// independent of GC's periodic tick, which for this case never fires at
+// all.
+func pruneDeadContainerAnnotations(annotations map[string]string) {
+	prefix := crdnames.AnnotationNetNS + "."
+	for key, netnsPath := range annotations {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		if netNSExistsFn(netnsPath) {
+			continue
+		}
+		containerIDSuffix := strings.TrimPrefix(key, prefix)
+		delete(annotations, key)
+		delete(annotations, crdnames.AnnotationAllocatedSubnetIPv6+"."+containerIDSuffix)
+		delete(annotations, crdnames.AnnotationAllocatedSubnetIPv4+"."+containerIDSuffix)
+	}
 }
 
 // publishBGPState creates the BGPVRFInstance and BGPAdvertisement CRDs and
@@ -402,6 +462,12 @@ func publishBGPState(
 			if ipv4Addr != "" {
 				adv.Annotations[crdnames.SubnetKeyIPv4(args.ContainerID)] = ipv4Addr
 			}
+			// Prune dead siblings before merging: a replaced pod's stale
+			// annotation must not be allowed to collide with this ADD's own
+			// (often identical, since IPAM re-allocates the same subnet for
+			// the same vpcAttachment identity) prefix — see
+			// pruneDeadContainerAnnotations's doc comment.
+			pruneDeadContainerAnnotations(adv.Annotations)
 			mergedPrefixes = allAdvertisedPrefixes(adv.Annotations)
 			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, mergedPrefixes, vrfID)
 			return nil

--- a/internal/cnibgp/bgp_test.go
+++ b/internal/cnibgp/bgp_test.go
@@ -8,12 +8,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/containernetworking/cni/pkg/skel"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,6 +39,10 @@ const (
 	testRD65000_1  = "65000:1"
 	testVPCHex1234 = "0000000004d2" // decimal 1234
 	testNetns      = "/proc/1/ns/net"
+
+	testUnrelatedAnnotationKey = "some.other/annotation"
+	testLiveNetnsPath          = "/proc/live/ns/net"
+	testDeadNetnsPath          = "/proc/dead/ns/net"
 )
 
 var testScheme = func() *runtime.Scheme {
@@ -370,7 +376,7 @@ func TestAllAdvertisedPrefixesIgnoresOtherAnnotations(t *testing.T) {
 	annotations := map[string]string{
 		crdnames.NetNSKey("cid-a"):      testNetns,
 		crdnames.SubnetKeyIPv4("cid-a"): v4,
-		"some.other/annotation":         "should be ignored",
+		testUnrelatedAnnotationKey:      "should be ignored",
 	}
 
 	got := allAdvertisedPrefixes(annotations)
@@ -378,6 +384,171 @@ func TestAllAdvertisedPrefixesIgnoresOtherAnnotations(t *testing.T) {
 	want := []string{v4 + "/32"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("prefixes = %v, want %v", got, want)
+	}
+}
+
+// TestAllAdvertisedPrefixesDedupesDuplicateCIDR is the regression test for
+// the bug this covers: BGPAdvertisement.spec.prefixes is
+// x-kubernetes-list-type=set, so two annotations that carry the identical
+// CIDR value under different containerID keys — the shape left behind when
+// a pod is replaced and IPAM re-allocates the same subnet for the same
+// vpcAttachment identity, and the old containerID's annotation was never
+// removed — must collapse to one entry rather than reach the API server as
+// a duplicate and reject the update.
+func TestAllAdvertisedPrefixesDedupesDuplicateCIDR(t *testing.T) {
+	const dupeV6 = "fd00:40:ff01::100:0/96"
+	annotations := map[string]string{
+		crdnames.NetNSKey("cid-old"):      testNetns,
+		crdnames.SubnetKeyIPv6("cid-old"): dupeV6,
+		crdnames.NetNSKey("cid-new"):      testNetns,
+		crdnames.SubnetKeyIPv6("cid-new"): dupeV6,
+	}
+
+	got := allAdvertisedPrefixes(annotations)
+
+	want := []string{dupeV6}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("prefixes = %v, want %v (identical CIDR from two containerIDs must collapse to one entry)", got, want)
+	}
+}
+
+func TestAllAdvertisedPrefixesDedupesDuplicateIPv4(t *testing.T) {
+	const dupeV4 = "172.20.1.5"
+	annotations := map[string]string{
+		crdnames.NetNSKey("cid-old"):      testNetns,
+		crdnames.SubnetKeyIPv4("cid-old"): dupeV4,
+		crdnames.NetNSKey("cid-new"):      testNetns,
+		crdnames.SubnetKeyIPv4("cid-new"): dupeV4,
+	}
+
+	got := allAdvertisedPrefixes(annotations)
+
+	want := []string{dupeV4 + "/32"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("prefixes = %v, want %v (identical address from two containerIDs must collapse to one entry)", got, want)
+	}
+}
+
+// ---- pruneDeadContainerAnnotations ------------------------------------------
+
+// withNetNSExistsFn overrides netNSExistsFn for the duration of the test,
+// so pruneDeadContainerAnnotations can be tested without a real netns
+// bind-mount under /var/run/netns.
+func withNetNSExistsFn(t *testing.T, fn func(string) bool) {
+	t.Helper()
+	orig := netNSExistsFn
+	netNSExistsFn = fn
+	t.Cleanup(func() { netNSExistsFn = orig })
+}
+
+func TestPruneDeadContainerAnnotationsRemovesDeadSibling(t *testing.T) {
+	const subnet = "fd00:40:ff01::100:0/96"
+	live := map[string]bool{testLiveNetnsPath: true, testDeadNetnsPath: false}
+	withNetNSExistsFn(t, func(path string) bool { return live[path] })
+
+	annotations := map[string]string{
+		crdnames.NetNSKey("cid-dead"):      testDeadNetnsPath,
+		crdnames.SubnetKeyIPv6("cid-dead"): subnet,
+		crdnames.NetNSKey("cid-live"):      testLiveNetnsPath,
+		crdnames.SubnetKeyIPv6("cid-live"): subnet,
+	}
+
+	pruneDeadContainerAnnotations(annotations)
+
+	want := map[string]string{
+		crdnames.NetNSKey("cid-live"):      testLiveNetnsPath,
+		crdnames.SubnetKeyIPv6("cid-live"): subnet,
+	}
+	if !reflect.DeepEqual(annotations, want) {
+		t.Errorf("annotations = %v, want %v (dead sibling annotations not fully removed)", annotations, want)
+	}
+}
+
+func TestPruneDeadContainerAnnotationsKeepsLiveContainers(t *testing.T) {
+	withNetNSExistsFn(t, func(string) bool { return true })
+
+	annotations := map[string]string{
+		crdnames.NetNSKey("cid-a"):      "/proc/a/ns/net",
+		crdnames.SubnetKeyIPv6("cid-a"): "fd00:10:ff01::1234/96",
+		crdnames.NetNSKey("cid-b"):      "/proc/b/ns/net",
+		crdnames.SubnetKeyIPv4("cid-b"): "172.20.1.5",
+	}
+	want := maps.Clone(annotations)
+
+	pruneDeadContainerAnnotations(annotations)
+
+	if !reflect.DeepEqual(annotations, want) {
+		t.Errorf("annotations = %v, want unchanged %v (every container is still live)", annotations, want)
+	}
+}
+
+func TestPruneDeadContainerAnnotationsIgnoresUnrelatedAnnotations(t *testing.T) {
+	withNetNSExistsFn(t, func(string) bool { return false })
+
+	annotations := map[string]string{
+		testUnrelatedAnnotationKey: "should be untouched",
+	}
+	want := map[string]string{
+		testUnrelatedAnnotationKey: "should be untouched",
+	}
+
+	pruneDeadContainerAnnotations(annotations)
+
+	if !reflect.DeepEqual(annotations, want) {
+		t.Errorf("annotations = %v, want %v (non-netns annotations must never be touched)", annotations, want)
+	}
+}
+
+// TestPublishBGPStateReplacedPodDoesNotDuplicatePrefix is the integration-style
+// regression test for the bug this file fixes end-to-end: a second
+// publishBGPState call for a replaced pod on the same vpcAttachment — same
+// subnet re-allocated by IPAM under a new containerID, old containerID's
+// netns now gone — must succeed, and must not leave two annotations with the
+// same CIDR value in spec.Prefixes.
+func TestPublishBGPStateReplacedPodDoesNotDuplicatePrefix(t *testing.T) {
+	const (
+		nodeName  = "node1"
+		namespace = "default"
+	)
+	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
+
+	router := routerForNode(testRouterName, nodeName, namespace, 65000)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	ipv6Subnet := mustParseCIDR(t, "fd00:40:ff01::100:0/96")
+
+	// Simulate the first pod's ADD, whose netns has since gone away, but
+	// whose annotation — recording the exact same subnet IPAM is about to
+	// re-allocate to the replacement pod below — was never cleaned up.
+	existing := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      advName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				crdnames.NetNSKey("old-container"):      "/proc/gone/ns/net",
+				crdnames.SubnetKeyIPv6("old-container"): ipv6Subnet.String(),
+			},
+		},
+	}
+	k8s := fakeClient(router, existing)
+
+	ipamResult := &cniipam.IPAMResult{IPv6Subnet: ipv6Subnet}
+	cfg := publishConfig{vpc: testVPC, vpcAttachment: testAttachment, ifaceType: ifaceTypeVeth}
+	args := &skel.CmdArgs{ContainerID: "new-container", Netns: testNetns}
+
+	_, err := publishBGPState(args, cfg, nodeName, namespace, ipamResult, testVPCHex1234, k8s)
+	if err != nil {
+		t.Fatalf("publishBGPState: unexpected error: %v", err)
+	}
+
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	if err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: namespace}, got); err != nil {
+		t.Fatalf("get BGPAdvertisement: %v", err)
+	}
+	if len(got.Spec.Prefixes) != 1 || string(got.Spec.Prefixes[0]) != ipv6Subnet.String() {
+		t.Errorf("Prefixes = %+v, want exactly one entry for the re-allocated subnet", got.Spec.Prefixes)
+	}
+	if _, ok := got.Annotations[crdnames.NetNSKey("old-container")]; ok {
+		t.Errorf("annotations = %v, want old-container's dead annotations pruned", got.Annotations)
 	}
 }
 


### PR DESCRIPTION
## Symptom

Pods attaching to a VPC network attachment (e.g. `vpc/vpc40` in `us-central-1-lab`) stuck in `Pending`/`ContainerCreating` forever. Every CNI ADD retry failed identically:

```
apply BGPAdvertisement: BGPAdvertisement.network.datumapis.com "40-40" is
invalid: spec.prefixes[1]: Duplicate value: "fd00:40:ff01::100:0/96"
```

## Root cause

`allAdvertisedPrefixes()` in `internal/cnibgp/bgp.go` collects the CIDR value from every per-containerID subnet annotation on the shared `BGPAdvertisement` and feeds it straight into `spec.Prefixes`, unduplicated.

On pod replacement, IPAM re-allocates the same subnet for the same `vpcAttachment` identity. `galactic-bgp` writes a new annotation under the new containerID; the old containerID's annotation stays (`cmdDel` is a deliberate no-op — cleanup is GC's job). Two annotations, identical CIDR, both land in `spec.Prefixes`: a `x-kubernetes-list-type=set` field. The API server rejects the update as a duplicate, and the ADD retries the same failure forever.

GC is the deeper gap: `internal/gc.CollectOrphanedCRDs` only deletes a whole `BGPAdvertisement`, only once every container that ever referenced it is dead. A Deployment-style replacement always leaves a live pod, so that sweep never fires — the dead sibling's annotation survives indefinitely. GC has no per-annotation pruning path.

## Fix

- `allAdvertisedPrefixes` dedupes by CIDR value — backstop against `spec.Prefixes` ever receiving a duplicate.
- New `pruneDeadContainerAnnotations`, called from `publishBGPState` before merging prefixes, drops every annotation (netns + both subnet keys) for a containerID whose netns no longer exists. Self-heals on the next ADD, independent of GC's tick.

## Tests

- `TestAllAdvertisedPrefixesDedupesDuplicateCIDR` / `...DedupesDuplicateIPv4`
- `TestPruneDeadContainerAnnotationsRemovesDeadSibling` / `...KeepsLiveContainers` / `...IgnoresUnrelatedAnnotations`
- `TestPublishBGPStateReplacedPodDoesNotDuplicatePrefix` — end-to-end: dead container's netns gone, same subnet re-allocated to a new container, `publishBGPState` succeeds with one prefix and the dead annotations gone.

`go build ./...`, `golangci-lint run` (0 issues), `task test:unit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)