### PR TITLE
feat: Automate VIP binding and per-VRF NPTv6 instantiation

### DIFF
--- a/cmd/galactic-gateway/gateway.go
+++ b/cmd/galactic-gateway/gateway.go
@@ -15,10 +15,11 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeattach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgemetrics"
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
-// gatewayDatapathKeepAlive holds the loaded *edgeprog.EdgenatObjects and
-// the attached link.Link for the life of this process, once
+// gatewayDatapathKeepAlive holds the loaded *edgeprog.EdgedsrObjects and the
+// attached link.Link for the life of this process, once
 // setupGatewayDatapath's attach path succeeds. Neither is Closed anywhere
 // in this file — see setupGatewayDatapath's doc comment for why — but a
 // value that isn't stored somewhere reachable is exactly as good as
@@ -26,32 +27,32 @@ import (
 // register a runtime finalizer that closes their underlying fd once the
 // garbage collector determines nothing reachable still points at them,
 // with no error surfaced anywhere when that happens. gateway.KernelDatapath
-// only keeps objs.RuleTable (via edgemap.KernelTable) alive on its own, so
-// without this package-level var, objs.EdgeNat (the program) and the
+// only keeps objs.VipTable (via edgemap.KernelTable) alive on its own, so
+// without this package-level var, objs.EdgeLb (the program) and the
 // link.Link returned by Attach — the two things actually keeping this
 // node's XDP attachment live on the wire — would eventually get GC'd and
 // silently detached, with every control-plane signal (the DaemonSet pod
-// healthy, ApplyRule succeeding, rule_table metrics populated) still
-// looking completely normal. Confirmed live: this is exactly what happened
-// the first time this path was ever exercised against a real interface
+// healthy, ApplyRule succeeding, vip_table metrics populated) still looking
+// completely normal. Confirmed live: this is exactly what happened the
+// first time this path was ever exercised against a real interface
 // (ingress traffic for a registered rule was never intercepted at all,
 // bouncing between this node and its transit-facing peer via ordinary
 // kernel routing instead) — no unit test exercises this path with a real
-// attach for a GC cycle to occur during, and Phase D's "manifests and the
-// live pod/eBPF path" validation predates any live underlay BGP peering
-// that would have delivered real traffic to notice the gap.
+// attach for a GC cycle to occur during, and this repo's own manifests-only
+// validation predates any live underlay BGP peering that would have
+// delivered real traffic to notice the gap.
 //
 // This var, and the rest of this file, moved here unchanged from
-// cmd/galactic-router/gateway.go: the edge NAT+LB gateway datapath now
+// cmd/galactic-router/gateway.go: the edge Maglev/DSR gateway datapath now
 // lives in its own process rather than sharing one with the tenant BGP
 // reconcilers.
 var gatewayDatapathKeepAlive struct {
-	objs *edgeprog.EdgenatObjects
+	objs *edgeprog.EdgedsrObjects
 	link link.Link
 }
 
-// setupGatewayDatapath loads and attaches the edge NAT+LB eBPF datapath to
-// publicInterface and returns the gateway.Datapath this node's Engine
+// setupGatewayDatapath loads and attaches the edge Maglev/DSR eBPF datapath
+// to publicInterface and returns the gateway.Datapath this node's Engine
 // should use. Unlike cmd/galactic-router's identically-named predecessor
 // (now removed), publicInterface and
 // srv6Address are both required here, not a jointly-optional pair with a
@@ -59,23 +60,39 @@ var gatewayDatapathKeepAlive struct {
 // rejects either being empty before runCmd ever calls this function, since
 // this binary only exists to run the gateway role.
 //
-// The loaded *edgeprog.EdgenatObjects and the returned link.Link are
+// The loaded *edgeprog.EdgedsrObjects and the returned link.Link are
 // stashed in gatewayDatapathKeepAlive (see that var's doc comment for why)
 // rather than Closed here: they, and the XDP attachment itself, must
 // survive for the life of this process — same convention as
 // internal/plumbing/ebpf/attach.Start's identical choice for the SRv6 uSID
 // datapath.
 //
+// srv6Address is written into encap_config_table as this node's own plain
+// SRv6-reachable encap source -- unlike this datapath's Full-NAT
+// predecessor, it is never a NAT/SNAT source and never has return-path
+// significance (see edgedsr.c's own header comment).
+//
 // metricsReg additionally gets an edgemetrics.Collector registered against
-// it once objs is loaded, reading rule_table/conn_table/drop_reasons live
-// at every scrape — see that package's doc comment for why this is a
+// it once objs is loaded, reading vip_table/vip_stats_table/drop_reasons
+// live at every scrape — see that package's doc comment for why this is a
 // pull-based Collector rather than incrementally-updated Gauges.
 func setupGatewayDatapath(
 	publicInterface, srv6Address string, metricsReg prometheus.Registerer,
 ) (gateway.Datapath, error) {
-	gwAddr, err := netip.ParseAddr(srv6Address)
+	encapSrc, err := netip.ParseAddr(srv6Address)
 	if err != nil {
 		return nil, fmt.Errorf("parse gateway SRv6 address %q: %w", srv6Address, err)
+	}
+
+	// Required for bpf_fib_lookup() (edgedsr.c's push_outer_header) to
+	// ever succeed on this interface -- see
+	// ConfigureFIBLookupUplinkSysctls's own doc comment for why (a real,
+	// previously-undiagnosed blocker, not a hypothetical one). Best-effort/
+	// non-fatal, matching this package's own established
+	// sysctl-configuration convention (internal/cni already calls
+	// ConfigureInterfaceSysctls the same way for VRF interfaces).
+	if err := sysctl.ConfigureFIBLookupUplinkSysctls(publicInterface); err != nil {
+		return nil, fmt.Errorf("configure IPv6 forwarding on public interface %q: %w", publicInterface, err)
 	}
 
 	objs, err := edgeattach.Load(edgeattach.PinDir)
@@ -83,13 +100,13 @@ func setupGatewayDatapath(
 		return nil, fmt.Errorf("load edge gateway eBPF datapath: %w", err)
 	}
 
-	xdpLink, err := edgeattach.Attach(objs.EdgeNat, publicInterface)
+	xdpLink, err := edgeattach.Attach(objs.EdgeLb, publicInterface)
 	if err != nil {
 		_ = objs.Close()
 		return nil, fmt.Errorf("attach edge gateway datapath to public interface %q: %w", publicInterface, err)
 	}
 
-	datapath, err := gateway.NewKernelDatapath(objs, gwAddr)
+	datapath, err := gateway.NewKernelDatapath(objs, encapSrc)
 	if err != nil {
 		_ = xdpLink.Close()
 		_ = objs.Close()

--- a/cmd/galactic-router/main.go
+++ b/cmd/galactic-router/main.go
@@ -20,13 +20,14 @@ const (
 	bgpAPIGroup   = "network.datumapis.com"
 	bgpAPIVersion = "v1alpha1"
 
-	resourceBGPRouters        = "bgprouters"
-	resourceBGPPeers          = "bgppeers"
-	resourceBGPAdvertisements = "bgpadvertisements"
-	resourceBGPPolicies       = "bgppolicies"
-	resourceBGPVRFInstances   = "bgpvrfinstances"
-	resourceSecrets           = "secrets"
-	resourceNodes             = "nodes"
+	resourceBGPRouters         = "bgprouters"
+	resourceBGPPeers           = "bgppeers"
+	resourceBGPAdvertisements  = "bgpadvertisements"
+	resourceBGPPolicies        = "bgppolicies"
+	resourceBGPVRFInstances    = "bgpvrfinstances"
+	resourceServiceVIPBindings = "servicevipbindings"
+	resourceSecrets            = "secrets"
+	resourceNodes              = "nodes"
 )
 
 func main() {
@@ -64,6 +65,7 @@ func checkWatchPermissions(mgr ctrl.Manager) {
 		{group: bgpAPIGroup, version: bgpAPIVersion, resource: resourceBGPAdvertisements},
 		{group: bgpAPIGroup, version: bgpAPIVersion, resource: resourceBGPPolicies},
 		{group: bgpAPIGroup, version: bgpAPIVersion, resource: resourceBGPVRFInstances},
+		{group: bgpAPIGroup, version: bgpAPIVersion, resource: resourceServiceVIPBindings},
 		{version: "v1", resource: resourceSecrets},
 		{version: "v1", resource: resourceNodes},
 	}

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -29,6 +29,8 @@ import (
 	"go.datum.net/galactic/internal/controller"
 	"go.datum.net/galactic/internal/hash"
 	"go.datum.net/galactic/internal/metadata"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/vipxlatmap"
 	"go.datum.net/galactic/internal/plumbing/loaddr"
 	"go.datum.net/galactic/internal/reconcile"
 	galacticruntime "go.datum.net/galactic/internal/runtime"
@@ -155,6 +157,36 @@ func runCmd(cfg *config.RouterConfig) error {
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 
+	// Open this node's own vip_xlat_table handle for
+	// ServiceVIPBindingReconciler's EgressKindTap branch. This is new
+	// plumbing (docs/agents/ARCHITECTURE-ROUTER.md's "For Claude" table
+	// pre-dates it): galactic-router has never before needed to reach any
+	// of the eBPF uSID datapath's maps -- that program is loaded/attached
+	// once, elsewhere, by galactic-cni/internal/plumbing/ebpf/attach; this
+	// only opens a *second* handle onto the map it already pinned, the
+	// exact pattern internal/plumbing/ebpf/usidmap.OpenPinnedRegistry
+	// already established for the short-lived galactic-cni plugin binary.
+	// Unlike that binary, galactic-router is long-lived, so the returned
+	// closer is deferred to process shutdown rather than closed
+	// immediately -- it never affects the pinned map's own lifetime.
+	//
+	// A missing pin (e.g. this node's eBPF uSID datapath hasn't loaded
+	// yet, or never will -- a route-reflector/control-role node has no
+	// CNI attach point at all) is not fatal: it only matters once a
+	// tap-kind ServiceVIPBinding is actually reconciled on this node, at
+	// which point ServiceVIPBindingReconciler.applyTapBind reports a
+	// clear, actionable error instead of silently no-op'ing. Every
+	// EgressKindVeth binding works regardless.
+	var vipTranslationTable controller.VIPTranslationTable
+	vipXlatTable, vipXlatCloser, vipXlatErr := vipxlatmap.OpenPinnedVipXlatTable(attach.PinDir)
+	if vipXlatErr != nil {
+		ctrl.Log.Error(vipXlatErr, "vip_xlat_table not available on this node; "+
+			"tap-kind ServiceVIPBinding objects will fail to bind until the eBPF uSID datapath is loaded")
+	} else {
+		vipTranslationTable = vipXlatTable
+		defer vipXlatCloser.Close() //nolint:errcheck // best-effort close of our own fd at shutdown
+	}
+
 	// Register field indexes.
 	if err := controller.RegisterIndexes(ctx, mgr); err != nil {
 		return fmt.Errorf("register field indexes: %w", err)
@@ -224,6 +256,16 @@ func runCmd(cfg *config.RouterConfig) error {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup Node controller: %w", err)
+	}
+
+	// Register ServiceVIPBinding controller.
+	if err := (&controller.ServiceVIPBindingReconciler{
+		Client:              mgr.GetClient(),
+		Scheme:              mgr.GetScheme(),
+		NodeName:            nodeName,
+		VIPTranslationTable: vipTranslationTable,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("setup ServiceVIPBinding controller: %w", err)
 	}
 
 	// Register GC controller for cleaning up orphaned BGP CRDs and VRFs.
@@ -349,5 +391,7 @@ func newRootCommand() *cobra.Command {
 		"Directory containing the webhook server's TLS cert/key; defaults to controller-runtime's own default")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
+
+	cmd.AddCommand(newVIPCommand())
 	return cmd
 }

--- a/cmd/galactic-router/vip.go
+++ b/cmd/galactic-router/vip.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/spf13/cobra"
+
+	"go.datum.net/galactic/internal/plumbing/vip"
+)
+
+// newVIPCommand builds the "vip" subcommand group: a thin, manual/debug
+// surface directly over internal/plumbing/vip's Bind/Unbind/Verify --
+// the same veth-branch mechanism ServiceVIPBindingReconciler
+// (internal/controller/servicevipbinding_controller.go) drives for every
+// EgressKindVeth ServiceVIPBinding. This is the first subcommand group
+// galactic-router's root command has ever had (see cmd/galactic-cni/main.go
+// for the established pattern this mirrors); the root command's own RunE
+// (root.go) still runs the router daemon itself when no subcommand is
+// given, unaffected by this addition.
+func newVIPCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vip",
+		Short: "Manually bind, unbind, or verify a service VIP on this node's galactic-vip0 interface",
+		Long: `vip is a manual/debug surface directly over internal/plumbing/vip -- the
+same mechanism ServiceVIPBindingReconciler drives automatically for every
+EgressKindVeth ServiceVIPBinding. It does not touch Kubernetes at all: it
+only manipulates this node's own galactic-vip0 dummy interface.`,
+	}
+	cmd.AddCommand(newVIPBindCommand(), newVIPUnbindCommand(), newVIPVerifyCommand())
+	return cmd
+}
+
+// parseVIPAddr parses addr as an IP address, returning a clear,
+// actionable error (rather than a nil net.IP silently propagating) if it
+// isn't one.
+func parseVIPAddr(addr string) (net.IP, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid IP address %q", addr)
+	}
+	return ip, nil
+}
+
+func newVIPBindCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bind <addr>",
+		Short: "Idempotently assign addr to galactic-vip0",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			addr, err := parseVIPAddr(args[0])
+			if err != nil {
+				return err
+			}
+			return vip.Bind(addr)
+		},
+	}
+}
+
+func newVIPUnbindCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unbind <addr>",
+		Short: "Idempotently remove addr from galactic-vip0",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			addr, err := parseVIPAddr(args[0])
+			if err != nil {
+				return err
+			}
+			return vip.Unbind(addr)
+		},
+	}
+}
+
+func newVIPVerifyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "verify <addr>",
+		Short: "Confirm addr is live on galactic-vip0 (present and resolvable as a local route)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			addr, err := parseVIPAddr(args[0])
+			if err != nil {
+				return err
+			}
+			if err := vip.Verify(addr); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s is live on %s\n", addr, vip.InterfaceName)
+			return err
+		},
+	}
+}

--- a/config/galactic-router/base/daemonset.yaml
+++ b/config/galactic-router/base/daemonset.yaml
@@ -89,12 +89,30 @@ spec:
               port: 5179
             initialDelaySeconds: 5
             periodSeconds: 10
+          # BPF (added alongside the pre-existing NET_ADMIN) and the bpf-fs
+          # volumeMount below are new plumbing for the DSR/Maglev redesign's
+          # ServiceVIPBindingReconciler (internal/controller/
+          # servicevipbinding_controller.go): its EgressKindTap branch opens
+          # a second handle onto vip_xlat_table, a map the eBPF uSID
+          # datapath already pinned elsewhere on this node (galactic-cni's
+          # own DaemonSet, config/galactic-cni/daemonset.yaml, loads and
+          # attaches that program; this container never does) --
+          # internal/plumbing/ebpf/vipxlatmap.OpenPinnedVipXlatTable's own
+          # doc comment has the full reasoning. Neither grant is
+          # unconditional the way galactic-cni's is (that DaemonSet's own
+          # comment: "the datapath is unconditional... there is no flag to
+          # gate this grant behind") -- a node with no tap-kind
+          # ServiceVIPBinding ever scheduled to it simply never exercises
+          # this path, but the grant/mount must still be present up front
+          # since ServiceVIPBindingReconciler.SetupWithManager always
+          # attempts to open the pin at startup (see root.go's runCmd).
           securityContext:
             runAsUser: 0
             capabilities:
               drop: ["ALL"]
               add:
                 - NET_ADMIN
+                - BPF
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
           resources:
@@ -112,8 +130,22 @@ spec:
             - name: netns
               mountPath: /var/run/netns
               readOnly: true
+            - name: bpf-fs
+              mountPath: /sys/fs/bpf
       volumes:
         - name: netns
           hostPath:
             path: /var/run/netns
             type: DirectoryOrCreate
+        - name: bpf-fs
+          # The host's bpffs mount, same convention/tradeoff
+          # config/galactic-cni/daemonset.yaml's own bpf-fs volume already
+          # documents in full (mirrored here rather than repeated verbatim):
+          # `Directory` (not DirectoryOrCreate) because bpffs must already
+          # be mounted at this path by the host/kubelet node setup, and this
+          # container gets read/write visibility into every other pinned
+          # BPF object under it, not just vip_xlat_table -- an accepted,
+          # largely inherent tradeoff of bpffs pinning on this platform.
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory

--- a/config/galactic-router/rbac.yaml
+++ b/config/galactic-router/rbac.yaml
@@ -23,6 +23,16 @@ rules:
       - bgpadvertisements
       - bgpvrfinstances
     verbs: ["get", "list", "watch", "delete"]
+  # servicevipbindings needs update/patch on the base resource (not just
+  # delete, unlike bgpadvertisements/bgpvrfinstances above):
+  # ServiceVIPBindingReconciler adds/removes its own teardown finalizer via
+  # a Patch call on the object itself (mirroring NetworkRuleReconciler's
+  # identical finalizer pattern on NetworkRule, config/galactic-gateway/
+  # rbac.yaml), not just its /status subresource.
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - servicevipbindings
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["network.datumapis.com"]
     resources:
       - bgprouters/status
@@ -30,6 +40,7 @@ rules:
       - bgpadvertisements/status
       - bgppolicies/status
       - bgpvrfinstances/status
+      - servicevipbindings/status
     verbs: ["get", "update", "patch"]
   - apiGroups: [""]
     resources:

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -11,8 +11,12 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/cni/veth"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
 func cmdDel(args *skel.CmdArgs) error {
@@ -71,6 +75,16 @@ func cmdDel(args *skel.CmdArgs) error {
 			"err", err, "containerID", args.ContainerID, "netns", args.Netns)
 	}
 
+	// Unregister this attachment's own ifindex_vrf_table entry (Milestone
+	// 7.1's ifindex_vrf_table addition), right before the host interface
+	// itself is destroyed below. Like the veth pair, this row is genuinely
+	// private to this one attachment's own ifindex — no sibling pod can
+	// ever share it — so it belongs in the same "no ADD-race to defer to GC
+	// for" category as veth.Delete just below, not the shared VRF/BGP CRD
+	// cleanup deferred further down. Best-effort/log-only, matching every
+	// other step in this function: DEL must always succeed regardless.
+	unregisterIfindexVRFEntry(vpc, vpcAtt, args.ContainerID)
+
 	// Delete this attachment's own host/guest veth pair. Unlike the VRF and
 	// BGP CRDs below, the veth pair is genuinely private to this attachment
 	// (see resourceTracker.cleanup's doc comment) — no sibling pod can ever
@@ -98,4 +112,38 @@ func cmdDel(args *skel.CmdArgs) error {
 	_ = types.PrintResult(result, pluginConf.CNIVersion)
 
 	return nil
+}
+
+// unregisterIfindexVRFEntry removes this attachment's own ifindex_vrf_table
+// entry (internal/plumbing/ebpf/ifindexvrfmap), if one exists. The host
+// interface's ifindex is resolved by its deterministic name
+// (intf.GenerateInterfaceNameHost, the same name registerEBPFDatapath
+// resolved it by at ADD time — internal/cnibgp/bgp.go), *before*
+// veth.Delete tears the interface down, since there is nothing left to
+// resolve an ifindex from afterward. Every failure here (interface already
+// gone, pinned map not present because the eBPF datapath isn't enabled,
+// etc.) is logged and swallowed, matching every other step in cmdDel: DEL
+// must always succeed.
+func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
+	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	link, err := netlink.LinkByName(hostName)
+	if err != nil {
+		// Nothing to unregister if the host interface is already gone (a
+		// prior DEL attempt may have already run this step, or ADD never
+		// got far enough to create it).
+		return
+	}
+
+	table, closer, err := ifindexvrfmap.OpenPinned(attach.PinDir)
+	if err != nil {
+		// No pinned map to clean up — eBPF datapath not enabled, or the
+		// "run" container hasn't finished loading it yet. Not an error.
+		return
+	}
+	defer func() { _ = closer.Close() }()
+
+	if err := table.Unregister(uint32(link.Attrs().Index)); err != nil {
+		slog.Warn("DEL: failed to unregister eBPF ifindex_vrf_table entry", "err", err,
+			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
+	}
 }

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -5,11 +5,27 @@
 // Package cnibgp implements galactic-bgp, the SRv6/BGP/eBPF publish plugin
 // in the galactic CNI chain. It is chain-invoked (per CNI conflist order)
 // after the master plugin (galactic-veth or galactic-tap), not called
-// as a library — it has zero kernel-interface dependency: every address it
-// advertises comes from prevResult (see prevresult.go), never from a
-// runtime call into the interface it doesn't own. Host-interface gateway
-// configuration lives in internal/hostgw instead, called directly by
-// the master plugins, for exactly this reason.
+// as a library — it has zero kernel-interface *configuration* dependency:
+// every address it advertises comes from prevResult (see prevresult.go),
+// never from a runtime call into the interface it doesn't own.
+// Host-interface gateway configuration lives in internal/hostgw instead,
+// called directly by the master plugins, for exactly this reason.
+//
+// One narrow, deliberate exception: registerEBPFDatapath (bgp.go) resolves
+// this attachment's own host-side interface's ifindex via a read-only
+// netlink.LinkByName lookup, to key its ifindex_vrf_table registration
+// (internal/plumbing/ebpf/ifindexvrfmap) on it. This is not a configuration
+// call — it neither creates, moves, nor mutates the interface the master
+// plugin already built, only reads its already-assigned kernel identity —
+// and the interface's name is fully deterministic
+// (intf.GenerateInterfaceNameHost(vpc, vpcAttachment), the same helper the
+// master plugin itself used to create it), so no prevResult plumbing is
+// needed to learn it. Kept here rather than threaded back through
+// prevResult because the (Block, Argument) values ifindex_vrf_table's row
+// pairs with are only known at this call site (registerEBPFDatapath is
+// where vrf_table's own registration for this same attachment already
+// happens), mirroring the design note's own point-6 guidance to key
+// ifindex_vrf_table at that exact call site.
 package cnibgp
 
 import (
@@ -24,6 +40,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/vishvananda/netlink"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,8 +49,10 @@ import (
 	"go.datum.net/galactic/internal/cniipam"
 	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/gc"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -439,7 +458,9 @@ func publishBGPState(
 		// they'd describe is shared by every attachment on this VPC/node,
 		// same as the BGPVRFInstance above — see resourceTracker.cleanup's
 		// doc comment for why a failed ADD must never unregister it.
-		if _, err := registerEBPFDatapath(bgp, cfg.vpc, cfg.ifaceType, uint16(vrfID), ebpfPinDir); err != nil {
+		if _, err := registerEBPFDatapath(
+			bgp, cfg.vpc, cfg.vpcAttachment, cfg.ifaceType, uint16(vrfID), ebpfPinDir,
+		); err != nil {
 			return fmt.Errorf("register eBPF uSID datapath: %w", err)
 		}
 
@@ -503,7 +524,7 @@ func publishBGPState(
 // intentionally not set up for this attachment. Any other failure is
 // returned as an error.
 func registerEBPFDatapath(
-	bgp bgpConfig, vpc, ifaceType string, argument uint16, pinDir string,
+	bgp bgpConfig, vpc, vpcAttachment, ifaceType string, argument uint16, pinDir string,
 ) (registered bool, err error) {
 	if bgp.srv6Locator == "" || bgp.nodeID == 0 {
 		return false, nil
@@ -533,6 +554,15 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
 	}
 
+	// The host-side interface's own ifindex, needed to key this
+	// attachment's ifindex_vrf_table row below — see this package's own
+	// doc comment for why this one read-only netlink call is an accepted
+	// exception to galactic-bgp's otherwise prevResult-only design.
+	hostIfindex, err := hostInterfaceIndex(vpc, vpcAttachment)
+	if err != nil {
+		return false, fmt.Errorf("resolve host interface ifindex for eBPF registration: %w", err)
+	}
+
 	registry, closer, err := usidmap.OpenPinnedRegistry(pinDir)
 	if err != nil {
 		return false, fmt.Errorf("open pinned eBPF uSID maps: %w", err)
@@ -549,7 +579,31 @@ func registerEBPFDatapath(
 	if err := registry.VRF.Register(block, argument, vrfTableID, egressKind); err != nil {
 		return false, fmt.Errorf("register eBPF vrf_table entry: %w", err)
 	}
+
+	ifindexTable, ifindexCloser, err := ifindexvrfmap.OpenPinned(pinDir)
+	if err != nil {
+		return false, fmt.Errorf("open pinned eBPF ifindex_vrf_table: %w", err)
+	}
+	defer func() { _ = ifindexCloser.Close() }()
+	if err := ifindexTable.Register(hostIfindex, block, argument); err != nil {
+		return false, fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
+	}
+
 	return true, nil
+}
+
+// hostInterfaceIndex resolves this attachment's own host-side veth/tap
+// interface's kernel ifindex, by name -- the same deterministic name
+// (intf.GenerateInterfaceNameHost) the master plugin (internal/cni or
+// internal/cnitap) already used to create it, so no value needs threading
+// through prevResult to find it again here.
+func hostInterfaceIndex(vpc, vpcAttachment string) (uint32, error) {
+	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	link, err := netlink.LinkByName(hostName)
+	if err != nil {
+		return 0, fmt.Errorf("look up host interface %q: %w", hostName, err)
+	}
+	return uint32(link.Attrs().Index), nil
 }
 
 // egressKindForInterfaceType maps a "veth"/"tap" interface type string to the

--- a/internal/cnibgp/bgp_ebpf_test.go
+++ b/internal/cnibgp/bgp_ebpf_test.go
@@ -6,12 +6,19 @@ package cnibgp
 
 import (
 	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/cni/veth"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
@@ -25,6 +32,16 @@ func requireRoot(t *testing.T) {
 	}
 }
 
+// blockFromLocator mirrors registerEBPFDatapath's own locator-to-Block
+// derivation, mirroring internal/gc/gc_ebpf_test.go's identical helper.
+func blockFromLocator(locator string) (uint64, error) {
+	prefix, err := netip.ParsePrefix(locator)
+	if err != nil {
+		return 0, err
+	}
+	return uformat.Block(prefix.Addr())
+}
+
 // TestRegisterEBPFDatapath_NotConfiguredIsNoOp covers the short-circuit for
 // a node whose BGPRouter has no SRv6Locator/NodeID configured at all: SRv6
 // is intentionally not set up for this attachment, so registerEBPFDatapath
@@ -32,7 +49,7 @@ func requireRoot(t *testing.T) {
 func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "", nodeID: 0}
 	registered, err := registerEBPFDatapath(
-		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
+		cfg, testVPC, testAttachment, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err != nil {
 		t.Errorf("registerEBPFDatapath with unconfigured BGPRouter = %v, want nil (no-op)", err)
 	}
@@ -49,7 +66,7 @@ func TestRegisterEBPFDatapath_NotConfiguredIsNoOp(t *testing.T) {
 func TestRegisterEBPFDatapath_RejectsOutOfRangeNodeID(t *testing.T) {
 	cfg := bgpConfig{srv6Locator: "2001:db8:1::/48", nodeID: 0x10001} // wraps to uint16(1) if narrowed unchecked
 	registered, err := registerEBPFDatapath(
-		cfg, testVPC, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
+		cfg, testVPC, testAttachment, ifaceTypeVeth, 42, "/sys/fs/bpf/galactic-does-not-exist")
 	if err == nil {
 		t.Fatal("registerEBPFDatapath with nodeID=0x10001 = nil error, want an out-of-range rejection")
 	}
@@ -80,6 +97,16 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = vrf.Delete(vpc) })
 
+	if err := veth.Add(vpc, testAttachment, 1500); err != nil {
+		t.Fatalf("veth.Add: %v", err)
+	}
+	t.Cleanup(func() { _ = veth.Delete(vpc, testAttachment) })
+	hostLinkObj, err := netlink.LinkByName(intf.GenerateInterfaceNameHost(vpc, testAttachment))
+	if err != nil {
+		t.Fatalf("look up host interface: %v", err)
+	}
+	hostLink := uint32(hostLinkObj.Attrs().Index)
+
 	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
 	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
 	loaderObjs, err := attach.Load(pinDir)
@@ -89,7 +116,7 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	t.Cleanup(func() { _ = loaderObjs.Close() })
 
 	cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
-	registered, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
+	registered, err := registerEBPFDatapath(cfg, vpc, testAttachment, ifaceTypeVeth, uint16(vrfID), pinDir)
 	if err != nil {
 		t.Fatalf("registerEBPFDatapath: %v", err)
 	}
@@ -102,6 +129,27 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 		t.Fatalf("OpenPinnedRegistry: %v", err)
 	}
 	defer func() { _ = closer.Close() }()
+
+	ifindexTable, ifindexCloser, err := ifindexvrfmap.OpenPinned(pinDir)
+	if err != nil {
+		t.Fatalf("ifindexvrfmap.OpenPinned: %v", err)
+	}
+	defer func() { _ = ifindexCloser.Close() }()
+
+	block, err := blockFromLocator(locator)
+	if err != nil {
+		t.Fatalf("derive block: %v", err)
+	}
+	ifEntry, ok, err := ifindexTable.Get(hostLink)
+	if err != nil {
+		t.Fatalf("ifindexvrfmap.Get: %v", err)
+	}
+	if !ok {
+		t.Fatalf("ifindex_vrf_table entry for host ifindex %d not found", hostLink)
+	}
+	if ifEntry.Block != block || ifEntry.Argument != uint16(vrfID) {
+		t.Errorf("ifindex_vrf_table entry = %+v, want Block=%#x Argument=%#x", ifEntry, block, uint16(vrfID))
+	}
 
 	vrfTableID, err := vrf.TableID(vpc)
 	if err != nil {
@@ -160,10 +208,24 @@ func TestRegisterEBPFDatapath_SecondAttachmentSharesEntry(t *testing.T) {
 		vrfID   = int32(42)
 	)
 
+	const (
+		firstAttachment  = testAttachment
+		secondAttachment = "def2"
+	)
+
 	if err := vrf.Add(vpc); err != nil {
 		t.Fatalf("vrf.Add: %v", err)
 	}
 	t.Cleanup(func() { _ = vrf.Delete(vpc) })
+
+	if err := veth.Add(vpc, firstAttachment, 1500); err != nil {
+		t.Fatalf("veth.Add(first): %v", err)
+	}
+	t.Cleanup(func() { _ = veth.Delete(vpc, firstAttachment) })
+	if err := veth.Add(vpc, secondAttachment, 1500); err != nil {
+		t.Fatalf("veth.Add(second): %v", err)
+	}
+	t.Cleanup(func() { _ = veth.Delete(vpc, secondAttachment) })
 
 	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
 	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
@@ -174,12 +236,12 @@ func TestRegisterEBPFDatapath_SecondAttachmentSharesEntry(t *testing.T) {
 	t.Cleanup(func() { _ = loaderObjs.Close() })
 
 	cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
-	if _, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir); err != nil {
+	if _, err := registerEBPFDatapath(cfg, vpc, firstAttachment, ifaceTypeVeth, uint16(vrfID), pinDir); err != nil {
 		t.Fatalf("first attachment's registerEBPFDatapath: %v", err)
 	}
 	// A second attachment on the same VPC/node resolves the same Argument
 	// (allocateArgument's idempotent lookup) and re-registers the same key.
-	registered, err := registerEBPFDatapath(cfg, vpc, ifaceTypeVeth, uint16(vrfID), pinDir)
+	registered, err := registerEBPFDatapath(cfg, vpc, secondAttachment, ifaceTypeVeth, uint16(vrfID), pinDir)
 	if err != nil {
 		t.Fatalf("second attachment's registerEBPFDatapath: %v", err)
 	}

--- a/internal/cnitap/ops_del.go
+++ b/internal/cnitap/ops_del.go
@@ -11,8 +11,12 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/cni/tap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
 // cmdDel mirrors internal/cni's own cmdDel, minus everything guest-netns
@@ -38,6 +42,14 @@ func cmdDel(args *skel.CmdArgs) error {
 				"containerID", args.ContainerID)
 		}
 	}
+
+	// Unregister this attachment's own ifindex_vrf_table entry -- mirrors
+	// internal/cni's own cmdDel (same reasoning: genuinely private to this
+	// one attachment's own ifindex, so it belongs alongside tap.Delete
+	// below, not the shared VRF/BGP CRD cleanup deferred further down).
+	// Resolved and removed *before* tap.Delete tears the interface down,
+	// since there is nothing left to resolve an ifindex from afterward.
+	unregisterIfindexVRFEntry(vpc, vpcAtt, args.ContainerID)
 
 	// Delete this attachment's own tap device. Unlike the VRF and BGP CRDs
 	// below, the tap device is genuinely private to this attachment (see
@@ -65,4 +77,28 @@ func cmdDel(args *skel.CmdArgs) error {
 	_ = types.PrintResult(result, pluginConf.CNIVersion)
 
 	return nil
+}
+
+// unregisterIfindexVRFEntry removes this attachment's own ifindex_vrf_table
+// entry (internal/plumbing/ebpf/ifindexvrfmap), if one exists -- mirrors
+// internal/cni's own identical helper (see its doc comment for the full
+// reasoning), adapted to a tap device's own host-side interface instead of
+// a veth pair's.
+func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
+	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	link, err := netlink.LinkByName(hostName)
+	if err != nil {
+		return
+	}
+
+	table, closer, err := ifindexvrfmap.OpenPinned(attach.PinDir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = closer.Close() }()
+
+	if err := table.Unregister(uint32(link.Attrs().Index)); err != nil {
+		slog.Warn("DEL: failed to unregister eBPF ifindex_vrf_table entry", "err", err,
+			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,33 @@ const (
 	LogLevelError   = "error"
 )
 
+// --- Shared CLI flag names --------------------------------------------
+
+// FlagNodeName/FlagMetricsPort/FlagGRPCHealthPort are the CLI flag name
+// strings every per-binary Config's BindFlags bindings table
+// (RouterConfig, GatewayConfig, NAT66Config) binds verbatim -- pulled out
+// to shared constants rather than left as three near-identical literal
+// copies (one per binary), which is exactly what golangci-lint's goconst
+// flags once a third copy exists.
+const (
+	FlagNodeName       = "node-name"
+	FlagMetricsPort    = "metrics-port"
+	FlagGRPCHealthPort = "grpc-health-port"
+)
+
+// --- Shared Viper key names ---------------------------------------------
+
+// KeyNodeName/KeyMetricsPort/KeyGRPCHealthPort are the Viper key strings
+// every per-binary Config's SetDefault/BindFlags/readFields trio uses for
+// the same three fields FlagNodeName/FlagMetricsPort/FlagGRPCHealthPort
+// bind -- pulled out for the same goconst-across-three-near-identical-
+// binaries reason as the Flag* constants above.
+const (
+	KeyNodeName       = "node_name"
+	KeyMetricsPort    = "metrics_port"
+	KeyGRPCHealthPort = "grpc_health_port"
+)
+
 // --- Shared helpers --------------------------------------------------------
 
 // NormalizeLogLevel maps common log level aliases to canonical values.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,22 @@ package config
 
 import "testing"
 
+// Shared test literals, factored out here so goconst doesn't need to be
+// silenced once a third per-binary *_test.go file (gateway_test.go,
+// router_test.go, nat66_test.go) repeats the same test-case name/error
+// substring -- see config.go's identical "shared CLI flag names"
+// rationale for the production-code half of this pattern.
+const (
+	testCaseMissingNodeName       = "missing node name"
+	testErrNodeNameRequired       = "node name is required"
+	testCaseInvalidMetricsPort    = "invalid metrics port"
+	testErrMetricsPortRange       = "metrics port must be between"
+	testCaseInvalidGRPCHealthPort = "invalid grpc health port"
+	testErrGRPCHealthPortRange    = "grpc health port must be between"
+	testIPv4Addr                  = "203.0.113.1"
+	testErrMustBeNativeIPv6       = "must be a native IPv6 address"
+)
+
 func TestNormalizeLogLevel(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -45,10 +45,13 @@ const (
 	// to support — see GatewayConfig.Validate.
 	EnvGatewayPublicInterface = "GALACTIC_GATEWAY_PUBLIC_INTERFACE"
 
-	// EnvGatewaySRv6Address is this gateway node's own SRv6-reachable
-	// address (network.datumapis.com/v1alpha1's NetworkGatewayStatus.
-	// SRv6Address), used as the Full-NAT SNAT source for every ingress
-	// flow this node translates. Required — see EnvGatewayPublicInterface.
+	// EnvGatewaySRv6Address is this gateway node's own plain
+	// SRv6-reachable address, used as the outer-header encap source for
+	// every packet this node's DSR datapath forwards (edgedsr.c's
+	// encap_config_table) — never a NAT/SNAT source and never compared
+	// against anything on a receive path, unlike the removed Full-NAT
+	// design's identically-named field. Required — see
+	// EnvGatewayPublicInterface.
 	EnvGatewaySRv6Address = "GALACTIC_GATEWAY_SRV6_ADDRESS"
 )
 
@@ -67,7 +70,7 @@ type GatewayConfig struct {
 	MetricsPort    int
 	GRPCHealthPort int
 
-	// PublicInterface/SRv6Address configure the edge NAT+LB gateway
+	// PublicInterface/SRv6Address configure the edge Maglev/DSR gateway
 	// datapath -- see EnvGatewayPublicInterface's doc comment. Both
 	// required; GatewayConfig.Validate rejects either being empty.
 	PublicInterface string
@@ -83,9 +86,9 @@ func NewGatewayConfig() *GatewayConfig {
 	v.SetEnvPrefix("GALACTIC_GATEWAY")
 	v.AutomaticEnv()
 
-	v.SetDefault("node_name", "")
-	v.SetDefault("metrics_port", DefaultGatewayMetricsPort)
-	v.SetDefault("grpc_health_port", DefaultGatewayGRPCHealthPort)
+	v.SetDefault(KeyNodeName, "")
+	v.SetDefault(KeyMetricsPort, DefaultGatewayMetricsPort)
+	v.SetDefault(KeyGRPCHealthPort, DefaultGatewayGRPCHealthPort)
 	v.SetDefault("public_interface", "")
 	v.SetDefault("srv6_address", "")
 
@@ -104,9 +107,9 @@ func (c *GatewayConfig) BindFlags(flags *pflag.FlagSet) {
 		flag string
 		key  string
 	}{
-		{"node-name", "node_name"},
-		{"metrics-port", "metrics_port"},
-		{"grpc-health-port", "grpc_health_port"},
+		{FlagNodeName, KeyNodeName},
+		{FlagMetricsPort, KeyMetricsPort},
+		{FlagGRPCHealthPort, KeyGRPCHealthPort},
 		{"gateway-public-interface", "public_interface"},
 		{"gateway-srv6-address", "srv6_address"},
 	}
@@ -123,9 +126,9 @@ func (c *GatewayConfig) BindFlags(flags *pflag.FlagSet) {
 
 // readFields populates the exported fields from the current Viper state.
 func (c *GatewayConfig) readFields() {
-	c.NodeName = c.v.GetString("node_name")
-	c.MetricsPort = c.v.GetInt("metrics_port")
-	c.GRPCHealthPort = c.v.GetInt("grpc_health_port")
+	c.NodeName = c.v.GetString(KeyNodeName)
+	c.MetricsPort = c.v.GetInt(KeyMetricsPort)
+	c.GRPCHealthPort = c.v.GetInt(KeyGRPCHealthPort)
 	c.PublicInterface = c.v.GetString("public_interface")
 	c.SRv6Address = c.v.GetString("srv6_address")
 }

--- a/internal/config/gateway_test.go
+++ b/internal/config/gateway_test.go
@@ -34,7 +34,7 @@ func TestGatewayConfigDefaults(t *testing.T) {
 }
 
 func TestGatewayConfigEnvOverride(t *testing.T) {
-	t.Setenv(EnvGatewayNodeName, "env-node")
+	t.Setenv(EnvGatewayNodeName, testEnvNode)
 	t.Setenv(EnvGatewayMetricsPort, "9090")
 	t.Setenv(EnvGatewayGRPCHealthPort, "9091")
 	t.Setenv(EnvGatewayPublicInterface, testGatewayIface)
@@ -42,8 +42,8 @@ func TestGatewayConfigEnvOverride(t *testing.T) {
 
 	cfg := NewGatewayConfig()
 
-	if cfg.NodeName != "env-node" {
-		t.Errorf("NodeName = %q, want %q", cfg.NodeName, "env-node")
+	if cfg.NodeName != testEnvNode {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, testEnvNode)
 	}
 	if cfg.MetricsPort != 9090 {
 		t.Errorf("MetricsPort = %d, want 9090", cfg.MetricsPort)
@@ -66,9 +66,9 @@ func TestGatewayConfigValidate(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "missing node name",
+			name:    testCaseMissingNodeName,
 			envVars: map[string]string{EnvGatewayPublicInterface: testGatewayIface, EnvGatewaySRv6Address: testGatewaySRv6},
-			wantErr: "node name is required",
+			wantErr: testErrNodeNameRequired,
 		},
 		{
 			name:    "missing public interface",
@@ -98,29 +98,29 @@ func TestGatewayConfigValidate(t *testing.T) {
 			envVars: map[string]string{
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
-				EnvGatewaySRv6Address:     "203.0.113.1",
+				EnvGatewaySRv6Address:     testIPv4Addr,
 			},
-			wantErr: "must be a native IPv6 address",
+			wantErr: testErrMustBeNativeIPv6,
 		},
 		{
-			name: "invalid metrics port",
+			name: testCaseInvalidMetricsPort,
 			envVars: map[string]string{
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
 				EnvGatewaySRv6Address:     testGatewaySRv6,
 				EnvGatewayMetricsPort:     "0",
 			},
-			wantErr: "metrics port must be between",
+			wantErr: testErrMetricsPortRange,
 		},
 		{
-			name: "invalid grpc health port",
+			name: testCaseInvalidGRPCHealthPort,
 			envVars: map[string]string{
 				EnvGatewayNodeName:        testGatewayNodeName,
 				EnvGatewayPublicInterface: testGatewayIface,
 				EnvGatewaySRv6Address:     testGatewaySRv6,
 				EnvGatewayGRPCHealthPort:  "0",
 			},
-			wantErr: "grpc health port must be between",
+			wantErr: testErrGRPCHealthPortRange,
 		},
 		{
 			name: "valid config",

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -92,12 +92,12 @@ func NewRouterConfig() *RouterConfig {
 	v.SetEnvPrefix("GALACTIC_ROUTER")
 	v.AutomaticEnv()
 
-	v.SetDefault("node_name", "")
+	v.SetDefault(KeyNodeName, "")
 	v.SetDefault("reflector", false)
 	v.SetDefault("bgp_listen_port", DefaultRouterBGPListenPort)
 	v.SetDefault("bgp_local_address", "")
-	v.SetDefault("metrics_port", DefaultRouterMetricsPort)
-	v.SetDefault("grpc_health_port", DefaultRouterGRPCHealthPort)
+	v.SetDefault(KeyMetricsPort, DefaultRouterMetricsPort)
+	v.SetDefault(KeyGRPCHealthPort, DefaultRouterGRPCHealthPort)
 	v.SetDefault("gc_namespace", DefaultRouterGCNamespace)
 	v.SetDefault("gc_interval", DefaultRouterGCInterval.String())
 	v.SetDefault("webhook_enabled", false)
@@ -119,12 +119,12 @@ func (c *RouterConfig) BindFlags(flags *pflag.FlagSet) {
 		flag string
 		key  string
 	}{
-		{"node-name", "node_name"},
+		{FlagNodeName, KeyNodeName},
 		{"reflector", "reflector"},
 		{"bgp-listen-port", "bgp_listen_port"},
 		{"bgp-local-address", "bgp_local_address"},
-		{"metrics-port", "metrics_port"},
-		{"grpc-health-port", "grpc_health_port"},
+		{FlagMetricsPort, KeyMetricsPort},
+		{FlagGRPCHealthPort, KeyGRPCHealthPort},
 		{"gc-namespace", "gc_namespace"},
 		{"gc-interval", "gc_interval"},
 		{"webhook-enabled", "webhook_enabled"},
@@ -144,12 +144,12 @@ func (c *RouterConfig) BindFlags(flags *pflag.FlagSet) {
 
 // readFields populates the exported fields from the current Viper state.
 func (c *RouterConfig) readFields() {
-	c.NodeName = c.v.GetString("node_name")
+	c.NodeName = c.v.GetString(KeyNodeName)
 	c.Reflector = c.v.GetBool("reflector")
 	c.BGPListenPort = c.v.GetInt("bgp_listen_port")
 	c.BGPLocalAddr = c.v.GetString("bgp_local_address")
-	c.MetricsPort = c.v.GetInt("metrics_port")
-	c.GRPCHealthPort = c.v.GetInt("grpc_health_port")
+	c.MetricsPort = c.v.GetInt(KeyMetricsPort)
+	c.GRPCHealthPort = c.v.GetInt(KeyGRPCHealthPort)
 	c.GCNamespace = c.v.GetString("gc_namespace")
 	c.GCInterval = c.v.GetDuration("gc_interval")
 	c.WebhookEnabled = c.v.GetBool("webhook_enabled")

--- a/internal/config/router_test.go
+++ b/internal/config/router_test.go
@@ -53,7 +53,7 @@ func TestRouterConfigDefaults(t *testing.T) {
 }
 
 func TestRouterConfigEnvOverride(t *testing.T) {
-	t.Setenv(EnvRouterNodeName, "env-node")
+	t.Setenv(EnvRouterNodeName, testEnvNode)
 	t.Setenv(EnvRouterReflector, testBoolTrue)
 	t.Setenv(EnvRouterBGPListenPort, "1790")
 	t.Setenv(EnvRouterBGPLocalAddr, "2001:db8::1")
@@ -67,8 +67,8 @@ func TestRouterConfigEnvOverride(t *testing.T) {
 
 	cfg := NewRouterConfig()
 
-	if cfg.NodeName != "env-node" {
-		t.Errorf("NodeName = %q, want %q", cfg.NodeName, "env-node")
+	if cfg.NodeName != testEnvNode {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, testEnvNode)
 	}
 	if !cfg.Reflector {
 		t.Error("Reflector = false, want true")
@@ -109,9 +109,9 @@ func TestRouterConfigValidate(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "missing node name",
+			name:    testCaseMissingNodeName,
 			envVars: map[string]string{},
-			wantErr: "node name is required",
+			wantErr: testErrNodeNameRequired,
 		},
 		{
 			name: "valid node name",
@@ -145,20 +145,20 @@ func TestRouterConfigValidate(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "invalid metrics port",
+			name: testCaseInvalidMetricsPort,
 			envVars: map[string]string{
 				EnvRouterNodeName:    testRouterNodeName,
 				EnvRouterMetricsPort: "0",
 			},
-			wantErr: "metrics port must be between",
+			wantErr: testErrMetricsPortRange,
 		},
 		{
-			name: "invalid grpc health port",
+			name: testCaseInvalidGRPCHealthPort,
 			envVars: map[string]string{
 				EnvRouterNodeName:       testRouterNodeName,
 				EnvRouterGRPCHealthPort: "0",
 			},
-			wantErr: "grpc health port must be between",
+			wantErr: testErrGRPCHealthPortRange,
 		},
 		{
 			name: "invalid webhook port",

--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -23,6 +23,7 @@ import (
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"go.datum.net/galactic/internal/model"
+	"go.datum.net/galactic/internal/plumbing/nptv6"
 	"go.datum.net/galactic/internal/reconcile"
 	galacticruntime "go.datum.net/galactic/internal/runtime"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
@@ -36,6 +37,10 @@ const annotationConfigHash = "galactic.datum.net/config-hash"
 // GoBGP session state. BGP FSM transitions are not Kubernetes events, so a
 // periodic requeue is required to keep BGPPeer status current.
 const peerStatusRequeue = 30 * time.Second
+
+// reasonAccepted is the shared condition Reason used across this
+// reconciler's Accepted-condition updates below.
+const reasonAccepted = "Accepted"
 
 // BGPRouterReconciler reconciles BGPRouter resources.
 type BGPRouterReconciler struct {
@@ -350,7 +355,7 @@ func (r *BGPRouterReconciler) updateAdvertisementStatuses(
 		setAdvertisementCondition(advCopy, metav1.Condition{
 			Type:    ConditionReady,
 			Status:  metav1.ConditionTrue,
-			Reason:  "Accepted",
+			Reason:  reasonAccepted,
 			Message: "Advertisement accepted",
 		})
 		if updateErr := r.Status().Update(ctx, advCopy); updateErr != nil {
@@ -411,12 +416,49 @@ func (r *BGPRouterReconciler) updateVRFInstanceStatuses(ctx context.Context, rou
 		setVRFInstanceCondition(vrfCopy, metav1.Condition{
 			Type:    ConditionReady,
 			Status:  metav1.ConditionTrue,
-			Reason:  "Accepted",
+			Reason:  reasonAccepted,
 			Message: "VRF instance accepted",
 		})
+		if vrfCopy.Spec.NPTv6 != nil {
+			setVRFInstanceCondition(vrfCopy, nptv6ConfiguredCondition(vrfCopy.Spec.NPTv6))
+		}
 		if updateErr := r.Status().Update(ctx, vrfCopy); updateErr != nil {
 			logger.Error(updateErr, "update BGPVRFInstance status", "vrf", vrf.Name)
 		}
+	}
+}
+
+// nptv6ConfiguredCondition validates spec (parseable CIDRs, matching prefix
+// lengths, and a supported prefix length — internal/plumbing/nptv6.Mapping's
+// own rules) and returns the ConditionNPTv6Configured condition reporting
+// the result. This reconciler has no access to the eBPF datapath's
+// nptv6_table map at all (galactic-router's DaemonSet has no /sys/fs/bpf
+// mount or CAP_BPF — see gc.SweepEBPFNPTv6Table's doc comment), so this
+// condition reflects spec validity only, never live kernel state.
+func nptv6ConfiguredCondition(spec *bgpv1alpha1.NPTv6Spec) metav1.Condition {
+	_, ula, err := net.ParseCIDR(spec.ULAPrefix)
+	if err != nil {
+		return metav1.Condition{
+			Type: ConditionNPTv6Configured, Status: metav1.ConditionFalse,
+			Reason: "InvalidULAPrefix", Message: err.Error(),
+		}
+	}
+	_, pub, err := net.ParseCIDR(spec.PublicPrefix)
+	if err != nil {
+		return metav1.Condition{
+			Type: ConditionNPTv6Configured, Status: metav1.ConditionFalse,
+			Reason: "InvalidPublicPrefix", Message: err.Error(),
+		}
+	}
+	if _, err := (nptv6.Mapping{ULAPrefix: ula, PublicPrefix: pub}).Adjustment(); err != nil {
+		return metav1.Condition{
+			Type: ConditionNPTv6Configured, Status: metav1.ConditionFalse,
+			Reason: "InvalidMapping", Message: err.Error(),
+		}
+	}
+	return metav1.Condition{
+		Type: ConditionNPTv6Configured, Status: metav1.ConditionTrue,
+		Reason: reasonAccepted, Message: "NPTv6 mapping is valid",
 	}
 }
 

--- a/internal/controller/servicevipbinding_controller.go
+++ b/internal/controller/servicevipbinding_controller.go
@@ -1,0 +1,479 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/vip"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// serviceVIPBindingFinalizer guards ServiceVIPBinding teardown: the
+// veth/tap-specific unbind (vip.Unbind, or the translation table's
+// Unregister calls) must complete before the object is actually removed
+// from etcd, mirroring networkRuleFinalizer's identical ordering purpose
+// on NetworkRule.
+const serviceVIPBindingFinalizer = "galactic.datum.net/servicevipbinding-teardown"
+
+// ipProtoTCP/ipProtoUDP are the wire protocol numbers (IANA) matching
+// usid.c's USID_IPPROTO_TCP/USID_IPPROTO_UDP constants -- the only two
+// protocols vip_xlat_table's rewrite path ever applies to.
+const (
+	ipProtoTCP = uint8(6)
+	ipProtoUDP = uint8(17)
+)
+
+// vipBindFn/vipUnbindFn/vipVerifyFn are package-level overridable indirections
+// onto internal/plumbing/vip's Bind/Unbind/Verify -- the same pattern
+// internal/plumbing/ebpf/attach.go uses (routeListFn/linkByIndexFn/
+// preflightCheckFn/filterPriorityFn) so tests can exercise the
+// EgressKindVeth branch's control flow without CAP_NET_ADMIN or a real
+// netlink socket. Production code never reassigns these; vip.go itself is
+// untouched.
+var (
+	vipBindFn   = vip.Bind
+	vipUnbindFn = vip.Unbind
+	vipVerifyFn = vip.Verify
+)
+
+// VIPTranslationTable is the interface ServiceVIPBindingReconciler drives
+// for EgressKindTap bindings, satisfied by *vipxlatmap.VipXlatTable in
+// production and a fake in tests -- the same interface-seam pattern
+// GatewayEngine (networkgateway_controller.go) provides for *gateway.Engine.
+type VIPTranslationTable interface {
+	RegisterIngress(block uint64, argument uint16, proto uint8,
+		vipAddr net.IP, vipPort uint16, backendAddr net.IP, backendPort uint16) error
+	RegisterEgress(block uint64, argument uint16, proto uint8,
+		backendAddr net.IP, backendPort uint16, vipAddr net.IP, vipPort uint16) error
+	UnregisterIngress(block uint64, argument uint16, proto uint8, vipPort uint16) error
+	UnregisterEgress(block uint64, argument uint16, proto uint8, backendPort uint16) error
+}
+
+// ServiceVIPBindingReconciler reconciles ServiceVIPBinding objects targeting
+// this node (spec.targetRef.name == NodeName) -- the backend-side half of
+// the DSR/Maglev gateway redesign (see ServiceVIPBinding's own doc
+// comment). It branches on Spec.EgressKind exactly like usid.c's own
+// vrf_table egress_kind field does:
+//
+//   - EgressKindVeth calls internal/plumbing/vip.Bind/Unbind/Verify.
+//   - EgressKindTap calls VIPTranslationTable's Register/Unregister methods
+//     (vip_xlat_table's two independent rows -- see
+//     internal/plumbing/ebpf/vipxlatmap's package doc comment), after
+//     resolving this node's own uSID Block and the tenant VRF's Argument
+//     via resolveTapVIPContext.
+//
+// VIPTranslationTable is nil-safe for veth-only tests/deployments (e.g. a
+// node with no eBPF uSID datapath loaded at all): a nil table only matters
+// once a tap-kind binding is actually reconciled, at which point it fails
+// with a clear, actionable error rather than a nil-pointer panic.
+type ServiceVIPBindingReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	NodeName string
+
+	// VIPTranslationTable is the tap-branch's kernel-map handle. See the
+	// type doc comment above for its nil-safety contract.
+	VIPTranslationTable VIPTranslationTable
+}
+
+// Reconcile reconciles a single ServiceVIPBinding.
+func (r *ServiceVIPBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	binding := &bgpv1alpha1.ServiceVIPBinding{}
+	if err := r.Get(ctx, req.NamespacedName, binding); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get ServiceVIPBinding %s: %w", req.NamespacedName, err)
+	}
+
+	if binding.Spec.TargetRef.Name != r.NodeName {
+		return ctrl.Result{}, nil
+	}
+
+	if !binding.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, binding)
+	}
+
+	if !controllerutil.ContainsFinalizer(binding, serviceVIPBindingFinalizer) {
+		patchBase := binding.DeepCopy()
+		controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
+		if err := r.Patch(ctx, binding, client.MergeFrom(patchBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add finalizer to ServiceVIPBinding %s: %w", req.NamespacedName, err)
+		}
+	}
+
+	if err := r.reconcileBind(ctx, binding); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// reconcileBind applies binding's desired bind/translation state and
+// records the outcome on Status.Conditions[Bound], mirroring
+// networkrule_controller.go's own condition-update style (status update
+// happens regardless of success/failure, and the bind/register error, if
+// any, is returned afterward so the controller-runtime requeues it).
+func (r *ServiceVIPBindingReconciler) reconcileBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
+	bindErr := r.applyBind(ctx, binding)
+
+	bindingCopy := binding.DeepCopy()
+	cond := metav1.Condition{Type: bgpv1alpha1.ConditionTypeBound}
+	if bindErr != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = "BindFailed"
+		cond.Message = bindErr.Error()
+	} else {
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = "Bound"
+		cond.Message = fmt.Sprintf("backend is reachable on VIP %s:%d (%s)",
+			binding.Spec.VIPAddress, binding.Spec.Port, binding.Spec.EgressKind)
+	}
+	setBindingCondition(bindingCopy, cond)
+	bindingCopy.Status.ObservedGeneration = binding.Generation
+	if err := r.Status().Update(ctx, bindingCopy); err != nil {
+		return fmt.Errorf("update ServiceVIPBinding %s/%s status: %w", binding.Namespace, binding.Name, err)
+	}
+
+	if bindErr != nil {
+		return fmt.Errorf("bind ServiceVIPBinding %s/%s: %w", binding.Namespace, binding.Name, bindErr)
+	}
+	return nil
+}
+
+// applyBind performs the actual veth bind or tap registration for binding,
+// branching on Spec.EgressKind.
+func (r *ServiceVIPBindingReconciler) applyBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
+	switch binding.Spec.EgressKind {
+	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
+		vipAddr := net.ParseIP(binding.Spec.VIPAddress)
+		if vipAddr == nil {
+			return fmt.Errorf("invalid vipAddress %q", binding.Spec.VIPAddress)
+		}
+		if err := vipBindFn(vipAddr); err != nil {
+			return fmt.Errorf("vip.Bind: %w", err)
+		}
+		if err := vipVerifyFn(vipAddr); err != nil {
+			return fmt.Errorf("vip.Verify: %w", err)
+		}
+		return nil
+	case bgpv1alpha1.ServiceVIPBindingEgressKindTap:
+		return r.applyTapBind(ctx, binding)
+	default:
+		return fmt.Errorf("unknown egressKind %q", binding.Spec.EgressKind)
+	}
+}
+
+// applyTapBind registers both vip_xlat_table rows (ingress and egress) for
+// a tap-kind binding, after resolving this node's own uSID Block and the
+// owning tenant VRF's Argument (resolveTapVIPContext).
+func (r *ServiceVIPBindingReconciler) applyTapBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
+	if r.VIPTranslationTable == nil {
+		return errors.New("vip_xlat_table is not available on this node (eBPF uSID datapath not loaded); " +
+			"cannot bind a tap-kind ServiceVIPBinding")
+	}
+
+	vipAddr := net.ParseIP(binding.Spec.VIPAddress)
+	if vipAddr == nil {
+		return fmt.Errorf("invalid vipAddress %q", binding.Spec.VIPAddress)
+	}
+	backendAddr := net.ParseIP(binding.Spec.BackendAddress)
+	if backendAddr == nil {
+		return fmt.Errorf("invalid backendAddress %q (required for egressKind tap)", binding.Spec.BackendAddress)
+	}
+	backendAddrIP, err := netip.ParseAddr(binding.Spec.BackendAddress)
+	if err != nil {
+		return fmt.Errorf("parse backendAddress %q: %w", binding.Spec.BackendAddress, err)
+	}
+
+	proto, err := ipProtocolNumber(binding.Spec.Protocol)
+	if err != nil {
+		return err
+	}
+
+	block, argument, err := resolveTapVIPContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
+	if err != nil {
+		return fmt.Errorf("resolve VRF context for tap VIP binding: %w", err)
+	}
+
+	vipPort := uint16(binding.Spec.Port)            //nolint:gosec // kubebuilder-validated 1-65535
+	backendPort := uint16(binding.Spec.BackendPort) //nolint:gosec // kubebuilder-validated 1-65535
+
+	if err := r.VIPTranslationTable.RegisterIngress(
+		block, argument, proto, vipAddr, vipPort, backendAddr, backendPort); err != nil {
+		return fmt.Errorf("register vip_xlat_table ingress row: %w", err)
+	}
+	if err := r.VIPTranslationTable.RegisterEgress(
+		block, argument, proto, backendAddr, backendPort, vipAddr, vipPort); err != nil {
+		return fmt.Errorf("register vip_xlat_table egress row: %w", err)
+	}
+	return nil
+}
+
+// reconcileDelete performs the finalizer-guarded unbind/unregister on
+// ServiceVIPBinding deletion, mirroring networkrule_controller.go's
+// reconcileDelete pattern: the finalizer is only removed once the
+// underlying unbind/unregister has actually succeeded, so a failure here
+// blocks deletion (and is retried) rather than silently leaking kernel/host
+// state.
+func (r *ServiceVIPBindingReconciler) reconcileDelete(
+	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
+) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(binding, serviceVIPBindingFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.applyUnbind(ctx, binding); err != nil {
+		return ctrl.Result{}, fmt.Errorf("unbind ServiceVIPBinding %s/%s: %w", binding.Namespace, binding.Name, err)
+	}
+
+	patchBase := binding.DeepCopy()
+	controllerutil.RemoveFinalizer(binding, serviceVIPBindingFinalizer)
+	if err := r.Patch(ctx, binding, client.MergeFrom(patchBase)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("remove finalizer from ServiceVIPBinding %s/%s: %w",
+			binding.Namespace, binding.Name, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+// applyUnbind performs the actual veth unbind or tap unregistration for
+// binding, branching on Spec.EgressKind.
+func (r *ServiceVIPBindingReconciler) applyUnbind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
+	switch binding.Spec.EgressKind {
+	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
+		vipAddr := net.ParseIP(binding.Spec.VIPAddress)
+		if vipAddr == nil {
+			return nil // already-invalid address; nothing meaningful to unbind
+		}
+		return vipUnbindFn(vipAddr)
+	case bgpv1alpha1.ServiceVIPBindingEgressKindTap:
+		if r.VIPTranslationTable == nil {
+			return errors.New(
+				"vip_xlat_table is not available on this node; cannot unregister a tap-kind ServiceVIPBinding")
+		}
+		return r.applyTapUnbind(ctx, binding)
+	default:
+		return nil
+	}
+}
+
+// applyTapUnbind removes both vip_xlat_table rows for a tap-kind binding.
+// Both directions are attempted even if resolving the VRF context or the
+// first Unregister call fails, and any errors are joined together --
+// mirroring usidmap.VRFTable.Reconcile's own "attempt every candidate even
+// if one fails" convention -- so a partial failure never silently leaves
+// the other row behind unregistered.
+func (r *ServiceVIPBindingReconciler) applyTapUnbind(
+	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
+) error {
+	proto, err := ipProtocolNumber(binding.Spec.Protocol)
+	if err != nil {
+		return err
+	}
+
+	backendAddrIP, err := netip.ParseAddr(binding.Spec.BackendAddress)
+	if err != nil {
+		return fmt.Errorf("parse backendAddress %q: %w", binding.Spec.BackendAddress, err)
+	}
+
+	block, argument, err := resolveTapVIPContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
+	if err != nil {
+		return fmt.Errorf("resolve VRF context for tap VIP unbind: %w", err)
+	}
+
+	vipPort := uint16(binding.Spec.Port)            //nolint:gosec // kubebuilder-validated 1-65535
+	backendPort := uint16(binding.Spec.BackendPort) //nolint:gosec // kubebuilder-validated 1-65535
+
+	var errs []error
+	if err := r.VIPTranslationTable.UnregisterIngress(block, argument, proto, vipPort); err != nil {
+		errs = append(errs, fmt.Errorf("unregister vip_xlat_table ingress row: %w", err))
+	}
+	if err := r.VIPTranslationTable.UnregisterEgress(block, argument, proto, backendPort); err != nil {
+		errs = append(errs, fmt.Errorf("unregister vip_xlat_table egress row: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+// ipProtocolNumber maps a NetworkRuleProtocol to the IANA protocol number
+// vip_xlat_table's key uses (usid.c's USID_IPPROTO_TCP/UDP).
+func ipProtocolNumber(proto bgpv1alpha1.NetworkRuleProtocol) (uint8, error) {
+	switch proto {
+	case bgpv1alpha1.NetworkRuleProtocolTCP:
+		return ipProtoTCP, nil
+	case bgpv1alpha1.NetworkRuleProtocolUDP:
+		return ipProtoUDP, nil
+	default:
+		return 0, fmt.Errorf(
+			"unsupported protocol %q (vip_xlat_table only supports tcp/udp, matching usid.c's USID_IPPROTO_TCP/UDP)", proto)
+	}
+}
+
+// resolveTapVIPContext resolves this node's own uSID Block (from its
+// BGPRouter's SRv6Locator) and the owning tenant VRF's Argument (from the
+// BGPVRFInstance whose VRFID is associated with a BGPAdvertisement whose
+// advertised prefix contains backendAddr) -- the (block, argument) pair
+// vip_xlat_table's key needs (usid.c's struct vip_xlat_key), for a
+// tap-kind ServiceVIPBinding on this node.
+//
+// # A documented ambiguity (no VPCRef/VRFRef field on ServiceVIPBinding)
+//
+// ServiceVIPBinding carries no VPCRef or VRFRef field of its own (see its
+// own doc comment and internal/controller/usidresolver.go's identical
+// concern for NetworkRule backends) -- the writer that is expected to
+// eventually populate ServiceVIPBinding objects (a future extension of
+// NetworkRuleReconciler, out of this reconciler's scope) has direct access
+// to the owning NetworkRule's VPCRef at creation time, but that identity is
+// not carried onto the ServiceVIPBinding object itself today. Absent that
+// field, this function resolves ownership the same way
+// usidresolver.go's backendSIDIndex already does for NetworkRule backends:
+// by matching BackendAddress against this node's own BGPVRFInstances'
+// advertised prefixes (reusing buildBackendSIDIndex directly rather than
+// re-listing the same CRDs) -- restricted to VRFs whose BGPVRFInstance
+// actually targets *this node's* own BGPRouter, since a tap binding's VRF
+// context is always local to the node it was written for.
+//
+// This resolution is unambiguous as long as no two VRFs on this same node
+// advertise overlapping prefixes that both contain backendAddr (e.g. two
+// tenants independently choosing the same ULA range) -- exactly the
+// scenario backendSIDIndex.verifyTenantOwnership already exists to guard
+// against elsewhere, but that guard needs a known vpcRef to check
+// ownership *against*, which this function does not have. When more than
+// one candidate VRF matches, this function fails closed (an explicit
+// error) rather than guessing, on the same reasoning
+// verifyTenantOwnership's own doc comment gives: silently picking one
+// candidate over another risks translating a backend's traffic into the
+// wrong tenant's VRF, not merely an inconvenience.
+//
+// TODO(dsr-maglev): once ServiceVIPBinding gains a VPCRef/VRFRef field (or
+// the writer encodes the resolved (block, argument) directly on the
+// object), replace this address-containment heuristic with a direct
+// lookup -- see crdnames.BGPVRFInstanceName(vpc, nodeName) for the
+// deterministic name that lookup would use.
+func resolveTapVIPContext(
+	ctx context.Context, c client.Client, namespace, nodeName string, backendAddr netip.Addr,
+) (block uint64, argument uint16, err error) {
+	idx, err := buildBackendSIDIndex(ctx, c, namespace)
+	if err != nil {
+		return 0, 0, fmt.Errorf("build backend SID index: %w", err)
+	}
+
+	var router *bgpv1alpha1.BGPRouter
+	for _, rt := range idx.routers {
+		if rt.Spec.TargetRef.Name == nodeName {
+			router = rt
+			break
+		}
+	}
+	if router == nil {
+		return 0, 0, fmt.Errorf("no BGPRouter targets node %q in namespace %q", nodeName, namespace)
+	}
+	if router.Spec.SRv6Locator == "" {
+		return 0, 0, fmt.Errorf("BGPRouter %s has no SRv6Locator set", router.Name)
+	}
+
+	prefix, err := netip.ParsePrefix(router.Spec.SRv6Locator)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse SRv6Locator %q of BGPRouter %s: %w", router.Spec.SRv6Locator, router.Name, err)
+	}
+	block, err = uformat.Block(prefix.Addr())
+	if err != nil {
+		return 0, 0, fmt.Errorf("derive uSID Block from BGPRouter %s's SRv6Locator: %w", router.Name, err)
+	}
+
+	localVRFIDs := make(map[int32]struct{})
+	for _, instance := range idx.vrfInstances {
+		if vrfInstanceTargetsRouter(instance, router) {
+			localVRFIDs[instance.Spec.VRFID] = struct{}{}
+		}
+	}
+
+	seen := make(map[int32]struct{})
+	var matches []int32
+	for _, adv := range idx.advs {
+		if adv.Spec.RouterRef.Name != router.Name || adv.Spec.VRFID == nil {
+			continue
+		}
+		vrfID := *adv.Spec.VRFID
+		if _, ok := localVRFIDs[vrfID]; !ok {
+			continue // not one of this node's own local VRFs
+		}
+		if _, already := seen[vrfID]; already {
+			continue
+		}
+		for _, p := range adv.Spec.Prefixes {
+			pfx, perr := netip.ParsePrefix(string(p))
+			if perr != nil {
+				continue
+			}
+			if pfx.Contains(backendAddr) {
+				seen[vrfID] = struct{}{}
+				matches = append(matches, vrfID)
+				break
+			}
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return 0, 0, fmt.Errorf(
+			"no local BGPVRFInstance on node %q has an advertised BGPAdvertisement prefix containing backend address %s",
+			nodeName, backendAddr)
+	case 1:
+		return block, uint16(matches[0]), nil //nolint:gosec // VRFID is kubebuilder-validated 1-65535
+	default:
+		return 0, 0, fmt.Errorf(
+			"ambiguous VRF ownership for backend address %s on node %q: %d candidate VRFIDs %v all advertise a "+
+				"containing prefix, and ServiceVIPBinding carries no VPCRef/VRFRef to disambiguate "+
+				"(see resolveTapVIPContext's doc comment); refusing to guess",
+			backendAddr, nodeName, len(matches), matches)
+	}
+}
+
+// vrfInstanceTargetsRouter reports whether vrf's RouterTarget (RouterRef or
+// RouterSelector) resolves to router -- mirroring routing.go's
+// enqueueRoutersForTarget matching logic, but as a boolean test against one
+// already-known router rather than a List-driven fan-out.
+func vrfInstanceTargetsRouter(vrf *bgpv1alpha1.BGPVRFInstance, router *bgpv1alpha1.BGPRouter) bool {
+	if vrf.Spec.RouterRef != nil {
+		return vrf.Spec.RouterRef.Name == router.Name
+	}
+	if vrf.Spec.RouterSelector != nil {
+		sel, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels:      vrf.Spec.RouterSelector.MatchLabels,
+			MatchExpressions: vrf.Spec.RouterSelector.MatchExpressions,
+		})
+		if err != nil {
+			return false
+		}
+		return sel.Matches(labels.Set(router.Labels))
+	}
+	return false
+}
+
+// SetupWithManager registers the ServiceVIPBindingReconciler with the
+// manager. ServiceVIPBinding is a leaf CRD written by another controller
+// and consumed only here -- no additional watch is needed beyond the
+// object itself, unlike NetworkRuleReconciler's NetworkGateway watch
+// (which reacts to a namespace-wide gateway-node pool changing).
+func (r *ServiceVIPBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&bgpv1alpha1.ServiceVIPBinding{}).
+		Named("servicevipbinding").
+		Complete(r)
+}

--- a/internal/controller/servicevipbinding_controller_test.go
+++ b/internal/controller/servicevipbinding_controller_test.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	testVIPBindingNode        = "vip-node-1"
+	testVIPBindingName        = "binding-1"
+	testVIPBindingVIPAddr     = "2001:db8:5:5::100"
+	testVIPBindingBackendAddr = "fd20:60::5:5"
+)
+
+func newTestServiceVIPBinding(
+	egressKind bgpv1alpha1.ServiceVIPBindingEgressKind, nodeName string,
+) *bgpv1alpha1.ServiceVIPBinding {
+	return &bgpv1alpha1.ServiceVIPBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testVIPBindingName},
+		Spec: bgpv1alpha1.ServiceVIPBindingSpec{
+			TargetRef:      bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: nodeName},
+			VIPAddress:     testVIPBindingVIPAddr,
+			Port:           8080,
+			Protocol:       bgpv1alpha1.NetworkRuleProtocolTCP,
+			BackendAddress: testVIPBindingBackendAddr,
+			BackendPort:    30080,
+			EgressKind:     egressKind,
+		},
+	}
+}
+
+func bindingKey() types.NamespacedName {
+	return types.NamespacedName{Namespace: testNamespace, Name: testVIPBindingName}
+}
+
+// vipCall records one RegisterIngress/RegisterEgress invocation against
+// fakeVIPTable.
+type vipCall struct {
+	block    uint64
+	argument uint16
+	proto    uint8
+	addr1    net.IP
+	port1    uint16
+	addr2    net.IP
+	port2    uint16
+}
+
+// unregisterCall records one UnregisterIngress/UnregisterEgress invocation.
+type unregisterCall struct {
+	block    uint64
+	argument uint16
+	proto    uint8
+	port     uint16
+}
+
+// fakeVIPTable is a fake VIPTranslationTable for testing
+// ServiceVIPBindingReconciler's tap branch without a real kernel map.
+type fakeVIPTable struct {
+	ingressCalls  []vipCall
+	egressCalls   []vipCall
+	unregIngress  []unregisterCall
+	unregEgress   []unregisterCall
+	registerErr   error
+	unregisterErr error
+}
+
+func (f *fakeVIPTable) RegisterIngress(block uint64, argument uint16, proto uint8,
+	vipAddr net.IP, vipPort uint16, backendAddr net.IP, backendPort uint16) error {
+	f.ingressCalls = append(f.ingressCalls, vipCall{block, argument, proto, vipAddr, vipPort, backendAddr, backendPort})
+	return f.registerErr
+}
+
+func (f *fakeVIPTable) RegisterEgress(block uint64, argument uint16, proto uint8,
+	backendAddr net.IP, backendPort uint16, vipAddr net.IP, vipPort uint16) error {
+	f.egressCalls = append(f.egressCalls, vipCall{block, argument, proto, backendAddr, backendPort, vipAddr, vipPort})
+	return f.registerErr
+}
+
+func (f *fakeVIPTable) UnregisterIngress(block uint64, argument uint16, proto uint8, vipPort uint16) error {
+	f.unregIngress = append(f.unregIngress, unregisterCall{block, argument, proto, vipPort})
+	return f.unregisterErr
+}
+
+func (f *fakeVIPTable) UnregisterEgress(block uint64, argument uint16, proto uint8, backendPort uint16) error {
+	f.unregEgress = append(f.unregEgress, unregisterCall{block, argument, proto, backendPort})
+	return f.unregisterErr
+}
+
+// stubVIPFns overrides vipBindFn/vipUnbindFn/vipVerifyFn for the duration
+// of one test, restoring the real functions on cleanup -- t.Cleanup runs
+// even if the test fails, so a later test never observes a stubbed
+// function left behind by an earlier one.
+func stubVIPFns(t *testing.T, bind, unbind, verify func(net.IP) error) {
+	t.Helper()
+	origBind, origUnbind, origVerify := vipBindFn, vipUnbindFn, vipVerifyFn
+	vipBindFn, vipUnbindFn, vipVerifyFn = bind, unbind, verify
+	t.Cleanup(func() { vipBindFn, vipUnbindFn, vipVerifyFn = origBind, origUnbind, origVerify })
+}
+
+func TestServiceVIPBindingReconciler_NotMineIsIgnored(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, "some-other-node")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(binding).
+		Build()
+
+	var bindCalled bool
+	stubVIPFns(t,
+		func(net.IP) error { bindCalled = true; return nil },
+		func(net.IP) error { return nil },
+		func(net.IP) error { return nil },
+	)
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if bindCalled {
+		t.Errorf("vip.Bind was called for a binding not targeting this node")
+	}
+
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	if err := fakeClient.Get(context.Background(), bindingKey(), got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, serviceVIPBindingFinalizer) {
+		t.Errorf("finalizer was added to a binding not targeting this node")
+	}
+}
+
+func TestServiceVIPBindingReconciler_VethBindSuccess(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(binding).
+		Build()
+
+	var boundAddr net.IP
+	stubVIPFns(t,
+		func(addr net.IP) error { boundAddr = addr; return nil },
+		func(net.IP) error { return nil },
+		func(net.IP) error { return nil },
+	)
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	if boundAddr == nil || !boundAddr.Equal(net.ParseIP(testVIPBindingVIPAddr)) {
+		t.Errorf("vip.Bind called with %v, want %s", boundAddr, testVIPBindingVIPAddr)
+	}
+
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	if err := fakeClient.Get(context.Background(), bindingKey(), got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, serviceVIPBindingFinalizer) {
+		t.Errorf("finalizer was not added")
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, bgpv1alpha1.ConditionTypeBound) {
+		t.Errorf("Bound condition = %+v, want True", got.Status.Conditions)
+	}
+}
+
+func TestServiceVIPBindingReconciler_VethUnbindOnDelete(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
+	now := metav1.Now()
+	binding.DeletionTimestamp = &now
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(binding).
+		Build()
+
+	var unboundAddr net.IP
+	stubVIPFns(t,
+		func(net.IP) error { return nil },
+		func(addr net.IP) error { unboundAddr = addr; return nil },
+		func(net.IP) error { return nil },
+	)
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	if unboundAddr == nil || !unboundAddr.Equal(net.ParseIP(testVIPBindingVIPAddr)) {
+		t.Errorf("vip.Unbind called with %v, want %s", unboundAddr, testVIPBindingVIPAddr)
+	}
+
+	// Removing the last finalizer from an object that already carries a
+	// DeletionTimestamp lets the (fake, like the real API server) client
+	// actually delete it from the store -- so the only observable proof
+	// the finalizer is gone is that the object is gone too.
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	err := fakeClient.Get(context.Background(), bindingKey(), got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("get: got err=%v, want NotFound (finalizer removal should let deletion complete)", err)
+	}
+}
+
+// TestServiceVIPBindingReconciler_FinalizerKeptWhenUnbindFails covers the
+// "finalizer add/remove ordering" requirement: a failing unbind/unregister
+// must never let the finalizer be removed, so the object stays present
+// (blocking deletion, and retried) rather than silently leaking host/kernel
+// state.
+func TestServiceVIPBindingReconciler_FinalizerKeptWhenUnbindFails(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
+	now := metav1.Now()
+	binding.DeletionTimestamp = &now
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(binding).
+		Build()
+
+	stubVIPFns(t,
+		func(net.IP) error { return nil },
+		func(net.IP) error { return errors.New("intentional unbind failure") },
+		func(net.IP) error { return nil },
+	)
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err == nil {
+		t.Fatal("Reconcile: expected an error when vip.Unbind fails")
+	}
+
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	if err := fakeClient.Get(context.Background(), bindingKey(), got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !controllerutil.ContainsFinalizer(got, serviceVIPBindingFinalizer) {
+		t.Errorf("finalizer was removed despite a failed unbind")
+	}
+}
+
+func TestServiceVIPBindingReconciler_TapRegisterSuccess(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindTap, testComputeNodeName)
+	binding.Spec.BackendAddress = testBackendAddr // must resolve via the fixtures' advertised prefix
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(router, adv, vrf, binding).
+		Build()
+
+	table := &fakeVIPTable{}
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName, VIPTranslationTable: table}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	if len(table.ingressCalls) != 1 || len(table.egressCalls) != 1 {
+		t.Fatalf("ingressCalls=%d egressCalls=%d, want 1 each", len(table.ingressCalls), len(table.egressCalls))
+	}
+	wantArgument := uint16(testBackendVRFID)
+	if table.ingressCalls[0].argument != wantArgument {
+		t.Errorf("ingress argument = %d, want %d", table.ingressCalls[0].argument, wantArgument)
+	}
+	if !table.ingressCalls[0].addr1.Equal(net.ParseIP(testVIPBindingVIPAddr)) {
+		t.Errorf("ingress row vip addr = %v, want %s", table.ingressCalls[0].addr1, testVIPBindingVIPAddr)
+	}
+	if !table.ingressCalls[0].addr2.Equal(net.ParseIP(testBackendAddr)) {
+		t.Errorf("ingress row value addr = %v, want %s (backend)", table.ingressCalls[0].addr2, testBackendAddr)
+	}
+
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	if err := fakeClient.Get(context.Background(), bindingKey(), got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !meta.IsStatusConditionTrue(got.Status.Conditions, bgpv1alpha1.ConditionTypeBound) {
+		t.Errorf("Bound condition = %+v, want True", got.Status.Conditions)
+	}
+}
+
+func TestServiceVIPBindingReconciler_TapUnregisterOnDelete(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindTap, testComputeNodeName)
+	binding.Spec.BackendAddress = testBackendAddr
+	controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
+	now := metav1.Now()
+	binding.DeletionTimestamp = &now
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(router, adv, vrf, binding).
+		Build()
+
+	table := &fakeVIPTable{}
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName, VIPTranslationTable: table}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+
+	if len(table.unregIngress) != 1 || len(table.unregEgress) != 1 {
+		t.Fatalf("unregIngress=%d unregEgress=%d, want 1 each", len(table.unregIngress), len(table.unregEgress))
+	}
+
+	// See the same note in TestServiceVIPBindingReconciler_VethUnbindOnDelete:
+	// finalizer removal here completes the deletion, so NotFound is the
+	// success signal, not a successful Get.
+	got := &bgpv1alpha1.ServiceVIPBinding{}
+	err := fakeClient.Get(context.Background(), bindingKey(), got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("get: got err=%v, want NotFound (finalizer removal should let deletion complete)", err)
+	}
+}
+
+func TestServiceVIPBindingReconciler_TapNilTableFails(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindTap, testComputeNodeName)
+	binding.Spec.BackendAddress = testBackendAddr
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(router, adv, vrf, binding).
+		Build()
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName} // no VIPTranslationTable
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err == nil {
+		t.Fatal("Reconcile: expected an error binding a tap-kind ServiceVIPBinding with no VIPTranslationTable")
+	}
+}
+
+func TestResolveTapVIPContext_Success(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
+
+	block, argument, err := resolveTapVIPContext(
+		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr(testBackendAddr))
+	if err != nil {
+		t.Fatalf("resolveTapVIPContext: unexpected error: %v", err)
+	}
+	if argument != uint16(testBackendVRFID) {
+		t.Errorf("argument = %d, want %d", argument, testBackendVRFID)
+	}
+	if block == 0 {
+		t.Errorf("block = 0, want the uSID Block derived from %s", testBackendLocator)
+	}
+}
+
+func TestResolveTapVIPContext_NoMatchingVRF(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
+
+	if _, _, err := resolveTapVIPContext(
+		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr("192.0.2.1")); err == nil {
+		t.Fatal("resolveTapVIPContext: expected an error for an address with no matching advertised prefix")
+	}
+}
+
+// TestResolveTapVIPContext_AmbiguousFailsClosed covers the documented
+// ambiguity: two local BGPVRFInstances on the same node both advertise a
+// prefix containing the same backend address (e.g. two tenants using the
+// same ULA range) -- resolveTapVIPContext must fail rather than guess.
+func TestResolveTapVIPContext_AmbiguousFailsClosed(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+
+	vrfID2 := int32(testBackendVRFID + 1)
+	function := bgpv1alpha1.SRv6FunctionEndDT46
+	adv2 := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "second-adv"},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: testBackendRouterName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{testBackendPrefix}, // same prefix, colliding
+			VRFID:         &vrfID2,
+			Function:      &function,
+		},
+	}
+	vrf2 := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "second-vrf"},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: testBackendRouterName}},
+			VRFID:              vrfID2,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTargetValue}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf, adv2, vrf2).Build()
+
+	_, _, err := resolveTapVIPContext(
+		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr(testBackendAddr))
+	if err == nil {
+		t.Fatal("resolveTapVIPContext: expected a fail-closed error for ambiguous VRF ownership")
+	}
+}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -102,12 +102,33 @@ func setVRFInstanceCondition(vrf *bgpv1alpha1.BGPVRFInstance, condition metav1.C
 	meta.SetStatusCondition(&vrf.Status.Conditions, condition)
 }
 
+// ConditionNPTv6Configured reports whether a BGPVRFInstance's own
+// Spec.NPTv6 field (when set) parses into a valid RFC 6296 mapping —
+// locally defined here (rather than added to the network module's own
+// vrf_types.go, which this workstream does not own) since generic
+// Conditions is exactly the extension point BGPVRFInstanceStatus already
+// exposes for this. It reflects config validity only, not live eBPF
+// datapath state: the process that actually registers/reconciles
+// nptv6_table entries (gc.SweepEBPFNPTv6Table, run from
+// internal/installer.Run inside the CNI "run" container) has no access
+// back to this CRD's status from there — see that function's own doc
+// comment for why eBPF map access is confined to that container.
+const ConditionNPTv6Configured = "NPTv6Configured"
+
 // setGatewayCondition sets or updates a condition on NetworkGateway.
 // ConditionTypeReady (reused from peer_types.go, not redeclared) is the
 // only condition type NetworkGateway currently uses.
 func setGatewayCondition(gw *bgpv1alpha1.NetworkGateway, condition metav1.Condition) {
 	condition.ObservedGeneration = gw.Generation
 	meta.SetStatusCondition(&gw.Status.Conditions, condition)
+}
+
+// setBindingCondition sets or updates a condition on ServiceVIPBinding.
+// bgpv1alpha1.ConditionTypeBound (vipbinding_types.go) is the only
+// condition type ServiceVIPBinding uses.
+func setBindingCondition(binding *bgpv1alpha1.ServiceVIPBinding, condition metav1.Condition) {
+	condition.ObservedGeneration = binding.Generation
+	meta.SetStatusCondition(&binding.Status.Conditions, condition)
 }
 
 // setRuleCondition sets or updates a condition on NetworkRule.
@@ -118,4 +139,13 @@ func setGatewayCondition(gw *bgpv1alpha1.NetworkGateway, condition metav1.Condit
 func setRuleCondition(rule *bgpv1alpha1.NetworkRule, condition metav1.Condition) {
 	condition.ObservedGeneration = rule.Generation
 	meta.SetStatusCondition(&rule.Status.Conditions, condition)
+}
+
+// setNAT66ShardCondition sets or updates a condition on NAT66Shard.
+// ConditionTypeReady (reused from peer_types.go, not redeclared) is the
+// only condition type NAT66Shard currently uses — mirrors
+// setGatewayCondition's identical shape for NetworkGateway.
+func setNAT66ShardCondition(shard *bgpv1alpha1.NAT66Shard, condition metav1.Condition) {
+	condition.ObservedGeneration = shard.Generation
+	meta.SetStatusCondition(&shard.Status.Conditions, condition)
 }

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"os"
 	"regexp"
@@ -17,8 +18,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"go.datum.net/galactic/internal/plumbing/ebpf/nptv6map"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/nptv6"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -46,7 +49,10 @@ type CleanupResult struct {
 	// from OrphanedVRFsRemoved's kernel VRF *interfaces* above (Milestone
 	// 7.3).
 	EBPFVRFEntriesRemoved int
-	Errors                int
+	// EBPFNPTv6EntriesRemoved counts stale eBPF uSID datapath nptv6_table
+	// map entries removed by SweepEBPFNPTv6Table.
+	EBPFNPTv6EntriesRemoved int
+	Errors                  int
 }
 
 // vrfNameRegex matches the deterministic VRF interface name pattern used by
@@ -533,6 +539,147 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	}
 
 	return result
+}
+
+// SweepEBPFNPTv6Table registers/reconciles the eBPF uSID datapath's
+// nptv6_table map (internal/plumbing/ebpf/nptv6map) against every live
+// BGPVRFInstance CRD's own Spec.NPTv6 field, owned by nodeName's
+// BGPRouter(s).
+//
+// Unlike SweepEBPFVRFTable (whose vrf_table registration happens at CNI ADD
+// time via internal/cnibgp's registerEBPFDatapath, and this function only
+// reconciles stale entries away), this function is nptv6_table's *only*
+// writer: nothing registers an NPTv6 mapping at CNI ADD time at all (the CNI
+// ADD path has no per-attachment notion of NPTv6 -- it is a per-VRF, not
+// per-attachment, config field). Every currently-live mapping is therefore
+// (re-)registered here, on the same tick that also reconciles stale ones
+// away -- see internal/plumbing/ebpf/nptv6map/doc.go's "no Generation/
+// monotonic-clock kernel field" section for why a single, sequential writer
+// (this function, never raced by a second writer) makes that safe without
+// vrf_table's own kernel-persisted generation field.
+//
+// Runs from the same place as SweepEBPFVRFTable
+// (internal/installer.Run's ebpfGCSweepTicker), for the identical reason:
+// the pinned nptv6_table map only exists inside that container -- see
+// SweepEBPFVRFTable's own doc comment for the full reasoning (galactic-router's
+// own DaemonSet has no /sys/fs/bpf mount or CAP_BPF, so the BGPVRFInstance
+// controller-runtime reconciler cannot open this map directly regardless of
+// how it validates the CRD's own NPTv6 field).
+func SweepEBPFNPTv6Table(ctx context.Context, k8s client.Client, namespace, nodeName, pinDir string) CleanupResult {
+	result := CleanupResult{}
+
+	if _, statErr := os.Stat(pinDir); statErr != nil {
+		return result
+	}
+
+	table, closer, err := nptv6map.OpenPinned(pinDir)
+	if err != nil {
+		slog.Error("GC: failed to open pinned eBPF nptv6_table for sweep", "pinDir", pinDir, "err", err)
+		result.Errors++
+		return result
+	}
+	defer func() { _ = closer.Close() }()
+
+	// Capture the cutoff *before* listing BGPVRFInstance CRDs and
+	// (re-)registering their live mappings below -- every entry this same
+	// call registers therefore stamps a generation >= cutoff, and Reconcile
+	// keeps it regardless (it is also always in live directly). See
+	// nptv6map/doc.go for why this table has no second writer to race.
+	cutoff := table.Generation()
+
+	routers, err := routersForNode(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		slog.Error("GC: failed to list BGPRouters for eBPF nptv6_table sweep", "err", err)
+		result.Errors++
+		return result
+	}
+	if len(routers) == 0 {
+		// See SweepEBPFVRFTable's own identical guard for why zero routers
+		// found is treated as "skip this tick," not "genuinely nothing is
+		// live."
+		slog.Warn("GC: no BGPRouter found for node during eBPF nptv6_table sweep, skipping reconcile this tick",
+			"nodeName", nodeName)
+		return result
+	}
+
+	vrfInstList := &bgpv1alpha1.BGPVRFInstanceList{}
+	if err := k8s.List(ctx, vrfInstList, client.InNamespace(namespace)); err != nil {
+		slog.Error("GC: failed to list BGPVRFInstances for eBPF nptv6_table sweep", "err", err)
+		result.Errors++
+		return result
+	}
+
+	live := make(map[nptv6map.NPTv6Key]struct{}, len(vrfInstList.Items))
+	for _, inst := range vrfInstList.Items {
+		if inst.Spec.RouterRef == nil || inst.Spec.NPTv6 == nil {
+			continue
+		}
+		router, ok := routers[inst.Spec.RouterRef.Name]
+		if !ok {
+			continue // not one of this node's routers
+		}
+		if router.Spec.SRv6Locator == "" {
+			continue // this router has no eBPF-relevant locator configured
+		}
+		prefix, err := netip.ParsePrefix(router.Spec.SRv6Locator)
+		if err != nil {
+			slog.Warn("GC: skipping BGPVRFInstance with unparseable router locator during eBPF nptv6_table sweep",
+				"vrfInstance", inst.Name, "router", router.Name, "locator", router.Spec.SRv6Locator, "err", err)
+			continue
+		}
+		block, err := uformat.Block(prefix.Addr())
+		if err != nil {
+			slog.Warn("GC: skipping BGPVRFInstance with invalid router locator during eBPF nptv6_table sweep",
+				"vrfInstance", inst.Name, "router", router.Name, "locator", router.Spec.SRv6Locator, "err", err)
+			continue
+		}
+		if inst.Spec.VRFID < int32(uformat.ArgumentMin) || inst.Spec.VRFID > int32(uformat.ArgumentMax) {
+			slog.Warn("GC: skipping BGPVRFInstance with out-of-range VRFID during eBPF nptv6_table sweep",
+				"vrfInstance", inst.Name, "vrfID", inst.Spec.VRFID)
+			continue
+		}
+		argument := uint16(inst.Spec.VRFID)
+
+		mapping, err := buildNPTv6Mapping(inst.Spec.NPTv6)
+		if err != nil {
+			slog.Warn("GC: skipping BGPVRFInstance with invalid NPTv6 mapping during eBPF nptv6_table sweep",
+				"vrfInstance", inst.Name, "err", err)
+			continue
+		}
+		if err := table.Register(block, argument, mapping); err != nil {
+			slog.Error("GC: failed to register eBPF nptv6_table entry", "vrfInstance", inst.Name, "err", err)
+			result.Errors++
+			continue
+		}
+		live[nptv6map.NPTv6Key{Block: block, Argument: argument}] = struct{}{}
+	}
+
+	removed, err := table.Reconcile(live, cutoff)
+	for _, e := range removed {
+		slog.Info("GC: removed stale eBPF nptv6_table entry", "block", e.Block, "argument", e.Argument)
+	}
+	result.EBPFNPTv6EntriesRemoved = len(removed)
+	if err != nil {
+		slog.Error("GC: errors while reconciling eBPF nptv6_table", "err", err)
+		result.Errors++
+	}
+
+	return result
+}
+
+// buildNPTv6Mapping converts a BGPVRFInstanceSpec's NPTv6 field (validated
+// only as parseable CIDRs here; nptv6.Mapping.Adjustment/Register perform
+// the fuller RFC 6296 range validation) into an internal/plumbing/nptv6.Mapping.
+func buildNPTv6Mapping(spec *bgpv1alpha1.NPTv6Spec) (nptv6.Mapping, error) {
+	_, ula, err := net.ParseCIDR(spec.ULAPrefix)
+	if err != nil {
+		return nptv6.Mapping{}, fmt.Errorf("parse ulaPrefix %q: %w", spec.ULAPrefix, err)
+	}
+	_, pub, err := net.ParseCIDR(spec.PublicPrefix)
+	if err != nil {
+		return nptv6.Mapping{}, fmt.Errorf("parse publicPrefix %q: %w", spec.PublicPrefix, err)
+	}
+	return nptv6.Mapping{ULAPrefix: ula, PublicPrefix: pub}, nil
 }
 
 // RunGC performs a full garbage collection pass: removes orphaned BGP CRDs

--- a/internal/gc/gc_ebpf_test.go
+++ b/internal/gc/gc_ebpf_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/nptv6map"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
@@ -225,4 +226,104 @@ func blockFromLocator(t *testing.T, locator string) (uint64, error) {
 		return 0, err
 	}
 	return uformat.Block(prefix.Addr())
+}
+
+// TestSweepEBPFNPTv6Table_MissingPinDirIsNoOp mirrors
+// TestSweepEBPFVRFTable_MissingPinDirIsNoOp for the nptv6_table sweep.
+func TestSweepEBPFNPTv6Table_MissingPinDirIsNoOp(t *testing.T) {
+	k8s := fake.NewClientBuilder().WithScheme(gcTestScheme(t)).Build()
+	result := SweepEBPFNPTv6Table(context.Background(), k8s, "default", "node-a", "/sys/fs/bpf/galactic-does-not-exist")
+	if result.Errors != 0 || result.EBPFNPTv6EntriesRemoved != 0 {
+		t.Errorf("result = %+v, want a zero-value result (no-op)", result)
+	}
+}
+
+// TestSweepEBPFNPTv6Table_RegistersLiveRemovesStale is nptv6_table's own
+// exit criterion, mirroring TestSweepEBPFVRFTable_RemovesStaleKeepsLive:
+// unlike vrf_table, this function is nptv6_table's *only* writer (see its
+// own doc comment), so it must both register a live BGPVRFInstance's own
+// NPTv6 mapping AND remove a stale one whose CRD is absent, in the same
+// call.
+func TestSweepEBPFNPTv6Table_RegistersLiveRemovesStale(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		namespace  = "default"
+		nodeName   = "node-a"
+		routerName = "router-a"
+		locator    = "2001:db8:1::/48"
+		liveVRFID  = int32(10)
+		staleVRFID = int32(20)
+	)
+
+	router := &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: routerName, Namespace: namespace},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Kind: "Node", Name: nodeName},
+			LocalASN:    65000,
+			SRv6Locator: locator,
+			NodeID:      5,
+		},
+	}
+	liveInst := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "live-vrf", Namespace: namespace},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: routerName}},
+			VRFID:              liveVRFID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: testRouteTarget}},
+			NPTv6: &bgpv1alpha1.NPTv6Spec{
+				ULAPrefix:    "fd00:1::/48",
+				PublicPrefix: "2001:db8:2::/48",
+			},
+		},
+	}
+	// staleVRFID's BGPVRFInstance is deliberately NOT created -- only
+	// live-vrf exists in the fake client; its nptv6_table row is seeded
+	// directly below to simulate one left behind by a deleted CRD.
+	k8s := fake.NewClientBuilder().WithScheme(gcTestScheme(t)).WithObjects(router, liveInst).Build()
+
+	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-gcsweep-nptv6-test-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+	loaderObjs, err := attach.Load(pinDir)
+	if err != nil {
+		t.Fatalf("attach.Load: %v", err)
+	}
+	t.Cleanup(func() { _ = loaderObjs.Close() })
+
+	table, closer, err := nptv6map.OpenPinned(pinDir)
+	if err != nil {
+		t.Fatalf("nptv6map.OpenPinned: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	block, err := blockFromLocator(t, locator)
+	if err != nil {
+		t.Fatalf("derive block: %v", err)
+	}
+	staleArgument := uint16(staleVRFID)
+	staleMapping, err := buildNPTv6Mapping(&bgpv1alpha1.NPTv6Spec{
+		ULAPrefix: "fd00:9::/48", PublicPrefix: "2001:db8:9::/48",
+	})
+	if err != nil {
+		t.Fatalf("buildNPTv6Mapping: %v", err)
+	}
+	if err := table.Register(block, staleArgument, staleMapping); err != nil {
+		t.Fatalf("seed stale entry: %v", err)
+	}
+
+	result := SweepEBPFNPTv6Table(context.Background(), k8s, namespace, nodeName, pinDir)
+	if result.Errors != 0 {
+		t.Errorf("result.Errors = %d, want 0", result.Errors)
+	}
+	if result.EBPFNPTv6EntriesRemoved != 1 {
+		t.Errorf("result.EBPFNPTv6EntriesRemoved = %d, want 1", result.EBPFNPTv6EntriesRemoved)
+	}
+
+	if _, ok, err := table.Get(block, uint16(liveVRFID)); err != nil || !ok {
+		t.Errorf("live entry after sweep: ok=%v err=%v, want ok=true (must be registered)", ok, err)
+	}
+	if _, ok, err := table.Get(block, staleArgument); err != nil || ok {
+		t.Errorf("stale entry after sweep: ok=%v err=%v, want ok=false (must be removed)", ok, err)
+	}
 }

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -454,8 +454,9 @@ func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathSta
 //     internal/plumbing/ebpf/attach.Health -- exit criterion "health check
 //     fails correctly when the program is unloaded".
 //  7. Periodically sweeps stale vrf_table entries via gc.SweepEBPFVRFTable
-//     (design plan §5.3; Milestone 7.3). This runs from here, not from
-//     galactic-router's existing GC controller
+//     (design plan §5.3; Milestone 7.3), and registers/reconciles
+//     nptv6_table entries via gc.SweepEBPFNPTv6Table. Both run from here,
+//     not from galactic-router's existing GC controller
 //     (internal/controller/gc_controller.go), because the pinned maps
 //     only exist inside this container -- see gc.SweepEBPFVRFTable's own
 //     doc comment for the full reasoning.
@@ -602,6 +603,17 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 			if result.EBPFVRFEntriesRemoved > 0 || result.Errors > 0 {
 				slog.Info("eBPF vrf_table GC sweep complete",
 					"removed", result.EBPFVRFEntriesRemoved, "errors", result.Errors)
+			}
+
+			// nptv6_table's own sweep: unlike vrf_table above, this is the
+			// map's *only* writer (see gc.SweepEBPFNPTv6Table's own doc
+			// comment) -- it both registers every currently-live NPTv6
+			// mapping and reconciles stale ones away on every tick.
+			nptv6Result := gc.SweepEBPFNPTv6Table(
+				ctx, ebpfState.k8sClient, ebpfState.namespace, ebpfState.nodeName, attach.PinDir)
+			if nptv6Result.EBPFNPTv6EntriesRemoved > 0 || nptv6Result.Errors > 0 {
+				slog.Info("eBPF nptv6_table GC sweep complete",
+					"removed", nptv6Result.EBPFNPTv6EntriesRemoved, "errors", nptv6Result.Errors)
 			}
 		}
 	}

--- a/internal/plumbing/ebpf/edgeprog/edgedsr.c
+++ b/internal/plumbing/ebpf/edgeprog/edgedsr.c
@@ -384,7 +384,20 @@ static EDGE_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 s
 	struct edge_ethhdr *eth = data;
 	struct edge_ip6hdr *outer = (void *) (eth + 1);
 
+	// vtc_flow's first nibble is the IPv6 version field -- must be 6, not
+	// left at a zeroed default. Found via live-kernel investigation (not
+	// BPF_PROG_TEST_RUN, which never validates this): a real receiver
+	// downstream of this push (e.g. tcpdump on a veth peer) parses this
+	// pushed header as "invalid IPv6, version 0 != 6" -- a real,
+	// previously uncaught bug (inherited unchanged from the removed
+	// edgenat.c's identical push_outer_header), not specific to DSR.
+	// usid_ingress's own decap doesn't validate the version nibble at all
+	// (it reads fields at fixed offsets unconditionally), so this was
+	// invisible on that specific receive path -- but any version-checking
+	// intermediate hop or receiver would legitimately reject every packet
+	// this datapath ever pushed.
 	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
+	outer->vtc_flow[0] = 0x60;
 	outer->payload_len = inner_payload_len_plus_ip6hdr;
 	outer->nexthdr = EDGE_IPPROTO_IPV6;
 	outer->hop_limit = 64;
@@ -499,9 +512,26 @@ int edge_lb(struct xdp_md *ctx)
 	// entire premise (design plan §0): no DNAT, no SNAT, no checksum
 	// touch, the client's own packet travels inside untouched all the way
 	// to the backend, which replies to the client directly.
-	__be16 inner_payload_len = ip6->payload_len;
+	//
+	// push_outer_header's own parameter name says "plus ip6hdr": the
+	// outer header's payload_len must cover the *entire* inner packet,
+	// including the inner IPv6 header itself (40 bytes), not just the
+	// inner UDP/TCP payload ip6->payload_len alone names. A previous
+	// version of this call site passed ip6->payload_len directly,
+	// undercounting the outer header's declared length by exactly 40
+	// bytes on every packet -- found via live-kernel investigation (a
+	// real receiver, e.g. tcpdump on a veth peer, parsed the result as
+	// "length 24 < 40 (invalid)"), inherited unchanged from the removed
+	// edgenat.c's identical bug. usid_ingress's own decap doesn't
+	// validate payload_len at all (fixed-offset reads only), so this was
+	// invisible on that specific receive path, same as the version-nibble
+	// bug this file's other recent fix addresses -- but any
+	// length-validating intermediate hop or receiver would have rejected
+	// every packet this datapath ever pushed.
+	__be16 inner_payload_len_plus_ip6hdr =
+		__builtin_bswap16((__u16) sizeof(struct edge_ip6hdr) + __builtin_bswap16(ip6->payload_len));
 
-	if (push_outer_header(ctx, cfg->encap_src, b->usid, inner_payload_len) != 0)
+	if (push_outer_header(ctx, cfg->encap_src, b->usid, inner_payload_len_plus_ip6hdr) != 0)
 		return XDP_DROP;
 
 	return XDP_TX;

--- a/internal/plumbing/ebpf/edgeprog/edgedsr_test.go
+++ b/internal/plumbing/ebpf/edgeprog/edgedsr_test.go
@@ -5,6 +5,7 @@
 package edgeprog
 
 import (
+	"encoding/binary"
 	"errors"
 	"net/netip"
 	"os"
@@ -223,6 +224,23 @@ func TestEdgeLB_ForwardsPacketUnmodifiedToBackend(t *testing.T) {
 	copy(gotOuterSaddr[:], out[ethLen+8:ethLen+24])
 	if wantOuterSaddr := encapSrc.As16(); gotOuterSaddr != wantOuterSaddr {
 		t.Errorf("outer saddr = %x, want %x (this node's own encap_src)", gotOuterSaddr, wantOuterSaddr)
+	}
+
+	// The outer header must be valid IPv6 on the wire: version nibble ==
+	// 6, and payload_len covering the *entire* inner packet (its own
+	// 40-byte IPv6 header plus its own payload), not just the inner
+	// payload alone. Both were real bugs found via live-kernel
+	// investigation (a synthetic BPF_PROG_TEST_RUN packet doesn't care,
+	// but a real receiver parsing this as wire-format IPv6 does) --
+	// regression-guarded here so they can't silently return.
+	if gotVersion := out[ethLen] >> 4; gotVersion != 6 {
+		t.Errorf("outer header IPv6 version = %d, want 6", gotVersion)
+	}
+	gotOuterPayloadLen := binary.BigEndian.Uint16(out[ethLen+4 : ethLen+6])
+	wantOuterPayloadLen := uint16(ip6Len + udpLen + len(payload))
+	if gotOuterPayloadLen != wantOuterPayloadLen {
+		t.Errorf("outer header payload_len = %d, want %d (inner ip6 header + inner payload)",
+			gotOuterPayloadLen, wantOuterPayloadLen)
 	}
 
 	const innerOffset = ethLen + ip6Len

--- a/internal/plumbing/ebpf/ifindexvrfmap/clock.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/clock.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import "golang.org/x/sys/unix"
+
+// monotonicNow returns a nanosecond CLOCK_MONOTONIC reading, used to stamp
+// this process's own in-memory Generation bookkeeping (see doc.go). A
+// deliberate small duplicate of usidmap's own unexported monotonicNow and
+// nptv6map's own copy of the same -- see nptv6map/clock.go's doc comment
+// for why duplicating this five-line syscall wrapper, rather than exporting
+// it from usidmap, is the intentional choice here.
+func monotonicNow() uint64 {
+	var ts unix.Timespec
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/internal/plumbing/ebpf/ifindexvrfmap/doc.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/doc.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package ifindexvrfmap implements the read/write API for the eBPF uSID
+// datapath's ifindex_vrf_table map (internal/plumbing/ebpf/prog/usid.c's
+// struct ifindex_vrf_value comment): one row per attachment (veth or tap),
+// keyed by that attachment's own host-side interface ifindex, mapping it to
+// the (Block, Argument) its VRF resolves to. usid_egress consults this to
+// resolve which VRF a plain, not-yet-encapsulated outbound packet on a
+// tenant's own interface belongs to, since it has no outer uSID destination
+// to decode that from the way usid_ingress does.
+//
+// # Reusing usidmap.Table/KernelTable/Iterator instead of duplicating them
+//
+// Same reasoning as nptv6map's own doc comment: ifindex_vrf_table is a map
+// of the same usid.c/prog package as vrf_table, not a second datapath, so
+// this package imports and depends on usidmap.Table/KernelTable/Iterator
+// directly rather than re-declaring them.
+//
+// # Lifecycle: CNI DEL, not a periodic GC sweep
+//
+// Unlike vrf_table (whose (Block, Argument) key is shared by every
+// attachment on one VPC/node, and therefore needs the GC-driven
+// list-live-CRDs-then-reconcile pattern -- see usidmap.VRFTable.Reconcile
+// and gc.SweepEBPFVRFTable), ifindex_vrf_table's key is a single
+// attachment's own host-side ifindex: genuinely private to that one
+// attachment, exactly the same category internal/cni's own cmdDel doc
+// comment already puts the host/guest veth pair itself in ("the veth pair
+// is genuinely private to this attachment ... no sibling pod can ever still
+// be depending on it, so there is no ADD-race to defer to GC for") and
+// internal/cnitap's cmdDel puts the tap device in.
+//
+// Register happens from internal/cnibgp's registerEBPFDatapath, the exact
+// call site that already registers this same attachment's vrf_table entry
+// (Milestone 7.1), keyed additionally by the host-side interface's ifindex
+// (resolved there via netlink.LinkByName + intf.GenerateInterfaceNameHost --
+// see registerEBPFDatapath's own doc comment for why that one, narrow,
+// read-only kernel query is an accepted exception to galactic-bgp's
+// otherwise "zero kernel-interface dependency" design).
+//
+// Unregister happens directly at CNI DEL time -- internal/cni's and
+// internal/cnitap's own cmdDel, immediately before (and using the same
+// already-resolved ifindex as) their existing veth.Delete/tap.Delete calls
+// -- rather than from a periodic GC sweep: no CRD anywhere records an
+// ifindex (crdnames carries no such annotation), so there is no live-set
+// gc.SweepEBPFVRFTable's own pattern could reconcile against without
+// inventing a new liveness-tracking mechanism this codebase has no
+// analogue for. CNI DEL already knows precisely when this attachment's own
+// interface is being destroyed and is best-effort/log-only on every other
+// step in that same function, so wiring Unregister there needs no new
+// machinery at all.
+//
+// Register/Unregister/Get/List/Reconcile method shapes mirror
+// usidmap.VRFTable's own for API consistency and testability, including a
+// process-local Generation (see nptv6map's doc comment for why this table's
+// value carries no kernel-persisted generation field either) -- but
+// Reconcile is not wired into any production sweep today, precisely because
+// CNI DEL already owns this table's cleanup; it exists for parity, test
+// coverage, and as a future defense-in-depth backstop (e.g. a kubelet force
+// delete that skips CNI DEL entirely) should one ever be added.
+package ifindexvrfmap

--- a/internal/plumbing/ebpf/ifindexvrfmap/faketable_test.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/faketable_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// fakeTable is an in-memory usidmap.Table implementation used across this
+// package's tests -- mirrors usidmap's own (unexported, package-local)
+// fakeTable, adapted to ifindex_vrf_table's own __u32 key (usidmap's vrf_table
+// fake uses a __u64 key) -- duplicated here rather than imported since Go
+// test-only helpers in another package's _test.go files are not importable.
+type fakeTable struct {
+	entries map[uint32]any
+	order   []uint32
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[uint32]any)}
+}
+
+func fakeTableKey(key any) uint32 {
+	k, ok := key.(uint32)
+	if !ok {
+		panic(fmt.Sprintf("fakeTable: key type %T not supported, want uint32", key))
+	}
+	return k
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	k := fakeTableKey(key)
+	if _, exists := f.entries[k]; !exists {
+		f.order = append(f.order, k)
+	}
+	f.entries[k] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	k := fakeTableKey(key)
+	v, ok := f.entries[k]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	k := fakeTableKey(key)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	for i, kk := range f.order {
+		if kk == k {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() usidmap.Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+func (f *fakeTable) len() int { return len(f.order) }
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }

--- a/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// IfindexVRFEntry is one fully decoded ifindex_vrf_table row, decoupled from
+// prog.UsidIfindexVrfValue's cilium/ebpf/BTF-generated field layout --
+// mirrors usidmap.VRFEntry's own reasoning.
+type IfindexVRFEntry struct {
+	Ifindex uint32
+	Block   uint64
+
+	// Argument is the 12-bit uSID Argument this ifindex's VRF resolves to.
+	Argument uint16
+
+	// Generation is this process's own in-memory bookkeeping of when this
+	// entry was last (re-)registered -- see doc.go and nptv6map's own doc
+	// comment for why this is not kernel-persisted.
+	Generation uint64
+}
+
+// IfindexVRFTable is the read/write API for ifindex_vrf_table.
+type IfindexVRFTable struct {
+	table usidmap.Table
+	clock func() uint64
+
+	mu         sync.Mutex
+	generation map[uint32]uint64
+}
+
+// NewIfindexVRFTable wraps table as an IfindexVRFTable. Production callers
+// pass a usidmap.KernelTable wrapping a loaded *prog.UsidObjects's
+// IfindexVrfTable map (or OpenPinned, below); tests pass a fake
+// usidmap.Table.
+func NewIfindexVRFTable(table usidmap.Table) *IfindexVRFTable {
+	return &IfindexVRFTable{table: table, clock: monotonicNow, generation: make(map[uint32]uint64)}
+}
+
+// OpenPinned opens ifindex_vrf_table from its pinned path under pinDir and
+// returns an IfindexVRFTable wrapping it, mirroring
+// usidmap.OpenPinnedRegistry -- for a process (internal/cnibgp's
+// registerEBPFDatapath, internal/cni's and internal/cnitap's cmdDel) that
+// did not itself load the datapath but needs to read/write this one map.
+// The returned *ebpf.Map is also this table's own io.Closer and must be
+// closed once the caller is done; it does not affect the map's pinned
+// lifetime.
+func OpenPinned(pinDir string) (*IfindexVRFTable, *ebpf.Map, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapIfindexVrfTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ifindexvrfmap: open pinned map %q: %w", prog.UsidMapIfindexVrfTable, err)
+	}
+	return NewIfindexVRFTable(usidmap.KernelTable{Map: m}), m, nil
+}
+
+// Generation returns a snapshot of this table's monotonic clock.
+func (t *IfindexVRFTable) Generation() uint64 {
+	return t.clock()
+}
+
+// Register writes (or overwrites) the ifindex_vrf_table entry for ifindex,
+// mapping it to (block, argument). Like nptv6map.NPTv6Table.Register, this
+// carries no counters and is always a plain overwrite -- there is no
+// read-modify-write step.
+func (t *IfindexVRFTable) Register(ifindex uint32, block uint64, argument uint16) error {
+	if err := uformat.ValidateBlock(block); err != nil {
+		return fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: register ifindex=%d: %w", ifindex, err)
+	}
+	if err := uformat.ValidateArgument(argument); err != nil {
+		return fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: register ifindex=%d: %w", ifindex, err)
+	}
+
+	value := prog.UsidIfindexVrfValue{Block: block, Argument: argument}
+	if err := t.table.Put(ifindex, value); err != nil {
+		return fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: register ifindex=%d: %w", ifindex, err)
+	}
+
+	t.mu.Lock()
+	t.generation[ifindex] = t.clock()
+	t.mu.Unlock()
+	return nil
+}
+
+// Unregister removes the ifindex_vrf_table entry for ifindex, if present.
+// Not an error to unregister an already-absent entry -- DEL is idempotent
+// per the CNI spec, and every caller of this (internal/cni's and
+// internal/cnitap's cmdDel) treats every cleanup step as best-effort.
+func (t *IfindexVRFTable) Unregister(ifindex uint32) error {
+	if err := t.table.Delete(ifindex); err != nil {
+		if !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: unregister ifindex=%d: %w", ifindex, err)
+		}
+	}
+	t.mu.Lock()
+	delete(t.generation, ifindex)
+	t.mu.Unlock()
+	return nil
+}
+
+// Get reads the ifindex_vrf_table entry for ifindex, reporting whether it
+// exists.
+func (t *IfindexVRFTable) Get(ifindex uint32) (IfindexVRFEntry, bool, error) {
+	var value prog.UsidIfindexVrfValue
+	if err := t.table.Lookup(ifindex, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return IfindexVRFEntry{}, false, nil
+		}
+		return IfindexVRFEntry{}, false, fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: get ifindex=%d: %w", ifindex, err)
+	}
+	return t.decode(ifindex, value), true, nil
+}
+
+// List returns every entry currently in ifindex_vrf_table, in unspecified
+// order.
+func (t *IfindexVRFTable) List() ([]IfindexVRFEntry, error) {
+	var (
+		entries []IfindexVRFEntry
+		rawKey  uint32
+		value   prog.UsidIfindexVrfValue
+	)
+	it := t.table.Iterate()
+	for it.Next(&rawKey, &value) {
+		entries = append(entries, t.decode(rawKey, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: list: %w", err)
+	}
+	return entries, nil
+}
+
+// Reconcile brings ifindex_vrf_table into agreement with live -- the
+// caller's current set of ifindexes that should have an entry -- removing
+// every entry whose key is absent from live, except an entry whose
+// Generation is >= cutoff. Mirrors usidmap.VRFTable.Reconcile's exact
+// semantics; see doc.go for why this is not wired into any production
+// sweep for this table today.
+func (t *IfindexVRFTable) Reconcile(live map[uint32]struct{}, cutoff uint64) (removed []IfindexVRFEntry, err error) {
+	entries, err := t.List()
+	if err != nil {
+		return nil, fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: reconcile: %w", err)
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, ok := live[e.Ifindex]; ok {
+			continue
+		}
+		if e.Generation >= cutoff {
+			continue
+		}
+		if err := t.Unregister(e.Ifindex); err != nil {
+			errs = append(errs, fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: reconcile: delete stale entry %+v: %w",
+				e, err))
+			continue
+		}
+		removed = append(removed, e)
+	}
+	return removed, errors.Join(errs...)
+}
+
+func (t *IfindexVRFTable) decode(ifindex uint32, value prog.UsidIfindexVrfValue) IfindexVRFEntry {
+	t.mu.Lock()
+	gen := t.generation[ifindex]
+	t.mu.Unlock()
+
+	return IfindexVRFEntry{
+		Ifindex:    ifindex,
+		Block:      value.Block,
+		Argument:   value.Argument,
+		Generation: gen,
+	}
+}

--- a/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf_test.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import (
+	"errors"
+	"testing"
+)
+
+const testBlock uint64 = 0x2001_0DB8_FF01
+
+var errIntentionalTestFailure = errors.New("ifindexvrfmap: intentional test failure")
+
+func newTestIfindexVRFTable(clock func() uint64) (*IfindexVRFTable, *fakeTable) {
+	ft := newFakeTable()
+	return &IfindexVRFTable{table: ft, clock: clock, generation: make(map[uint32]uint64)}, ft
+}
+
+func constClock(value uint64) func() uint64 {
+	return func() uint64 { return value }
+}
+
+func TestIfindexVRFTable_RegisterAndGet(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(7))
+
+	if err := it.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := it.Get(42)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after Register")
+	}
+	want := IfindexVRFEntry{Ifindex: 42, Block: testBlock, Argument: 0x123, Generation: 7}
+	if entry != want {
+		t.Errorf("Get = %+v, want %+v", entry, want)
+	}
+}
+
+func TestIfindexVRFTable_GetMissingEntry(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(1))
+
+	_, ok, err := it.Get(42)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if ok {
+		t.Errorf("Get: ok = true for an entry never registered")
+	}
+}
+
+func TestIfindexVRFTable_RegisterRejectsReservedArgumentZero(t *testing.T) {
+	it, ft := newTestIfindexVRFTable(constClock(1))
+
+	if err := it.Register(42, testBlock, 0x000); err == nil {
+		t.Errorf("Register(argument=0x000) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(argument=0x000) wrote %d entries, want 0", ft.len())
+	}
+}
+
+func TestIfindexVRFTable_RegisterRejectsBlockOverflow(t *testing.T) {
+	it, ft := newTestIfindexVRFTable(constClock(1))
+
+	const overflowBlock = uint64(1) << 48
+	if err := it.Register(42, overflowBlock, 0x123); err == nil {
+		t.Errorf("Register(overflowing block) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(overflowing block) wrote an entry, want none")
+	}
+}
+
+func TestIfindexVRFTable_RegisterOverwrites(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(1))
+
+	if err := it.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("first Register: unexpected error: %v", err)
+	}
+	it.clock = constClock(99)
+	if err := it.Register(42, testBlock, 0x456); err != nil {
+		t.Fatalf("second Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := it.Get(42)
+	if err != nil || !ok {
+		t.Fatalf("Get after re-register: ok=%v err=%v", ok, err)
+	}
+	if entry.Argument != 0x456 {
+		t.Errorf("Argument = %#x after re-register, want %#x", entry.Argument, 0x456)
+	}
+	if entry.Generation != 99 {
+		t.Errorf("Generation = %d after re-register, want 99", entry.Generation)
+	}
+}
+
+func TestIfindexVRFTable_Unregister(t *testing.T) {
+	it, ft := newTestIfindexVRFTable(constClock(1))
+
+	if err := it.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if err := it.Unregister(42); err != nil {
+		t.Fatalf("Unregister: unexpected error: %v", err)
+	}
+	if ft.len() != 0 {
+		t.Errorf("table has %d entries after Unregister, want 0", ft.len())
+	}
+	if _, ok, err := it.Get(42); err != nil || ok {
+		t.Errorf("Get after Unregister: ok=%v err=%v, want ok=false", ok, err)
+	}
+}
+
+func TestIfindexVRFTable_UnregisterAbsentIsNotError(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(1))
+
+	if err := it.Unregister(42); err != nil {
+		t.Errorf("Unregister(never-registered entry) = %v, want nil", err)
+	}
+}
+
+func TestIfindexVRFTable_List(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(1))
+
+	if err := it.Register(42, testBlock, 0x001); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := it.Register(43, testBlock, 0x002); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	entries, err := it.List()
+	if err != nil {
+		t.Fatalf("List: unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2: %+v", len(entries), entries)
+	}
+}
+
+func TestIfindexVRFTable_Generation(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(123))
+	if got := it.Generation(); got != 123 {
+		t.Errorf("Generation() = %d, want 123", got)
+	}
+}
+
+func TestIfindexVRFTable_Reconcile_RemovesStaleKeepsLive(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(10))
+
+	if err := it.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := it.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	live := map[uint32]struct{}{43: {}}
+	removed, err := it.Reconcile(live, 20)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Ifindex != 42 {
+		t.Fatalf("Reconcile removed = %+v, want exactly ifindex 42", removed)
+	}
+	if _, ok, err := it.Get(42); err != nil || ok {
+		t.Errorf("Get(42) after Reconcile: ok=%v err=%v, want gone", ok, err)
+	}
+	if _, ok, err := it.Get(43); err != nil || !ok {
+		t.Errorf("Get(43) after Reconcile: ok=%v err=%v, want it to survive", ok, err)
+	}
+}
+
+func TestIfindexVRFTable_Reconcile_RegistrationMidSweepSurvives(t *testing.T) {
+	it, _ := newTestIfindexVRFTable(constClock(10))
+
+	if err := it.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register(stale): unexpected error: %v", err)
+	}
+
+	const cutoff = 20
+	it.clock = constClock(30)
+	if err := it.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register(mid-sweep): unexpected error: %v", err)
+	}
+
+	removed, err := it.Reconcile(map[uint32]struct{}{}, cutoff)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Ifindex != 42 {
+		t.Fatalf("Reconcile removed = %+v, want exactly ifindex 42", removed)
+	}
+	if _, ok, err := it.Get(43); err != nil || !ok {
+		t.Fatalf("Get(43) after Reconcile: ok=%v err=%v, want the mid-sweep registration to have survived", ok, err)
+	}
+}
+
+func TestIfindexVRFTable_Reconcile_ContinuesPastDeleteFailure(t *testing.T) {
+	it, ft := newTestIfindexVRFTable(constClock(10))
+
+	if err := it.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := it.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	sabotaged := &deleteFailingTable{fakeTable: ft, failKey: 42}
+	sabotagedIT := &IfindexVRFTable{table: sabotaged, clock: it.clock, generation: it.generation}
+
+	removed, err := sabotagedIT.Reconcile(map[uint32]struct{}{}, 20)
+	if err == nil {
+		t.Fatalf("Reconcile: want a non-nil error when a delete fails")
+	}
+	if !errors.Is(err, errIntentionalTestFailure) {
+		t.Errorf("Reconcile error = %v, want it to wrap errIntentionalTestFailure", err)
+	}
+	if len(removed) != 1 || removed[0].Ifindex != 43 {
+		t.Fatalf("Reconcile removed = %+v, want exactly ifindex 43", removed)
+	}
+}
+
+type deleteFailingTable struct {
+	*fakeTable
+	failKey uint32
+}
+
+func (d *deleteFailingTable) Delete(key any) error {
+	if k, ok := key.(uint32); ok && k == d.failKey {
+		return errIntentionalTestFailure
+	}
+	return d.fakeTable.Delete(key)
+}

--- a/internal/plumbing/ebpf/nat66prog/nat66.c
+++ b/internal/plumbing/ebpf/nat66prog/nat66.c
@@ -416,7 +416,13 @@ static NAT66_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 
 	struct nat66_ethhdr *eth = data;
 	struct nat66_ip6hdr *outer = (void *) (eth + 1);
 
+	// vtc_flow[0]'s high nibble is the IPv6 version field -- see
+	// edgedsr.c's identical fix (push_outer_header) for the full story:
+	// a real, previously uncaught bug inherited from the removed
+	// edgenat.c, found via live-kernel investigation, not
+	// BPF_PROG_TEST_RUN (which never validates this field).
 	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
+	outer->vtc_flow[0] = 0x60;
 	outer->payload_len = inner_payload_len_plus_ip6hdr;
 	outer->nexthdr = NAT66_IPPROTO_IPV6;
 	outer->hop_limit = 64;
@@ -587,7 +593,13 @@ static NAT66_ALWAYS_INLINE int handle_return(struct xdp_md *ctx, struct nat66_ip
 	__builtin_memcpy(ip6->daddr, cv->backend_addr, 16);
 	*l4v.dport_ptr = cv->backend_port;
 
-	__be16 inner_payload_len = ip6->payload_len;
+	// Must include the inner IPv6 header's own 40 bytes, not just its
+	// payload -- see edgedsr.c's identical fix (its handle_forward call
+	// site) for the full story: a real, previously uncaught bug
+	// inherited from the removed edgenat.c, found via live-kernel
+	// investigation, not BPF_PROG_TEST_RUN.
+	__be16 inner_payload_len_plus_ip6hdr =
+		__builtin_bswap16((__u16) sizeof(struct nat66_ip6hdr) + __builtin_bswap16(ip6->payload_len));
 
 	// Outer source is this shard's own SRv6-reachable identity
 	// (shard_sid), not any field of cv -- the tenant's worker node
@@ -595,7 +607,7 @@ static NAT66_ALWAYS_INLINE int handle_return(struct xdp_md *ctx, struct nat66_ip
 	// does not care about (or validate) the encap source, but it must
 	// still be a real, this-node address, not the internet peer's own
 	// address cv->dest_addr holds.
-	if (push_outer_header(ctx, cfg->shard_sid, cv->backend_usid, inner_payload_len) != 0)
+	if (push_outer_header(ctx, cfg->shard_sid, cv->backend_usid, inner_payload_len_plus_ip6hdr) != 0)
 		return XDP_DROP;
 
 	return XDP_TX;

--- a/internal/plumbing/ebpf/nat66prog/nat66_test.go
+++ b/internal/plumbing/ebpf/nat66prog/nat66_test.go
@@ -344,6 +344,22 @@ func TestNat66Ingress_ReturnUnNATsAndReencapsulates(t *testing.T) {
 		t.Errorf("outer saddr = %x, want %x (this shard's own shard_sid)", gotOuterSaddr, shardSID.As16())
 	}
 
+	// Regression guard for the two real bugs found via live-kernel
+	// investigation (see edgedsr.c's identical push_outer_header fixes):
+	// version nibble must be 6, and payload_len must cover the inner
+	// packet's own IPv6 header (40 bytes) plus its own payload, not just
+	// the payload alone.
+	if gotVersion := out[ethLen] >> 4; gotVersion != 6 {
+		t.Errorf("outer header IPv6 version = %d, want 6", gotVersion)
+	}
+	const replyPayloadLen = len("reply")
+	gotOuterPayloadLen := binary.BigEndian.Uint16(out[ethLen+4 : ethLen+6])
+	wantOuterPayloadLen := uint16(ip6Len + udpLen + replyPayloadLen)
+	if gotOuterPayloadLen != wantOuterPayloadLen {
+		t.Errorf("outer header payload_len = %d, want %d (inner ip6 header + inner UDP + payload)",
+			gotOuterPayloadLen, wantOuterPayloadLen)
+	}
+
 	const innerDaddrOffset = ethLen + ip6Len + 24
 	const innerUDPOffset = ethLen + ip6Len + ip6Len
 	var gotInnerDaddr [16]byte

--- a/internal/plumbing/ebpf/nptv6map/clock.go
+++ b/internal/plumbing/ebpf/nptv6map/clock.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6map
+
+import "golang.org/x/sys/unix"
+
+// monotonicNow returns a nanosecond CLOCK_MONOTONIC reading, used to stamp
+// this process's own in-memory Generation bookkeeping (see doc.go and
+// NPTv6Table.Register). This is a small, deliberate duplicate of
+// usidmap's own unexported monotonicNow (internal/plumbing/ebpf/usidmap/
+// table.go) rather than an exported/imported dependency on it: it is five
+// lines wrapping one syscall, and usidmap's own egresskind.go/
+// prog/dropreason.go already establish the precedent in this codebase of
+// hand-keeping a tiny piece of logic in sync across packages rather than
+// introducing a shared-but-barely-used export for it. See table.go's
+// monotonicNow for the full reasoning on why CLOCK_MONOTONIC, not
+// wall-clock time.Now(), is used here.
+func monotonicNow() uint64 {
+	var ts unix.Timespec
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/internal/plumbing/ebpf/nptv6map/doc.go
+++ b/internal/plumbing/ebpf/nptv6map/doc.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package nptv6map implements the read/write API for the eBPF uSID
+// datapath's nptv6_table map (internal/plumbing/ebpf/prog/usid.c's struct
+// nptv6_value comment) -- one row per VRF configuring stateless RFC 6296
+// Network Prefix Translation (internal/plumbing/nptv6), keyed identically to
+// vrf_table: Block(48)<<12 | Argument(12) (internal/plumbing/ebpf/uformat's
+// NewVRFKey).
+//
+// # Reusing usidmap.Table/KernelTable/Iterator instead of duplicating them
+//
+// nptv6_table is defined in the exact same usid.c/prog package as vrf_table
+// (internal/plumbing/ebpf/usidmap), not a second, independent datapath --
+// unlike internal/plumbing/ebpf/edgemap (a different eBPF program entirely,
+// with no shared map layout at all, which is usidmap/doc.go's own stated
+// reason for NOT importing edgemap's duplicate Table/KernelTable/Iterator
+// definitions). Because nptv6_table and vrf_table are two maps of the one
+// uSID datapath, the map-operation seam usidmap.Table already defines (plus
+// its KernelTable adapter over a real *ebpf.Map, and its Iterator interface)
+// applies unchanged here: this package imports and depends on usidmap
+// directly rather than re-declaring an identical interface, which would
+// only invite the two to drift.
+//
+// # Why this table has no Generation/monotonic-clock kernel field, unlike vrf_table
+//
+// vrf_table's value (struct vrf_value) carries a real `generation` field,
+// because vrf_table has two independent, unsynchronized OS-process writers
+// that can race each other: the kubelet-invoked galactic-cni plugin binary
+// (VRFTable.Register, on the CNI ADD path) and the long-lived "run"
+// container's periodic GC sweep (VRFTable.Reconcile) -- see usidmap/doc.go's
+// "plugin-binary-vs-run-container race" section. nptv6_table's value
+// (struct nptv6_value) was deliberately not given an equivalent field: this
+// milestone's only writer of nptv6_table is that same "run" container's own
+// periodic sweep (gc.SweepEBPFNPTv6Table, called from
+// internal/installer.Run's ebpfGCSweepTicker, exactly where
+// gc.SweepEBPFVRFTable already runs -- see that function's own doc comment
+// for why eBPF map access is confined to this one container: galactic-router's
+// DaemonSet has no /sys/fs/bpf hostPath mount or CAP_BPF at all, so the
+// BGPVRFInstance reconciler (internal/controller) cannot open a pinned eBPF
+// map to register anything into directly, regardless of how the CRD's own
+// NPTv6 field is validated). A single writer, ticking sequentially in one
+// goroutine, cannot race itself between listing BGPVRFInstance CRDs and
+// reconciling nptv6_table against them -- there is no second process able to
+// register a brand-new mapping in the gap the way a concurrent CNI ADD can
+// for vrf_table.
+//
+// NPTv6Table still exposes Generation/Reconcile with the same method shape
+// as usidmap.VRFTable, for interface parity and because a future second
+// writer is not inconceivable, but the generation value itself is tracked
+// only in this process's own memory (an internal map keyed by NPTv6Key),
+// not persisted into the kernel value the way vrf_table's is. This means a
+// process restart forgets every previously-registered entry's generation
+// (it reads back as zero, "older than any cutoff"), unlike vrf_table's
+// kernel-persisted field, which survives a control-daemon restart within
+// the same boot. This is an accepted, intentional tradeoff, not an
+// oversight: gc.SweepEBPFNPTv6Table's own caller (internal/installer.Run)
+// re-registers every currently-live NPTv6 mapping on every tick before
+// reconciling stale ones away, so a post-restart Reconcile call only ever
+// mis-judges an entry's freshness for at most one sweep interval before the
+// same tick's own Register calls (which run first) re-stamp it -- see
+// SweepEBPFNPTv6Table's own doc comment for the exact ordering.
+//
+// # No counter-preservation
+//
+// Unlike vrf_table's per-Argument hit counters (packets/bytes/last_seen_ns/
+// dropped_packets), nptv6_table carries no counters at all -- its value is
+// purely the two prefixes and the precomputed RFC 6296 adjustment. Register
+// therefore has no read-modify-write step to carry anything forward from an
+// existing entry; every call is a plain overwrite.
+package nptv6map

--- a/internal/plumbing/ebpf/nptv6map/faketable_test.go
+++ b/internal/plumbing/ebpf/nptv6map/faketable_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6map
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// fakeTable is an in-memory usidmap.Table implementation used across this
+// package's tests -- mirrors usidmap's own (unexported, package-local)
+// fakeTable in internal/plumbing/ebpf/usidmap/faketable_test.go exactly,
+// duplicated here rather than imported since Go test-only helpers in
+// another package's _test.go files are not importable.
+type fakeTable struct {
+	entries map[uint64]any
+	order   []uint64
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[uint64]any)}
+}
+
+func fakeTableKey(key any) uint64 {
+	k, ok := key.(uint64)
+	if !ok {
+		panic(fmt.Sprintf("fakeTable: key type %T not supported, want uint64", key))
+	}
+	return k
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	k := fakeTableKey(key)
+	if _, exists := f.entries[k]; !exists {
+		f.order = append(f.order, k)
+	}
+	f.entries[k] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	k := fakeTableKey(key)
+	v, ok := f.entries[k]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	k := fakeTableKey(key)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	for i, kk := range f.order {
+		if kk == k {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() usidmap.Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+func (f *fakeTable) len() int { return len(f.order) }
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }

--- a/internal/plumbing/ebpf/nptv6map/nptv6.go
+++ b/internal/plumbing/ebpf/nptv6map/nptv6.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6map
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sync"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/nptv6"
+)
+
+// NPTv6Key identifies one nptv6_table row: the uSID Block that matched in
+// locator_table, plus the 12-bit Argument -- the identical composition
+// usidmap.VRFKey uses, kept as its own type here (rather than reusing
+// usidmap.VRFKey directly) purely so this package's own exported API never
+// forces a caller to import usidmap just to build a key.
+type NPTv6Key struct {
+	Block    uint64
+	Argument uint16
+}
+
+// NPTv6Entry is one fully decoded nptv6_table row, decoupled from
+// prog.UsidNptv6Value's cilium/ebpf/BTF-generated field layout -- mirrors
+// usidmap.VRFEntry's own reasoning.
+type NPTv6Entry struct {
+	NPTv6Key
+
+	// Mapping is the RFC 6296 prefix pair this entry applies -- see
+	// internal/plumbing/nptv6's doc comment for the translation itself.
+	Mapping nptv6.Mapping
+
+	// Adjustment is the precomputed RFC 6296 §3.6 checksum-neutral
+	// adjustment (nptv6.Mapping.Adjustment), stored in the kernel value so
+	// the datapath never recomputes it per packet.
+	Adjustment uint16
+
+	// Generation is this process's own in-memory bookkeeping of when this
+	// entry was last (re-)registered by Register -- see doc.go's "no
+	// Generation/monotonic-clock kernel field" section for why this is not
+	// persisted in the kernel value the way usidmap.VRFEntry's own
+	// Generation is.
+	Generation uint64
+}
+
+// NPTv6Table is the read/write API for nptv6_table.
+type NPTv6Table struct {
+	table usidmap.Table
+	clock func() uint64
+
+	mu         sync.Mutex
+	generation map[NPTv6Key]uint64
+}
+
+// NewNPTv6Table wraps table as an NPTv6Table. Production callers pass a
+// usidmap.KernelTable wrapping a loaded *prog.UsidObjects's Nptv6Table map
+// (or OpenPinned, below, for a process that did not itself load the
+// datapath); tests pass a fake usidmap.Table.
+func NewNPTv6Table(table usidmap.Table) *NPTv6Table {
+	return &NPTv6Table{table: table, clock: monotonicNow, generation: make(map[NPTv6Key]uint64)}
+}
+
+// OpenPinned opens nptv6_table from its pinned path under pinDir
+// (internal/plumbing/ebpf/attach.Load pins each map at
+// <pinDir>/<map name>) and returns an NPTv6Table wrapping it, mirroring
+// usidmap.OpenPinnedRegistry -- for a process (internal/gc's periodic
+// sweep, via internal/installer.Run) that did not itself load the
+// datapath but needs to read/write this one map. The returned io.Closer
+// (the opened *ebpf.Map itself) must be closed once the caller is done; it
+// does not affect the map's pinned lifetime.
+func OpenPinned(pinDir string) (*NPTv6Table, *ebpf.Map, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapNptv6Table), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("nptv6map: open pinned map %q: %w", prog.UsidMapNptv6Table, err)
+	}
+	return NewNPTv6Table(usidmap.KernelTable{Map: m}), m, nil
+}
+
+// Generation returns a snapshot of this table's monotonic clock -- see
+// doc.go for why this is process-local rather than kernel-persisted.
+func (t *NPTv6Table) Generation() uint64 {
+	return t.clock()
+}
+
+// Register writes (or overwrites) the nptv6_table entry for (block,
+// argument): computes m.Adjustment() internally and converts m's two
+// prefixes into the fixed 16-byte zero-padded arrays prog.UsidNptv6Value
+// expects, mirroring exactly how internal/plumbing/nptv6.prefixChecksum/
+// Translate already read prefix bytes (net.IPNet.IP, as produced by
+// net.ParseCIDR, is already zero-padded beyond its own prefix length). There
+// is no read-modify-write step here (unlike usidmap.VRFTable.Register):
+// nptv6_table carries no per-entry counters to preserve across a
+// re-registration, so every call is a plain overwrite.
+func (t *NPTv6Table) Register(block uint64, argument uint16, m nptv6.Mapping) error {
+	if err := uformat.ValidateArgument(argument); err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: %w", block, argument, err)
+	}
+	key, err := uformat.NewVRFKey(block, argument)
+	if err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: %w", block, argument, err)
+	}
+
+	adjustment, err := m.Adjustment()
+	if err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: compute adjustment: %w",
+			block, argument, err)
+	}
+	value, err := toValue(m, adjustment)
+	if err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: %w", block, argument, err)
+	}
+
+	if err := t.table.Put(uint64(key), value); err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: %w", block, argument, err)
+	}
+
+	nk := NPTv6Key{Block: block, Argument: argument}
+	t.mu.Lock()
+	t.generation[nk] = t.clock()
+	t.mu.Unlock()
+	return nil
+}
+
+// Unregister removes the nptv6_table entry for (block, argument), if
+// present. Not an error to unregister an already-absent entry, matching
+// usidmap.VRFTable.Unregister's own idempotent contract.
+func (t *NPTv6Table) Unregister(block uint64, argument uint16) error {
+	key, err := uformat.NewVRFKey(block, argument)
+	if err != nil {
+		return fmt.Errorf("nptv6map: nptv6_table: unregister block=%#x argument=%#x: %w", block, argument, err)
+	}
+	if err := t.table.Delete(uint64(key)); err != nil {
+		if !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("nptv6map: nptv6_table: unregister block=%#x argument=%#x: %w", block, argument, err)
+		}
+	}
+	t.mu.Lock()
+	delete(t.generation, NPTv6Key{Block: block, Argument: argument})
+	t.mu.Unlock()
+	return nil
+}
+
+// Get reads the nptv6_table entry for (block, argument), reporting whether
+// it exists.
+func (t *NPTv6Table) Get(block uint64, argument uint16) (NPTv6Entry, bool, error) {
+	key, err := uformat.NewVRFKey(block, argument)
+	if err != nil {
+		return NPTv6Entry{}, false, fmt.Errorf("nptv6map: nptv6_table: get block=%#x argument=%#x: %w",
+			block, argument, err)
+	}
+
+	var value prog.UsidNptv6Value
+	if err := t.table.Lookup(uint64(key), &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return NPTv6Entry{}, false, nil
+		}
+		return NPTv6Entry{}, false, fmt.Errorf("nptv6map: nptv6_table: get block=%#x argument=%#x: %w",
+			block, argument, err)
+	}
+	return t.decode(block, argument, value), true, nil
+}
+
+// List returns every entry currently in nptv6_table, in unspecified order.
+func (t *NPTv6Table) List() ([]NPTv6Entry, error) {
+	var (
+		entries []NPTv6Entry
+		rawKey  uint64
+		value   prog.UsidNptv6Value
+	)
+	it := t.table.Iterate()
+	for it.Next(&rawKey, &value) {
+		block := rawKey >> uformat.ArgumentBits
+		argument := uint16(rawKey & (1<<uformat.ArgumentBits - 1))
+		entries = append(entries, t.decode(block, argument, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("nptv6map: nptv6_table: list: %w", err)
+	}
+	return entries, nil
+}
+
+// Reconcile brings nptv6_table into agreement with live -- the caller's
+// current set of (Block, Argument) pairs that should have an entry --
+// removing every entry whose key is absent from live, except an entry whose
+// Generation is >= cutoff. Mirrors usidmap.VRFTable.Reconcile's exact
+// semantics; see doc.go for why this table's own writer (a single,
+// sequential periodic sweep) makes the race that mechanism guards against
+// far narrower here than for vrf_table, and why Generation is nonetheless
+// still tracked and honored the same way.
+func (t *NPTv6Table) Reconcile(live map[NPTv6Key]struct{}, cutoff uint64) (removed []NPTv6Entry, err error) {
+	entries, err := t.List()
+	if err != nil {
+		return nil, fmt.Errorf("nptv6map: nptv6_table: reconcile: %w", err)
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, ok := live[e.NPTv6Key]; ok {
+			continue
+		}
+		if e.Generation >= cutoff {
+			continue
+		}
+		if err := t.Unregister(e.Block, e.Argument); err != nil {
+			errs = append(errs, fmt.Errorf("nptv6map: nptv6_table: reconcile: delete stale entry %+v: %w",
+				e.NPTv6Key, err))
+			continue
+		}
+		removed = append(removed, e)
+	}
+	return removed, errors.Join(errs...)
+}
+
+// decode converts a raw kernel value plus its (block, argument) key into an
+// NPTv6Entry, filling in Generation from this process's own in-memory
+// bookkeeping (zero if this entry was never registered by this process
+// instance -- see doc.go).
+func (t *NPTv6Table) decode(block uint64, argument uint16, value prog.UsidNptv6Value) NPTv6Entry {
+	nk := NPTv6Key{Block: block, Argument: argument}
+
+	ula := make(net.IP, net.IPv6len)
+	copy(ula, value.UlaPrefix[:])
+	pub := make(net.IP, net.IPv6len)
+	copy(pub, value.PublicPrefix[:])
+	mask := net.CIDRMask(int(value.PrefixLen), 128)
+
+	t.mu.Lock()
+	gen := t.generation[nk]
+	t.mu.Unlock()
+
+	return NPTv6Entry{
+		NPTv6Key: nk,
+		Mapping: nptv6.Mapping{
+			ULAPrefix:    &net.IPNet{IP: ula, Mask: mask},
+			PublicPrefix: &net.IPNet{IP: pub, Mask: mask},
+		},
+		Adjustment: value.Adjustment,
+		Generation: gen,
+	}
+}
+
+// toValue converts m (plus its precomputed adjustment) into the fixed
+// 16-byte zero-padded arrays prog.UsidNptv6Value expects. m.ULAPrefix/
+// m.PublicPrefix.IP are already 16-byte, zero-padded-beyond-prefix-length
+// slices by construction of net.ParseCIDR (the same assumption
+// nptv6.prefixChecksum documents), so this only needs a To16 conversion, no
+// further masking.
+func toValue(m nptv6.Mapping, adjustment uint16) (prog.UsidNptv6Value, error) {
+	ulaIP := m.ULAPrefix.IP.To16()
+	if ulaIP == nil {
+		return prog.UsidNptv6Value{}, fmt.Errorf("ULAPrefix %v is not a valid IPv6 CIDR", m.ULAPrefix)
+	}
+	pubIP := m.PublicPrefix.IP.To16()
+	if pubIP == nil {
+		return prog.UsidNptv6Value{}, fmt.Errorf("PublicPrefix %v is not a valid IPv6 CIDR", m.PublicPrefix)
+	}
+	ones, _ := m.ULAPrefix.Mask.Size()
+
+	var value prog.UsidNptv6Value
+	copy(value.UlaPrefix[:], ulaIP)
+	copy(value.PublicPrefix[:], pubIP)
+	value.PrefixLen = uint8(ones)
+	value.Adjustment = adjustment
+	return value, nil
+}

--- a/internal/plumbing/ebpf/nptv6map/nptv6_test.go
+++ b/internal/plumbing/ebpf/nptv6map/nptv6_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nptv6map
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/nptv6"
+)
+
+// testBlock is an arbitrary 48-bit Block value, mirroring usidmap's own
+// testBlock constant.
+const testBlock uint64 = 0x2001_0DB8_FF01
+
+// errIntentionalTestFailure is a sentinel error used to simulate one
+// specific underlying-table call failing.
+var errIntentionalTestFailure = errors.New("nptv6map: intentional test failure")
+
+func newTestNPTv6Table(clock func() uint64) (*NPTv6Table, *fakeTable) {
+	ft := newFakeTable()
+	return &NPTv6Table{table: ft, clock: clock, generation: make(map[NPTv6Key]uint64)}, ft
+}
+
+func constClock(value uint64) func() uint64 {
+	return func() uint64 { return value }
+}
+
+// testMapping returns a valid, small /48 RFC 6296 mapping usable across
+// this file's tests (nptv6.Mapping only supports prefixes /48 or shorter --
+// see internal/plumbing/nptv6/doc.go).
+func testMapping(t *testing.T) nptv6.Mapping {
+	t.Helper()
+	_, ula, err := net.ParseCIDR("fd00:1::/48")
+	if err != nil {
+		t.Fatalf("parse ULAPrefix: %v", err)
+	}
+	_, pub, err := net.ParseCIDR("2001:db8:1::/48")
+	if err != nil {
+		t.Fatalf("parse PublicPrefix: %v", err)
+	}
+	return nptv6.Mapping{ULAPrefix: ula, PublicPrefix: pub}
+}
+
+func TestNPTv6Table_RegisterAndGet(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(7))
+	mapping := testMapping(t)
+
+	if err := nt.Register(testBlock, 0x123, mapping); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := nt.Get(testBlock, 0x123)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after Register")
+	}
+	if entry.Generation != 7 {
+		t.Errorf("Generation = %d, want 7", entry.Generation)
+	}
+	wantAdjustment, err := mapping.Adjustment()
+	if err != nil {
+		t.Fatalf("compute want adjustment: %v", err)
+	}
+	if entry.Adjustment != wantAdjustment {
+		t.Errorf("Adjustment = %#x, want %#x", entry.Adjustment, wantAdjustment)
+	}
+	if !entry.Mapping.ULAPrefix.IP.Equal(mapping.ULAPrefix.IP) {
+		t.Errorf("ULAPrefix = %v, want %v", entry.Mapping.ULAPrefix, mapping.ULAPrefix)
+	}
+	if !entry.Mapping.PublicPrefix.IP.Equal(mapping.PublicPrefix.IP) {
+		t.Errorf("PublicPrefix = %v, want %v", entry.Mapping.PublicPrefix, mapping.PublicPrefix)
+	}
+	if ones, _ := entry.Mapping.ULAPrefix.Mask.Size(); ones != 48 {
+		t.Errorf("ULAPrefix mask = /%d, want /48", ones)
+	}
+}
+
+func TestNPTv6Table_GetMissingEntry(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(1))
+
+	_, ok, err := nt.Get(testBlock, 0x123)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if ok {
+		t.Errorf("Get: ok = true for an entry never registered")
+	}
+}
+
+func TestNPTv6Table_RegisterRejectsReservedArgumentZero(t *testing.T) {
+	nt, ft := newTestNPTv6Table(constClock(1))
+
+	if err := nt.Register(testBlock, 0x000, testMapping(t)); err == nil {
+		t.Errorf("Register(argument=0x000) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(argument=0x000) wrote %d entries, want 0", ft.len())
+	}
+}
+
+func TestNPTv6Table_RegisterRejectsBlockOverflow(t *testing.T) {
+	nt, ft := newTestNPTv6Table(constClock(1))
+
+	const overflowBlock = uint64(1) << 48
+	if err := nt.Register(overflowBlock, 0x123, testMapping(t)); err == nil {
+		t.Errorf("Register(overflowing block) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(overflowing block) wrote an entry, want none")
+	}
+}
+
+func TestNPTv6Table_RegisterRejectsInvalidMapping(t *testing.T) {
+	nt, ft := newTestNPTv6Table(constClock(1))
+
+	if err := nt.Register(testBlock, 0x123, nptv6.Mapping{}); err == nil {
+		t.Errorf("Register(zero-value mapping) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(invalid mapping) wrote an entry, want none")
+	}
+}
+
+// TestNPTv6Table_RegisterOverwritesNoCounterState confirms re-registering an
+// existing key is a plain overwrite (no read-modify-write step) -- unlike
+// usidmap.VRFTable.Register, nptv6_table has no counters to preserve.
+func TestNPTv6Table_RegisterOverwritesNoCounterState(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(1))
+
+	if err := nt.Register(testBlock, 0x123, testMapping(t)); err != nil {
+		t.Fatalf("first Register: unexpected error: %v", err)
+	}
+
+	nt.clock = constClock(99)
+	_, ula, _ := net.ParseCIDR("fd00:2::/48")
+	_, pub, _ := net.ParseCIDR("2001:db8:2::/48")
+	second := nptv6.Mapping{ULAPrefix: ula, PublicPrefix: pub}
+	if err := nt.Register(testBlock, 0x123, second); err != nil {
+		t.Fatalf("second Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := nt.Get(testBlock, 0x123)
+	if err != nil || !ok {
+		t.Fatalf("Get after re-register: ok=%v err=%v", ok, err)
+	}
+	if entry.Generation != 99 {
+		t.Errorf("Generation = %d after re-register, want 99", entry.Generation)
+	}
+	if !entry.Mapping.ULAPrefix.IP.Equal(second.ULAPrefix.IP) {
+		t.Errorf("ULAPrefix after re-register = %v, want the second mapping's %v",
+			entry.Mapping.ULAPrefix, second.ULAPrefix)
+	}
+}
+
+func TestNPTv6Table_RegisterPropagatesPutFailure(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(1))
+	sabotaged := &putFailingTable{fakeTable: newFakeTable()}
+	sabotagedNT := &NPTv6Table{table: sabotaged, clock: nt.clock, generation: make(map[NPTv6Key]uint64)}
+
+	if err := sabotagedNT.Register(testBlock, 0x123, testMapping(t)); err == nil {
+		t.Fatalf("Register: want a non-nil error when the underlying Put fails")
+	} else if !errors.Is(err, errIntentionalTestFailure) {
+		t.Errorf("Register error = %v, want it to wrap errIntentionalTestFailure", err)
+	}
+}
+
+type putFailingTable struct {
+	*fakeTable
+}
+
+func (p *putFailingTable) Put(key, value any) error {
+	return errIntentionalTestFailure
+}
+
+func TestNPTv6Table_Unregister(t *testing.T) {
+	nt, ft := newTestNPTv6Table(constClock(1))
+
+	if err := nt.Register(testBlock, 0x123, testMapping(t)); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if err := nt.Unregister(testBlock, 0x123); err != nil {
+		t.Fatalf("Unregister: unexpected error: %v", err)
+	}
+	if ft.len() != 0 {
+		t.Errorf("table has %d entries after Unregister, want 0", ft.len())
+	}
+	if _, ok, err := nt.Get(testBlock, 0x123); err != nil || ok {
+		t.Errorf("Get after Unregister: ok=%v err=%v, want ok=false", ok, err)
+	}
+}
+
+func TestNPTv6Table_UnregisterAbsentIsNotError(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(1))
+
+	if err := nt.Unregister(testBlock, 0x123); err != nil {
+		t.Errorf("Unregister(never-registered entry) = %v, want nil", err)
+	}
+}
+
+func TestNPTv6Table_List(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(1))
+	mapping := testMapping(t)
+
+	if err := nt.Register(testBlock, 0x001, mapping); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := nt.Register(testBlock, 0x002, mapping); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	entries, err := nt.List()
+	if err != nil {
+		t.Fatalf("List: unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2: %+v", len(entries), entries)
+	}
+}
+
+func TestNPTv6Table_Generation(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(123))
+	if got := nt.Generation(); got != 123 {
+		t.Errorf("Generation() = %d, want 123", got)
+	}
+}
+
+func TestNPTv6Table_Reconcile_RemovesStaleEntry(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(10))
+
+	if err := nt.Register(testBlock, 0x100, testMapping(t)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	removed, err := nt.Reconcile(map[NPTv6Key]struct{}{}, 20)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Argument != 0x100 {
+		t.Fatalf("Reconcile removed = %+v, want exactly one entry for argument 0x100", removed)
+	}
+	if _, ok, err := nt.Get(testBlock, 0x100); err != nil || ok {
+		t.Errorf("Get after Reconcile: ok=%v err=%v, want the stale entry gone", ok, err)
+	}
+}
+
+func TestNPTv6Table_Reconcile_KeepsLiveEntry(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(10))
+
+	if err := nt.Register(testBlock, 0x100, testMapping(t)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	live := map[NPTv6Key]struct{}{{Block: testBlock, Argument: 0x100}: {}}
+	removed, err := nt.Reconcile(live, 20)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("Reconcile removed = %+v, want none (entry is live)", removed)
+	}
+	if _, ok, err := nt.Get(testBlock, 0x100); err != nil || !ok {
+		t.Errorf("Get after Reconcile: ok=%v err=%v, want the live entry to remain", ok, err)
+	}
+}
+
+// TestNPTv6Table_Reconcile_RegistrationMidSweepSurvives mirrors
+// usidmap.VRFTable's own race-scenario test, adapted to this table's
+// in-memory Generation bookkeeping (see doc.go): a Register call landing
+// after cutoff was captured must survive a Reconcile call whose live set
+// predates it.
+func TestNPTv6Table_Reconcile_RegistrationMidSweepSurvives(t *testing.T) {
+	nt, _ := newTestNPTv6Table(constClock(10))
+
+	if err := nt.Register(testBlock, 0x100, testMapping(t)); err != nil {
+		t.Fatalf("Register(stale): unexpected error: %v", err)
+	}
+
+	const cutoff = 20
+
+	nt.clock = constClock(30)
+	if err := nt.Register(testBlock, 0x200, testMapping(t)); err != nil {
+		t.Fatalf("Register(mid-sweep): unexpected error: %v", err)
+	}
+
+	live := map[NPTv6Key]struct{}{}
+	removed, err := nt.Reconcile(live, cutoff)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Argument != 0x100 {
+		t.Fatalf("Reconcile removed = %+v, want exactly the stale 0x100 entry", removed)
+	}
+	if _, ok, err := nt.Get(testBlock, 0x200); err != nil || !ok {
+		t.Fatalf("Get(0x200) after Reconcile: ok=%v err=%v, want the mid-sweep registration to have survived", ok, err)
+	}
+}
+
+func TestNPTv6Table_Reconcile_ContinuesPastDeleteFailure(t *testing.T) {
+	nt, ft := newTestNPTv6Table(constClock(10))
+
+	if err := nt.Register(testBlock, 0x100, testMapping(t)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := nt.Register(testBlock, 0x200, testMapping(t)); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	badKey, err := uformat.NewVRFKey(testBlock, 0x100)
+	if err != nil {
+		t.Fatalf("NewVRFKey: %v", err)
+	}
+	sabotaged := &deleteFailingTable{fakeTable: ft, failKey: uint64(badKey)}
+	sabotagedNT := &NPTv6Table{table: sabotaged, clock: nt.clock, generation: nt.generation}
+
+	removed, err := sabotagedNT.Reconcile(map[NPTv6Key]struct{}{}, 20)
+	if err == nil {
+		t.Fatalf("Reconcile: want a non-nil error when a delete fails")
+	}
+	if !errors.Is(err, errIntentionalTestFailure) {
+		t.Errorf("Reconcile error = %v, want it to wrap errIntentionalTestFailure", err)
+	}
+	if len(removed) != 1 || removed[0].Argument != 0x200 {
+		t.Fatalf("Reconcile removed = %+v, want exactly argument 0x200", removed)
+	}
+}
+
+type deleteFailingTable struct {
+	*fakeTable
+	failKey uint64
+}
+
+func (d *deleteFailingTable) Delete(key any) error {
+	if k, ok := key.(uint64); ok && k == d.failKey {
+		return errIntentionalTestFailure
+	}
+	return d.fakeTable.Delete(key)
+}

--- a/internal/plumbing/ebpf/vipxlatmap/clock.go
+++ b/internal/plumbing/ebpf/vipxlatmap/clock.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vipxlatmap
+
+import "golang.org/x/sys/unix"
+
+// monotonicNow returns a nanosecond reading from CLOCK_MONOTONIC, used as
+// this table's in-memory Generation source (VipXlatTable.Generation) -- see
+// the package doc comment for why this is in-memory only, unlike
+// usidmap.VRFTable's kernel-stored generation field.
+//
+// This is a deliberate, small duplicate of
+// internal/plumbing/ebpf/usidmap/table.go's own monotonicNow (identical
+// body, identical reasoning: CLOCK_MONOTONIC rather than wall-clock
+// time.Now(), for the same immune-to-NTP-step-corrections and
+// stable-across-a-restart-within-the-same-boot properties that function's
+// doc comment explains in full) -- that function is unexported inside a
+// different package, so it cannot be imported directly; copying roughly ten
+// lines here was judged simpler and clearer than exporting it solely for
+// this one cross-package reuse.
+func monotonicNow() uint64 {
+	var ts unix.Timespec
+	// See usidmap/table.go's monotonicNow for the failure-mode reasoning if
+	// this syscall is ever rejected (e.g. a syscall-filtering sandbox):
+	// every reading in this process then reads 0, which fails toward never
+	// reaping an entry rather than reaping one out from under live state.
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/internal/plumbing/ebpf/vipxlatmap/faketable_test.go
+++ b/internal/plumbing/ebpf/vipxlatmap/faketable_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vipxlatmap
+
+import (
+	"reflect"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// fakeTable is an in-memory usidmap.Table implementation for this
+// package's tests, mirroring internal/plumbing/ebpf/usidmap's own
+// faketable_test.go -- generalized to a comparable `any` key instead of a
+// hardcoded uint64, since vip_xlat_table's key is a struct
+// (prog.UsidVipXlatKey), not a plain uint64 like vrf_table's. It stores
+// each value as the concrete Go struct Put was given (not raw bytes),
+// copying into/out of callers' pointer arguments via reflection to mirror
+// *ebpf.Map's own copy-in/copy-out semantics, without needing a kernel,
+// BTF, or root privileges.
+type fakeTable struct {
+	entries map[any]any
+	order   []any // insertion order, for deterministic Iterate/List in tests
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[any]any)}
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	if _, exists := f.entries[key]; !exists {
+		f.order = append(f.order, key)
+	}
+	f.entries[key] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	if _, ok := f.entries[key]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, key)
+	for i, k := range f.order {
+		if k == key {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() usidmap.Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+// len reports the number of entries currently stored -- a test-only
+// convenience, not part of the usidmap.Table interface.
+func (f *fakeTable) len() int { return len(f.order) }
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }
+
+// constClock returns a func() uint64 that always returns value -- mirrors
+// usidmap's own identical test helper, used to give VipXlatTable a
+// deterministic, test-controlled Generation source instead of a real clock.
+func constClock(value uint64) func() uint64 {
+	return func() uint64 { return value }
+}

--- a/internal/plumbing/ebpf/vipxlatmap/pin.go
+++ b/internal/plumbing/ebpf/vipxlatmap/pin.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vipxlatmap
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// OpenPinnedVipXlatTable opens vip_xlat_table from its pinned path under
+// pinDir (internal/plumbing/ebpf/attach.Load pins every usid_ingress map at
+// <pinDir>/<map name>, e.g. <pinDir>/vip_xlat_table -- the same convention
+// usidmap.OpenPinnedRegistry already documents and relies on for
+// vrf_table/locator_table/function_table) and returns a *VipXlatTable
+// wrapping it.
+//
+// This is new plumbing: nothing in this codebase needed galactic-router to
+// reach any of usid.c's maps before the DSR/Maglev tap-VIP substitution --
+// galactic-router loads/attaches no eBPF program of its own (that happens
+// once, elsewhere, driven by galactic-cni/internal/plumbing/ebpf/attach on
+// the CNI side), so this function's only job is to open a *second* handle
+// onto maps some other, already-running process on this node pinned --
+// exactly usidmap.OpenPinnedRegistry's own established pattern, reused here
+// for the one additional map that pattern didn't yet cover.
+//
+// Unlike usidmap.OpenPinnedRegistry's intended caller (the short-lived
+// galactic-cni plugin binary, one process per CNI ADD/DEL), galactic-router
+// is a long-lived daemon: the returned io.Closer should be closed once at
+// process shutdown, not immediately after use -- it does not affect the
+// map's pinned lifetime either way (closing only releases this process's
+// own file descriptor onto the kernel-side map object).
+func OpenPinnedVipXlatTable(pinDir string) (*VipXlatTable, io.Closer, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapVipXlatTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("vipxlatmap: open pinned map %q under %q: %w", prog.UsidMapVipXlatTable, pinDir, err)
+	}
+	return NewVipXlatTable(usidmap.KernelTable{Map: m}), m, nil
+}

--- a/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
+++ b/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
@@ -1,0 +1,422 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package vipxlatmap implements the read/write API for the eBPF uSID
+// datapath's vip_xlat_table map (usid.c's struct vip_xlat_key/
+// vip_xlat_value) -- the DSR/Maglev redesign's tap-backend VIP-boundary
+// substitution (design plan §0.1, §2). It is the ServiceVIPBinding
+// reconciler's (internal/controller/servicevipbinding_controller.go)
+// EgressKindTap counterpart to internal/plumbing/vip's veth-branch
+// Bind/Unbind/Verify, mirroring internal/plumbing/ebpf/usidmap's own
+// Register/Unregister/Get/List/Reconcile shape for vrf_table.
+//
+// # Two independent rows per binding
+//
+// usid.c's struct vip_xlat_key doc comment describes vip_xlat_table's
+// direction convention precisely: the *ingress*-direction lookup (in
+// usid_ingress, on a client's inbound request) keys on the packet's own
+// destination port -- the VIP port a client dialed -- and rewrites the
+// packet's destination to the backend's real address:port; the
+// *egress*-direction lookup (in usid_egress, on the backend's own reply)
+// keys on the packet's own source port -- the backend's real port -- and
+// rewrites the packet's source back to the VIP's address:port. These are
+// two independent map entries, not a single symmetric pair sharing one key:
+// RegisterIngress and RegisterEgress each write exactly one row, with
+// reversed key/value roles (RegisterIngress keys on the VIP port and values
+// the backend address:port; RegisterEgress keys on the backend port and
+// values the VIP address:port).
+//
+// # No on-disk generation field, unlike vrf_table
+//
+// usidmap.VRFTable's crash-safety Generation convention (see usidmap's own
+// doc comment, "The plugin-binary-vs-run-container race") relies on a
+// generation field stored directly in vrf_table's own kernel value struct
+// (prog.UsidVrfValue.Generation), so it survives a control-daemon restart.
+// struct vip_xlat_value (usid.c) has no equivalent field -- it is a bare
+// `{addr[16], port}` substitution target with no spare bytes for one, and
+// this package does not modify usid.c to add one (that file is a shared,
+// already-verified eBPF program; changing its value layout is out of this
+// package's scope). Generation/Reconcile below are therefore backed by an
+// in-memory, per-process map instead of a kernel-stored field: Reconcile
+// still protects against the intra-process race (a Register call landing
+// between a caller's live-snapshot and its own Reconcile call, within the
+// same running reconciler process -- the scenario GC-style sweeps care
+// about day to day), but a process restart resets the tracked generations
+// to unknown (surfaced as Generation 0 on every pre-existing entry), so
+// immediately after a restart Reconcile can only safely trust the caller's
+// live set, not an entry's staleness history. This is an accepted, smaller
+// guarantee than VRFTable's, forced by struct vip_xlat_value's fixed
+// layout -- see this package's own tests for the exact behavior.
+package vipxlatmap
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// Supported transport protocols -- the only two vip_xlat_table's rewrite
+// path is ever consulted for (usid_ingress/usid_egress both gate the
+// vip_xlat_table lookup behind `nexthdr == USID_IPPROTO_TCP ||
+// USID_IPPROTO_UDP`, usid.c). Register rejects any other proto value
+// outright rather than silently writing a kernel entry the datapath can
+// never reach.
+const (
+	ProtoTCP = uint8(unix.IPPROTO_TCP)
+	ProtoUDP = uint8(unix.IPPROTO_UDP)
+)
+
+// Key identifies one vip_xlat_table row exactly as the kernel key is
+// composed (usid.c's struct vip_xlat_key): Block/Argument identify the
+// tenant VRF (same composition as vrf_table's own key), Proto is the
+// transport protocol, and Port is direction-dependent -- see this
+// package's doc comment. Port is host order here; RegisterIngress/
+// RegisterEgress/Get/List/Reconcile all convert to/from the kernel's
+// wire-order representation internally (see hostToNetwork16).
+type Key struct {
+	Block    uint64
+	Argument uint16
+	Proto    uint8
+	Port     uint16
+}
+
+// Entry is one fully decoded vip_xlat_table row, decoupled from
+// prog.UsidVipXlatKey/Value's cilium/ebpf/BTF-generated layout so callers
+// outside this package don't need to import prog or cilium/ebpf directly.
+type Entry struct {
+	Key
+
+	// Addr is the rewrite target's address (backend for an ingress-direction
+	// row, VIP for an egress-direction row).
+	Addr net.IP
+
+	// RewritePort is the rewrite target's port (host order), paired with
+	// Addr.
+	RewritePort uint16
+
+	// Generation is this table wrapper's own in-memory registration
+	// sequence number (see the package doc comment) -- 0 for any entry this
+	// process did not itself Register (e.g. one pinned by a previous
+	// process incarnation, discovered only via List/Get).
+	Generation uint64
+}
+
+// VipXlatTable is the read/write API for vip_xlat_table.
+type VipXlatTable struct {
+	table usidmap.Table
+	clock func() uint64
+
+	mu          sync.Mutex
+	generations map[prog.UsidVipXlatKey]uint64
+}
+
+// NewVipXlatTable wraps table as a VipXlatTable. Production callers pass a
+// usidmap.KernelTable wrapping a loaded vip_xlat_table map (see
+// OpenPinnedVipXlatTable); tests pass a fake usidmap.Table.
+func NewVipXlatTable(table usidmap.Table) *VipXlatTable {
+	return &VipXlatTable{
+		table:       table,
+		clock:       monotonicNow,
+		generations: make(map[prog.UsidVipXlatKey]uint64),
+	}
+}
+
+// Generation returns a snapshot of this table's own in-memory monotonic
+// clock -- see the package doc comment for how this differs from
+// usidmap.VRFTable.Generation.
+func (t *VipXlatTable) Generation() uint64 {
+	return t.clock()
+}
+
+// validateProto returns an error unless proto is ProtoTCP or ProtoUDP.
+func validateProto(proto uint8) error {
+	if proto != ProtoTCP && proto != ProtoUDP {
+		return fmt.Errorf(
+			"vipxlatmap: vip_xlat_table: proto %d is not tcp (%d) or udp (%d) -- "+
+				"usid_ingress/usid_egress never consult vip_xlat_table for any other protocol",
+			proto, ProtoTCP, ProtoUDP)
+	}
+	return nil
+}
+
+// validatePort returns an error if port is the reserved-invalid value 0.
+func validatePort(port uint16) error {
+	if port == 0 {
+		return errors.New("vipxlatmap: vip_xlat_table: port 0 is never a valid TCP/UDP port")
+	}
+	return nil
+}
+
+// addrTo16 returns addr's raw 16 bytes in wire order, or an error if addr is
+// not a genuine IPv6 address. Both usid_ingress's inner-packet path and
+// usid_egress are IPv6-only by design (usid_egress's own doc comment: "IPv6
+// only (component 2/0.1 are both IPv6-only by design)"), so an IPv4
+// (or IPv4-mapped) address is rejected here rather than silently truncated
+// or zero-padded into something the datapath would misinterpret.
+func addrTo16(addr net.IP) ([16]byte, error) {
+	if addr == nil {
+		return [16]byte{}, errors.New("vipxlatmap: vip_xlat_table: address is nil")
+	}
+	a, ok := netip.AddrFromSlice(addr)
+	if !ok {
+		return [16]byte{}, fmt.Errorf("vipxlatmap: vip_xlat_table: %v is not a valid IP address", addr)
+	}
+	a = a.Unmap()
+	if !a.Is6() {
+		return [16]byte{}, fmt.Errorf(
+			"vipxlatmap: vip_xlat_table: %s is not a 16-byte IPv6 address (the tap-VIP substitution is IPv6-only)", a)
+	}
+	return a.As16(), nil
+}
+
+// register is the shared primitive RegisterIngress/RegisterEgress build
+// their (key, value) pair around. keyPort is the port this row's kernel key
+// is composed with (direction-dependent -- see the package doc comment);
+// valAddr/valPort are the rewrite target this row substitutes in.
+func (t *VipXlatTable) register(
+	block uint64, argument uint16, proto uint8, keyPort uint16, valAddr net.IP, valPort uint16,
+) error {
+	if err := uformat.ValidateBlock(block); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: %w", err)
+	}
+	if err := uformat.ValidateArgument(argument); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: %w", err)
+	}
+	if err := validateProto(proto); err != nil {
+		return err
+	}
+	if err := validatePort(keyPort); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: key port: %w", err)
+	}
+	if err := validatePort(valPort); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: rewrite port: %w", err)
+	}
+	rawAddr, err := addrTo16(valAddr)
+	if err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: rewrite address: %w", err)
+	}
+
+	key := prog.UsidVipXlatKey{
+		Block:    block,
+		Argument: argument,
+		Proto:    proto,
+		Port:     hostToNetwork16(keyPort),
+	}
+	value := prog.UsidVipXlatValue{
+		Addr: rawAddr,
+		Port: hostToNetwork16(valPort),
+	}
+	if err := t.table.Put(key, value); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register block=%#x argument=%#x proto=%d port=%d: %w",
+			block, argument, proto, keyPort, err)
+	}
+
+	t.mu.Lock()
+	t.generations[key] = t.clock()
+	t.mu.Unlock()
+	return nil
+}
+
+// RegisterIngress writes vip_xlat_table's ingress-direction row for one
+// ServiceVIPBinding: keyed on (block, argument, proto, vipPort) -- the
+// packet's own destination port on a client's inbound request, per
+// usid_ingress's lookup -- and rewriting to backendAddr:backendPort.
+//
+// vipAddr is accepted for call-site symmetry with RegisterEgress and with
+// ServiceVIPBindingSpec's own field set (so a caller can pass the binding's
+// VIPAddress/Port/BackendAddress/BackendPort straight through in the order
+// they appear on the CRD) and is validated for family consistency with
+// backendAddr, but it is not itself part of the kernel key or value:
+// usid.c's struct vip_xlat_key carries no address field at all (only
+// Proto+Port), and the ingress row's value is backendAddr:backendPort, not
+// vipAddr.
+func (t *VipXlatTable) RegisterIngress(
+	block uint64, argument uint16, proto uint8,
+	vipAddr net.IP, vipPort uint16,
+	backendAddr net.IP, backendPort uint16,
+) error {
+	if _, err := addrTo16(vipAddr); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register ingress: vip address: %w", err)
+	}
+	return t.register(block, argument, proto, vipPort, backendAddr, backendPort)
+}
+
+// RegisterEgress writes vip_xlat_table's egress-direction row for one
+// ServiceVIPBinding: keyed on (block, argument, proto, backendPort) -- the
+// packet's own source port on the backend's own reply, per usid_egress's
+// lookup -- and rewriting to vipAddr:vipPort. See RegisterIngress's doc
+// comment for why backendAddr is accepted but not itself part of the
+// kernel key.
+func (t *VipXlatTable) RegisterEgress(
+	block uint64, argument uint16, proto uint8,
+	backendAddr net.IP, backendPort uint16,
+	vipAddr net.IP, vipPort uint16,
+) error {
+	if _, err := addrTo16(backendAddr); err != nil {
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: register egress: backend address: %w", err)
+	}
+	return t.register(block, argument, proto, backendPort, vipAddr, vipPort)
+}
+
+// unregister removes the vip_xlat_table entry keyed by (block, argument,
+// proto, port), if present. Not an error if already absent, mirroring
+// usidmap.VRFTable.Unregister's identical idempotency contract.
+func (t *VipXlatTable) unregister(block uint64, argument uint16, proto uint8, port uint16) error {
+	key := prog.UsidVipXlatKey{
+		Block:    block,
+		Argument: argument,
+		Proto:    proto,
+		Port:     hostToNetwork16(port),
+	}
+	if err := t.table.Delete(key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("vipxlatmap: vip_xlat_table: unregister block=%#x argument=%#x proto=%d port=%d: %w",
+			block, argument, proto, port, err)
+	}
+	t.mu.Lock()
+	delete(t.generations, key)
+	t.mu.Unlock()
+	return nil
+}
+
+// UnregisterIngress removes the ingress-direction row RegisterIngress
+// would have written for (block, argument, proto, vipPort).
+func (t *VipXlatTable) UnregisterIngress(block uint64, argument uint16, proto uint8, vipPort uint16) error {
+	return t.unregister(block, argument, proto, vipPort)
+}
+
+// UnregisterEgress removes the egress-direction row RegisterEgress would
+// have written for (block, argument, proto, backendPort).
+func (t *VipXlatTable) UnregisterEgress(block uint64, argument uint16, proto uint8, backendPort uint16) error {
+	return t.unregister(block, argument, proto, backendPort)
+}
+
+// decodeEntry converts a raw kernel key/value pair into an Entry, attaching
+// this table's own in-memory Generation bookkeeping for key (0 if unknown --
+// see the package doc comment).
+func (t *VipXlatTable) decodeEntry(key prog.UsidVipXlatKey, value prog.UsidVipXlatValue) Entry {
+	t.mu.Lock()
+	gen := t.generations[key]
+	t.mu.Unlock()
+
+	addr := make(net.IP, 16)
+	copy(addr, value.Addr[:])
+
+	return Entry{
+		Key: Key{
+			Block:    key.Block,
+			Argument: key.Argument,
+			Proto:    key.Proto,
+			Port:     hostToNetwork16(key.Port), // self-inverse: wire -> host
+		},
+		Addr:        addr,
+		RewritePort: hostToNetwork16(value.Port), // self-inverse: wire -> host
+		Generation:  gen,
+	}
+}
+
+// Get reads the vip_xlat_table entry for (block, argument, proto, port),
+// reporting whether it exists. port is whichever key a caller wants to
+// inspect -- the VIP port for an ingress-direction row, or the backend port
+// for an egress-direction row.
+func (t *VipXlatTable) Get(block uint64, argument uint16, proto uint8, port uint16) (Entry, bool, error) {
+	key := prog.UsidVipXlatKey{
+		Block:    block,
+		Argument: argument,
+		Proto:    proto,
+		Port:     hostToNetwork16(port),
+	}
+	var value prog.UsidVipXlatValue
+	if err := t.table.Lookup(key, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return Entry{}, false, nil
+		}
+		return Entry{}, false, fmt.Errorf("vipxlatmap: vip_xlat_table: get block=%#x argument=%#x proto=%d port=%d: %w",
+			block, argument, proto, port, err)
+	}
+	return t.decodeEntry(key, value), true, nil
+}
+
+// List returns every entry currently in vip_xlat_table, in unspecified
+// order. There is no way to tell an ingress-direction row apart from an
+// egress-direction row purely from a raw entry -- both are just
+// (block, argument, proto, port) -> (addr, port) rows to the kernel; a
+// caller that needs to know which direction a given entry belongs to must
+// bring that context itself (e.g. from the ServiceVIPBinding it expects to
+// correspond to it).
+func (t *VipXlatTable) List() ([]Entry, error) {
+	var (
+		entries []Entry
+		key     prog.UsidVipXlatKey
+		value   prog.UsidVipXlatValue
+	)
+	it := t.table.Iterate()
+	for it.Next(&key, &value) {
+		entries = append(entries, t.decodeEntry(key, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("vipxlatmap: vip_xlat_table: list: %w", err)
+	}
+	return entries, nil
+}
+
+// Reconcile brings vip_xlat_table into agreement with live -- the caller's
+// current set of Keys that should exist -- removing every entry whose Key
+// is absent from live, except an entry whose Generation is >= cutoff.
+//
+// cutoff must be a value returned by this table's own Generation, captured
+// by the caller immediately before it builds live, mirroring
+// usidmap.VRFTable.Reconcile's identical contract. See the package doc
+// comment for how this method's crash-safety differs from VRFTable's: an
+// entry this process did not itself Register (Generation 0, e.g. one left
+// by a previous process incarnation) is never treated as "too new to
+// judge" by this rule alone -- only entries this process has itself
+// Registered at or after the snapshot are protected. A fresh process
+// should let its own reconciler re-Register every live binding before ever
+// calling Reconcile, rather than relying on this method alone to preserve
+// state across a restart.
+func (t *VipXlatTable) Reconcile(live map[Key]struct{}, cutoff uint64) (removed []Entry, err error) {
+	entries, err := t.List()
+	if err != nil {
+		return nil, fmt.Errorf("vipxlatmap: vip_xlat_table: reconcile: %w", err)
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, ok := live[e.Key]; ok {
+			continue
+		}
+		if e.Generation >= cutoff {
+			continue
+		}
+		if err := t.unregister(e.Block, e.Argument, e.Proto, e.Port); err != nil {
+			errs = append(errs, fmt.Errorf("vipxlatmap: vip_xlat_table: reconcile: delete stale entry %+v: %w", e.Key, err))
+			continue
+		}
+		removed = append(removed, e)
+	}
+	return removed, errors.Join(errs...)
+}
+
+// hostToNetwork16 converts a host-order uint16 to the network/big-endian
+// byte order struct vip_xlat_key.Port and struct vip_xlat_value.Port
+// require on the wire: bpf2go generates prog.UsidVipXlatKey/Value's Port
+// fields as a plain uint16 with no automatic byte-swap (mirroring
+// internal/plumbing/ebpf/prog/usid_test.go's own bswap16 helper, which
+// performs the identical swap for the same reason -- populating the same
+// map from a test). uint16 byte-swap is its own inverse, so this same
+// function also converts a wire-order value read back out of the kernel to
+// host order (see decodeEntry above).
+func hostToNetwork16(v uint16) uint16 { return v<<8 | v>>8 }

--- a/internal/plumbing/ebpf/vipxlatmap/vipxlat_test.go
+++ b/internal/plumbing/ebpf/vipxlatmap/vipxlat_test.go
@@ -1,0 +1,319 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package vipxlatmap
+
+import (
+	"net"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+)
+
+const testBlock uint64 = 0x2001_0DB8_FF01
+
+func newTestTable(clock func() uint64) (*VipXlatTable, *fakeTable) {
+	ft := newFakeTable()
+	return &VipXlatTable{table: ft, clock: clock, generations: make(map[prog.UsidVipXlatKey]uint64)}, ft
+}
+
+func TestVipXlatTable_RegisterIngressAndGet(t *testing.T) {
+	vt, _ := newTestTable(constClock(7))
+
+	vip := net.ParseIP("2001:db8:5:5::100")
+	backend := net.ParseIP("fd20:60::5:5")
+	const vipPort, backendPort = 8080, 30080
+
+	if err := vt.RegisterIngress(testBlock, 0x654, ProtoUDP, vip, vipPort, backend, backendPort); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+
+	entry, ok, err := vt.Get(testBlock, 0x654, ProtoUDP, vipPort)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after RegisterIngress")
+	}
+	if entry.Block != testBlock || entry.Argument != 0x654 || entry.Proto != ProtoUDP || entry.Port != vipPort {
+		t.Errorf("Get key = %+v, want block=%#x argument=0x654 proto=%d port=%d", entry.Key, testBlock, ProtoUDP, vipPort)
+	}
+	if !entry.Addr.Equal(backend) {
+		t.Errorf("Get addr = %s, want %s (ingress row rewrites to the backend)", entry.Addr, backend)
+	}
+	if entry.RewritePort != backendPort {
+		t.Errorf("Get rewrite port = %d, want %d", entry.RewritePort, backendPort)
+	}
+	if entry.Generation != 7 {
+		t.Errorf("Get generation = %d, want 7", entry.Generation)
+	}
+}
+
+func TestVipXlatTable_RegisterEgressAndGet(t *testing.T) {
+	vt, _ := newTestTable(constClock(3))
+
+	vip := net.ParseIP("2001:db8:5:5::100")
+	backend := net.ParseIP("fd20:60::5:5")
+	const vipPort, backendPort = 8080, 30080
+
+	if err := vt.RegisterEgress(testBlock, 0x654, ProtoTCP, backend, backendPort, vip, vipPort); err != nil {
+		t.Fatalf("RegisterEgress: unexpected error: %v", err)
+	}
+
+	entry, ok, err := vt.Get(testBlock, 0x654, ProtoTCP, backendPort)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after RegisterEgress")
+	}
+	if entry.Port != backendPort {
+		t.Errorf("Get key port = %d, want %d (egress keys on the backend's own port)", entry.Port, backendPort)
+	}
+	if !entry.Addr.Equal(vip) {
+		t.Errorf("Get addr = %s, want %s (egress row rewrites back to the VIP)", entry.Addr, vip)
+	}
+	if entry.RewritePort != vipPort {
+		t.Errorf("Get rewrite port = %d, want %d", entry.RewritePort, vipPort)
+	}
+}
+
+// TestVipXlatTable_IngressAndEgressRowsAreSwapped proves, for one binding,
+// that the ingress and egress rows really do have swapped key/value roles,
+// exactly as usid.c's struct vip_xlat_key doc comment describes: the
+// ingress row is keyed on the VIP's own port and rewrites to the backend;
+// the egress row is keyed on the backend's own port and rewrites to the
+// VIP. These are two distinct map entries (different keys), not the same
+// entry read two ways.
+func TestVipXlatTable_IngressAndEgressRowsAreSwapped(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8:5:5::100")
+	backend := net.ParseIP("fd20:60::5:5")
+	const vipPort, backendPort = 8080, 30080
+
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, vipPort, backend, backendPort); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+	if err := vt.RegisterEgress(testBlock, 0x1, ProtoTCP, backend, backendPort, vip, vipPort); err != nil {
+		t.Fatalf("RegisterEgress: unexpected error: %v", err)
+	}
+
+	if got, want := ft.len(), 2; got != want {
+		t.Fatalf("table has %d entries after both registrations, want %d (two independent rows)", got, want)
+	}
+
+	ingress, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, vipPort)
+	if err != nil || !ok {
+		t.Fatalf("Get(ingress key): ok=%v err=%v", ok, err)
+	}
+	egress, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, backendPort)
+	if err != nil || !ok {
+		t.Fatalf("Get(egress key): ok=%v err=%v", ok, err)
+	}
+
+	// Keys differ (ports are swapped between the two rows).
+	if ingress.Port != vipPort {
+		t.Errorf("ingress row key port = %d, want %d (VIP port)", ingress.Port, vipPort)
+	}
+	if egress.Port != backendPort {
+		t.Errorf("egress row key port = %d, want %d (backend port)", egress.Port, backendPort)
+	}
+	// Values are the opposite side from each row's own key.
+	if !ingress.Addr.Equal(backend) || ingress.RewritePort != backendPort {
+		t.Errorf("ingress row value = %s:%d, want %s:%d (backend)", ingress.Addr, ingress.RewritePort, backend, backendPort)
+	}
+	if !egress.Addr.Equal(vip) || egress.RewritePort != vipPort {
+		t.Errorf("egress row value = %s:%d, want %s:%d (VIP)", egress.Addr, egress.RewritePort, vip, vipPort)
+	}
+	// Neither row is a no-op self-mapping.
+	if ingress.Port == ingress.RewritePort {
+		t.Errorf("ingress row's key port and rewrite port are both %d -- rows must not collapse to a no-op", ingress.Port)
+	}
+}
+
+func TestVipXlatTable_GetMissingEntry(t *testing.T) {
+	vt, _ := newTestTable(constClock(1))
+
+	_, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, 443)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if ok {
+		t.Errorf("Get: ok = true for an entry never registered")
+	}
+}
+
+func TestVipXlatTable_RegisterRejectsInvalidProto(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x1, 1 /* ICMP */, vip, 8080, backend, 30080); err == nil {
+		t.Errorf("RegisterIngress(proto=ICMP) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("RegisterIngress(proto=ICMP) wrote %d entries, want 0 (reject outright)", ft.len())
+	}
+}
+
+func TestVipXlatTable_RegisterRejectsIPv4Address(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backendV4 := net.ParseIP("10.0.0.5")
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backendV4, 30080); err == nil {
+		t.Errorf("RegisterIngress(backend=IPv4) = nil error, want rejection (IPv6-only substitution)")
+	}
+	if ft.len() != 0 {
+		t.Errorf("RegisterIngress(backend=IPv4) wrote %d entries, want 0", ft.len())
+	}
+}
+
+func TestVipXlatTable_RegisterRejectsReservedArgumentZero(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x000, ProtoTCP, vip, 8080, backend, 30080); err == nil {
+		t.Errorf("RegisterIngress(argument=0x000) = nil error, want rejection (reserved value)")
+	}
+	if ft.len() != 0 {
+		t.Errorf("RegisterIngress(argument=0x000) wrote %d entries, want 0", ft.len())
+	}
+}
+
+func TestVipXlatTable_UnregisterIsIdempotent(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backend, 30080); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+	if err := vt.UnregisterIngress(testBlock, 0x1, ProtoTCP, 8080); err != nil {
+		t.Fatalf("UnregisterIngress: unexpected error: %v", err)
+	}
+	if ft.len() != 0 {
+		t.Errorf("table has %d entries after unregister, want 0", ft.len())
+	}
+	// Second call: already absent, still not an error.
+	if err := vt.UnregisterIngress(testBlock, 0x1, ProtoTCP, 8080); err != nil {
+		t.Errorf("UnregisterIngress on an already-absent entry: unexpected error: %v", err)
+	}
+}
+
+func TestVipXlatTable_List(t *testing.T) {
+	vt, _ := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backend, 30080); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+	if err := vt.RegisterEgress(testBlock, 0x1, ProtoTCP, backend, 30080, vip, 8080); err != nil {
+		t.Fatalf("RegisterEgress: unexpected error: %v", err)
+	}
+
+	entries, err := vt.List()
+	if err != nil {
+		t.Fatalf("List: unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2", len(entries))
+	}
+}
+
+func TestVipXlatTable_ReconcileRemovesStaleEntries(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backend, 30080); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+	if err := vt.RegisterIngress(testBlock, 0x2, ProtoTCP, vip, 9090, backend, 40040); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+
+	// Only argument 0x1's key is still live; argument 0x2's is stale.
+	live := map[Key]struct{}{
+		{Block: testBlock, Argument: 0x1, Proto: ProtoTCP, Port: 8080}: {},
+	}
+
+	// cutoff above both entries' generation (1) means neither is "too new
+	// to judge" -- both are eligible, only the absent one is removed.
+	removed, err := vt.Reconcile(live, 2)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("Reconcile removed %d entries, want 1", len(removed))
+	}
+	if removed[0].Argument != 0x2 {
+		t.Errorf("Reconcile removed argument %#x, want 0x2", removed[0].Argument)
+	}
+	if ft.len() != 1 {
+		t.Errorf("table has %d entries after Reconcile, want 1", ft.len())
+	}
+}
+
+func TestVipXlatTable_ReconcileKeepsEntriesAtOrAfterCutoff(t *testing.T) {
+	vt, ft := newTestTable(constClock(5))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	// Registered at generation 5, i.e. at-or-after a cutoff of 5 -- must be
+	// kept even though its key is absent from live (it is simply too new
+	// to judge against a live set snapshotted before it existed).
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backend, 30080); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+
+	removed, err := vt.Reconcile(map[Key]struct{}{}, 5)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("Reconcile removed %d entries, want 0 (entry's generation >= cutoff)", len(removed))
+	}
+	if ft.len() != 1 {
+		t.Errorf("table has %d entries after Reconcile, want 1 (kept)", ft.len())
+	}
+}
+
+func TestVipXlatTable_ReconcileKeepsLiveEntries(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8::1")
+	backend := net.ParseIP("fd20:60::1")
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, 8080, backend, 30080); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+
+	live := map[Key]struct{}{
+		{Block: testBlock, Argument: 0x1, Proto: ProtoTCP, Port: 8080}: {},
+	}
+	removed, err := vt.Reconcile(live, 2)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("Reconcile removed %d entries, want 0 (key is live)", len(removed))
+	}
+	if ft.len() != 1 {
+		t.Errorf("table has %d entries after Reconcile, want 1", ft.len())
+	}
+}
+
+func TestVipXlatTable_GenerationAdvancesWithClock(t *testing.T) {
+	vt, _ := newTestTable(constClock(1))
+	if got := vt.Generation(); got != 1 {
+		t.Errorf("Generation() = %d, want 1", got)
+	}
+	vt.clock = constClock(42)
+	if got := vt.Generation(); got != 42 {
+		t.Errorf("Generation() after clock change = %d, want 42", got)
+	}
+}

--- a/internal/plumbing/sysctl/sysctl.go
+++ b/internal/plumbing/sysctl/sysctl.go
@@ -42,6 +42,42 @@ func ConfigureInterfaceSysctls(iface string) error {
 	return nil
 }
 
+// ConfigureFIBLookupUplinkSysctls enables IPv6 forwarding on iface (a
+// galactic-gateway or galactic-nat66 node's public/fabric-facing uplink --
+// the interface edgedsr.c's edge_lb and nat66.c's nat66_ingress XDP
+// programs each attach to) and, needed alongside it,
+// net.ipv6.conf.all.forwarding.
+//
+// Without this, bpf_fib_lookup() (edgedsr.c's push_outer_header, and
+// nat66.c's identical mechanism in both its forward and return paths)
+// returns BPF_FIB_LKUP_RET_NOT_FWDED for every lookup -- the kernel
+// correctly refusing to resolve a forwarding route on an interface that
+// isn't configured as a router -- which neither datapath's own drop-reason
+// accounting could distinguish from a generic FIB lookup failure (see
+// edgedsr.c's DROP_REASON_FIB_LOOKUP_FAILED fallback and nat66.c's
+// equivalent). Found via live-kernel investigation of the containerlab
+// veth/XDP_TX blocker (deploy/containerlab/README.md): this sysctl gap,
+// not XDP_TX itself, is what actually prevented every gateway node's
+// bpf_fib_lookup from ever succeeding in that lab. Both the per-interface
+// and the "all" sysctl are set together because that combination is what
+// was empirically confirmed to unblock bpf_fib_lookup; per-interface alone
+// was not independently verified sufficient, and setting only "all" would
+// affect every interface on the node instead of just the uplink -- setting
+// both is the validated-safe choice, not a guess. Silently skips sysctls
+// that don't exist, matching ConfigureInterfaceSysctls's own convention.
+func ConfigureFIBLookupUplinkSysctls(iface string) error {
+	settings := []struct{ key, value string }{
+		{fmt.Sprintf("net.ipv6.conf.%s.forwarding", iface), "1"},
+		{"net.ipv6.conf.all.forwarding", "1"},
+	}
+	for _, s := range settings {
+		if err := gosysctl.Set(s.key, s.value); err != nil {
+			logger.Warn("failed to set sysctl (non-fatal)", "sysctl", s.key, "err", err)
+		}
+	}
+	return nil
+}
+
 // ConfigureTapSysctls applies sysctls appropriate for a tap interface
 // connected to a VM. Unlike ConfigureInterfaceSysctls, it skips
 // proxy_arp and proxy_ndp since the VM handles its own address resolution.


### PR DESCRIPTION
## Summary

The eBPF datapath from the previous PR has no controller driving it yet. This wires it up on the `galactic-router` side: a `ServiceVIPBinding` controller that automates loopback+tap VIP binding, and per-VRF NPTv6 instantiation triggered off `BGPVRFInstance`. Includes the shared status-condition helpers and config-key refactor both controllers build on, plus garbage collection and installer updates for the new eBPF maps.

## Test plan

- [ ] `task test`
- [ ] `task test:e2e`