### PR TITLE
fix: mark BGPAdvertisements that never requested addressing

### DIFF
--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -462,6 +462,17 @@ func publishBGPState(
 			if ipv4Addr != "" {
 				adv.Annotations[crdnames.SubnetKeyIPv4(args.ContainerID)] = ipv4Addr
 			}
+			// ipamResult is nil when this attachment's config carries no
+			// "ipam" block at all (e.g. a tap workload managing its own
+			// addressing) — mark the advertisement so its empty
+			// spec.prefixes reads as intentional, not as addressing that
+			// silently failed to arrive (#342). Cleared the moment any ADD
+			// for this attachment does carry an allocation.
+			if ipamResult == nil {
+				adv.Annotations[crdnames.AnnotationNoAddressing] = crdnames.AnnotationNoAddressingValue
+			} else {
+				delete(adv.Annotations, crdnames.AnnotationNoAddressing)
+			}
 			// Prune dead siblings before merging: a replaced pod's stale
 			// annotation must not be allowed to collide with this ADD's own
 			// (often identical, since IPAM re-allocates the same subnet for

--- a/internal/cnibgp/bgp_test.go
+++ b/internal/cnibgp/bgp_test.go
@@ -552,6 +552,85 @@ func TestPublishBGPStateReplacedPodDoesNotDuplicatePrefix(t *testing.T) {
 	}
 }
 
+// TestPublishBGPStateNilIPAMMarksNoAddressing verifies that an attachment
+// with no IPAM allocation at all (e.g. a tap workload managing its own
+// addressing) gets crdnames.AnnotationNoAddressing set on its
+// BGPAdvertisement — so its empty spec.Prefixes reads as intentional, not as
+// addressing that silently failed to arrive (#342).
+func TestPublishBGPStateNilIPAMMarksNoAddressing(t *testing.T) {
+	const (
+		nodeName  = "node1"
+		namespace = "default"
+	)
+	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
+
+	router := routerForNode(testRouterName, nodeName, namespace, 65000)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	k8s := fakeClient(router)
+
+	cfg := publishConfig{vpc: testVPC, vpcAttachment: testAttachment, ifaceType: ifaceTypeTap}
+	args := &skel.CmdArgs{ContainerID: "self-addressed-container", Netns: testNetns}
+
+	if _, err := publishBGPState(args, cfg, nodeName, namespace, nil, testVPCHex1234, k8s); err != nil {
+		t.Fatalf("publishBGPState: unexpected error: %v", err)
+	}
+
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	if err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: namespace}, got); err != nil {
+		t.Fatalf("get BGPAdvertisement: %v", err)
+	}
+	if len(got.Spec.Prefixes) != 0 {
+		t.Errorf("Prefixes = %+v, want empty for an attachment with no IPAM allocation", got.Spec.Prefixes)
+	}
+	if got.Annotations[crdnames.AnnotationNoAddressing] != crdnames.AnnotationNoAddressingValue {
+		t.Errorf("annotations = %v, want %s=%s", got.Annotations,
+			crdnames.AnnotationNoAddressing, crdnames.AnnotationNoAddressingValue)
+	}
+}
+
+// TestPublishBGPStateIPAMClearsNoAddressing verifies that once an attachment
+// does carry an IPAM allocation, crdnames.AnnotationNoAddressing is cleared —
+// covering an attachment whose config changes, or a retried ADD that now
+// resolves an allocation after a previous attempt ran without one.
+func TestPublishBGPStateIPAMClearsNoAddressing(t *testing.T) {
+	const (
+		nodeName  = "node1"
+		namespace = "default"
+	)
+	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
+
+	router := routerForNode(testRouterName, nodeName, namespace, 65000)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	existing := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      advName,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				crdnames.AnnotationNoAddressing: crdnames.AnnotationNoAddressingValue,
+			},
+		},
+	}
+	k8s := fakeClient(router, existing)
+
+	ipv6Subnet := mustParseCIDR(t, "fd00:40:ff01::100:0/96")
+	ipamResult := &cniipam.IPAMResult{IPv6Subnet: ipv6Subnet}
+	cfg := publishConfig{vpc: testVPC, vpcAttachment: testAttachment, ifaceType: ifaceTypeVeth}
+	args := &skel.CmdArgs{ContainerID: "addressed-container", Netns: testNetns}
+
+	if _, err := publishBGPState(args, cfg, nodeName, namespace, ipamResult, testVPCHex1234, k8s); err != nil {
+		t.Fatalf("publishBGPState: unexpected error: %v", err)
+	}
+
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	if err := k8s.Get(context.Background(), client.ObjectKey{Name: advName, Namespace: namespace}, got); err != nil {
+		t.Fatalf("get BGPAdvertisement: %v", err)
+	}
+	if _, ok := got.Annotations[crdnames.AnnotationNoAddressing]; ok {
+		t.Errorf("annotations = %v, want %s cleared once an allocation exists",
+			got.Annotations, crdnames.AnnotationNoAddressing)
+	}
+}
+
 // ---- buildAdvertisementSpec -------------------------------------------------
 
 func TestBuildAdvertisementSpec(t *testing.T) {

--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -34,6 +34,27 @@ const AnnotationAllocatedSubnetIPv4 = "galactic.datum.net/allocated-subnet-ipv4"
 // full key appends a truncated container ID; see NetNSKey.
 const AnnotationNetNS = "galactic.datum.net/netns"
 
+// AnnotationNoAddressing marks a BGPAdvertisement whose spec.prefixes is
+// empty by design — the attachment's config carries no "ipam" block, so no
+// address was ever requested for it (a VM managing its own addressing is a
+// supported case; see internal/cnitap). Unlike the annotations above, this
+// one is not keyed per container ID: every container attaching under the
+// same VPCAttachment shares the same master-plugin config, so they always
+// agree on whether addressing was requested, and the value only needs to
+// reflect the most recent ADD.
+//
+// Without this, an empty spec.prefixes cannot be told apart from one whose
+// addressing silently failed to arrive (#342) — the same failure #327 closed
+// for the case where a stale config caused it. Set to
+// AnnotationNoAddressingValue whenever publishBGPState runs with a nil
+// *cniipam.IPAMResult, cleared otherwise.
+const AnnotationNoAddressing = "galactic.datum.net/no-addressing"
+
+// AnnotationNoAddressingValue is the only value AnnotationNoAddressing is
+// ever set to — a named constant instead of a literal "true" purely so
+// callers and tests share one spelling.
+const AnnotationNoAddressingValue = "true"
+
 // containerIDLen is the number of characters used from a container ID in
 // annotation keys. Kubernetes limits the name part of an annotation key to
 // 63 bytes. The longest prefix sharing this constant is


### PR DESCRIPTION
## Summary

An attachment with no IPAM allocation — a tap workload managing its own addressing, a supported case — still gets a BGPAdvertisement created with an empty prefix list, indistinguishable from one whose addressing silently failed. The object still has to exist either way: GC treats "no BGPAdvertisement for this VPC/node" as the signal that the shared VRF and its eBPF registration are safe to reclaim, and those are set up the same for self-addressed and addressed attachments alike. The advertisement now carries an annotation marking that no addressing was ever requested, so an empty prefix list always states why.

## Test plan

- [ ] An attachment with no ipam block gets the no-addressing annotation and an empty prefix list
- [ ] An attachment with an allocation has the annotation cleared

Fixes #342
