### PR TITLE
fix(gateway): withdraw advertisements by label, not reconstructed names

### DIFF
--- a/docs/plans/367-networkrule-teardown-label-selector.md
+++ b/docs/plans/367-networkrule-teardown-label-selector.md
@@ -1,0 +1,247 @@
+# Implementation Plan — Withdraw Every Advertisement a NetworkRule Ever Created
+
+- **Issue:** [datum-cloud/galactic#367](https://github.com/datum-cloud/galactic/issues/367) — "A rule created
+  before its gateway nodes waits hours to be programmed."
+- **Found while reviewing:** #351.
+- **Status:** planning only — no implementation started.
+
+## 1. Issue recap and current status
+
+The issue describes two timing gaps in `internal/controller/networkrule_controller.go`'s
+per-rule lifecycle:
+
+1. **No re-examination when gateway nodes register.** A rule created before any
+   gateway node exists parks at `Accepted=False`/`NoGatewayNodes` and nothing
+   re-queues it — `SetupWithManager` only watched `NetworkRule`, and the
+   zero-nodes comment claimed a re-trigger that the watch graph didn't actually
+   provide.
+2. **Teardown naming can't survive node churn.** Deleting a rule withdraws its
+   `BGPAdvertisement`s by reconstructing their names from
+   `gatewayNodeNames(ctx, r.Client, rule.Namespace)` — the gateway nodes
+   registered *right now*. A node that was registered when the rule was
+   created and has since left the namespace is not in that list, so the
+   advertisement created for it is never named and never withdrawn. The
+   finalizer is removed anyway, leaving a route advertised with no forwarding
+   state behind it.
+
+**Gap 1 is already fixed**, on `main`, by commit `7fe39ec` ("fix(gateway): watch
+NetworkGateway from NetworkRuleReconciler"): `SetupWithManager` now also
+watches `NetworkGateway` via `gatewayToRuleRequests`, which re-queues every
+`NetworkRule` in the namespace on any gateway-node change, and the zero-nodes
+comment was rewritten to describe that watch accurately instead of the
+non-existent re-trigger. Verified by reading current
+`internal/controller/networkrule_controller.go:120-140,244-292` — matches the
+issue's "Desired outcome" items 1 and 2 exactly. **No further work needed for
+gap 1.**
+
+This plan covers **gap 2 only**: teardown discovery.
+
+## 2. Root cause
+
+`bgpAdvertisementNamesForRule(rule, nodeNames)` (`networkrule_controller.go:302`)
+derives each advertisement's name as `rule.Name + "-" + node + "-v4"/"-v6"` for
+every node in `nodeNames`. `applyBGPAdvertisements`
+(`networkgateway_controller.go:474`) uses the identical convention when
+*creating* them — one object per gateway node per non-empty VIP address
+family, name-qualified by that node's own name, because Active-Active means
+every gateway node advertises the same rule independently (see that method's
+doc comment on the AlreadyExists race it fixed).
+
+The two sides agree on the naming convention, but only one of them has a
+stable view of *which nodes ever created one*. Creation is driven by "this
+node is reconciling this rule" — inherently per-node, at whatever moment that
+node is registered. Teardown reconstructs "every node" from
+`gatewayNodeNames` at deletion time, which answers "which nodes are
+registered now," not "which nodes ever were." Membership is not
+monotonic — nodes can be added and removed over a rule's lifetime — so name
+reconstruction from current membership is structurally unable to find
+advertisements for departed nodes. This is the same class of bug gap 1 was:
+inferring historical state from a present-tense list.
+
+## 3. Fix: discover by label, not by reconstructing names
+
+Add a label to every `BGPAdvertisement` a rule owns at creation time, and have
+teardown `List` by that label instead of reconstructing names. A label
+recorded once at creation is immune to membership changing later — it doesn't
+need to be recomputed, so there's nothing for node churn to invalidate.
+
+Owner references (also suggested in the issue's comment) were considered as
+well; see §6 for why this plan proposes the label alone rather than both.
+
+### 3.1 New label constant
+
+Add to `internal/controller/networkrule_controller.go`, next to
+`networkRuleFinalizer` (same file, same convention as the `annotationConfigHash`
+constant in `bgprouter_controller.go` / `crdnames`'s annotation constants —
+this one is a label, not an annotation, since it exists purely to be listed
+against, not read as data):
+
+```go
+// networkRuleLabel is set to rule.Name on every BGPAdvertisement a
+// NetworkRule owns (one per gateway node per non-empty VIP address family —
+// see applyBGPAdvertisements), so reconcileDelete can discover all of them
+// with a List + label selector instead of reconstructing their names from
+// the namespace's *current* gateway-node membership. A node that was
+// registered when the rule was created and has since left would not appear
+// in that reconstruction — see issue #367.
+const networkRuleLabel = "galactic.datum.net/network-rule"
+```
+
+### 3.2 `applyBGPAdvertisements` sets and backfills the label
+
+`networkgateway_controller.go:507-540` — set the label in the `IsNotFound`
+(create) branch's `ObjectMeta`:
+
+```go
+adv = &bgpv1alpha1.BGPAdvertisement{
+    ObjectMeta: metav1.ObjectMeta{
+        Namespace: rule.Namespace,
+        Name:      name,
+        Labels:    map[string]string{networkRuleLabel: rule.Name},
+    },
+    Spec: ...,
+}
+```
+
+And backfill it in the update branch, so any advertisement that predates this
+fix (created by a cluster already running the old code) self-heals the next
+time its owning node reconciles it, rather than being invisible to teardown
+forever:
+
+```go
+advCopy := adv.DeepCopy()
+if advCopy.Labels == nil {
+    advCopy.Labels = map[string]string{}
+}
+advCopy.Labels[networkRuleLabel] = rule.Name
+advCopy.Spec.RouterRef = ...
+```
+
+### 3.3 `reconcileDelete` lists by label instead of reconstructing names
+
+`networkrule_controller.go:201-222` — replace the
+`gatewayNodeNames` + `bgpAdvertisementNamesForRule` loop:
+
+```go
+advList := &bgpv1alpha1.BGPAdvertisementList{}
+if err := r.List(ctx, advList,
+    client.InNamespace(rule.Namespace),
+    client.MatchingLabels{networkRuleLabel: rule.Name},
+); err != nil {
+    return ctrl.Result{}, fmt.Errorf("list BGPAdvertisements for NetworkRule %s/%s teardown: %w",
+        rule.Namespace, rule.Name, err)
+}
+for i := range advList.Items {
+    if delErr := r.Delete(ctx, &advList.Items[i]); delErr != nil && !apierrors.IsNotFound(delErr) {
+        return ctrl.Result{}, fmt.Errorf("withdraw BGPAdvertisement %s: %w", advList.Items[i].Name, delErr)
+    }
+}
+```
+
+This finds every advertisement ever created for the rule regardless of
+whether the node that created it is still registered, closing the gap
+directly — no dependency on node membership at all during teardown.
+
+No RBAC change: `config/gateway/rbac.yaml` already grants `list` on
+`bgpadvertisements` to this ServiceAccount (`galactic-gateway` ClusterRole,
+full CRUD comment already covers create+delete for this exact code path).
+
+### 3.4 Remove now-dead code
+
+- `bgpAdvertisementNamesForRule` (`networkrule_controller.go:302-325`) has no
+  remaining caller once §3.3 lands (it was only ever called from
+  `reconcileDelete`; `applyBGPAdvertisements` constructs its name inline and
+  never called this helper) — delete it.
+- `gatewayNodeNames` is still used elsewhere (`assignPrimaryNode`,
+  `isGatewayNode`) — no change there.
+- Update `applyBGPAdvertisements`'s doc comment
+  (`networkgateway_controller.go:460-473`), which currently says the node
+  qualifier keeps it "shared with networkrule_controller.go's teardown logic,
+  so both sides always agree on which objects exist for a given rule" — that
+  claim is no longer true (teardown no longer depends on the naming
+  convention at all, only on the label) and should be rewritten to say so.
+
+## 4. Testing
+
+`internal/controller/networkrule_controller_test.go`:
+
+- `TestNetworkRuleReconciler_TeardownOrder_WithdrawsBGPBeforeRemovingFinalizer`
+  — its `adv` fixture needs the `networkRuleLabel` set (matching what
+  `applyBGPAdvertisements` would now write) so the label-selector `List`
+  finds it; otherwise this existing test starts failing under the new
+  discovery mechanism.
+- New: `TestNetworkRuleReconciler_TeardownWithdrawsAdvertisementForDepartedNode`
+  — the regression test for the actual bug. Fixture: a `NetworkRule` with the
+  finalizer and a deletion timestamp, a `BGPAdvertisement` labeled for that
+  rule but named with a node (e.g. `testNodeGWB`) that has **no**
+  corresponding `NetworkGateway` object in the fake client (simulating a node
+  that registered, got an advertisement created, then left). Assert the
+  advertisement is still deleted. This is the case the old
+  `gatewayNodeNames`-reconstruction approach could never pass.
+- New: `TestNetworkRuleReconciler_TeardownIgnoresAdvertisementForDifferentRule`
+  — a second rule's differently-labeled advertisement in the same namespace
+  must survive one rule's teardown, guarding against a selector that's too
+  broad (e.g. an empty/missing label match).
+
+`internal/controller/networkgateway_controller_test.go`:
+
+- Extend `TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref`
+  (or add a sibling) to assert the created object carries
+  `networkRuleLabel: rule.Name`.
+- New: `TestNetworkGatewayReconciler_BackfillsLabelOnExistingAdvertisement` —
+  a pre-existing `BGPAdvertisement` without the label, reconciled once,
+  should come out with the label set (covers the self-heal path in §3.2).
+
+## 5. Rollout
+
+Per [[project_galactic_cni_not_production]]'s sibling reasoning for the
+gateway control plane (also pre-production, per this repo's `docs/agents/
+ARCHITECTURE-GATEWAY.md`), there's no back-compat constraint on existing
+`BGPAdvertisement` objects lacking the label — the backfill-on-update in
+§3.2 heals them the next time any gateway node reconciles the rule, which
+happens on every `NetworkRule`/`NetworkGateway` change and at worst by the
+informer's periodic resync. No manual migration step, no deployment ordering
+constraint.
+
+## 6. Alternative considered: owner references
+
+The issue comment suggests owner references as an alternative to (or
+alongside) a label. Considered and set aside for this pass:
+
+- An owner reference from each `BGPAdvertisement` to its `NetworkRule` would
+  give a Kubernetes-GC backstop (dependents get cleaned up once the owner is
+  actually removed from etcd), but that's *after* `reconcileDelete` has
+  already run `RemoveFinalizer` — by the time GC could act, this reconciler's
+  own explicit delete-before-finalizer-removal ordering (the design plan's
+  Teardown Ordering this finalizer exists to guard) has already had to find
+  and delete the objects itself. Owner references don't help *find* them any
+  more directly than a label does; `List` still needs a selector (label or
+  field) either way — `client.Client.List` has no "list by owner reference"
+  filter without also indexing on it, which is the same amount of plumbing
+  as indexing/matching on a label.
+- A label is one field on `ObjectMeta`, no `Scheme`/`controllerutil.
+  SetControllerReference` call, and no risk of colliding with a future
+  legitimate owner (e.g. if `BGPAdvertisement` ever gains a different owner
+  for GC purposes elsewhere in this codebase — it doesn't today, but nothing
+  rules it out).
+- Nothing in this codebase uses owner references today (confirmed: no
+  `SetOwnerReference`/`OwnerReferences` call site anywhere under `internal/`),
+  so a label keeps this fix consistent with the codebase's existing
+  all-explicit-reconciliation style rather than introducing the first
+  dependency on implicit Kubernetes GC behavior.
+
+If a future need arises for Kubernetes-native cascade delete independent of
+this reconciler (e.g. an operator manually deleting a `BGPAdvertisement`
+namespace-wide), owner references can be added later without conflicting with
+the label — they're not mutually exclusive, just not necessary to close this
+issue.
+
+## 7. Open questions for review
+
+- Should the label key also be usable for `internal/gc`'s existing
+  orphan-sweep logic (`gc.CollectOrphanedCRDs`), or is that sweep's
+  containerID-based liveness check (CNI-side attachments) unrelated enough to
+  the gateway's rule-based advertisements that they should stay separate
+  vocabularies? Leaning toward separate — the gateway's `BGPAdvertisement`s
+  and the CNI attach chain's are different producers with different liveness
+  models — but flagging since both ultimately clean up the same CRD kind.

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -459,18 +459,23 @@ func (r *NetworkGatewayReconciler) routerNameForNode(ctx context.Context, namesp
 
 // applyBGPAdvertisements reconciles the BGPAdvertisement object(s) for a
 // single rule — one per non-empty VIP address family, name-qualified by
-// r.NodeName, per bgpAdvertisementNamesForRule's naming convention (shared
-// with networkrule_controller.go's teardown logic, so both sides always
-// agree on which objects exist for a given rule). The node qualifier is
-// required, not cosmetic: this reconciler runs once per gateway node
-// (Active-Active — every gateway node advertises every rule it holds, at
-// its own local preference, see this file's package doc comment), so
-// without it every gateway node in a namespace would compute the exact
-// same name for the same rule and race to create/update a single shared
-// object — confirmed live the first time a rule's primary node differed
-// from the first node to reconcile it: the second node's Create failed
-// with AlreadyExists on every pass, forever, and only the first node's
-// advertisement (and therefore only its BGP path) ever existed.
+// r.NodeName. The node qualifier is required, not cosmetic: this reconciler
+// runs once per gateway node (Active-Active — every gateway node advertises
+// every rule it holds, at its own local preference, see this file's package
+// doc comment), so without it every gateway node in a namespace would
+// compute the exact same name for the same rule and race to create/update a
+// single shared object — confirmed live the first time a rule's primary
+// node differed from the first node to reconcile it: the second node's
+// Create failed with AlreadyExists on every pass, forever, and only the
+// first node's advertisement (and therefore only its BGP path) ever
+// existed.
+//
+// Every object created or touched here is also labeled with
+// networkRuleLabel (backfilled on existing objects too), which is what lets
+// networkrule_controller.go's teardown find every advertisement this rule
+// ever caused across every gateway node — including one for a node that
+// has since left the namespace — without depending on this naming
+// convention at all; see networkRuleLabel's doc comment.
 func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 	ctx context.Context, rule *bgpv1alpha1.NetworkRule, desired gateway.DesiredRule, routerName string,
 ) error {
@@ -510,7 +515,11 @@ func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 		switch {
 		case apierrors.IsNotFound(err):
 			adv = &bgpv1alpha1.BGPAdvertisement{
-				ObjectMeta: metav1.ObjectMeta{Namespace: rule.Namespace, Name: name},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rule.Namespace,
+					Name:      name,
+					Labels:    map[string]string{networkRuleLabel: rule.Name},
+				},
 				Spec: bgpv1alpha1.BGPAdvertisementSpec{
 					RouterRef:       bgpv1alpha1.RouterRef{Name: routerName},
 					AddressFamily:   bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
@@ -530,6 +539,14 @@ func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 		}
 
 		advCopy := adv.DeepCopy()
+		// Backfills networkRuleLabel on an advertisement created before this
+		// label existed, so teardown's label-selector List (see
+		// networkrule_controller.go's reconcileDelete) finds it too — self-
+		// healing, not just a create-time concern.
+		if advCopy.Labels == nil {
+			advCopy.Labels = map[string]string{}
+		}
+		advCopy.Labels[networkRuleLabel] = rule.Name
 		advCopy.Spec.RouterRef = bgpv1alpha1.RouterRef{Name: routerName}
 		advCopy.Spec.AddressFamily = bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN}
 		advCopy.Spec.Prefixes = prefixes

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -390,6 +390,55 @@ func TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref(t
 	if len(adv.Spec.Prefixes) != 1 || adv.Spec.Prefixes[0] != testVIPPrefix {
 		t.Errorf("Prefixes = %v, want [%s]", adv.Spec.Prefixes, testVIPPrefix)
 	}
+	if got := adv.Labels[networkRuleLabel]; got != testRuleName {
+		t.Errorf("Labels[%s] = %q, want %q (networkrule_controller.go's teardown depends on this)",
+			networkRuleLabel, got, testRuleName)
+	}
+}
+
+// TestNetworkGatewayReconciler_BackfillsLabelOnExistingAdvertisement covers
+// applyBGPAdvertisements's update path self-healing an advertisement that
+// was created before networkRuleLabel existed (issue #367) — without this,
+// an advertisement from an older release would stay permanently invisible
+// to NetworkRuleReconciler's teardown List.
+func TestNetworkGatewayReconciler_BackfillsLabelOnExistingAdvertisement(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+	backendRouter, backendAdv := newBackendFixtures()
+	router := newTestRouter()
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+	rule.Status.PrimaryNode = testNodeGWA
+	acceptRule(rule)
+
+	preexisting := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testRuleAdvV4}, // no label
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: testRouterName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testVIPPrefix},
+		},
+	}
+
+	fakeClient := newIndexedClientBuilder(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
+		WithObjects(gwA, router, backendRouter, backendAdv, rule, preexisting).
+		Build()
+
+	engine := newFakeGatewayEngine()
+	r := newGatewayReconciler(fakeClient, scheme, engine, testNodeGWA)
+	req := ctrl.Request{NamespacedName: testRuleKey(testNodeGWA)}
+
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(testRuleAdvV4), adv); err != nil {
+		t.Fatalf("get BGPAdvertisement %s: %v", testRuleAdvV4, err)
+	}
+	if got := adv.Labels[networkRuleLabel]; got != testRuleName {
+		t.Errorf("Labels[%s] = %q, want %q (backfill on update path)", networkRuleLabel, got, testRuleName)
+	}
 }
 
 // TestNetworkGatewayReconciler_PublishesSelfAddress verifies

--- a/internal/controller/networkrule_controller.go
+++ b/internal/controller/networkrule_controller.go
@@ -7,7 +7,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"net/netip"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,6 +28,16 @@ import (
 // NetworkRule deletion: BGP-route withdrawal must complete before
 // NAT/conntrack state is released — see reconcileDelete.
 const networkRuleFinalizer = "galactic.datum.net/networkrule-teardown"
+
+// networkRuleLabel is set to rule.Name on every BGPAdvertisement a
+// NetworkRule owns (one per gateway node per non-empty VIP address family —
+// see NetworkGatewayReconciler.applyBGPAdvertisements), so reconcileDelete
+// can discover all of them with a List + label selector instead of
+// reconstructing their names from the namespace's *current* gateway-node
+// membership. A node that was registered when the rule was created and has
+// since left would not appear in that reconstruction, leaving its
+// advertisement never found and never withdrawn — see issue #367.
+const networkRuleLabel = "galactic.datum.net/network-rule"
 
 // NetworkRuleReconciler owns two pieces of NetworkRule per-object lifecycle
 // that NetworkGatewayReconciler's aggregate, List-driven reconcile loop is
@@ -199,25 +208,23 @@ func (r *NetworkRuleReconciler) reconcileDelete(
 		return ctrl.Result{}, nil
 	}
 
-	nodeNames, err := gatewayNodeNames(ctx, r.Client, rule.Namespace)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("list gateway nodes for NetworkRule %s/%s teardown: %w",
+	// Listed by networkRuleLabel rather than reconstructed from the
+	// namespace's current gateway-node membership (as a name-based lookup
+	// would have to be) — this finds every advertisement this rule ever
+	// caused to be created, including ones for a node that has since left
+	// the namespace. See networkRuleLabel's doc comment and issue #367.
+	advList := &bgpv1alpha1.BGPAdvertisementList{}
+	if err := r.List(ctx, advList,
+		client.InNamespace(rule.Namespace),
+		client.MatchingLabels{networkRuleLabel: rule.Name},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("list BGPAdvertisements for NetworkRule %s/%s teardown: %w",
 			rule.Namespace, rule.Name, err)
 	}
-
-	for _, name := range bgpAdvertisementNamesForRule(rule, nodeNames) {
-		adv := &bgpv1alpha1.BGPAdvertisement{}
-		key := types.NamespacedName{Namespace: rule.Namespace, Name: name}
-		err := r.Get(ctx, key, adv)
-		switch {
-		case apierrors.IsNotFound(err):
-			// already withdrawn
-		case err != nil:
-			return ctrl.Result{}, fmt.Errorf("get BGPAdvertisement %s for teardown: %w", name, err)
-		default:
-			if delErr := r.Delete(ctx, adv); delErr != nil && !apierrors.IsNotFound(delErr) {
-				return ctrl.Result{}, fmt.Errorf("withdraw BGPAdvertisement %s: %w", name, delErr)
-			}
+	for i := range advList.Items {
+		adv := &advList.Items[i]
+		if delErr := r.Delete(ctx, adv); delErr != nil && !apierrors.IsNotFound(delErr) {
+			return ctrl.Result{}, fmt.Errorf("withdraw BGPAdvertisement %s: %w", adv.Name, delErr)
 		}
 	}
 
@@ -289,37 +296,4 @@ func gatewayToRuleRequests(ctx context.Context, c client.Client, obj client.Obje
 		})
 	}
 	return reqs
-}
-
-// bgpAdvertisementNamesForRule returns the deterministic BGPAdvertisement
-// object name(s) for rule — one per gateway node in nodeNames per
-// non-empty VIP address family, matching
-// NetworkGatewayReconciler.applyBGPAdvertisements's naming convention
-// exactly (including the node-name qualifier — see that method's doc
-// comment for why it's required, not cosmetic), so this reconciler's
-// teardown always finds every object that reconciler created across every
-// gateway node, not just the first one to have reconciled this rule.
-func bgpAdvertisementNamesForRule(rule *bgpv1alpha1.NetworkRule, nodeNames []string) []string {
-	var hasV4, hasV6 bool
-	for _, v := range rule.Spec.VIPAddresses {
-		addr, err := netip.ParseAddr(v)
-		if err != nil {
-			continue
-		}
-		if addr.Is4() {
-			hasV4 = true
-		} else {
-			hasV6 = true
-		}
-	}
-	var names []string
-	for _, node := range nodeNames {
-		if hasV4 {
-			names = append(names, rule.Name+"-"+node+"-v4")
-		}
-		if hasV6 {
-			names = append(names, rule.Name+"-"+node+"-v6")
-		}
-	}
-	return names
 }

--- a/internal/controller/networkrule_controller_test.go
+++ b/internal/controller/networkrule_controller_test.go
@@ -364,7 +364,11 @@ func TestNetworkRuleReconciler_TeardownOrder_WithdrawsBGPBeforeRemovingFinalizer
 	rule.DeletionTimestamp = &now
 
 	adv := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testRuleAdvV4},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testRuleAdvV4,
+			Labels:    map[string]string{networkRuleLabel: testRuleName},
+		},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: testRouterName},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
@@ -397,6 +401,99 @@ func TestNetworkRuleReconciler_TeardownOrder_WithdrawsBGPBeforeRemovingFinalizer
 	err = fakeClient.Get(context.Background(), req.NamespacedName, gotRule)
 	if err == nil {
 		t.Fatal("NetworkRule was not removed after finalizer teardown completed")
+	}
+}
+
+// TestNetworkRuleReconciler_TeardownWithdrawsAdvertisementForDepartedNode is
+// the regression test for issue #367: an advertisement created for a node
+// that has since left the namespace (no corresponding NetworkGateway object
+// exists any more) must still be withdrawn on rule teardown. Discovery by
+// networkRuleLabel doesn't depend on the namespace's current gateway-node
+// membership the way reconstructing the name from gatewayNodeNames did.
+func TestNetworkRuleReconciler_TeardownWithdrawsAdvertisementForDepartedNode(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	// Only gw-a is registered now; the advertisement below was created for
+	// gw-b, which has since left.
+	gwA := newTestGateway(testNodeGWA)
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+	rule.Finalizers = []string{networkRuleFinalizer}
+	now := metav1.Now()
+	rule.DeletionTimestamp = &now
+
+	departedNodeAdvName := testRuleName + "-" + testNodeGWB + "-v4"
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      departedNodeAdvName,
+			Labels:    map[string]string{networkRuleLabel: testRuleName},
+		},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: testRouterName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testVIPPrefix},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkRule{}).
+		WithObjects(gwA, rule, adv).
+		Build()
+
+	r := &NetworkRuleReconciler{Client: fakeClient, Scheme: scheme, NodeName: testNodeGWA}
+	req := ctrl.Request{NamespacedName: testRuleKey(testRuleName)}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gotAdv := &bgpv1alpha1.BGPAdvertisement{}
+	err := fakeClient.Get(context.Background(), testRuleKey(departedNodeAdvName), gotAdv)
+	if err == nil {
+		t.Fatal("BGPAdvertisement for a departed node was not withdrawn on NetworkRule deletion")
+	}
+}
+
+// TestNetworkRuleReconciler_TeardownIgnoresAdvertisementForDifferentRule
+// guards against a label selector broad enough to sweep up another rule's
+// advertisement in the same namespace.
+func TestNetworkRuleReconciler_TeardownIgnoresAdvertisementForDifferentRule(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+	rule := newTestRule(testRuleName, "vpc-1", testVIP)
+	rule.Finalizers = []string{networkRuleFinalizer}
+	now := metav1.Now()
+	rule.DeletionTimestamp = &now
+
+	const otherRuleName = "rule-2"
+	otherAdvName := otherRuleName + "-" + testNodeGWA + "-v4"
+	otherAdv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      otherAdvName,
+			Labels:    map[string]string{networkRuleLabel: otherRuleName},
+		},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: testRouterName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testVIPPrefix},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.NetworkRule{}).
+		WithObjects(gwA, rule, otherAdv).
+		Build()
+
+	r := &NetworkRuleReconciler{Client: fakeClient, Scheme: scheme, NodeName: testNodeGWA}
+	req := ctrl.Request{NamespacedName: testRuleKey(testRuleName)}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	gotAdv := &bgpv1alpha1.BGPAdvertisement{}
+	if err := fakeClient.Get(context.Background(), testRuleKey(otherAdvName), gotAdv); err != nil {
+		t.Fatalf("another rule's BGPAdvertisement was incorrectly withdrawn: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

A rule's BGPAdvertisements were withdrawn by rebuilding their names from the gateway nodes registered in the namespace right now. A node that created an advertisement and later left was no longer in that reconstruction, so its advertisement was never found, never withdrawn, and the finalizer was removed anyway — leaving a route advertised with no forwarding state behind it. Advertisements are now labeled with their owning rule at creation (and backfilled on existing ones), so teardown discovers them all by List + label selector instead of depending on current node membership.

## Test plan

- [ ] An advertisement for a node that left the namespace is still withdrawn on rule deletion
- [ ] One rule's teardown never touches another rule's advertisement
- [ ] Build, lint, and unit tests pass

Fixes #367
