### PR TITLE
ci: cap every CI job with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,11 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    # Without an explicit cap, a hung step (e.g. apt-get stalling against a
+    # flaky mirror -- observed hanging the whole job against GitHub's
+    # default 360-minute job timeout) blocks the PR for hours instead of
+    # failing fast; every job below gets the same treatment.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -50,6 +55,7 @@ jobs:
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -97,6 +103,7 @@ jobs:
   test-unit-root:
     name: Unit Tests (root)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -153,6 +160,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
 
@@ -185,6 +193,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [lint, test-unit, test-unit-root, build]
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

PR #411's `Lint` job hung 6 hours on `apt-get install clang-18 llvm-18 linux-libc-dev`, stuck against a flaky mirror.

GitHub's default 360-minute job timeout eventually cancelled it. `test-e2e` needs `lint`, so it sat `SKIPPED` the whole time.

No job in `ci.yaml` sets `timeout-minutes`. Any hang, anywhere, blocks a PR for hours with no signal something is wrong.

This adds `timeout-minutes` to every job, sized against observed run times (Build ~2m, Unit Tests ~1.5m, Unit Tests (root) ~1m, Lint ~3m, E2E ~5m):

- `lint`, `test-unit`, `test-unit-root`, `build`: 15 minutes
- `test-e2e`: 25 minutes

## Test plan

- [x] Reran the hung `Lint` job on PR #411. It completed in ~3 minutes, well inside the new cap.
- [ ] Watch the next few CI runs for caps that are too tight.