### PR TITLE
fix: Clean up leftover host network interfaces after teardown

### DIFF
--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -11,6 +11,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ipam"
+
+	"go.datum.net/galactic/internal/cni/veth"
 )
 
 func cmdDel(args *skel.CmdArgs) error {
@@ -69,10 +71,22 @@ func cmdDel(args *skel.CmdArgs) error {
 			"err", err, "containerID", args.ContainerID, "netns", args.Netns)
 	}
 
-	// Shared resources (VRF, veth, routes, SRv6 ingress, BGPAdvertisement,
-	// BGPVRFInstance) are keyed by (vpc, vpcAttachment) and may still be in use
-	// by another pod. Deleting them here races with cmdAdd during pod restarts —
-	// the old pod's DEL can destroy resources the new pod just created.
+	// Delete this attachment's own host/guest veth pair. Unlike the VRF and
+	// BGP CRDs below, the veth pair is genuinely private to this attachment
+	// (see resourceTracker.cleanup's doc comment) — no sibling pod can ever
+	// still be depending on it, so there is no ADD-race to defer to GC for.
+	// Deleting the host end removes both ends of the pair regardless of
+	// which netns the guest end currently lives in, so this reclaims the
+	// interface even when the host-device DEL step above failed or no-op'd.
+	if err := veth.Delete(vpc, vpcAtt); err != nil {
+		slog.Warn("DEL: failed to delete host/guest veth pair", "err", err,
+			"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
+	}
+
+	// Shared resources (VRF, BGPAdvertisement, BGPVRFInstance) are keyed by
+	// (vpc, vpcAttachment) or (vpc, node) and may still be in use by another
+	// pod. Deleting them here races with cmdAdd during pod restarts — the old
+	// pod's DEL can destroy resources the new pod just created.
 	//
 	// The GC runs periodically and removes orphaned resources safely by checking
 	// whether any live container still references them. See gc.CollectOrphanedCRDs

--- a/internal/cnitap/ops_del.go
+++ b/internal/cnitap/ops_del.go
@@ -11,6 +11,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ipam"
+
+	"go.datum.net/galactic/internal/cni/tap"
 )
 
 // cmdDel mirrors internal/cni's own cmdDel, minus everything guest-netns
@@ -37,11 +39,25 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Shared resources (VRF, tap, routes, SRv6 ingress, BGPAdvertisement,
-	// BGPVRFInstance) are keyed by (vpc, vpcAttachment) and may still be in
-	// use by another VM. Deleting them here races with cmdAdd during
-	// restarts, so cleanup is left to galactic-router's GC controller — see
-	// internal/cni's own cmdDel for the full reasoning.
+	// Delete this attachment's own tap device. Unlike the VRF and BGP CRDs
+	// below, the tap device is genuinely private to this attachment (see
+	// resourceTracker.cleanup's doc comment) — no sibling VM can ever still
+	// be depending on it, so there is no ADD-race to defer to GC for.
+	//
+	// A VMM (Kata/Firecracker/QEMU) that still holds the tap's fd open at
+	// this point can make the kernel delete lazily rather than immediately,
+	// but never blocks or fails this call — tap.Delete is best-effort and
+	// idempotent either way, matching every other step in this function.
+	if err := tap.Delete(vpc, vpcAtt); err != nil {
+		slog.Warn("DEL: failed to delete tap device", "err", err,
+			"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
+	}
+
+	// Shared resources (VRF, BGPAdvertisement, BGPVRFInstance) are keyed by
+	// (vpc, vpcAttachment) or (vpc, node) and may still be in use by another
+	// VM. Deleting them here races with cmdAdd during restarts, so cleanup
+	// is left to galactic-router's GC controller — see internal/cni's own
+	// cmdDel for the full reasoning.
 	slog.Info("DEL: skipping shared resource cleanup (handled by GC)",
 		"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 


### PR DESCRIPTION
## Summary

After a pod or VM detached, its host-side network interface was left behind once garbage collection reclaimed the shared VRF it depended on, so dangling devices accumulated on nodes over time. The CNI plugin now deletes that interface immediately on teardown instead of waiting on garbage collection, which never reclaimed it in the first place. This only affects the interface private to the workload being removed — the VRF and BGP state it shares with other attachments still go through the existing garbage-collection safeguards, so pod restarts still can't race each other.

## Test plan

- [ ] Detaching a pod removes its host interface immediately, without waiting on garbage collection
- [ ] Detaching a VM removes its tap device immediately, without waiting on garbage collection
- [ ] Existing attach/rollback behavior on a failed attach is unaffected