### PR TITLE
fix: Prevent cross-tenant uSID resolution collisions

### DIFF
--- a/.github/actions/install-ebpf-deps/action.yaml
+++ b/.github/actions/install-ebpf-deps/action.yaml
@@ -25,5 +25,12 @@ runs:
     - name: Install clang/llvm/linux-libc-dev
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # -o Acquire::Retries/::*::Timeout: bare `apt-get update` has no
+        # per-request timeout, so a stalled connection to GitHub's default
+        # regional mirror (azure.archive.ubuntu.com has been observed
+        # hanging outright) blocks until the job's own timeout-minutes
+        # finally kills it -- burning the whole budget on jobs #424/#425
+        # both hit. These bound each attempt and retry instead, so a bad
+        # mirror fails in seconds rather than minutes.
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang-18 llvm-18 linux-libc-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,9 +134,13 @@ jobs:
         # same fix and same reasoning as scripts/ci.sh's e2etest case,
         # which needs this for the same underlying reason (SEG6Local
         # END.DT46's VRFTABLE flag) and already does this exact install.
+        #
+        # -o Acquire::Retries/::*::Timeout: see install-ebpf-deps' own
+        # identical flags -- without them this step hung the whole job
+        # against a stalled mirror until timeout-minutes killed it (#425).
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update -qq
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
           sudo modprobe vrf
 
       - name: Install eBPF build dependencies

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -462,7 +462,7 @@ func buildDesiredRule(
 		if err != nil {
 			return gateway.DesiredRule{}, fmt.Errorf("invalid backend address %q: %w", b.Address, err)
 		}
-		usid, err := sidIndex.resolveUSID(addr)
+		usid, err := sidIndex.resolveUSID(addr, rule.Spec.VPCRef)
 		if err != nil {
 			return gateway.DesiredRule{}, fmt.Errorf("resolve backend %s: %w", addr, err)
 		}

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -216,7 +216,12 @@ func TestNetworkGatewayReconciler_BuildsDesiredStateForAcceptedAssignedRules(t *
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
 	gwB := newTestGateway(testNodeGWB)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
+	// secondary-on-a resolves the identical backend address under a
+	// different tenant (vpc-2) -- its own BGPAdvertisement/BGPVRFInstance,
+	// same shared physical router, proving the two rules' backend
+	// resolutions don't need (or get) cross-tenant help from one another.
+	_, backendAdv2, backendVRF2 := newBackendFixtures("vpc-2")
 
 	primary := newTestRule("primary-on-a", "vpc-1", testVIP)
 	primary.Status.PrimaryNode = testNodeGWA
@@ -242,7 +247,8 @@ func TestNetworkGatewayReconciler_BuildsDesiredStateForAcceptedAssignedRules(t *
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, gwB, backendRouter, backendAdv, primary, secondary, unassigned, notAccepted, deleting).
+		WithObjects(gwA, gwB, backendRouter, backendAdv, backendVRF, backendAdv2, backendVRF2,
+			primary, secondary, unassigned, notAccepted, deleting).
 		Build()
 
 	engine := newFakeGatewayEngine()
@@ -323,14 +329,14 @@ func TestNetworkGatewayReconciler_ExcludesRuleWithUnresolvableBackend(t *testing
 func TestNetworkGatewayReconciler_SkipsBGPAdvertisementWiringWithoutRouter(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWA
 	acceptRule(rule)
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, backendRouter, backendAdv, rule).
+		WithObjects(gwA, backendRouter, backendAdv, backendVRF, rule).
 		Build()
 
 	engine := newFakeGatewayEngine()
@@ -356,7 +362,7 @@ func TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref(t
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
 	gwB := newTestGateway(testNodeGWB)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
 	router := newTestRouter()
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWB // this node (gw-a) is secondary
@@ -364,7 +370,7 @@ func TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref(t
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, gwB, router, backendRouter, backendAdv, rule).
+		WithObjects(gwA, gwB, router, backendRouter, backendAdv, backendVRF, rule).
 		Build()
 
 	engine := newFakeGatewayEngine()
@@ -407,7 +413,7 @@ func TestNetworkGatewayReconciler_CreatesBGPAdvertisementWithComputedLocalPref(t
 func TestNetworkGatewayReconciler_BackfillsLabelOnExistingAdvertisement(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
 	router := newTestRouter()
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWA
@@ -424,7 +430,7 @@ func TestNetworkGatewayReconciler_BackfillsLabelOnExistingAdvertisement(t *testi
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, router, backendRouter, backendAdv, rule, preexisting).
+		WithObjects(gwA, router, backendRouter, backendAdv, backendVRF, rule, preexisting).
 		Build()
 
 	engine := newFakeGatewayEngine()
@@ -498,7 +504,7 @@ func TestNetworkGatewayReconciler_PublishesSelfAddress(t *testing.T) {
 func TestNetworkGatewayReconciler_AdvertisementFailureSurfaces(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
 	router := newTestRouter()
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWA
@@ -506,7 +512,7 @@ func TestNetworkGatewayReconciler_AdvertisementFailureSurfaces(t *testing.T) {
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, router, backendRouter, backendAdv, rule).
+		WithObjects(gwA, router, backendRouter, backendAdv, backendVRF, rule).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(
 				ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption,
@@ -549,7 +555,7 @@ func TestNetworkGatewayReconciler_AdvertisementFailureSurfaces(t *testing.T) {
 func TestNetworkGatewayReconciler_ReportsEngineHealthyOnCleanPass(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	gwA := newTestGateway(testNodeGWA)
-	backendRouter, backendAdv := newBackendFixtures()
+	backendRouter, backendAdv, backendVRF := newBackendFixtures("vpc-1")
 	router := newTestRouter()
 	rule := newTestRule(testRuleName, "vpc-1", testVIP)
 	rule.Status.PrimaryNode = testNodeGWA
@@ -557,7 +563,7 @@ func TestNetworkGatewayReconciler_ReportsEngineHealthyOnCleanPass(t *testing.T) 
 
 	fakeClient := newIndexedClientBuilder(scheme).
 		WithStatusSubresource(&bgpv1alpha1.NetworkGateway{}).
-		WithObjects(gwA, router, backendRouter, backendAdv, rule).
+		WithObjects(gwA, router, backendRouter, backendAdv, backendVRF, rule).
 		Build()
 
 	engine := newFakeGatewayEngine()

--- a/internal/controller/networkrule_controller_test.go
+++ b/internal/controller/networkrule_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"go.datum.net/galactic/internal/crdnames"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
@@ -52,6 +53,13 @@ const (
 	// testTargetRefKind is the TargetRef.Kind used by every fixture in
 	// this test package -- extracted to a constant per goconst.
 	testTargetRefKind = "Node"
+
+	// testBackendRouterID and testRouteTargetValue are shared placeholder
+	// values for BGPRouter.Spec.RouterID / BGPVRFInstance route targets
+	// across this file's and usidresolver_test.go's fixtures -- extracted
+	// to constants per goconst.
+	testBackendRouterID  = "1.1.1.2"
+	testRouteTargetValue = "65000:1"
 )
 
 func newRuleTestScheme(t *testing.T) *runtime.Scheme {
@@ -86,12 +94,23 @@ func newTestRule(name, vpcRef string, vips ...string) *bgpv1alpha1.NetworkRule {
 	}
 }
 
-// newBackendFixtures returns the BGPRouter/BGPAdvertisement pair that
-// resolves testBackendAddr (newTestRule's default backend) to a real SRv6
-// uSID via usidresolver.go's containment matching — without these, every
-// rule newTestRule builds fails buildDesiredRule and is silently excluded
-// from desired state.
-func newBackendFixtures() (*bgpv1alpha1.BGPRouter, *bgpv1alpha1.BGPAdvertisement) {
+// newBackendFixtures returns the BGPRouter/BGPAdvertisement/BGPVRFInstance
+// triple that resolves testBackendAddr (newTestRule's default backend) to a
+// real SRv6 uSID via usidresolver.go's containment-plus-tenant-ownership
+// matching — without these, every rule newTestRule builds for vpcRef fails
+// buildDesiredRule and is silently excluded from desired state.
+//
+// The BGPVRFInstance is what verifyTenantOwnership checks a candidate
+// BGPAdvertisement against: its name is crdnames.BGPVRFInstanceName(vpcRef,
+// testComputeNodeName), the exact deterministic name galactic-bgp would
+// have written for this VPC on this node, and its VRFID must equal the
+// advertisement's own VRFID for the match to be trusted. Two calls with
+// different vpcRef values produce independently-named advertisements and
+// VRF instances (crdnames.BGPAdvertisementName includes vpcRef), so callers
+// resolving more than one VPC in the same fake client never collide.
+func newBackendFixtures(
+	vpcRef string,
+) (*bgpv1alpha1.BGPRouter, *bgpv1alpha1.BGPAdvertisement, *bgpv1alpha1.BGPVRFInstance) {
 	vrfID := int32(testBackendVRFID)
 	function := bgpv1alpha1.SRv6FunctionEndDT46
 	router := &bgpv1alpha1.BGPRouter{
@@ -99,14 +118,14 @@ func newBackendFixtures() (*bgpv1alpha1.BGPRouter, *bgpv1alpha1.BGPAdvertisement
 		Spec: bgpv1alpha1.BGPRouterSpec{
 			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testComputeNodeName},
 			LocalASN:    65000,
-			RouterID:    "1.1.1.2",
+			RouterID:    testBackendRouterID,
 			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			SRv6Locator: testBackendLocator,
 			NodeID:      testBackendNodeID,
 		},
 	}
 	adv := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "backend-adv"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcRef, "attach-1")},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: testBackendRouterName},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
@@ -115,7 +134,17 @@ func newBackendFixtures() (*bgpv1alpha1.BGPRouter, *bgpv1alpha1.BGPAdvertisement
 			Function:      &function,
 		},
 	}
-	return router, adv
+	vrfInstanceName := crdnames.BGPVRFInstanceName(vpcRef, testComputeNodeName)
+	vrfInstance := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: vrfInstanceName},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: testBackendRouterName}},
+			VRFID:              vrfID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+		},
+	}
+	return router, adv, vrfInstance
 }
 
 func testRuleKey(name string) types.NamespacedName {

--- a/internal/controller/usidresolver.go
+++ b/internal/controller/usidresolver.go
@@ -11,13 +11,16 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
 // backendSIDIndex resolves a NetworkRule backend's address to the SRv6 uSID
-// of the worker node it is reachable through, by listing BGPAdvertisement
-// and BGPRouter CRDs directly and matching by prefix containment.
+// of the worker node it is reachable through, by listing BGPAdvertisement,
+// BGPRouter, and BGPVRFInstance CRDs directly and matching by prefix
+// containment — then confirming tenant ownership of the match (see
+// verifyTenantOwnership) before trusting it.
 //
 // This is a genuinely new problem an earlier, rejected design never
 // had to solve: that design tunneled every rule's traffic to a static
@@ -38,26 +41,33 @@ import (
 // Pod address a NetworkRule could plausibly name is covered by exactly the
 // same CRDs this reads.
 //
-// Known limitation: matching is by address containment only, with no
-// tenant-identity check, because BGPAdvertisement carries no VPCRef/
-// VPCAttachmentRef field to disambiguate against (neither does
-// resolveSRv6SID's own matching, which is scoped by the caller already
-// holding the specific BGPAdvertisement in hand). Two different tenants
-// advertising overlapping private address space would resolve
-// ambiguously here. This is a pre-existing gap in the address model, not
-// one this resolver introduces, and is out of scope to close in this
-// phase.
+// Tenant ownership, not address containment alone, is what makes a match
+// trustworthy: BGPAdvertisement carries no VPCRef field of its own to
+// disambiguate against, so two tenants advertising overlapping (e.g.
+// colliding ULA) address space would otherwise resolve to whichever
+// advertisement the list happened to return first — silently routing a
+// packet into the wrong tenant's VRF, not just an ambiguous-but-harmless
+// pick. verifyTenantOwnership closes this the same way NPTv6 and the NAT66
+// shard tier resolve tenant identity elsewhere in this design: from VRF
+// context, never from the address alone. It costs no new CRD field —
+// crdnames.BGPVRFInstanceName(vpc, nodeName) is already the deterministic
+// name galactic-bgp writes a tenant's own BGPVRFInstance under (see
+// internal/cnibgp/bgp.go), so a candidate match's (router, VRFID) pair can
+// be cross-checked directly against the one BGPVRFInstance the calling
+// NetworkRule's own VPCRef actually owns on that router's node.
 type backendSIDIndex struct {
-	routers map[string]*bgpv1alpha1.BGPRouter
-	advs    []*bgpv1alpha1.BGPAdvertisement
+	routers      map[string]*bgpv1alpha1.BGPRouter
+	advs         []*bgpv1alpha1.BGPAdvertisement
+	vrfInstances map[string]*bgpv1alpha1.BGPVRFInstance // keyed by name: crdnames.BGPVRFInstanceName(vpc, nodeName)
 }
 
-// buildBackendSIDIndex lists every BGPRouter and BGPAdvertisement in
-// namespace once, so resolving N backends across a reconcile costs one pair
-// of List calls rather than N. Advertisements with no VRFID/Function set
-// are excluded up front — those carry no SRv6 decap behavior of their own
-// (see NetworkGatewayReconciler's own VIP-preference advertisements, which
-// are exactly that shape) and can never be a backend's location.
+// buildBackendSIDIndex lists every BGPRouter, BGPAdvertisement, and
+// BGPVRFInstance in namespace once, so resolving N backends across a
+// reconcile costs one triple of List calls rather than N. Advertisements
+// with no VRFID/Function set are excluded up front — those carry no SRv6
+// decap behavior of their own (see NetworkGatewayReconciler's own
+// VIP-preference advertisements, which are exactly that shape) and can
+// never be a backend's location.
 func buildBackendSIDIndex(ctx context.Context, c client.Client, namespace string) (*backendSIDIndex, error) {
 	routerList := &bgpv1alpha1.BGPRouterList{}
 	if err := c.List(ctx, routerList, client.InNamespace(namespace)); err != nil {
@@ -80,24 +90,58 @@ func buildBackendSIDIndex(ctx context.Context, c client.Client, namespace string
 		advs = append(advs, &advList.Items[i])
 	}
 
-	return &backendSIDIndex{routers: routers, advs: advs}, nil
+	vrfList := &bgpv1alpha1.BGPVRFInstanceList{}
+	if err := c.List(ctx, vrfList, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPVRFInstances: %w", err)
+	}
+	vrfInstances := make(map[string]*bgpv1alpha1.BGPVRFInstance, len(vrfList.Items))
+	for i := range vrfList.Items {
+		vrfInstances[vrfList.Items[i].Name] = &vrfList.Items[i]
+	}
+
+	return &backendSIDIndex{routers: routers, advs: advs, vrfInstances: vrfInstances}, nil
+}
+
+// verifyTenantOwnership reports whether adv (matched against addr by prefix
+// containment) actually belongs to vpcRef on router's own node, rather than
+// to some other tenant whose advertised prefix happens to contain addr too.
+//
+// galactic-bgp names a tenant's BGPVRFInstance deterministically —
+// crdnames.BGPVRFInstanceName(vpc, nodeName) — and that VRFID is what a
+// BGPAdvertisement's own VRFID must equal for the advertisement to have
+// been originated on vpcRef's behalf on this node. A mismatch (or a
+// missing BGPVRFInstance altogether) means adv belongs to a different
+// tenant that happens to share router's node and, for a colliding-ULA
+// backend address, possibly the same prefix — fail closed rather than
+// trust it.
+func (idx *backendSIDIndex) verifyTenantOwnership(vpcRef string, router *bgpv1alpha1.BGPRouter, vrfID int32) bool {
+	vrfName := crdnames.BGPVRFInstanceName(vpcRef, router.Spec.TargetRef.Name)
+	vrf, ok := idx.vrfInstances[vrfName]
+	return ok && vrf.Spec.VRFID == vrfID
 }
 
 // resolveUSID returns the SRv6 uSID of the worker node addr (a backend
-// Pod's address) is reachable through, per the matching strategy documented
-// on backendSIDIndex.
-func (idx *backendSIDIndex) resolveUSID(addr netip.Addr) (netip.Addr, error) {
+// Pod's address, belonging to vpcRef) is reachable through, per the
+// matching strategy documented on backendSIDIndex. vpcRef scopes the match
+// to advertisements this specific tenant's own BGPVRFInstance actually
+// owns (verifyTenantOwnership) — a prefix-containment hit alone is never
+// sufficient, so two tenants with colliding backend address space can
+// never resolve into each other's VRF.
+func (idx *backendSIDIndex) resolveUSID(addr netip.Addr, vpcRef string) (netip.Addr, error) {
 	for _, adv := range idx.advs {
+		router, ok := idx.routers[adv.Spec.RouterRef.Name]
+		if !ok || router.Spec.SRv6Locator == "" || router.Spec.NodeID == 0 {
+			continue
+		}
+		if !idx.verifyTenantOwnership(vpcRef, router, *adv.Spec.VRFID) {
+			continue // adv belongs to some other tenant on this node; never a candidate for vpcRef
+		}
 		for _, p := range adv.Spec.Prefixes {
 			prefix, err := netip.ParsePrefix(string(p))
 			if err != nil {
 				continue // malformed prefix; not this resolver's job to validate
 			}
 			if !prefix.Contains(addr) {
-				continue
-			}
-			router, ok := idx.routers[adv.Spec.RouterRef.Name]
-			if !ok || router.Spec.SRv6Locator == "" || router.Spec.NodeID == 0 {
 				continue
 			}
 			sid, err := srv6.ComputeSID(router.Spec.SRv6Locator, router.Spec.NodeID, *adv.Spec.VRFID, *adv.Spec.Function)
@@ -110,5 +154,6 @@ func (idx *backendSIDIndex) resolveUSID(addr netip.Addr) (netip.Addr, error) {
 		}
 	}
 	return netip.Addr{}, fmt.Errorf(
-		"no BGPAdvertisement with a matching prefix and SRv6 VRFID/Function found for backend address %s", addr)
+		"no BGPAdvertisement owned by VPC %s with a matching prefix and SRv6 VRFID/Function found for backend address %s",
+		vpcRef, addr)
 }

--- a/internal/controller/usidresolver_test.go
+++ b/internal/controller/usidresolver_test.go
@@ -12,21 +12,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
+// testVPCRef is the tenant identity used by the single-VPC fixtures below.
+// See TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes for
+// the case where two different VPCRef values are in play at once.
+const testVPCRef = "vpc-1"
+
 func TestBackendSIDIndex_ResolvesMatchingPrefix(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	router, adv := newBackendFixtures()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv).Build()
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
 
 	idx, err := buildBackendSIDIndex(context.Background(), fakeClient, testNamespace)
 	if err != nil {
 		t.Fatalf("buildBackendSIDIndex: %v", err)
 	}
 
-	got, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr))
+	got, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr), testVPCRef)
 	if err != nil {
 		t.Fatalf("resolveUSID: %v", err)
 	}
@@ -42,15 +48,15 @@ func TestBackendSIDIndex_ResolvesMatchingPrefix(t *testing.T) {
 
 func TestBackendSIDIndex_NoMatchingPrefixIsError(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	router, adv := newBackendFixtures()
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv).Build()
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
 
 	idx, err := buildBackendSIDIndex(context.Background(), fakeClient, testNamespace)
 	if err != nil {
 		t.Fatalf("buildBackendSIDIndex: %v", err)
 	}
 
-	if _, err := idx.resolveUSID(netip.MustParseAddr("192.0.2.1")); err == nil {
+	if _, err := idx.resolveUSID(netip.MustParseAddr("192.0.2.1"), testVPCRef); err == nil {
 		t.Fatal("resolveUSID: expected error for an address with no matching BGPAdvertisement prefix")
 	}
 }
@@ -63,7 +69,7 @@ func TestBackendSIDIndex_NoMatchingPrefixIsError(t *testing.T) {
 // address, since it carries no SRv6 decap behavior of its own.
 func TestBackendSIDIndex_ExcludesAdvertisementsWithoutVRFIDOrFunction(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	router, _ := newBackendFixtures()
+	router, _, _ := newBackendFixtures(testVPCRef)
 	plainAdv := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "plain-adv"},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
@@ -83,7 +89,7 @@ func TestBackendSIDIndex_ExcludesAdvertisementsWithoutVRFIDOrFunction(t *testing
 		t.Fatalf("advs = %d, want 0 (VRFID/Function-less advertisement must be excluded)", len(idx.advs))
 	}
 
-	if _, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr)); err == nil {
+	if _, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr), testVPCRef); err == nil {
 		t.Fatal("resolveUSID: expected error since the only matching advertisement has no VRFID/Function")
 	}
 }
@@ -101,7 +107,7 @@ func TestBackendSIDIndex_SkipsRouterWithoutSRv6Config(t *testing.T) {
 		Spec: bgpv1alpha1.BGPRouterSpec{
 			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testComputeNodeName},
 			LocalASN:  65000,
-			RouterID:  "1.1.1.2",
+			RouterID:  testBackendRouterID,
 			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			// No SRv6Locator/NodeID.
 		},
@@ -122,7 +128,160 @@ func TestBackendSIDIndex_SkipsRouterWithoutSRv6Config(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildBackendSIDIndex: %v", err)
 	}
-	if _, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr)); err == nil {
+	if _, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr), testVPCRef); err == nil {
 		t.Fatal("resolveUSID: expected error since the matching router has no SRv6Locator/NodeID")
 	}
 }
+
+// TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes is the
+// regression test for the gap usidresolver.go's own doc comment used to
+// flag: two tenants (here vpc-1 and vpc-2) each advertising the *same*
+// backend prefix -- realistic for colliding ULA space across VPCs -- must
+// resolve independently and correctly, never into each other's VRF, even
+// though both candidate BGPAdvertisements pass prefix containment.
+func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+
+	const (
+		vpcA        = "vpc-1"
+		vpcB        = "vpc-2"
+		vpcAVRFID   = int32(100)
+		vpcBVRFID   = int32(101)
+		vpcALocator = "2001:db8:ff01::/48"
+		vpcBLocator = "2001:db8:ff02::/48"
+	)
+
+	// Two tenants, two separate BGPRouters (distinct nodes), each
+	// advertising the identical colliding prefix under its own VPC.
+	routerA := &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "router-vpc-a"},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: "node-a"},
+			LocalASN:    65000,
+			RouterID:    "1.1.1.1",
+			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
+			SRv6Locator: vpcALocator,
+			NodeID:      7,
+		},
+	}
+	routerB := &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "router-vpc-b"},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: "node-b"},
+			LocalASN:    65000,
+			RouterID:    testBackendRouterID,
+			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
+			SRv6Locator: vpcBLocator,
+			NodeID:      8,
+		},
+	}
+
+	advA := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcA, "attach-a")},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: routerA.Name},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testBackendPrefix}, // same prefix as vpc-b, on purpose
+			VRFID:         ptr(vpcAVRFID),
+			Function:      ptr(bgpv1alpha1.SRv6FunctionEndDT46),
+		},
+	}
+	advB := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcB, "attach-b")},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: routerB.Name},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testBackendPrefix}, // colliding ULA: identical to advA's
+			VRFID:         ptr(vpcBVRFID),
+			Function:      ptr(bgpv1alpha1.SRv6FunctionEndDT46),
+		},
+	}
+
+	vrfA := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPVRFInstanceName(vpcA, "node-a")},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: routerA.Name}},
+			VRFID:              vpcAVRFID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+		},
+	}
+	vrfB := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPVRFInstanceName(vpcB, "node-b")},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: routerB.Name}},
+			VRFID:              vpcBVRFID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:2"}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:2"}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(routerA, routerB, advA, advB, vrfA, vrfB).Build()
+
+	idx, err := buildBackendSIDIndex(context.Background(), fakeClient, testNamespace)
+	if err != nil {
+		t.Fatalf("buildBackendSIDIndex: %v", err)
+	}
+
+	addr := netip.MustParseAddr(testBackendAddr) // falls within both advA's and advB's prefix
+
+	gotA, err := idx.resolveUSID(addr, vpcA)
+	if err != nil {
+		t.Fatalf("resolveUSID(vpc-1): %v", err)
+	}
+	wantA, err := srv6.ComputeSID(vpcALocator, routerA.Spec.NodeID, vpcAVRFID, bgpv1alpha1.SRv6FunctionEndDT46)
+	if err != nil {
+		t.Fatalf("srv6.ComputeSID(vpc-1): %v", err)
+	}
+	if gotA != wantA {
+		t.Errorf("resolveUSID(vpc-1) = %s, want %s (vpc-1's own SID, not vpc-2's)", gotA, wantA)
+	}
+
+	gotB, err := idx.resolveUSID(addr, vpcB)
+	if err != nil {
+		t.Fatalf("resolveUSID(vpc-2): %v", err)
+	}
+	wantB, err := srv6.ComputeSID(vpcBLocator, routerB.Spec.NodeID, vpcBVRFID, bgpv1alpha1.SRv6FunctionEndDT46)
+	if err != nil {
+		t.Fatalf("srv6.ComputeSID(vpc-2): %v", err)
+	}
+	if gotB != wantB {
+		t.Errorf("resolveUSID(vpc-2) = %s, want %s (vpc-2's own SID, not vpc-1's)", gotB, wantB)
+	}
+
+	if gotA == gotB {
+		t.Fatal("resolveUSID(vpc-1) and resolveUSID(vpc-2) must never agree for a colliding backend address")
+	}
+}
+
+// TestBackendSIDIndex_UnrelatedTenantVRFIsNotTrusted verifies that a
+// BGPVRFInstance existing for some *other* VPC on the same node doesn't
+// vouch for an advertisement it doesn't actually own -- resolveUSID must
+// still fail rather than fall back to whatever it can find.
+func TestBackendSIDIndex_UnrelatedTenantVRFIsNotTrusted(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, _ := newBackendFixtures(testVPCRef) // note: vrf instance for testVPCRef intentionally omitted
+	otherVRFName := crdnames.BGPVRFInstanceName("vpc-other", testComputeNodeName)
+	otherVRF := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: otherVRFName},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: testBackendRouterName}},
+			VRFID:              testBackendVRFID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:9"}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:9"}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, otherVRF).Build()
+
+	idx, err := buildBackendSIDIndex(context.Background(), fakeClient, testNamespace)
+	if err != nil {
+		t.Fatalf("buildBackendSIDIndex: %v", err)
+	}
+	if _, err := idx.resolveUSID(netip.MustParseAddr(testBackendAddr), testVPCRef); err == nil {
+		t.Fatal("resolveUSID: expected error -- no BGPVRFInstance named for testVPCRef exists, " +
+			"a same-node VRF instance belonging to a different VPC must not be trusted")
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/runtime/gobgp/anycast_spike_test.go
+++ b/internal/runtime/gobgp/anycast_spike_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gobgp
+
+import (
+	"testing"
+
+	api "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	"go.datum.net/galactic/internal/model"
+)
+
+// TestAnycastSpike_TwoGatewayNodesSamePrefixSurviveIndependently is a
+// go/no-go spike for the DSR/Maglev redesign's anycast premise (every
+// gateway node advertises the same VIP prefix at equal preference — see the
+// kitt design doc's §0). The specific risk under test: an earlier, rejected
+// design (docs referenced: `~/.claude/datum/plans/merry-percolating-tulip.md`
+// §4) avoided colocating the gateway in a tenant VRF specifically to sidestep
+// two named GoBGP issues — monitor.go's processEVPNPath skipping local paths
+// before RT match, and rtIndex being 1:1 not fan-out. Reading those two
+// functions directly (see monitor.go) shows both are scoped to advertisements
+// that carry a VRFID/Function (tenant-VRF SEG6 kernel-route installation) —
+// a gateway VIP/self-address advertisement carries neither (see
+// publishSelfAddress's doc comment), so it never reaches that code path at
+// all. Those two issues are real but irrelevant to this design.
+//
+// What actually determines whether two gateway nodes' identical-VIP-prefix
+// advertisements coexist is buildEVPNPaths' RD derivation (paths.go's
+// deriveRD): when DesiredAdvertisement.VRFID is nil (true for a
+// VRFID/Function-less advertisement), the RD falls back to "routerID:0" —
+// different per originating router. RFC 4364 §4.3.2 (and EVPN's identical
+// convention) says PE routers never compare routes for the same prefix
+// carrying different RDs — they're definitionally different routes, not
+// best-path competitors. This test proves gobgp v4, as actually driven by
+// this codebase's real buildEVPNPaths function (not a reimplementation),
+// honors that: two paths for the identical prefix, originated with two
+// different router IDs (simulating two gateway nodes), both survive as
+// independent RIB entries rather than one silently replacing the other.
+func TestAnycastSpike_TwoGatewayNodesSamePrefixSurviveIndependently(t *testing.T) {
+	b := newTestBgpServer(t)
+
+	const vipPrefix = "203.0.113.5/32"
+
+	gw1 := model.DesiredAdvertisement{
+		Name:          "gw1-selfaddr",
+		AddressFamily: model.AddressFamily{AFI: afiL2VPN, SAFI: safiEVPN},
+		Prefixes:      []string{vipPrefix},
+		NextHop:       "2001:db8::1",
+		// VRFID intentionally nil: this is the exact shape
+		// NetworkGatewayReconciler.publishSelfAddress produces for a VIP/
+		// self-address advertisement — no VRFID/Function, per its own doc
+		// comment ("carries no VRFID/Function... not reached via a per-tenant
+		// VRF decap at all").
+	}
+	gw2 := model.DesiredAdvertisement{
+		Name:          "gw2-selfaddr",
+		AddressFamily: model.AddressFamily{AFI: afiL2VPN, SAFI: safiEVPN},
+		Prefixes:      []string{vipPrefix},
+		NextHop:       "2001:db8::2",
+	}
+
+	// Two distinct router IDs, simulating two distinct gateway nodes each
+	// applying their own advertisement locally — buildEVPNPaths is exactly
+	// the function galactic-gateway's own applyEVPN call already uses.
+	if err := buildEVPNPaths(b, gw1, "1.1.1.1", false); err != nil {
+		t.Fatalf("buildEVPNPaths(gw1): %v", err)
+	}
+	if err := buildEVPNPaths(b, gw2, "1.1.1.2", false); err != nil {
+		t.Fatalf("buildEVPNPaths(gw2): %v", err)
+	}
+
+	type observed struct {
+		rd      string
+		nextHop string
+		best    bool
+	}
+	collect := func() []observed {
+		var got []observed
+		listErr := b.ListPath(apiutil.ListPathRequest{
+			TableType: api.TableType_TABLE_TYPE_GLOBAL,
+			Family:    bgp.RF_EVPN,
+		}, func(_ bgp.NLRI, paths []*apiutil.Path) {
+			for _, path := range paths {
+				evpnNLRI, ok := path.Nlri.(*bgp.EVPNNLRI)
+				if !ok {
+					continue
+				}
+				ipPrefix, ok := evpnNLRI.RouteTypeData.(*bgp.EVPNIPPrefixRoute)
+				if !ok {
+					continue
+				}
+				if ipPrefix.IPPrefixLength != 32 || ipPrefix.IPPrefix.String() != "203.0.113.5" {
+					continue
+				}
+				got = append(got, observed{
+					rd:      evpnNLRI.RD().String(),
+					nextHop: evpnMpReachNexthop(path.Attrs),
+					best:    path.Best,
+				})
+			}
+		})
+		if listErr != nil {
+			t.Fatalf("ListPath: %v", listErr)
+		}
+		return got
+	}
+
+	got := collect()
+
+	if len(got) != 2 {
+		t.Fatalf("got %d paths for %s, want 2 (one per gateway node) — got %+v", len(got), vipPrefix, got)
+	}
+
+	rds := map[string]bool{}
+	nextHops := map[string]bool{}
+	for _, o := range got {
+		rds[o.rd] = true
+		nextHops[o.nextHop] = true
+		if !o.best {
+			t.Errorf("path %+v not marked Best — a non-competing (distinct-RD) route should never be "+
+				"suppressed by best-path selection", o)
+		}
+	}
+	if len(rds) != 2 {
+		t.Errorf("expected 2 distinct route distinguishers (one per router ID), got %d: %+v", len(rds), got)
+	}
+	if len(nextHops) != 2 {
+		t.Errorf("expected 2 distinct next-hops (one per gateway node), got %d: %+v", len(nextHops), got)
+	}
+
+	// Withdrawing one gateway node's path must not disturb the other's —
+	// the property that matters for "a gateway node goes down, the other
+	// keeps serving the VIP, unaffected."
+	if err := buildEVPNPaths(b, gw1, "1.1.1.1", true); err != nil {
+		t.Fatalf("withdraw gw1: %v", err)
+	}
+
+	got = collect()
+	if len(got) != 1 {
+		t.Fatalf("after withdrawing gw1, got %d paths, want 1 (gw2's own, untouched) — got %+v", len(got), got)
+	}
+	if got[0].nextHop != "2001:db8::2" {
+		t.Errorf("surviving path next-hop = %q, want gw2's own (2001:db8::2) — gw1's withdrawal must not "+
+			"have touched gw2's independent route", got[0].nextHop)
+	}
+}
+
+// TestAnycastSpike_SameRouterIDCollapsesToOnePath is the negative control
+// for the spike above: it proves the test methodology actually discriminates
+// between "independent routes" and "one replaces the other," rather than
+// the previous test passing by accident (e.g. a bug in the collection
+// helper that always reports 2 regardless of what gobgp actually did). Two
+// advertisements for the identical prefix under the identical router ID
+// share the identical RD ("routerID:0" both times) — the identical NLRI —
+// so the second AddPath call must update the existing route, not create a
+// second one. If this test failed (saw 2 paths), the spike above would not
+// be trustworthy evidence of anything.
+func TestAnycastSpike_SameRouterIDCollapsesToOnePath(t *testing.T) {
+	b := newTestBgpServer(t)
+	const vipPrefix = "203.0.113.5/32"
+
+	first := model.DesiredAdvertisement{
+		Name: "adv", AddressFamily: model.AddressFamily{AFI: afiL2VPN, SAFI: safiEVPN},
+		Prefixes: []string{vipPrefix}, NextHop: "2001:db8::1",
+	}
+	second := model.DesiredAdvertisement{
+		Name: "adv", AddressFamily: model.AddressFamily{AFI: afiL2VPN, SAFI: safiEVPN},
+		Prefixes: []string{vipPrefix}, NextHop: "2001:db8::9", // different next-hop, same RD
+	}
+
+	if err := buildEVPNPaths(b, first, "1.1.1.1", false); err != nil {
+		t.Fatalf("buildEVPNPaths(first): %v", err)
+	}
+	if err := buildEVPNPaths(b, second, "1.1.1.1", false); err != nil { // same router ID as first
+		t.Fatalf("buildEVPNPaths(second): %v", err)
+	}
+
+	var count int
+	var lastNextHop string
+	listErr := b.ListPath(apiutil.ListPathRequest{
+		TableType: api.TableType_TABLE_TYPE_GLOBAL,
+		Family:    bgp.RF_EVPN,
+	}, func(_ bgp.NLRI, paths []*apiutil.Path) {
+		for _, path := range paths {
+			evpnNLRI, ok := path.Nlri.(*bgp.EVPNNLRI)
+			if !ok {
+				continue
+			}
+			ipPrefix, ok := evpnNLRI.RouteTypeData.(*bgp.EVPNIPPrefixRoute)
+			if !ok || ipPrefix.IPPrefixLength != 32 || ipPrefix.IPPrefix.String() != "203.0.113.5" {
+				continue
+			}
+			count++
+			lastNextHop = evpnMpReachNexthop(path.Attrs)
+		}
+	})
+	if listErr != nil {
+		t.Fatalf("ListPath: %v", listErr)
+	}
+	if count != 1 {
+		t.Fatalf("got %d paths for the identical RD, want 1 (second must replace first, not coexist) — "+
+			"if this fails, TestAnycastSpike_TwoGatewayNodesSamePrefixSurviveIndependently's "+
+			"2-paths result is not meaningful evidence of anything", count)
+	}
+	if lastNextHop != "2001:db8::9" {
+		t.Errorf("surviving path next-hop = %q, want %q (the second, more recent advertisement)",
+			lastNextHop, "2001:db8::9")
+	}
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,11 +44,15 @@ case "$COMMAND" in
 
     if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
       echo "--- Loading kernel modules required by galactic"
-      sudo apt-get update -qq
+      # -o Acquire::Retries/::*::Timeout: bare `apt-get update` has no
+      # per-request timeout, so a stalled mirror connection hangs until the
+      # job's own timeout-minutes kills it -- see ci.yaml's identical flags
+      # on this same install for the incident that motivated them (#425).
+      sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update -qq
       # Pin to the running kernel so modprobe finds the modules. The unversioned
       # meta-package may pull a newer kernel's modules than the one the runner is
       # actually executing, which causes modprobe to fail.
-      sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+      sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
     fi
     sudo modprobe vrf
 


### PR DESCRIPTION
## Summary

Two tenants with colliding address prefixes (legitimate under per-VRF NPTv6/overlapping ULA space) could resolve to each other's uSID, because the resolver matched by address containment alone with no ownership check. It now cross-checks the candidate against the requesting tenant's own VRF instance before trusting it. This PR also adds a spike test confirming GoBGP keeps two gateway nodes' identical-VIP-prefix advertisements as independent, non-competing routes — the anycast assumption later PRs in this stack depend on.

## Test plan

- [ ] Two tenants with overlapping prefixes resolve to their own backend, not each other's
- [ ] `task test`