### PR TITLE
fix: flush routing table on the legacy-name VRF removal path

### DIFF
--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -361,11 +361,30 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 		if !ok {
 			// Not a current-shape name — this is where a legacy VRF collected
 			// by vpcFromVRFName lands. Delete the interface we actually
-			// observed, by name.
+			// observed, by name, but flush its routing table first — the
+			// same order vrf.Delete uses — so this path leaves behind the
+			// same state as the one above rather than leaning on Add's own
+			// flush-on-reuse to clean up a table this path skipped (#343).
 			link, err := netlink.LinkByName(name)
 			if err != nil {
 				// Already gone — not an error.
 				continue
+			}
+			if vrfLink, ok := link.(*netlink.Vrf); ok {
+				if flushErr := vrf.FlushTable(vrfLink.Table); flushErr != nil {
+					slog.Error("GC: failed to flush routing table for orphaned VRF by name",
+						"name", name, "table", vrfLink.Table, "err", flushErr)
+					result.Errors++
+					continue
+				}
+			} else {
+				// CollectOrphanedVRFs only ever collects names from
+				// vrf.ListVRFLinks, which filters to *netlink.Vrf — this
+				// branch means the interface changed kind between that scan
+				// and this delete. Nothing to flush; fall through and
+				// remove whatever is there now.
+				slog.Warn("GC: orphaned VRF name no longer resolves to a VRF interface, skipping flush",
+					"name", name)
 			}
 			if delErr := netlink.LinkDel(link); delErr != nil {
 				slog.Error("GC: failed to delete orphaned VRF by name",

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -61,7 +61,7 @@ func Add(vpc string) error {
 		return err
 	}
 
-	if err := flush(vrfID); err != nil {
+	if err := FlushTable(vrfID); err != nil {
 		return err
 	}
 
@@ -108,7 +108,7 @@ func Delete(vpc string) error {
 		return nil // VRF already gone — idempotent
 	}
 
-	if err := flush(vrfID); err != nil {
+	if err := FlushTable(vrfID); err != nil {
 		return err
 	}
 
@@ -136,7 +136,19 @@ func Exists(vpc string) error {
 	return nil
 }
 
-func flush(vrfID uint32) error {
+// FlushTable removes every IPv4 and IPv6 route from the given Linux routing
+// table ID. Add calls this before creating a VRF on a reused table ID (a
+// table can be reused if a previous VRF using it was removed without going
+// through Delete, e.g. a hard node reboot), and Delete calls it before
+// removing the VRF interface — so a stale table is always cleared on reuse
+// rather than inherited.
+//
+// Exported so internal/gc's legacy-name fallback in RemoveOrphanedVRFs (a
+// pre-rename VRF interface Delete can't resolve by name, so it removes the
+// link directly instead of going through Delete) can flush the table itself
+// before removing the link, and get the same guarantee Delete gives the
+// normal path — see RemoveOrphanedVRFs' own doc comment and #343.
+func FlushTable(vrfID uint32) error {
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		routes, err := netlink.RouteListFiltered(
 			family,


### PR DESCRIPTION
## Summary

The garbage collector has two ways to remove a stranded VRF. One flushes the routing table before removing the interface; the other, used for pre-rename VRF names that can't be resolved back to a VPC, removed the interface directly. Nothing leaked because VRF creation flushes any reused table before handing it out, but that made the shorter path's safety depend on a guarantee enforced somewhere else, undocumented. Both paths now flush the table in the same order before removing the interface.

## Test plan

- [ ] `task test:unit` and `task lint` pass

Fixes #343
