### PR TITLE
fix(cni): grant galactic-cni get on network-attachment-definitions

### DIFF
--- a/config/galactic-cni/rbac.yaml
+++ b/config/galactic-cni/rbac.yaml
@@ -15,7 +15,7 @@ rules:
   - apiGroups: ["k8s.cni.cncf.io"]
     resources:
       - network-attachment-definitions
-    verbs: ["patch"]
+    verbs: ["get", "patch"]
   - apiGroups: [""]
     resources:
       - nodes


### PR DESCRIPTION
## Summary

`d3c1ca3` (#331) added a `Get` call on the pod's
`NetworkAttachmentDefinition` before creating any kernel state
(`internal/nadpatch.VerifyChainComplete`), but the `galactic-cni`
ClusterRole only granted `patch` on `network-attachment-definitions` —
the verb the later NAD-annotation step needs, not this new pre-check.

Every ADD failed Forbidden before any interface, VRF, or route was
created, wedging every pod attaching through the "private" NAD chain in
`ContainerCreating`.

## Test plan

- Applied to all three `deploy/containerlab` clusters; `task verify`
  passes (bgp-transit, bgp-fabric, bgp-peers, srv6, evpn, gateway,
  ns10–ns40 scenarios all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)