### PR TITLE
feat: Add Maglev consistent-hash ring and RFC 6296 NPTv6 translation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/vishvananda/netlink v1.3.2-0.20260803231012-156a440d85e5
-	go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee
+	github.com/vishvananda/netns v0.0.5
+	go.datum.net/network v0.0.0-20260814001919-96677d648672
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.83.0
@@ -71,7 +72,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -104,3 +104,5 @@ require (
 )
 
 tool github.com/cilium/ebpf/cmd/bpf2go
+
+replace go.datum.net/network => ../network

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/vishvananda/netlink v1.3.2-0.20260803231012-156a440d85e5
-	github.com/vishvananda/netns v0.0.5
-	go.datum.net/network v0.0.0-20260814001919-96677d648672
+	go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.83.0
@@ -72,6 +71,7 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
@@ -104,5 +104,3 @@ require (
 )
 
 tool github.com/cilium/ebpf/cmd/bpf2go
-
-replace go.datum.net/network => ../network

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee h1:7tA+0C1pb/fu/wrgB3Vu+P3nOJK4aNnKaUeB5wzrxVY=
-go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
+go.datum.net/network v0.0.0-20260814001919-96677d648672 h1:Kl1+MHxos5yH7tH6TqvzTmYTi39VsEX2K7zYi7/rm58=
+go.datum.net/network v0.0.0-20260814001919-96677d648672/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/go.sum
+++ b/go.sum
@@ -182,10 +182,6 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-go.datum.net/network v0.0.0-20260812184454-6e8a6c4cbd40 h1:83gROUl0ziuMzB4sBP3OTwpMr1A7nQPkcVFwoZoY77c=
-go.datum.net/network v0.0.0-20260812184454-6e8a6c4cbd40/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
-go.datum.net/network v0.0.0-20260814001919-96677d648672 h1:Kl1+MHxos5yH7tH6TqvzTmYTi39VsEX2K7zYi7/rm58=
-go.datum.net/network v0.0.0-20260814001919-96677d648672/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee h1:7tA+0C1pb/fu/wrgB3Vu+P3nOJK4aNnKaUeB5wzrxVY=
+go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/internal/maglev/doc.go
+++ b/internal/maglev/doc.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package maglev implements Google's Maglev consistent-hashing lookup table
+// (Eisenbrand et al., "Maglev: A Fast and Reliable Software Network Load
+// Balancer", NSDI 2016, §3.4). Every backend gets an independent
+// pseudo-random permutation of table slots (derived from two hashes of its
+// own key, never from any other backend's key or from table contents), and
+// slots are handed out round-robin over each backend's own permutation
+// until the table is full. Two properties fall out of that construction,
+// both load-bearing for how this package is used:
+//
+//   - Given the identical backend set and the identical table size, every
+//     caller builds the byte-identical table — no coordination, no shared
+//     state, no RPC between callers. This is what makes it safe for every
+//     galactic-gateway node to independently compute the same backend
+//     assignment for the design's anycast/DSR forwarding model (see the
+//     design plan's §0): ECMP or BGP reconvergence can move a flow's
+//     packets to a different gateway node mid-connection, and that node
+//     still picks the identical backend, because it built the identical
+//     table from the identical (VIP, backend list) input.
+//   - Removing or adding one backend only reassigns approximately 1/N of
+//     the table's slots (N = backend count) rather than reshuffling
+//     everything, unlike a plain hash(key) % len(backends) scheme (see
+//     TestTable_DisruptionBound). This is the property that makes this
+//     package usable for both this repo's own consistent-hash use sites
+//     without sharing a ring between them: galactic-gateway's ingress
+//     backend-selection ring, and galactic-nat66's independent
+//     shard-placement ring (design plan §3.1) — conflating the two rings
+//     is explicitly not what this package is for; construct one *Table
+//     per ring.
+//
+// This package is pure Go with no kernel/CRD dependency, mirroring
+// internal/plumbing/nptv6's identical split between pure computation and
+// whatever eBPF/CRD wiring consumes it.
+package maglev

--- a/internal/maglev/table.go
+++ b/internal/maglev/table.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package maglev
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+)
+
+// Backend is one candidate a Table can assign lookup-table slots to. Key
+// must be stable and unique within one Table's backend set — it is the sole
+// input to both of a backend's permutation hashes (offsetSeed/skipSeed
+// below), so two backends sharing a Key would collide onto the identical
+// permutation and are not distinguishable by this package.
+type Backend interface {
+	Key() string
+}
+
+// offsetSeed/skipSeed are fixed salts distinguishing the two independent
+// hashes Maglev's permutation generation needs (the paper's h1/h2) from one
+// underlying hash function (fnv1a) applied to Key() + a different seed,
+// rather than requiring two unrelated hash algorithms.
+const (
+	offsetSeed uint64 = 0xda7a5eed0ffce7e5
+	skipSeed   uint64 = 0x5eedda7a1ceb00c5
+)
+
+// Table is a Maglev consistent-hash lookup table over a fixed backend set.
+// See doc.go for the properties this construction gives: deterministic
+// given (backends, size), and a bounded (~1/N) disruption fraction on
+// backend-set changes.
+type Table struct {
+	size     int
+	entries  []Backend
+	backends []Backend // sorted by Key(), for deterministic iteration/inspection
+}
+
+// New builds a Table assigning size lookup slots across backends. size must
+// be prime (see IsPrime) and, per the Maglev paper, at least 100x
+// len(backends) for the disruption-bound property to hold in practice — New
+// does not itself enforce the 100x guidance (a caller validating a small
+// fixed table against a handful of backends in a test is a legitimate use
+// that would otherwise be rejected), but does reject a size that cannot even
+// fit one slot per backend, and any non-prime size (the permutation-cycle
+// argument the paper's disruption bound rests on requires it).
+//
+// backends must be non-empty and every Key() unique; New returns an error
+// otherwise rather than silently building a degenerate table. The input
+// slice order does not affect the result — backends are sorted by Key()
+// internally, so every caller building a Table from the identical backend
+// set (regardless of the order each independently observed it in, e.g. from
+// unordered CRD list results) produces the byte-identical table.
+func New(backends []Backend, size int) (*Table, error) {
+	if len(backends) == 0 {
+		return nil, errors.New("maglev: at least one backend is required")
+	}
+	if size < len(backends) {
+		return nil, fmt.Errorf("maglev: table size %d smaller than backend count %d", size, len(backends))
+	}
+	if !IsPrime(size) {
+		return nil, fmt.Errorf("maglev: table size %d is not prime", size)
+	}
+
+	sorted := make([]Backend, len(backends))
+	copy(sorted, backends)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Key() < sorted[j].Key() })
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i].Key() == sorted[i-1].Key() {
+			return nil, fmt.Errorf("maglev: duplicate backend key %q", sorted[i].Key())
+		}
+	}
+
+	t := &Table{size: size, backends: sorted, entries: make([]Backend, size)}
+	t.fill()
+	return t, nil
+}
+
+// fill runs the paper's round-robin permutation-preference algorithm
+// (§3.4): each backend repeatedly proposes its next-preferred still-free
+// slot (computed lazily from its own offset/skip, never materializing a
+// full n-by-size permutation matrix) until every slot is claimed.
+func (t *Table) fill() {
+	n := len(t.backends)
+	offset := make([]uint64, n)
+	skip := make([]uint64, n)
+	next := make([]uint64, n) // this backend's next permutation step to try
+	claimed := make([]bool, t.size)
+
+	size := uint64(t.size) //nolint:gosec // size validated positive and prime above
+	for i, b := range t.backends {
+		offset[i] = hashKey(b.Key(), offsetSeed) % size
+		skip[i] = hashKey(b.Key(), skipSeed)%(size-1) + 1
+	}
+
+	filled := 0
+	for filled < t.size {
+		for i, b := range t.backends {
+			var slot uint64
+			for {
+				slot = (offset[i] + next[i]*skip[i]) % size
+				next[i]++
+				if !claimed[slot] {
+					break
+				}
+			}
+			claimed[slot] = true
+			t.entries[slot] = b
+			filled++
+			if filled == t.size {
+				break
+			}
+		}
+	}
+}
+
+// Lookup returns the backend assigned to key's slot (key mod the table
+// size). Every Table built from the identical (backends, size) input
+// resolves the identical key to the identical backend — see doc.go.
+func (t *Table) Lookup(key uint64) Backend {
+	return t.entries[key%uint64(t.size)]
+}
+
+// Size returns the table's configured slot count.
+func (t *Table) Size() int { return t.size }
+
+// Backends returns the backend set this table was built from, sorted by
+// Key(). Callers must not mutate the returned slice.
+func (t *Table) Backends() []Backend { return t.backends }
+
+// IsPrime reports whether n is a prime number (n < 2 is never prime). Trial
+// division is intentionally used rather than a probabilistic test: table
+// sizes in this package's use are modest (tens of thousands at most, chosen
+// once per rule/shard-set change, not per packet), and correctness matters
+// more than the marginal speed of a Miller-Rabin implementation here.
+func IsPrime(n int) bool {
+	if n < 2 {
+		return false
+	}
+	if n%2 == 0 {
+		return n == 2
+	}
+	for d := 3; d*d <= n; d += 2 {
+		if n%d == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// hashKey derives one of the two independent hash values Maglev's
+// permutation generation needs from a single fnv1a hash of key's own bytes
+// followed by seed's own 8 bytes — a different seed produces an
+// uncorrelated-in-practice second hash without depending on a second,
+// unrelated hash algorithm.
+func hashKey(key string, seed uint64) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	var seedBuf [8]byte
+	binary.BigEndian.PutUint64(seedBuf[:], seed)
+	_, _ = h.Write(seedBuf[:])
+	return h.Sum64()
+}

--- a/internal/maglev/table_test.go
+++ b/internal/maglev/table_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package maglev
+
+import (
+	"fmt"
+	"testing"
+)
+
+type testBackend string
+
+func (b testBackend) Key() string { return string(b) }
+
+func backends(keys ...string) []Backend {
+	out := make([]Backend, len(keys))
+	for i, k := range keys {
+		out[i] = testBackend(k)
+	}
+	return out
+}
+
+func TestIsPrime(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want bool
+	}{
+		{"Negative", -1, false},
+		{"Zero", 0, false},
+		{"One", 1, false},
+		{"Two", 2, true},
+		{"Three", 3, true},
+		{"Four", 4, false},
+		{"KnownPrime", 65537, true},
+		{"KnownComposite", 65536, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPrime(tt.n); got != tt.want {
+				t.Errorf("IsPrime(%d) = %v, want %v", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		backends  []Backend
+		size      int
+		wantError bool
+	}{
+		{"Empty", backends(), 101, true},
+		{"TooSmall", backends("a", "b"), 1, true},
+		{"NotPrime", backends("a", "b"), 100, true},
+		{"DuplicateKey", backends("a", "a"), 101, true},
+		{"Valid", backends("a", "b", "c"), 101, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.backends, tt.size)
+			if (err != nil) != tt.wantError {
+				t.Errorf("New() error = %v, wantError = %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+// TestNew_Deterministic verifies that two tables built from the same
+// backend set in different input orders produce the byte-identical
+// assignment — the property every gateway node's independent Table
+// construction depends on.
+func TestNew_Deterministic(t *testing.T) {
+	const size = 1009
+	a, err := New(backends("b1", "b2", "b3", "b4"), size)
+	if err != nil {
+		t.Fatalf("New(a): %v", err)
+	}
+	b, err := New(backends("b4", "b3", "b2", "b1"), size)
+	if err != nil {
+		t.Fatalf("New(b): %v", err)
+	}
+
+	for key := range uint64(5000) {
+		if a.Lookup(key).Key() != b.Lookup(key).Key() {
+			t.Fatalf("Lookup(%d) diverged: %q vs %q", key, a.Lookup(key).Key(), b.Lookup(key).Key())
+		}
+	}
+}
+
+// TestTable_EveryEntryAssigned verifies the fill algorithm leaves no slot
+// unclaimed (a nil Backend would panic Lookup's caller).
+func TestTable_EveryEntryAssigned(t *testing.T) {
+	table, err := New(backends("b1", "b2", "b3"), 1009)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for i, e := range table.entries {
+		if e == nil {
+			t.Fatalf("entries[%d] is nil", i)
+		}
+	}
+}
+
+// TestTable_LookupStable verifies repeated Lookup calls for the identical
+// key against the identical table always return the identical backend.
+func TestTable_LookupStable(t *testing.T) {
+	table, err := New(backends("b1", "b2", "b3"), 1009)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	want := table.Lookup(42)
+	for range 10 {
+		if got := table.Lookup(42); got.Key() != want.Key() {
+			t.Errorf("Lookup(42) = %q, want %q", got.Key(), want.Key())
+		}
+	}
+}
+
+// TestTable_DisruptionBound is the classic Maglev property test (the paper's
+// own evaluation, §5.3): removing one backend from an N-backend set should
+// only reassign approximately 1/N of keys, not reshuffle the whole table the
+// way a plain hash(key) % len(backends) scheme would. Some slack over the
+// exact 1/N is allowed (this is an approximate bound, not an exact one).
+func TestTable_DisruptionBound(t *testing.T) {
+	const (
+		n         = 50
+		size      = 65537
+		sampleKey = 20000
+	)
+	keys := make([]string, n)
+	for i := range n {
+		keys[i] = fmt.Sprintf("backend-%d", i)
+	}
+
+	before, err := New(backends(keys...), size)
+	if err != nil {
+		t.Fatalf("New(before): %v", err)
+	}
+	after, err := New(backends(keys[:n-1]...), size) // drop the last backend
+	if err != nil {
+		t.Fatalf("New(after): %v", err)
+	}
+
+	reassigned := 0
+	for key := range uint64(sampleKey) {
+		if before.Lookup(key).Key() != after.Lookup(key).Key() {
+			reassigned++
+		}
+	}
+
+	gotFraction := float64(reassigned) / float64(sampleKey)
+	// Expect ~1/n; allow generous slack (2/n) for statistical noise at this
+	// sample size rather than asserting the exact theoretical bound.
+	maxFraction := 2.0 / float64(n)
+	if gotFraction > maxFraction {
+		t.Errorf("reassigned fraction = %.4f, want <= %.4f (~1/%d, with slack)", gotFraction, maxFraction, n)
+	}
+}
+
+// TestTable_BackendsSortedByKey verifies Backends() returns a deterministic,
+// sorted view regardless of the constructor's input order.
+func TestTable_BackendsSortedByKey(t *testing.T) {
+	table, err := New(backends("z", "a", "m"), 101)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	got := table.Backends()
+	want := []string{"a", "m", "z"}
+	for i, w := range want {
+		if got[i].Key() != w {
+			t.Errorf("Backends()[%d] = %q, want %q", i, got[i].Key(), w)
+		}
+	}
+}

--- a/internal/plumbing/nptv6/doc.go
+++ b/internal/plumbing/nptv6/doc.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package nptv6 implements RFC 6296 stateless IPv6-to-IPv6 Network Prefix
+// Translation for backends presenting a ULA that must appear as a different
+// (public/global) prefix. Unlike NAT66/masquerade (internal/maglev's
+// separately-sharded stateful tier), this is a pure 1:1 prefix rewrite with
+// no connection table: the same source address always maps to the same
+// translated address, in both directions, with no per-flow state anywhere.
+//
+// # Checksum neutrality
+//
+// A naive prefix rewrite would invalidate every TCP/UDP checksum that
+// covers the address (the IPv6 pseudo-header includes both addresses) —
+// RFC 6296 avoids that without ever touching the L4 header by folding a
+// precomputed "adjustment" value into one 16-bit word of the address itself
+// (§3.4), chosen so the address's own 1's-complement checksum contribution
+// is unchanged end to end. Adjustment is a pure function of the two
+// configured prefixes (Mapping.Adjustment) — the same value applies to
+// every address sharing that Mapping and never needs recomputing per
+// packet; Translate then does one 1's-complement add/subtract of that
+// precomputed value into the fixed word, exactly the O(1)-per-packet cost
+// the design plan requires.
+//
+// # Scope: /48-or-shorter prefixes only
+//
+// RFC 6296 defines two placements for the adjustment word: §3.4 (MUST
+// support), for prefixes of length 48 or shorter, fixes it at bits 48..63 —
+// implemented here. §3.5 (SHOULD support), for prefixes of length 49..64,
+// instead scans the address's own Interface Identifier words (64..79,
+// 80..95, 96..111, 112..127, in that order) for the first word that isn't
+// already 0xFFFF and uses that — a genuinely per-address decision, not a
+// fixed location, and not implemented here: this repo's own VPC subnet
+// prefixes are /48 (see deploy/containerlab/resources/tenants/*/nad.yaml's
+// "ipv6_subnet" fields), so the §3.4 case is the one this design actually
+// needs. Mapping.Adjustment and Translate both reject a prefix longer than
+// /48 with a clear error rather than attempting the more complex §3.5
+// scheme incorrectly.
+//
+// # VRFID-keyed, never address-keyed
+//
+// This package itself has no notion of a VRF or tenant at all — a Mapping
+// is just two prefixes. Scoping by VRFID (so two tenants may configure the
+// identical ULAPrefix without collision) is the caller's job: the eBPF-side
+// table this package's Adjustment feeds (a new nptv6map, mirroring
+// internal/plumbing/ebpf/edgemap's Register/Reconcile/Generation
+// crash-safety convention) is keyed by VRFID, consulted only after the
+// existing SRv6 uSID decap program (internal/plumbing/ebpf/prog/usid.c) has
+// already resolved which tenant VRF a packet belongs to — see the design
+// plan's §2.
+package nptv6

--- a/internal/plumbing/nptv6/nptv6.go
+++ b/internal/plumbing/nptv6/nptv6.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+)
+
+// maxSupportedPrefixLen is RFC 6296 §3.4's boundary: prefixes of this
+// length or shorter place the adjustment at a fixed word (bits 48..63).
+// Longer prefixes need §3.5's per-address IID-word scheme — see doc.go.
+const maxSupportedPrefixLen = 48
+
+// adjustmentWordOffset is the byte offset of the 16-bit word (bits 48..63)
+// RFC 6296 §3.4 fixes the checksum adjustment into, for prefixes of length
+// maxSupportedPrefixLen or shorter.
+const adjustmentWordOffset = 6
+
+// Mapping is one VRF's stateless RFC 6296 prefix translation: backends
+// presenting an address in ULAPrefix are translated, checksum-neutrally and
+// bidirectionally, to the corresponding address in PublicPrefix.
+type Mapping struct {
+	// ULAPrefix is the tenant-facing IPv6 ULA prefix, as presented by
+	// backends inside the VRF.
+	ULAPrefix *net.IPNet
+
+	// PublicPrefix is the externally-routable prefix ULAPrefix translates
+	// to/from. Must share ULAPrefix's own prefix length — RFC 6296
+	// translation only ever rewrites the shared prefix, never host bits.
+	PublicPrefix *net.IPNet
+}
+
+// prefixLen validates that ULAPrefix/PublicPrefix are both set, both IPv6,
+// share an identical prefix length, and that length is within this
+// package's supported range (see doc.go). Returns the shared length.
+func (m Mapping) prefixLen() (int, error) {
+	if m.ULAPrefix == nil || m.PublicPrefix == nil {
+		return 0, errors.New("nptv6: ULAPrefix and PublicPrefix are both required")
+	}
+	ulaOnes, ulaBits := m.ULAPrefix.Mask.Size()
+	pubOnes, pubBits := m.PublicPrefix.Mask.Size()
+	if ulaBits != 128 || pubBits != 128 {
+		return 0, errors.New("nptv6: ULAPrefix and PublicPrefix must both be IPv6 (/128-bit mask) CIDRs")
+	}
+	if ulaOnes != pubOnes {
+		return 0, fmt.Errorf("nptv6: ULAPrefix length /%d and PublicPrefix length /%d must match", ulaOnes, pubOnes)
+	}
+	if ulaOnes > maxSupportedPrefixLen {
+		return 0, fmt.Errorf(
+			"nptv6: prefix length /%d exceeds the supported maximum /%d (RFC 6296 §3.5's longer-prefix "+
+				"IID-word scheme is not implemented)", ulaOnes, maxSupportedPrefixLen)
+	}
+	return ulaOnes, nil
+}
+
+// Adjustment precomputes the RFC 6296 §3.6 checksum-neutral adjustment
+// value for m, control-plane side, once — Translate applies it as a cheap
+// 1's-complement add/subtract, never recomputing it per packet.
+func (m Mapping) Adjustment() (uint16, error) {
+	if _, err := m.prefixLen(); err != nil {
+		return 0, err
+	}
+	intChecksum := prefixChecksum(m.ULAPrefix.IP)
+	pubChecksum := prefixChecksum(m.PublicPrefix.IP)
+	// RFC 6296 §3.6: adjustment = external checksum - internal checksum,
+	// in 1's-complement arithmetic (subtraction = add the complement).
+	return onesComplementAdd(pubChecksum, ^intChecksum), nil
+}
+
+// Translate applies m to addr. outbound=true translates a ULAPrefix address
+// to its PublicPrefix counterpart (the internal-to-external direction, RFC
+// 6296 §3.4 — adjustment is added); outbound=false translates the reverse
+// direction (adjustment is subtracted). Pure function, no state: the
+// identical (m, addr, outbound) input always produces the identical output.
+func Translate(m Mapping, addr net.IP, outbound bool) (net.IP, error) {
+	length, err := m.prefixLen()
+	if err != nil {
+		return nil, err
+	}
+
+	addr16 := addr.To16()
+	if addr16 == nil || addr.To4() != nil {
+		return nil, fmt.Errorf("nptv6: %v is not an IPv6 address", addr)
+	}
+
+	from, to := m.PublicPrefix, m.ULAPrefix
+	if outbound {
+		from, to = m.ULAPrefix, m.PublicPrefix
+	}
+	if !from.Contains(addr16) {
+		return nil, fmt.Errorf("nptv6: address %v is not within %v", addr, from)
+	}
+
+	result := make(net.IP, net.IPv6len)
+	copy(result, addr16)
+	copyPrefixBits(result, to.IP, length)
+
+	adjustment, err := m.Adjustment()
+	if err != nil {
+		return nil, err
+	}
+	word := binary.BigEndian.Uint16(result[adjustmentWordOffset : adjustmentWordOffset+2])
+	if outbound {
+		word = onesComplementAdd(word, adjustment)
+	} else {
+		word = onesComplementAdd(word, ^adjustment)
+	}
+	binary.BigEndian.PutUint16(result[adjustmentWordOffset:adjustmentWordOffset+2], word)
+
+	return result, nil
+}
+
+// prefixChecksum computes the RFC 1071-style 1's-complement checksum (sum
+// with end-around carry, then bitwise complement) of prefix's first 48
+// bits (3 big-endian 16-bit words) — RFC 6296 §3.6's "one's complement
+// checksum of the prefix". prefix is assumed already zero-padded beyond its
+// own configured length (true of any net.IPNet.IP produced by
+// net.ParseCIDR), so a prefix shorter than 48 bits contributes zero words
+// for its own unused high-order bits, matching the RFC's worked example.
+func prefixChecksum(prefix net.IP) uint16 {
+	ip := prefix.To16()
+	var sum uint32
+	for i := 0; i < 6; i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(ip[i : i+2]))
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// onesComplementAdd adds a and b using 1's-complement (end-around-carry)
+// arithmetic — the same construction an IP/TCP checksum update uses, and
+// what RFC 6296 §3.6 means by "using one's complement arithmetic" for both
+// the adjustment computation and its application (subtraction is addition
+// of the bitwise complement).
+func onesComplementAdd(a, b uint16) uint16 {
+	sum := uint32(a) + uint32(b)
+	for sum>>16 != 0 {
+		sum = (sum & 0xFFFF) + (sum >> 16)
+	}
+	return uint16(sum)
+}
+
+// copyPrefixBits overwrites dst's first prefixLen bits with src's first
+// prefixLen bits, leaving every bit at position >= prefixLen in dst
+// untouched. Both dst and src must be 16-byte (net.IPv6len) slices.
+func copyPrefixBits(dst, src net.IP, prefixLen int) {
+	fullBytes := prefixLen / 8
+	copy(dst[:fullBytes], src[:fullBytes])
+
+	if remBits := prefixLen % 8; remBits != 0 {
+		mask := byte(0xFF << (8 - remBits))
+		dst[fullBytes] = (src[fullBytes] & mask) | (dst[fullBytes] &^ mask)
+	}
+}

--- a/internal/plumbing/nptv6/nptv6_test.go
+++ b/internal/plumbing/nptv6/nptv6_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return n
+}
+
+// rfcExampleMapping is RFC 6296 §3.6's own worked example — internal
+// FD01:0203:0405::/48, external 2001:0DB8:0001::/48, precomputed adjustment
+// 0xD54F. Used as a test vector directly against the RFC's published
+// numbers, not just internal self-consistency.
+func rfcExampleMapping(t *testing.T) Mapping {
+	t.Helper()
+	return Mapping{
+		ULAPrefix:    mustCIDR(t, "fd01:203:405::/48"),
+		PublicPrefix: mustCIDR(t, "2001:db8:1::/48"),
+	}
+}
+
+// TestMapping_Adjustment_RFCExample pins Adjustment's result against RFC
+// 6296 §3.6's own published checksums and adjustment value.
+func TestMapping_Adjustment_RFCExample(t *testing.T) {
+	got, err := rfcExampleMapping(t).Adjustment()
+	if err != nil {
+		t.Fatalf("Adjustment: %v", err)
+	}
+	if got != 0xD54F {
+		t.Errorf("Adjustment() = %#04x, want %#04x (RFC 6296 §3.6)", got, 0xD54F)
+	}
+}
+
+// TestTranslate_RFCExample pins Translate's result against RFC 6296 §3.6's
+// own published example address translation.
+func TestTranslate_RFCExample(t *testing.T) {
+	m := rfcExampleMapping(t)
+
+	internal := net.ParseIP("fd01:203:405:1::1234")
+	wantExternal := net.ParseIP("2001:db8:1:d550::1234")
+
+	got, err := Translate(m, internal, true)
+	if err != nil {
+		t.Fatalf("Translate(outbound): %v", err)
+	}
+	if !got.Equal(wantExternal) {
+		t.Errorf("Translate(outbound) = %v, want %v", got, wantExternal)
+	}
+
+	// And the reverse direction must recover the original address exactly.
+	back, err := Translate(m, got, false)
+	if err != nil {
+		t.Fatalf("Translate(inbound): %v", err)
+	}
+	if !back.Equal(internal) {
+		t.Errorf("Translate(inbound) round-trip = %v, want %v", back, internal)
+	}
+}
+
+// TestTranslate_HostBitsUnchanged verifies bits below the fixed adjustment
+// word (the Interface Identifier) are never modified — RFC 6296's whole
+// premise is that the IID is untouched.
+func TestTranslate_HostBitsUnchanged(t *testing.T) {
+	m := rfcExampleMapping(t)
+	internal := net.ParseIP("fd01:203:405:1::abcd:ef01")
+
+	got, err := Translate(m, internal, true)
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if !got[8:].Equal(internal.To16()[8:]) {
+		t.Errorf("IID bytes changed: got %x, want %x", got[8:], internal.To16()[8:])
+	}
+}
+
+// TestTranslate_TwoTenantsCollidingULA is the overlapping-address-space
+// property this package exists for: two independent Mappings sharing the
+// identical ULAPrefix must translate to different, correct PublicPrefix
+// addresses, with no shared state or cross-contamination — the caller
+// (nptv6map, keyed by VRFID) is what keeps them from ever being applied to
+// the wrong tenant's packet, but Translate itself must not silently produce
+// the same output for both when given each mapping independently.
+func TestTranslate_TwoTenantsCollidingULA(t *testing.T) {
+	const sharedULA = "fd20:60::/48"
+	tenantA := Mapping{ULAPrefix: mustCIDR(t, sharedULA), PublicPrefix: mustCIDR(t, "2001:db8:a::/48")}
+	tenantB := Mapping{ULAPrefix: mustCIDR(t, sharedULA), PublicPrefix: mustCIDR(t, "2001:db8:b::/48")}
+
+	addr := net.ParseIP("fd20:60::100:0")
+
+	gotA, err := Translate(tenantA, addr, true)
+	if err != nil {
+		t.Fatalf("Translate(tenantA): %v", err)
+	}
+	gotB, err := Translate(tenantB, addr, true)
+	if err != nil {
+		t.Fatalf("Translate(tenantB): %v", err)
+	}
+	if gotA.Equal(gotB) {
+		t.Fatalf("tenantA and tenantB translated the identical colliding ULA to the same public address: %v", gotA)
+	}
+	if !mustCIDR(t, "2001:db8:a::/48").Contains(gotA) {
+		t.Errorf("tenantA result %v not within its own PublicPrefix", gotA)
+	}
+	if !mustCIDR(t, "2001:db8:b::/48").Contains(gotB) {
+		t.Errorf("tenantB result %v not within its own PublicPrefix", gotB)
+	}
+}
+
+func TestMapping_Errors(t *testing.T) {
+	tests := []struct {
+		name      string
+		mapping   Mapping
+		wantError bool
+	}{
+		{"Nil", Mapping{}, true},
+		{"MismatchedLength", Mapping{
+			ULAPrefix:    mustCIDR(t, "fd20:60::/48"),
+			PublicPrefix: mustCIDR(t, "2001:db8::/56"),
+		}, true},
+		{"TooLong", Mapping{
+			ULAPrefix:    mustCIDR(t, "fd20:60::/56"),
+			PublicPrefix: mustCIDR(t, "2001:db8::/56"),
+		}, true},
+		{"Valid", rfcExampleMapping(t), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.mapping.Adjustment()
+			if (err != nil) != tt.wantError {
+				t.Errorf("Adjustment() error = %v, wantError = %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+// TestTranslate_RejectsOutOfRangeAddress verifies Translate refuses an
+// address that isn't actually within the expected source prefix, rather
+// than silently translating garbage.
+func TestTranslate_RejectsOutOfRangeAddress(t *testing.T) {
+	m := rfcExampleMapping(t)
+	_, err := Translate(m, net.ParseIP("fd99::1"), true)
+	if err == nil {
+		t.Error("Translate: expected error for address outside ULAPrefix, got nil")
+	}
+}
+
+// TestCopyPrefixBits_NonByteAligned exercises the partial-byte boundary
+// case directly (a /48 in the tests above never touches it — all this
+// package's real callers use byte-aligned /48 prefixes today, but the
+// helper itself must not silently corrupt bits for a non-byte-aligned
+// length).
+func TestCopyPrefixBits_NonByteAligned(t *testing.T) {
+	dst := net.IP{0xFF, 0xFF, 0xFF, 0xFF}
+	src := net.IP{0x00, 0x00, 0x00, 0x00}
+
+	copyPrefixBits(dst, src, 20) // 2 full bytes + top 4 bits of byte 2
+
+	want := []byte{0x00, 0x00, 0x0F, 0xFF} // byte2's low nibble (unmasked) survives from dst
+	if !bytes.Equal(dst, want) {
+		t.Errorf("copyPrefixBits result = %x, want %x", dst, want)
+	}
+}


### PR DESCRIPTION
## Summary

The DSR/Maglev gateway redesign needs two algorithms neither the codebase nor its dependencies provide: a Maglev consistent-hash ring for backend selection, and RFC 6296 NPTv6 for stateless per-VRF prefix translation. Both land here as plain Go packages with no eBPF or controller wiring, so their correctness can be reviewed and tested in isolation before anything depends on them.

Building against the new CRD types this needs (`ServiceVIPBinding`, `NAT66Shard`, `BGPVRFInstanceSpec.NPTv6`) required a temporary local `replace` pointing `go.datum.net/network` at a sibling checkout. That resolves on a dev machine but breaks every CI runner (no such directory exists there), so a second commit here pins straight to the published module version instead, skipping the replace entirely.

## Test plan

- [ ] `task test`
- [ ] `task ci` (module resolution succeeds with no sibling `../network` checkout)