### PR TITLE
fix: read host conflist via shared hostconf package

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -6,7 +6,6 @@ package installer
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,6 +29,7 @@ import (
 
 	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/gc"
+	"go.datum.net/galactic/internal/hostconf"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/metrics"
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
@@ -72,52 +72,6 @@ var (
 	SourceRouteBinary      = "/galactic-route"
 	SourceHostDeviceBinary = "/host-device"
 )
-
-// HostConf holds node-local settings read from the conflist.
-type HostConf struct {
-	NodeName   string `json:"node_name"`
-	Kubeconfig string `json:"kubeconfig"`
-	Namespace  string `json:"namespace"`
-	LogFile    string `json:"log_file"`
-	LogLevel   string `json:"log_level,omitempty"`
-}
-
-type conflistEnvelope struct {
-	CNIVersion string            `json:"cniVersion"`
-	Name       string            `json:"name"`
-	Plugins    []json.RawMessage `json:"plugins"`
-}
-
-// loadHostConf is a helper to read the HostConf from HostConflist.
-func loadHostConf(filePath string) (*HostConf, error) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	var env conflistEnvelope
-	if err := json.Unmarshal(data, &env); err != nil {
-		return nil, fmt.Errorf("parse conflist envelope: %w", err)
-	}
-
-	for _, raw := range env.Plugins {
-		var meta struct {
-			Type string `json:"type"`
-		}
-		if err := json.Unmarshal(raw, &meta); err != nil {
-			continue
-		}
-		if meta.Type == "galactic-cni" {
-			var conf HostConf
-			if err := json.Unmarshal(raw, &conf); err != nil {
-				return nil, fmt.Errorf("parse host CNI config: %w", err)
-			}
-			return &conf, nil
-		}
-	}
-
-	return nil, fmt.Errorf("conflist at %q does not contain a plugin with type \"galactic-cni\"", filePath)
-}
 
 // atomicWriteFile writes data to destPath atomically.
 func atomicWriteFile(destPath string, content []byte, mode os.FileMode) error {
@@ -462,7 +416,7 @@ func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathSta
 	// above, GC is a background maintenance task, not a hard requirement
 	// for the datapath to forward traffic -- it just means this node's
 	// sweep ticker stays inert until the next restart.
-	if hostConf, err := loadHostConf(HostConflist); err != nil {
+	if hostConf, err := hostconf.Load(HostConflist, hostconf.PluginType); err != nil {
 		slog.Warn("eBPF vrf_table GC sweep disabled: failed to load host conf", "err", err)
 	} else if k8sClient, err := newK8sClientFn(); err != nil {
 		slog.Warn("eBPF vrf_table GC sweep disabled: failed to create k8s client", "err", err)
@@ -656,7 +610,7 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 // getLogFileHostPath resolves the CNI log file path from HostConflist
 // and prefixes it with "/host" since the container views host filesystem via /host mount.
 func getLogFileHostPath() string {
-	hostConf, err := loadHostConf(HostConflist)
+	hostConf, err := hostconf.Load(HostConflist, hostconf.PluginType)
 	if err != nil || hostConf.LogFile == "" {
 		return filepath.Join("/host", config.DefaultLogFile)
 	}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/hostconf"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 )
 
@@ -184,7 +185,7 @@ func TestBootstrap(t *testing.T) {
 		assertBinaryCopied(t, filepath.Join(HostBinDir, "galactic-route"), "route-content")
 
 		// Verify conflist written
-		conflist, err := loadHostConf(HostConflist)
+		conflist, err := hostconf.Load(HostConflist, hostconf.PluginType)
 		if err != nil {
 			t.Fatalf("failed to read conflist: %v", err)
 		}
@@ -263,7 +264,7 @@ func TestBootstrap(t *testing.T) {
 			t.Fatalf("Bootstrap failed unexpectedly: %v", err)
 		}
 
-		conflist, err := loadHostConf(HostConflist)
+		conflist, err := hostconf.Load(HostConflist, hostconf.PluginType)
 		if err != nil {
 			t.Fatalf("failed to read conflist: %v", err)
 		}
@@ -289,7 +290,7 @@ func TestBootstrap(t *testing.T) {
 			t.Fatalf("Bootstrap failed unexpectedly: %v", err)
 		}
 
-		conflist, err := loadHostConf(HostConflist)
+		conflist, err := hostconf.Load(HostConflist, hostconf.PluginType)
 		if err != nil {
 			t.Fatalf("failed to read conflist: %v", err)
 		}

--- a/internal/installer/manifest_test.go
+++ b/internal/installer/manifest_test.go
@@ -16,11 +16,11 @@ import (
 
 // TestDaemonsetManifest_RunContainerMountsHostConflistDir is a regression
 // test for a manifest/code mismatch that shipped silently: startEBPFDatapath
-// (and getLogFileHostPath) call loadHostConf(HostConflist) from inside
+// (and getLogFileHostPath) call hostconf.Load(HostConflist, ...) from inside
 // whichever container runs the installer's "run" command
 // (credential-refresh in config/cni/daemonset.yaml). If that container's
 // volumeMounts don't cover the host directory HostConflist lives under,
-// loadHostConf fails on every node, and the eBPF vrf_table GC sweep (and
+// hostconf.Load fails on every node, and the eBPF vrf_table GC sweep (and
 // log-rotation's host-path lookup) permanently disables itself with only a
 // slog.Warn("eBPF vrf_table GC sweep disabled: ...") to show for it --
 // config/cni/daemonset.yaml previously mounted cni-net-dir into the
@@ -51,7 +51,7 @@ func TestDaemonsetManifest_RunContainerMountsHostConflistDir(t *testing.T) {
 	}
 
 	// Find the container that invokes `/galactic-cni run` -- that's the one
-	// that calls loadHostConf(HostConflist) at runtime.
+	// that calls hostconf.Load(HostConflist, ...) at runtime.
 	var runContainerName string
 	var mountPaths []string
 	found := false
@@ -77,7 +77,7 @@ func TestDaemonsetManifest_RunContainerMountsHostConflistDir(t *testing.T) {
 	hostConflistDir := filepath.Dir(hostConflistDefault)
 	if !slices.Contains(mountPaths, hostConflistDir) {
 		t.Errorf("container %q in %s does not mount %s (needed to read HostConflist=%s via "+
-			"loadHostConf; without it the eBPF vrf_table GC sweep and log-rotation host-path "+
+			"hostconf.Load; without it the eBPF vrf_table GC sweep and log-rotation host-path "+
 			"lookup silently disable themselves on every node); mounted paths: %v",
 			runContainerName, manifestPath, hostConflistDir, hostConflistDefault, mountPaths)
 	}


### PR DESCRIPTION
## Summary

The CNI installer read the node's static conflist with its own inline copy of the read-parse-match logic, hardcoded to a single plugin type. A shared package already does this for every other binary in the CNI chain, so a recent fix to the shared missing-file behavior landed in four copies and skipped this fifth one. The installer now calls that shared loader instead of carrying its own copy.

## Test plan

- [ ] Installer bootstrap still writes a valid conflist and Run still resolves host settings from it

Fixes #341
