### PR TITLE
fix: Restore IPv6-only Cilium networking in containerlab labs

### DIFF
--- a/deploy/containerlab/scripts/deploy-cni.sh
+++ b/deploy/containerlab/scripts/deploy-cni.sh
@@ -29,24 +29,40 @@ for site in dfw sjc iad; do
   echo "Installing galactic-cni on ${site}..."
 
   # Cilium — installed via the cilium CLI (no Helm binary/repo needed;
-  # the CLI vendors the chart itself). What looked like the CLI
-  # "ignoring --set" was actually stale value keys: Cilium's chart
-  # flattened ipv4.enabled/ipv6.enabled into top-level enableIPv4/
-  # enableIPv6, so the old nested --set was a silent no-op against the
-  # current chart and Cilium fell back to its IPv4 default, allocating
-  # from 10.0.0.0/8 — unreachable from these IPv6-only clusters
-  # (ipFamily: ipv6). The clusters need Cilium told to disable IPv4 via
-  # the current flat keys. Tunnel mode is used since Cilium v1.20
-  # requires IPv4 for native routing mode with cluster-pool IPAM.
+  # the CLI vendors the chart itself). There is no "flattened" enableIPv4/
+  # enableIPv6 key in any Cilium chart (checked v1.18.2, the CLI's
+  # unpinned default, and v1.20.0, the CLI's "stable" — both only expose
+  # the nested ipv4.enabled/ipv6.enabled). --set enableIPv4=false/
+  # enableIPv6=true was a silent no-op against those unknown keys, so
+  # Cilium fell back to its real default (ipv4.enabled: true, ipv6.enabled:
+  # false), allocating from 10.0.0.0/8 — unreachable from these IPv6-only
+  # clusters (ipFamily: ipv6) and why CoreDNS/any non-edge-node pod can't
+  # reach the IPv6 [fd00:200::1]:443 apiserver service. Likewise the
+  # cluster-pool IPv6 CIDR lives at ipam.operator.clusterPoolIPv6PodCIDRList
+  # (a list) / clusterPoolIPv6MaskSize, not clusterPoolIPv6.clusterCIDR/
+  # maskSize. Tunnel mode is used since Cilium v1.20 requires IPv4 for
+  # native routing mode with cluster-pool IPAM.
+  # `install` vs `upgrade`: install refuses to touch an already-existing
+  # Helm release ("cannot re-use a name that is still in use") but doesn't
+  # fail the outer script — that error is printed by the *inner* bash -c,
+  # which has no `set -e` of its own, so it falls through to `cilium
+  # status --wait` (which succeeds against the untouched old release) and
+  # docker exec exits 0. Re-running this script against an already-cilium'd
+  # node silently kept serving the old config instead of applying the fix
+  # above. `set -e` inside the inner script plus install-or-upgrade makes
+  # reruns actually idempotent.
   docker exec "${node}" bash -c "
+    set -e
     curl -sL https://github.com/cilium/cilium-cli/releases/download/${CILIUM_VERSION}/cilium-linux-${ARCH}.tar.gz | tar xz -C /usr/local/bin
     chmod +x /usr/local/bin/cilium
-    cilium install \
-      --set enableIPv4=false \
-      --set enableIPv6=true \
+    CILIUM_ACTION=install
+    cilium status &>/dev/null && CILIUM_ACTION=upgrade
+    cilium \${CILIUM_ACTION} \
+      --set ipv4.enabled=false \
+      --set ipv6.enabled=true \
       --set ipam.mode=cluster-pool \
-      --set clusterPoolIPv6.clusterCIDR=fd00:100::/48 \
-      --set clusterPoolIPv6.maskSize=64 \
+      --set ipam.operator.clusterPoolIPv6PodCIDRList='{fd00:100::/48}' \
+      --set ipam.operator.clusterPoolIPv6MaskSize=64 \
       --set cni.exclusive=false \
       --set kubeProxyReplacement=true \
       --set tunnelProtocol=vxlan \

--- a/deploy/containerlab/scripts/deploy-cni.sh
+++ b/deploy/containerlab/scripts/deploy-cni.sh
@@ -21,6 +21,10 @@ GALACTIC_CNI_DIR=$(cd "${SCRIPT_DIR}/../../../config/cni" && pwd)
 CILIUM_VERSION="v0.18.8"
 MULTUS_VERSION="v4.2.3"
 
+# Must match the podSubnet in node_files/{dfw,sjc,iad}/config.yaml.
+CILIUM_POD_CIDR_V6="fd00:100::/48"
+CILIUM_POD_CIDR_V6_MASK_SIZE=64
+
 ARCH=amd64
 if [ "$(uname -m)" = "aarch64" ]; then ARCH=arm64; fi
 
@@ -61,8 +65,8 @@ for site in dfw sjc iad; do
       --set ipv4.enabled=false \
       --set ipv6.enabled=true \
       --set ipam.mode=cluster-pool \
-      --set ipam.operator.clusterPoolIPv6PodCIDRList='{fd00:100::/48}' \
-      --set ipam.operator.clusterPoolIPv6MaskSize=64 \
+      --set ipam.operator.clusterPoolIPv6PodCIDRList='{${CILIUM_POD_CIDR_V6}}' \
+      --set ipam.operator.clusterPoolIPv6MaskSize=${CILIUM_POD_CIDR_V6_MASK_SIZE} \
       --set cni.exclusive=false \
       --set kubeProxyReplacement=true \
       --set tunnelProtocol=vxlan \


### PR DESCRIPTION
## Summary

CoreDNS (and any pod scheduled off the edge-labeled node) sat at 0/1 Ready in the containerlab labs because Cilium silently fell back to IPv4-only pod networking, which can't reach these clusters' IPv6-only Kubernetes service network. The `--set` flags meant to force Cilium into IPv6-only mode referenced keys that don't exist in any Cilium chart, so they were ignored. This switches to the real chart keys and makes the install step idempotent so a rerun actually applies the fix instead of silently keeping the broken config.

> [!NOTE]
> This fixes the install path for a fresh cluster. Live-upgrading an already-broken cluster to IPv6-only may still need manual repair of stale per-node IPAM state left over from the IPv4 allocation.

## Test plan

- [ ] Fresh `task deploy` brings up Cilium IPv6-only and CoreDNS reaches Ready on all three sites
- [ ] Re-running `deploy-cni.sh` against an already-provisioned cluster upgrades Cilium instead of silently no-op'ing
