### PR TITLE
feat: Add the NAT66Shard controller and galactic-nat66 binary

### DIFF
--- a/cmd/galactic-nat66/main.go
+++ b/cmd/galactic-nat66/main.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Command galactic-nat66 is one shard of the sharded, stateful NAT66
+// egress tier of the Galactic data plane. It loads and attaches
+// internal/plumbing/ebpf/nat66prog's XDP program to this shard's own
+// fabric-facing uplink interface and registers the NAT66ShardReconciler
+// that publishes this shard's operator-configured identity
+// (Status.ShardAddress/Status.ShardSID) and Ready condition.
+//
+// This binary is deliberately its own standalone datapath, not a
+// personality bolted onto galactic-gateway: tenant egress traffic
+// (backend -> arbitrary internet destination) is a different traffic
+// pattern from ingress (fixed VIP, fixed backend pool) and needs its own
+// placement ring, own state, own self-routing return path -- see
+// nat66prog's own doc comment and nat66.c's header comment for the full
+// design.
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	networkAPIGroup   = "network.datumapis.com"
+	networkAPIVersion = "v1alpha1"
+
+	resourceNAT66Shards = "nat66shards"
+)
+
+func main() {
+	cmd := newRootCommand()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// checkWatchPermissions issues a SelfSubjectAccessReview for nat66shards,
+// checking the watch verb. If the review denies the request the informer
+// cache will never sync and NAT66ShardReconciler will be silently
+// blocked; this logs a clear, actionable message at startup so the
+// problem is immediately obvious. Mirrors cmd/galactic-gateway/main.go's
+// identically-named function, scoped to this binary's own single
+// resource: unlike galactic-gateway's NetworkGatewayReconciler,
+// NAT66ShardReconciler reads no other CRD (no BGPRouter/BGPAdvertisement
+// lookup -- see internal/controller/nat66shard_controller.go's own doc
+// comment for why this reconciler is deliberately much simpler).
+func checkWatchPermissions(mgr ctrl.Manager) {
+	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		ctrl.Log.Error(err, "RBAC pre-flight: cannot create client, skipping check")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logger := ctrl.Log.WithName("rbac-preflight")
+
+	review := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Verb:     "watch",
+				Group:    networkAPIGroup,
+				Version:  networkAPIVersion,
+				Resource: resourceNAT66Shards,
+			},
+		},
+	}
+	if err := c.Create(ctx, review); err != nil {
+		logger.Error(err, "RBAC pre-flight: failed to submit access review for "+resourceNAT66Shards, "verb", "watch")
+		return
+	}
+	if review.Status.Allowed {
+		return
+	}
+	logger.Error(nil, "missing watch RBAC for "+resourceNAT66Shards,
+		"verb", "watch", "detail", "informer cache will not sync; add resource to ServiceAccount ClusterRole and restart")
+}

--- a/cmd/galactic-nat66/metrics.go
+++ b/cmd/galactic-nat66/metrics.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66map"
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+const metricsNamespace = "galactic_nat66"
+
+// nat66Collector is a prometheus.Collector reading this shard's live eBPF
+// map state at every scrape: drops by reason (drop_reasons) and the
+// current nat66_conn_table occupancy -- mirroring
+// internal/plumbing/ebpf/edgemetrics.Collector's pull-based-collector
+// shape (reading live at scrape time rather than incrementally-updated
+// Gauges), scoped down to what nat66map actually exposes read access to
+// (see that package's doc comment for why nat66_conn_table is
+// observability-only: it is entirely datapath-owned).
+type nat66Collector struct {
+	connTable   *nat66map.ConnTable
+	dropReasons nat66map.DropReasonsReader
+}
+
+// newNat66Collector builds a nat66Collector reading directly from a
+// loaded *nat66prog.Nat66Objects's Nat66ConnTable/DropReasons maps -- the
+// object internal/plumbing/ebpf/nat66attach.Load returns.
+func newNat66Collector(objs *nat66prog.Nat66Objects) *nat66Collector {
+	return &nat66Collector{
+		connTable:   nat66map.NewConnTable(nat66map.KernelTable{Map: objs.Nat66ConnTable}),
+		dropReasons: objs.DropReasons,
+	}
+}
+
+var (
+	connsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(metricsNamespace, "", "conns"),
+		"Current number of flows in this shard's nat66_conn_table -- a point-in-time snapshot; the table "+
+			"is a self-evicting LRU, so this can fluctuate independently of actual live traffic under memory pressure.",
+		nil, nil,
+	)
+	dropsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(metricsNamespace, "", "drops_total"),
+		"Packets dropped by the nat66_ingress program, by reason (drop_reasons map).",
+		[]string{"reason"}, nil,
+	)
+)
+
+// Describe implements prometheus.Collector.
+func (c *nat66Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- connsDesc
+	ch <- dropsDesc
+}
+
+// Collect implements prometheus.Collector.
+func (c *nat66Collector) Collect(ch chan<- prometheus.Metric) {
+	c.collectConns(ch)
+	c.collectDrops(ch)
+}
+
+func (c *nat66Collector) collectConns(ch chan<- prometheus.Metric) {
+	entries, err := c.connTable.List()
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(connsDesc, fmt.Errorf("list nat66_conn_table: %w", err))
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(connsDesc, prometheus.GaugeValue, float64(len(entries)))
+}
+
+func (c *nat66Collector) collectDrops(ch chan<- prometheus.Metric) {
+	if c.dropReasons == nil {
+		return
+	}
+	totals, err := nat66map.DropReasonTotals(c.dropReasons)
+	if err != nil {
+		ch <- prometheus.NewInvalidMetric(dropsDesc, fmt.Errorf("read drop_reasons: %w", err))
+		return
+	}
+	for i, total := range totals {
+		name := nat66prog.DropReasonNames[i]
+		if name == "" {
+			name = fmt.Sprintf("unknown_%d", i)
+		}
+		ch <- prometheus.MustNewConstMetric(dropsDesc, prometheus.CounterValue, float64(total), name)
+	}
+}

--- a/cmd/galactic-nat66/nat66.go
+++ b/cmd/galactic-nat66/nat66.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"fmt"
+	"net/netip"
+	"sync/atomic"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66map"
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+	"go.datum.net/galactic/internal/plumbing/sysctl"
+)
+
+// nat66DatapathKeepAlive holds the loaded *nat66prog.Nat66Objects and the
+// attached link.Link for the life of this process, once
+// setupNat66Datapath's attach path succeeds. Neither is Closed anywhere in
+// this file -- mirrors cmd/galactic-gateway/gateway.go's
+// gatewayDatapathKeepAlive var and its doc comment's full rationale
+// (cilium/ebpf's *ebpf.Program, *ebpf.Map, and link.Link types all
+// register a runtime finalizer that closes their underlying fd once the
+// garbage collector determines nothing reachable still points at them,
+// with no error surfaced anywhere when that happens -- confirmed live the
+// first time gatewayDatapathKeepAlive's absence was ever exercised against
+// a real interface: ingress traffic for a registered rule was silently
+// never intercepted at all). Without an equivalent var here,
+// objs.Nat66Ingress (the program) and the link.Link returned by Attach --
+// the two things actually keeping this shard's XDP attachment live on the
+// wire -- would eventually get GC'd and silently detached, with the
+// NAT66Shard's own Ready condition still reporting healthy.
+var nat66DatapathKeepAlive struct {
+	objs *nat66prog.Nat66Objects
+	link link.Link
+}
+
+// nat66DatapathStatus implements controller.NAT66DatapathHealth,
+// reporting whether setupNat66Datapath has completed a successful
+// load+attach+configure pass. attached is only ever set true, once, by
+// setupNat66Datapath after every step below succeeds -- there is no
+// runtime detach detection here (the datapath is expected to survive for
+// this process's whole lifetime, mirroring gatewayDatapathKeepAlive's own
+// "attached once at startup, held open forever" convention), so an
+// atomic.Bool rather than a mutex-guarded struct is sufficient: it's only
+// ever written once and read concurrently by every subsequent
+// NAT66ShardReconciler.Reconcile call.
+type nat66DatapathStatus struct {
+	attached atomic.Bool
+}
+
+func (s *nat66DatapathStatus) Attached() bool { return s.attached.Load() }
+
+// setupNat66Datapath loads and attaches the NAT66 egress eBPF datapath to
+// uplinkInterface, writes shardSID/shardPubAddr into shard_config_table,
+// and registers this shard's Prometheus metrics, returning the
+// controller.NAT66DatapathHealth NAT66ShardReconciler uses to report its
+// Ready condition.
+//
+// Mirrors cmd/galactic-gateway/gateway.go's setupGatewayDatapath: the
+// loaded *nat66prog.Nat66Objects and the returned link.Link are stashed in
+// nat66DatapathKeepAlive (see that var's doc comment for why) rather than
+// Closed here -- they, and the XDP attachment itself, must survive for the
+// life of this process.
+func setupNat66Datapath(
+	uplinkInterface, shardSID, shardPubAddr string, metricsReg prometheus.Registerer,
+) (*nat66DatapathStatus, error) {
+	sidAddr, err := netip.ParseAddr(shardSID)
+	if err != nil {
+		return nil, fmt.Errorf("parse shard SID %q: %w", shardSID, err)
+	}
+	pubAddr, err := netip.ParseAddr(shardPubAddr)
+	if err != nil {
+		return nil, fmt.Errorf("parse shard public address %q: %w", shardPubAddr, err)
+	}
+
+	// Required for bpf_fib_lookup() (nat66.c's push_outer_header, used by
+	// both the forward and return paths) to ever succeed on this interface
+	// -- see sysctl.ConfigureFIBLookupUplinkSysctls's own doc comment for
+	// why (a real, previously-undiagnosed blocker, first found against
+	// edgedsr.c but equally applicable here since both datapaths share the
+	// identical bpf_fib_lookup mechanism). Best-effort/non-fatal, matching
+	// cmd/galactic-gateway/gateway.go's identical call.
+	if err := sysctl.ConfigureFIBLookupUplinkSysctls(uplinkInterface); err != nil {
+		return nil, fmt.Errorf("configure IPv6 forwarding on uplink interface %q: %w", uplinkInterface, err)
+	}
+
+	objs, err := nat66attach.Load(nat66attach.PinDir)
+	if err != nil {
+		return nil, fmt.Errorf("load NAT66 egress eBPF datapath: %w", err)
+	}
+
+	xdpLink, err := nat66attach.Attach(objs.Nat66Ingress, uplinkInterface)
+	if err != nil {
+		_ = objs.Close()
+		return nil, fmt.Errorf("attach NAT66 egress datapath to uplink interface %q: %w", uplinkInterface, err)
+	}
+
+	shardConfigTable := nat66map.NewShardConfigTable(nat66map.KernelTable{Map: objs.ShardConfigTable})
+	if err := shardConfigTable.Set(nat66map.ShardConfig{ShardSID: sidAddr, ShardPubAddr: pubAddr}); err != nil {
+		_ = xdpLink.Close()
+		_ = objs.Close()
+		return nil, fmt.Errorf("write shard_config_table: %w", err)
+	}
+
+	collector := newNat66Collector(objs)
+	if err := metricsReg.Register(collector); err != nil {
+		_ = xdpLink.Close()
+		_ = objs.Close()
+		return nil, fmt.Errorf("register NAT66 shard metrics collector: %w", err)
+	}
+
+	nat66DatapathKeepAlive.objs = objs
+	nat66DatapathKeepAlive.link = xdpLink
+
+	status := &nat66DatapathStatus{}
+	status.attached.Store(true)
+	return status, nil
+}

--- a/cmd/galactic-nat66/root.go
+++ b/cmd/galactic-nat66/root.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	grpchealth "google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/controller"
+	"go.datum.net/galactic/internal/metadata"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	appName = "galactic-nat66"
+
+	appDesc = `Galactic sharded NAT66 egress datapath
+
+ Find more information at: https://www.datum.net/docs`
+)
+
+// runCmd contains the application startup logic: it loads and attaches
+// this shard's NAT66 egress eBPF datapath to its fabric-facing uplink
+// interface and registers the NAT66ShardReconciler that publishes this
+// shard's identity/health. Mirrors cmd/galactic-gateway/root.go's runCmd
+// closely -- see that file's own doc comment for the gRPC health server's
+// NOT_SERVING-until-datapath-attached rationale (#360), which applies
+// unchanged here.
+func runCmd(cfg *config.NAT66Config) error {
+	nodeName := cfg.NodeName
+	metricsPort := cfg.MetricsPort
+	grpcHealthPort := cfg.GRPCHealthPort
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(bgpv1alpha1.AddToScheme(scheme))
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                 scheme,
+		HealthProbeBindAddress: "0",
+		Metrics: metricsserver.Options{
+			BindAddress: fmt.Sprintf(":%d", metricsPort),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create manager: %w", err)
+	}
+
+	// ctx's cause distinguishes a normal signal-triggered shutdown from the
+	// health server's own Serve failure below (#360) -- see the cause check
+	// after mgr.Start.
+	ctx, cancel := context.WithCancelCause(ctrl.SetupSignalHandler())
+	defer cancel(nil)
+
+	// Start gRPC health server. grpchealth.NewServer() defaults the ""
+	// overall-health service to SERVING, so that must be overridden to
+	// NOT_SERVING here, explicitly and immediately: otherwise a probe could
+	// see "healthy" for the entire window before the datapath below is even
+	// attached. Only once the datapath is attached does this flip to
+	// SERVING, further down.
+	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcHealthPort))
+	if err != nil {
+		return fmt.Errorf("listen on gRPC health port %d: %w", grpcHealthPort, err)
+	}
+	grpcSrv := grpc.NewServer()
+	healthSrv := grpchealth.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+	go func() {
+		// A Serve failure here is fatal, not merely logged: with no health
+		// server left running and nothing to notice, the process would
+		// otherwise carry on with no health signal at all. Canceling ctx
+		// with this error as its cause carries it out through mgr.Start
+		// below, the same way any other fatal startup error does.
+		if serveErr := grpcSrv.Serve(lis); serveErr != nil {
+			cancel(fmt.Errorf("gRPC health server: %w", serveErr))
+		}
+	}()
+	go func() {
+		<-ctx.Done()
+		grpcSrv.GracefulStop()
+	}()
+
+	// Pre-flight RBAC check.
+	checkWatchPermissions(mgr)
+
+	// Load and attach the NAT66 egress eBPF datapath. Always loads a real
+	// datapath -- config.NAT66Config.Validate already rejects an empty
+	// UplinkInterface/ShardSID/ShardPubAddr before runCmd is ever reached,
+	// since this binary only exists to run a NAT66 shard.
+	datapathHealth, err := setupNat66Datapath(cfg.UplinkInterface, cfg.ShardSID, cfg.ShardPubAddr, ctrlmetrics.Registry)
+	if err != nil {
+		return fmt.Errorf("setup NAT66 egress eBPF datapath: %w", err)
+	}
+	// Only now is the datapath attached -- report serving from here on, not
+	// from process start (#360).
+	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+
+	// Register NAT66Shard controller.
+	if err := (&controller.NAT66ShardReconciler{
+		Client:       mgr.GetClient(),
+		Scheme:       mgr.GetScheme(),
+		NodeName:     nodeName,
+		ShardAddress: cfg.ShardPubAddr,
+		ShardSID:     cfg.ShardSID,
+		Datapath:     datapathHealth,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("setup NAT66Shard controller: %w", err)
+	}
+
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("manager exited: %w", err)
+	}
+	// mgr.Start only returns nil once ctx is Done, and by then ctx always
+	// has a cause: either context.Canceled (an ordinary signal-triggered
+	// shutdown) or the gRPC health server's own fatal Serve error from
+	// above. Only the latter should fail the process.
+	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
+		return cause
+	}
+
+	return nil
+}
+
+// newRootCommand builds the root cobra command with all flags and the
+// application startup logic.
+func newRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   appName,
+		Short: strings.Split(appDesc, "\n")[0],
+		Long:  appDesc,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if ok, _ := cmd.Flags().GetBool("build-info"); ok {
+				fmt.Println(metadata.BuildInfo(appName))
+				return nil
+			}
+			if ok, _ := cmd.Flags().GetBool("version"); ok {
+				fmt.Printf("galactic-nat66 version %s\n", metadata.Version)
+				return nil
+			}
+
+			cfg := config.NewNAT66Config()
+			cfg.BindFlags(cmd.Flags())
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+			return runCmd(cfg)
+		},
+	}
+
+	cmd.Flags().StringP("node-name", "n", "", "Kubernetes node name (required)")
+	cmd.Flags().IntP("metrics-port", "",
+		config.DefaultNAT66MetricsPort,
+		"Metrics listen port")
+	cmd.Flags().IntP("grpc-health-port", "",
+		config.DefaultNAT66GRPCHealthPort,
+		"gRPC health check port")
+	cmd.Flags().StringP("nat66-uplink-interface", "", "",
+		"Fabric-facing uplink interface this NAT66 shard's XDP datapath attaches to (required)")
+	cmd.Flags().StringP("nat66-shard-sid", "", "",
+		"This shard's own SRv6 uSID, encapsulation target for tenant egress traffic (required)")
+	cmd.Flags().StringP("nat66-shard-pub-addr", "", "",
+		"This shard's own publicly-routable masquerade source address (required)")
+	cmd.Flags().Bool("build-info", false, "Print build information and exit")
+	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
+	return cmd
+}

--- a/config/galactic-nat66/base/daemonset.yaml
+++ b/config/galactic-nat66/base/daemonset.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-nat66
+  namespace: galactic-system
+  labels:
+    app.kubernetes.io/name: galactic-nat66
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: galactic-nat66
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: galactic-nat66
+    spec:
+      # Dedicated NAT66-shard-role nodes only, opt-in, matching every
+      # other role's pattern (config/galactic-router/tenant,
+      # config/galactic-router/tenant-control,
+      # config/galactic-gateway/base). "nat66" is a new
+      # galactic.datumapis.com/node value, introduced here alongside
+      # "edge"/"control"/"gateway" for the same reason "gateway" was: this
+      # is its own dedicated, opt-in node role with no generic default,
+      # not a variant of any existing one -- a NAT66 shard's own SID/public
+      # address must be unique per node (see ../kustomization.yaml), the
+      # same uniqueness property that already justifies "gateway" being
+      # its own label value rather than reusing "edge". Excludes
+      # control-plane outright for the same reason those do. See
+      # ../kustomization.yaml for why this base is meant to be instantiated
+      # once per shard node rather than applied as-is.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.datumapis.com/node
+                    operator: In
+                    values:
+                      - nat66
+      serviceAccountName: galactic-nat66
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      # Loss of galactic-nat66 blackholes this shard's own claimed
+      # masquerade addresses/ports -- every in-flight egress flow it owns
+      # loses its return path -- so the scheduler/kubelet must never
+      # preempt it for ordinary workloads under node pressure. Same
+      # rationale as config/galactic-gateway/base/daemonset.yaml's
+      # identical setting.
+      priorityClassName: system-node-critical
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: galactic-nat66
+          # ":latest" is a placeholder only: no such tag is ever pushed to
+          # GHCR. CI resolves and stamps real version tags here when it
+          # publishes the ghcr.io/datum-cloud/galactic-kustomize OCI bundle
+          # (see .github/workflows/publish.yaml); applying this manifest
+          # directly from a git checkout will fail to pull the image
+          # unless you override the tag first.
+          image: ghcr.io/datum-cloud/galactic-nat66:latest
+          command:
+            - /galactic-nat66
+          env:
+            - name: GALACTIC_NAT66_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Also the binary's own default (config.DefaultNAT66GRPCHealthPort).
+            # Set explicitly here anyway so it can't silently drift.
+            - name: GALACTIC_NAT66_GRPC_HEALTH_PORT
+              value: "5182"
+            # GALACTIC_NAT66_UPLINK_INTERFACE/_SHARD_SID/_SHARD_PUB_ADDR are
+            # intentionally left unset here: the interface name is
+            # deployment-specific and the shard SID/public address must be
+            # unique per shard node (no in-cluster mechanism yet derives
+            # them automatically -- see internal/config/nat66.go's
+            # EnvNAT66ShardSID doc comment, the same gap
+            # GALACTIC_GATEWAY_SRV6_ADDRESS has today).
+            # config.NAT66Config.Validate requires all three -- applying
+            # this base as-is produces a crash-looping container. The
+            # deployer's per-node overlay must set all three; see
+            # deploy/containerlab/resources/galactic-gateway/ for a worked
+            # example of the equivalent per-node overlay pattern for
+            # galactic-gateway.
+          ports:
+            - name: metrics
+              containerPort: 9182
+              protocol: TCP
+            - name: grpc-health
+              containerPort: 5182
+              protocol: TCP
+          # The eBPF XDP loader (map creation/attach) has the same
+          # slow-cold-start shape as galactic-cni's/galactic-gateway's --
+          # see either manifest's startupProbe comment.
+          startupProbe:
+            grpc:
+              port: 5182
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            grpc:
+              port: 5182
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            grpc:
+              port: 5182
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # This container needs CAP_BPF for the bpf() syscalls themselves
+          # (program/map creation) on top of NET_ADMIN for the netlink XDP
+          # attach -- the same pair config/galactic-gateway/base/daemonset.yaml's
+          # own eBPF-loading container uses. PERFMON is additionally
+          # required: the verifier only allows pointer+scalar arithmetic on
+          # packet data/data_end (nat66.c's SNAT/un-SNAT header rewrites)
+          # when the loading process is perfmon_capable() -- without it the
+          # verifier falls back to its unprivileged-BPF ruleset and rejects
+          # the program even though the container runs as root.
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              drop: ["ALL"]
+              add:
+                - NET_ADMIN
+                - BPF
+                - PERFMON
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            # nat66attach.PinDir pins every nat66prog map under
+            # /sys/fs/bpf/galactic-nat66, same convention
+            # config/galactic-gateway/base/daemonset.yaml's bpf-fs mount
+            # documents: bpffs must already be mounted at this host path by
+            # the node itself (type: Directory, not DirectoryOrCreate --
+            # creating a plain directory here if bpffs weren't mounted
+            # would silently produce a regular filesystem path instead of a
+            # real bpf filesystem, masking the failure instead of
+            # surfacing it at load time). The galactic-nat66/ subdirectory
+            # itself is created by this container on first pin.
+            - name: bpf-fs
+              mountPath: /sys/fs/bpf
+      volumes:
+        - name: bpf-fs
+          hostPath:
+            path: /sys/fs/bpf
+            type: Directory

--- a/config/galactic-nat66/base/kustomization.yaml
+++ b/config/galactic-nat66/base/kustomization.yaml
@@ -1,0 +1,11 @@
+# The single-container NAT66 shard pod's shared base -- see
+# ../kustomization.yaml for why this isn't applied as-is: this is meant to
+# be instantiated once per shard node by a further overlay that pins it to
+# one node (kubernetes.io/hostname) and sets that node's own
+# GALACTIC_NAT66_UPLINK_INTERFACE/_SHARD_SID/_SHARD_PUB_ADDR values,
+# mirroring config/galactic-gateway/base/kustomization.yaml's identical
+# per-node overlay pattern (see
+# deploy/containerlab/resources/galactic-gateway/ for a worked example of
+# that pattern applied to a sibling component).
+resources:
+  - daemonset.yaml

--- a/config/galactic-nat66/kustomization.yaml
+++ b/config/galactic-nat66/kustomization.yaml
@@ -1,0 +1,21 @@
+# The sharded NAT66 egress datapath control plane. Unlike
+# config/galactic-router/'s equivalent kustomization.yaml, this
+# deliberately does NOT include base/: base/daemonset.yaml's
+# galactic-nat66 container has no generic default for
+# GALACTIC_NAT66_UPLINK_INTERFACE/_SHARD_SID/_SHARD_PUB_ADDR (all three
+# required -- config.NAT66Config.Validate -- and the shard SID/public
+# address must be unique per shard node), so applying it as shipped here
+# would produce a crash-looping container. config/galactic-gateway/ and
+# config/fabric-router/ have the same exemption for the same reason.
+#
+# serviceaccount.yaml/rbac.yaml have no such per-node uniqueness problem --
+# they're safe and idempotent to apply cluster-wide regardless of how many
+# NAT66 shard nodes exist or which ones -- so this kustomization covers
+# only those two. Apply with `kubectl apply -k config/galactic-nat66/`,
+# once, before applying any per-node overlay of ../base. This whole
+# directory is deliberately NOT part of the root config/kustomization.yaml's
+# default resource list: this role is not "batteries included" cluster
+# bring-up.
+resources:
+  - serviceaccount.yaml
+  - rbac.yaml

--- a/config/galactic-nat66/rbac.yaml
+++ b/config/galactic-nat66/rbac.yaml
@@ -1,0 +1,43 @@
+# The sharded NAT66 egress datapath's own RBAC. This ClusterRole covers
+# only what NAT66ShardReconciler (internal/controller/nat66shard_controller.go)
+# actually touches.
+#
+# Unlike galactic-gateway's own RBAC (config/galactic-gateway/rbac.yaml),
+# this binary reads no other CRD at all: NAT66ShardReconciler's own doc
+# comment describes it as deliberately much simpler than
+# NetworkGatewayReconciler -- no rule/backend desired-state assembly, no
+# BGPRouter/BGPAdvertisement lookup, no BGPAdvertisement wiring. It only
+# gets/lists/watches its own NAT66Shard object and updates its status.
+#
+# networkegresspolicies is deliberately NOT granted here: NAT66ShardReconciler
+# never reads or writes that CRD (it belongs to the earlier, now-superseded
+# #865 egress-policy stack this sharded-NAT66 design replaces), so granting
+# it would be scope creep past what this binary's own reconciler actually
+# does -- see this ClusterRole's own principle of granting exactly what is
+# used, not what a future phase might use.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: galactic-nat66
+rules:
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - nat66shards
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - nat66shards/status
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: galactic-nat66
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: galactic-nat66
+subjects:
+  - kind: ServiceAccount
+    name: galactic-nat66
+    namespace: galactic-system

--- a/config/galactic-nat66/serviceaccount.yaml
+++ b/config/galactic-nat66/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: galactic-nat66
+  namespace: galactic-system

--- a/containers/galactic-nat66/Dockerfile
+++ b/containers/galactic-nat66/Dockerfile
@@ -1,0 +1,63 @@
+# Build the galactic-nat66 binary
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG GIT_TREE_STATE=unknown
+ARG BUILD_DATE=unknown
+ARG SPDX_LICENSE=AGPL-3.0-or-later
+ARG GIT_URL=https://github.com/datum-cloud/galactic
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/ cmd/
+COPY internal/ internal/
+
+# galactic-nat66 transitively imports both
+# internal/plumbing/ebpf/nat66prog (the sharded NAT66 egress XDP program it
+# loads directly) and, via internal/plumbing/ebpf/nat66attach ->
+# internal/plumbing/ebpf/nat66map -> ... no further transitive eBPF
+# program dependency of its own -- but galactic-router's shared
+# internal/plumbing/ebpf/prog (the SRv6 uSID TC-BPF program) is still
+# generated here too, matching containers/galactic-gateway/Dockerfile's
+# own two-package-generate pattern, since a NAT66 shard node also needs the
+# uSID decap datapath transitively available to the rest of this module's
+# build graph. Neither package's bpf2go output (*_bpfel.go/.o,
+# *_bpfeb.go/.o) is committed to git (see each package's doc.go), so both
+# must be regenerated here.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      clang llvm linux-libc-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN go generate ./internal/plumbing/ebpf/prog/...
+RUN go generate ./internal/plumbing/ebpf/nat66prog/...
+
+# Build galactic-nat66
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
+    -ldflags "-s -w \
+      -X go.datum.net/galactic/internal/metadata.Version=${VERSION} \
+      -X go.datum.net/galactic/internal/metadata.GitCommit=${GIT_COMMIT} \
+      -X go.datum.net/galactic/internal/metadata.GitTreeState=${GIT_TREE_STATE} \
+      -X go.datum.net/galactic/internal/metadata.BuildDate=${BUILD_DATE} \
+      -X go.datum.net/galactic/internal/metadata.SPDXLicense=${SPDX_LICENSE} \
+      -X go.datum.net/galactic/internal/metadata.GitURL=${GIT_URL}" \
+    -o galactic-nat66 ./cmd/galactic-nat66
+
+# Use distroless as minimal base image to package the binary. galactic-nat66
+# drives its eBPF/XDP and NAT66Shard CRD state through the cilium/ebpf and
+# controller-runtime Go libraries directly, never shells out to `ip` or any
+# other host CLI tool, so no shell is required in the final image.
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/galactic-nat66 .
+USER 65532:65532
+
+ENTRYPOINT ["/galactic-nat66"]

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -41,9 +41,15 @@ two-container pod, `galactic-router` + `galactic-gateway`).
 They never run `galactic-cni` (config/galactic-cni's affinity is edge-only) or a route-reflector.
 **Underlay BGP peering on their `tr3` uplinks is now wired** (`node_files/tr3/frr.conf`,
 plus two `BGPPeer` objects in `resources/galactic-control/iad/` for the route reflector side)
-and the full fabric converges, but real end-to-end ingress traffic through the datapath still
-doesn't reach a backend in this topology — it currently stops on a veth-specific `XDP_TX`
-behavior in this lab environment, not a code bug; see `resources/galactic-gateway/`.
+and the full fabric converges. Real end-to-end ingress traffic through the datapath is not yet
+live-validated here — this used to be attributed to a generic veth `XDP_TX` behavior, but
+root-causing found two stacked issues: IPv6 forwarding sysctls weren't enabled (now fixed,
+`sysctl.ConfigureFIBLookupUplinkSysctls`), and veth's native `XDP_TX` fast path stays invisible
+to tcpdump/AF_PACKET unless the peer interface also runs an XDP program — a genuine veth/kernel
+characteristic of this lab's veth-pair uplink simulation, not a code bug and not a production
+concern. See the redesign plan's
+[§8](../../docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md#8-containerlab-validation) and
+`resources/galactic-gateway/`.
 
 `dfw`, `iad`, and `sjc` are the three Kind cluster names — not separate ContainerLab
 topology nodes. Each cluster's `control-plane`/`worker` nodes above are its members.

--- a/deploy/containerlab/gvpc.clab.yaml
+++ b/deploy/containerlab/gvpc.clab.yaml
@@ -249,7 +249,7 @@ topology:
     - endpoints: ["iad-worker:eth1", "tr3:eth5"]
     - endpoints: ["iad-worker2:eth1", "tr3:eth4"]
 
-    # Gateway node uplinks (edge XDP NAT+LB DaemonSet; see
+    # Gateway node uplinks (edge XDP Maglev/DSR DaemonSet; see
     # config/galactic-gateway/base/ and deploy/containerlab/resources/
     # galactic-gateway/). tr3 (iad's transit router) already
     # consumed eth1/eth2/eth3 for the TR mesh and eth4/eth5 for
@@ -257,9 +257,16 @@ topology:
     # peering on these links is now configured (node_files/tr3/frr.conf,
     # plus two BGPPeer objects in resources/galactic-control/iad/ for the
     # route reflector side) and the fabric fully converges over them, but
-    # real end-to-end ingress traffic through the datapath still doesn't
-    # reach a backend -- a veth-specific XDP_TX behavior in this lab
-    # environment, not a code bug.
+    # real end-to-end ingress traffic through the datapath is not yet
+    # live-validated here -- two stacked issues, not the generic
+    # veth-specific XDP_TX behavior this comment used to attribute it
+    # to: (1) IPv6 forwarding sysctls weren't enabled (now fixed,
+    # sysctl.ConfigureFIBLookupUplinkSysctls), and (2) veth's native
+    # XDP_TX fast path stays invisible to tcpdump/AF_PACKET unless the
+    # peer interface also runs an XDP program -- a genuine veth/kernel
+    # characteristic of this lab's veth-pair uplink simulation, not a
+    # code bug and not a production concern. See the redesign plan's
+    # §8 (docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md).
     #
     # mtu: 1500 on both ends, unlike every other link in this topology
     # (which gets containerlab's jumbo-frame veth default, ~9500) --

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway1/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway1/node-patch.yaml
@@ -31,8 +31,9 @@ spec:
           env:
             # eth1 is this lab's dedicated transit-fabric-facing uplink on
             # every node (see resources/galactic-cni/daemonset-patch.yaml's
-            # comment) -- the same interface edgenat's XDP program attaches
-            # to for both underlay BGP and (once wired) ingress traffic.
+            # comment) -- the same interface edgedsr.c's edge_lb XDP
+            # program attaches to for both underlay BGP and ingress
+            # traffic.
             - name: GALACTIC_GATEWAY_PUBLIC_INTERFACE
               value: eth1
             # uFMT 48+16 uSID over this PoP's shared locator
@@ -43,10 +44,15 @@ spec:
             # comment), Argument=0 (reserved, PR #740). Computed via
             # internal/plumbing/ebpf/uformat.Encode directly, bypassing
             # srv6.ComputeSID's argument==0 guard (that guard exists for
-            # tenant-VRF SID derivation specifically -- see
-            # internal/controller/networkgateway_controller.go's
-            # publishSelfAddress doc comment for why this value is
-            # supplied statically rather than computed by that
-            # reconciler today).
+            # tenant-VRF SID derivation specifically). This is this
+            # node's own plain SRv6-reachable address, used only as the
+            # DSR datapath's outer-header encap source
+            # (edgedsr.c's encap_config_table) -- never a NAT/SNAT
+            # source and never compared against anything on a receive
+            # path (see internal/config/gateway.go's
+            # EnvGatewaySRv6Address doc comment). No in-cluster
+            # mechanism yet derives this automatically, so it is
+            # supplied statically per node here rather than computed by
+            # a reconciler.
             - name: GALACTIC_GATEWAY_SRV6_ADDRESS
               value: "2001:db8:ff03:2:e000::"

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway2/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway2/node-patch.yaml
@@ -31,8 +31,9 @@ spec:
           env:
             # eth1 is this lab's dedicated transit-fabric-facing uplink on
             # every node (see resources/galactic-cni/daemonset-patch.yaml's
-            # comment) -- the same interface edgenat's XDP program attaches
-            # to for both underlay BGP and (once wired) ingress traffic.
+            # comment) -- the same interface edgedsr.c's edge_lb XDP
+            # program attaches to for both underlay BGP and ingress
+            # traffic.
             - name: GALACTIC_GATEWAY_PUBLIC_INTERFACE
               value: eth1
             # uFMT 48+16 uSID over this PoP's shared locator
@@ -43,10 +44,15 @@ spec:
             # comment), Argument=0 (reserved, PR #740). Computed via
             # internal/plumbing/ebpf/uformat.Encode directly, bypassing
             # srv6.ComputeSID's argument==0 guard (that guard exists for
-            # tenant-VRF SID derivation specifically -- see
-            # internal/controller/networkgateway_controller.go's
-            # publishSelfAddress doc comment for why this value is
-            # supplied statically rather than computed by that
-            # reconciler today).
+            # tenant-VRF SID derivation specifically). This is this
+            # node's own plain SRv6-reachable address, used only as the
+            # DSR datapath's outer-header encap source
+            # (edgedsr.c's encap_config_table) -- never a NAT/SNAT
+            # source and never compared against anything on a receive
+            # path (see internal/config/gateway.go's
+            # EnvGatewaySRv6Address doc comment). No in-cluster
+            # mechanism yet derives this automatically, so it is
+            # supplied statically per node here rather than computed by
+            # a reconciler.
             - name: GALACTIC_GATEWAY_SRV6_ADDRESS
               value: "2001:db8:ff03:3:e000::"

--- a/deploy/containerlab/resources/galactic-gateway/iad/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/kustomization.yaml
@@ -1,9 +1,11 @@
 # The single entry point for iad's gateway-role canary: both gateway
 # nodes' DaemonSet+BGP+NetworkGateway instantiations, plus the ns60
-# NetworkRule. scripts/deploy-galactic-router.sh applies this one
-# path rather than ../iad-gateway1/ and ../iad-gateway2/ separately.
+# NetworkRule and its backend's ServiceVIPBinding sample.
+# scripts/deploy-galactic-router.sh applies this one path rather than
+# ../iad-gateway1/ and ../iad-gateway2/ separately.
 namespace: galactic-system
 resources:
   - ../iad-gateway1
   - ../iad-gateway2
   - networkrule-ns60.yaml
+  - servicevipbinding-ns60.yaml

--- a/deploy/containerlab/resources/galactic-gateway/iad/networkrule-ns60.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/networkrule-ns60.yaml
@@ -1,18 +1,23 @@
 # ns60: a live web service (resources/tenants/ns60/, vpc=60/vpcattachment=60,
 # fd20:60:ff03::/48 -- see ns60/iad/nad.yaml) exposed through the edge XDP
-# NAT+LB gateway on a real, routable ingress VIP. This rule's backend
+# Maglev/DSR gateway on a real, routable ingress VIP. This rule's backend
 # address is the nginx Deployment's actual live pod address
 # (`kubectl get pod -n ns60 -o wide`) and its VIP is IPv6, matching the
 # datapath's current scope: IPv6-only, plain TCP/UDP, no IPv4 support yet
-# (see edgenat.c).
+# (see edgedsr.c).
 # 2001:db8:6060::1 is a documentation-range (RFC 3849, 2001:db8::/32)
 # address picked to avoid colliding with any address already in use
 # elsewhere in this topology (transit mesh: 2001:db8:0:*::/64 and
 # 2001:db8:1:*::/64; SRv6 locators: 2001:db8:ff0X::/48) -- there is no
 # real "public internet" in this lab, so this rule's own BGPAdvertisement
-# (originated by both iad-gateway1 and iad-gateway2, active-active) is what
-# makes it reachable from any other site's node once the underlay carries
-# it, exactly like a real anycast ingress VIP would be.
+# (originated identically and independently by both iad-gateway1 and
+# iad-gateway2 -- DSR's anycast model, no primary/secondary
+# status.primaryNode assignment and no BGP local-preference split
+# between them; both routes are equally preferred by construction, see
+# internal/controller/networkgateway_controller.go's package doc
+# comment) is what makes it reachable from any other site's node once
+# the underlay carries it, exactly like a real anycast ingress VIP
+# would be.
 apiVersion: network.datumapis.com/v1alpha1
 kind: NetworkRule
 metadata:

--- a/deploy/containerlab/resources/galactic-gateway/iad/servicevipbinding-ns60.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/servicevipbinding-ns60.yaml
@@ -1,0 +1,33 @@
+# Sample ServiceVIPBinding for ns60's backend, alongside networkrule-ns60.yaml
+# (same VIP/backend pair -- see that file's own comment for the address
+# provenance). ns60's nginx Deployment (resources/tenants/ns60/) has no
+# node pin of its own beyond excluding control-plane nodes, and lands on
+# iad-worker in practice (the only untainted, non-route-reflector,
+# non-gateway-role worker in the iad cluster -- iad-worker2/
+# iad-worker-control is the route reflector and iad-gateway1/iad-gateway2
+# are tainted gateway-role nodes; confirm the live pod's actual node with
+# `kubectl get pod -n ns60 -o wide` the same way that file's comment
+# already documents for the backend address itself).
+#
+# egressKind: veth, since ns60's backend is a plain container Deployment
+# (veth attach, not a tap/VM backend) -- see ServiceVIPBinding's own doc
+# comment for the veth/tap fork. backendAddress/backendPort are omitted:
+# per that same doc comment, both are ignored for the veth kind (a veth
+# binding's backend answers on vipAddress itself once bound, via
+# internal/plumbing/vip's galactic-vip0 dummy-interface bind) -- they
+# exist on the spec only for the tap case, where there is no fixture in
+# this lab yet (see the redesign plan's §8, "no tap/VM fixture exists in
+# this lab at all").
+apiVersion: network.datumapis.com/v1alpha1
+kind: ServiceVIPBinding
+metadata:
+  name: ns60-web-iad-worker
+  namespace: galactic-system
+spec:
+  targetRef:
+    kind: Node
+    name: iad-worker
+  vipAddress: 2001:db8:6060::1
+  port: 80
+  protocol: tcp
+  egressKind: veth

--- a/deploy/containerlab/resources/galactic-nat66/README.md
+++ b/deploy/containerlab/resources/galactic-nat66/README.md
@@ -1,0 +1,44 @@
+# galactic-nat66 lab overlay (3-shard, not yet wired up)
+
+What's here: a per-site containerlab overlay for `galactic-nat66`, the
+sharded NAT66 egress datapath control plane (`config/galactic-nat66/`),
+built on the same base/per-node-overlay shape
+`resources/galactic-gateway/` uses:
+
+- `base/` — the lab's patch onto `config/galactic-nat66/base` (image
+  override for Kind's locally-built images; see `base/kustomization.yaml`
+  and `base/nat66-lab-patch.yaml`). Not applied directly, same reason
+  `config/galactic-nat66/base` itself isn't ("all three of
+  `GALACTIC_NAT66_UPLINK_INTERFACE`/`_SHARD_SID`/`_SHARD_PUB_ADDR` are
+  required and must be unique per shard node").
+- `dfw/`, `iad/`, `sjc/` — one per-site overlay each, per the redesign
+  plan's own §8 suggestion to reuse the three existing site workers
+  (`dfw-worker`, `iad-worker`, `sjc-worker`) as a 3-shard DaemonSet rather
+  than inventing new lab topology. Each pins the DaemonSet to that site's
+  own worker via `kubernetes.io/hostname` (`node-patch.yaml`, mirroring
+  `resources/galactic-gateway/iad-gateway1/`'s per-node-pin pattern) and
+  sets that shard's own `GALACTIC_NAT66_SHARD_SID`/`_SHARD_PUB_ADDR` —
+  see each `node-patch.yaml`'s own comments for the exact uFMT 48+16
+  encoding and address choices, including the note on why the NAT66
+  shards use `Argument=1` rather than reusing the gateway nodes'
+  `Argument=0` on iad's shared locator. Each site directory also carries
+  a sample `NAT66Shard` object (`nat66shard.yaml`) targeting that site's
+  worker node.
+
+What this reuses: the three existing site workers as shard nodes (no new
+lab topology, no new containerlab nodes), and the exact
+base/per-node-overlay/patch shape `resources/galactic-gateway/` already
+established.
+
+What this is **not**: none of this is wired into `gvpc.clab.yaml` or
+`Taskfile.yaml` yet — no bring-up target applies it, no image build step
+adds `galactic-nat66` to the Kind image load sequence, and no
+`ClusterRoleBinding` from `config/galactic-nat66/` is applied anywhere in
+this lab today. That's a deliberate, separate integration decision (new
+`task deploy:galactic-nat66`/`task verify:nat66-sharding` targets, per the
+redesign plan's §8), not done here. These manifests are self-consistent
+and buildable (verified with `kubectl kustomize` against a locally staged
+copy of `config/galactic-nat66/base`'s nested `nat66/` directory — see
+`base/kustomization.yaml`'s doc comment for why that directory isn't
+checked into git) but standing them up live is out of scope for this
+pass.

--- a/deploy/containerlab/resources/galactic-nat66/base/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/base/kustomization.yaml
@@ -1,0 +1,23 @@
+# Mirrors resources/galactic-gateway/base/'s pattern exactly, pointed at
+# config/galactic-nat66/base instead of config/galactic-gateway/base: "nat66"
+# is meant to be copied onto the node at deploy time by a
+# copy_nat66_config-style helper (see scripts/deploy-galactic-router.sh's
+# copy_router_gateway_config for the equivalent, already-written gateway
+# helper), nested here so this kustomization's "nat66" resource reference
+# resolves. That helper does not exist yet -- this whole directory is not
+# wired into any deploy script or Taskfile target (see ../README.md) -- so
+# applying this kustomization today requires manually copying
+# config/galactic-nat66/base's contents to
+# resources/galactic-nat66/base/nat66/ first (or docker cp'ing it, same
+# idea copy_router_gateway_config automates for galactic-gateway).
+# config/galactic-nat66/base is self-contained (its own full
+# single-container DaemonSet spec, not a patch onto some other config/
+# base), so there is no separate "base" resource to nest alongside it here
+# -- same as config/galactic-gateway/base's own equivalent note.
+resources:
+  - nat66
+patches:
+  - path: nat66-lab-patch.yaml
+    target:
+      kind: DaemonSet
+      name: galactic-nat66

--- a/deploy/containerlab/resources/galactic-nat66/base/nat66-lab-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/base/nat66-lab-patch.yaml
@@ -1,0 +1,17 @@
+# Lab-only image override, same idea as resources/galactic-gateway/base/
+# router-lab-patch.yaml: Kind loads locally-built images by tag, so the
+# real ghcr.io/datum-cloud/galactic-nat66:<version> reference
+# config/galactic-nat66/base/daemonset.yaml ships is swapped for the
+# locally-tagged image with imagePullPolicy: Never so the kubelet never
+# tries to pull it from GHCR.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-nat66
+spec:
+  template:
+    spec:
+      containers:
+        - name: galactic-nat66
+          image: galactic-nat66:latest
+          imagePullPolicy: Never

--- a/deploy/containerlab/resources/galactic-nat66/dfw/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/dfw/kustomization.yaml
@@ -1,0 +1,16 @@
+# dfw's instantiation of ../base as this site's NAT66 shard, reusing the
+# already-existing dfw-worker node (see node-patch.yaml and ../README.md)
+# rather than a new dedicated "nat66"-labeled node. Mirrors
+# resources/galactic-router/dfw/'s per-site pattern (no rename needed the
+# way resources/galactic-gateway/iad-gateway{1,2}/ require: dfw/iad/sjc
+# are three separate clusters, so "galactic-nat66" never collides with
+# itself the way two DaemonSets in the same iad cluster would).
+namespace: galactic-system
+resources:
+  - ../base
+  - nat66shard.yaml
+patches:
+  - path: node-patch.yaml
+    target:
+      kind: DaemonSet
+      name: galactic-nat66

--- a/deploy/containerlab/resources/galactic-nat66/dfw/nat66shard.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/dfw/nat66shard.yaml
@@ -1,0 +1,17 @@
+# Sample NAT66Shard for dfw-worker, this cluster's own shard node --
+# alongside node-patch.yaml the same way resources/galactic-gateway/
+# iad-gateway1/networkgateway.yaml sits alongside its own node-patch.yaml.
+# Status is left empty: NAT66ShardReconciler (running inside the
+# galactic-nat66 process on dfw-worker itself, per node-patch.yaml's
+# GALACTIC_NAT66_SHARD_SID/_SHARD_PUB_ADDR) fills in
+# status.shardAddress/status.shardSID from its own config at startup --
+# this object only needs to exist and target the right node.
+apiVersion: network.datumapis.com/v1alpha1
+kind: NAT66Shard
+metadata:
+  name: dfw-worker-nat66
+  namespace: galactic-system
+spec:
+  targetRef:
+    kind: Node
+    name: dfw-worker

--- a/deploy/containerlab/resources/galactic-nat66/dfw/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/dfw/node-patch.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-nat66
+spec:
+  template:
+    spec:
+      # config/galactic-nat66/base/daemonset.yaml's own affinity requires
+      # galactic.datumapis.com/node: nat66 -- a dedicated node role this
+      # lab has never introduced (see AGENTS.md's "Node labels" note:
+      # every site worker here is labeled galactic.datumapis.com/node:
+      # edge). Per the redesign plan's own §8 suggestion, this lab reuses
+      # dfw-worker itself as a shard rather than adding a new dedicated
+      # nat66-labeled node, so this patch replaces the whole affinity
+      # block to match dfw-worker's real "edge" label plus a
+      # kubernetes.io/hostname pin -- otherwise the base's own affinity
+      # would never match any node in this cluster and the DaemonSet
+      # would sit at zero replicas forever. GALACTIC_NAT66_SHARD_SID/
+      # _SHARD_PUB_ADDR below must be unique per shard node (see
+      # config/galactic-nat66/kustomization.yaml's doc comment), so
+      # dfw/iad/sjc are three separate per-node overlays rather than one
+      # overlay matching all three site workers with identical env --
+      # mirrors resources/galactic-gateway/iad-gateway1/'s identical
+      # per-node-overlay rationale.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.datumapis.com/node
+                    operator: In
+                    values:
+                      - edge
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - dfw-worker
+      containers:
+        - name: galactic-nat66
+          env:
+            # eth1 is this lab's dedicated transit-fabric-facing uplink on
+            # every node (see resources/galactic-cni/daemonset-patch.yaml's
+            # comment) -- the same interface internal/plumbing/ebpf/
+            # nat66prog's XDP program attaches to.
+            - name: GALACTIC_NAT66_UPLINK_INTERFACE
+              value: eth1
+            # uFMT 48+16 uSID over dfw's own locator (2001:db8:ff01::/48,
+            # see resources/galactic-router/dfw/bgprouter.yaml's
+            # srv6Locator), nodeID=1 -- reusing dfw-worker's own already-
+            # registered node identity (its BGPRouter's nodeID) rather
+            # than minting a new one, since this shard runs on that exact
+            # physical node, not a separate dedicated node the way
+            # iad-gateway1/iad-gateway2 are. Function=End.DT46 (0xE),
+            # matching resources/galactic-gateway/iad-gateway1/
+            # node-patch.yaml's convention, even though this address is
+            # never actually looked up through function_table/vrf_table
+            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
+            # doc comment says it's advertised as a plain /128
+            # node-reachability route "no VRFID/Function" -- the uFMT
+            # encoding here is only to keep the address inside dfw's
+            # locator block without colliding with any real tenant VRF
+            # SID. Argument=1, NOT 0: dfw has no other node sharing this
+            # locator (unlike iad, where iad-gateway1/2 already claim
+            # Argument=0 at nodeID=2/3), so 0 would not literally collide
+            # here either, but 1 is used on all three shards for one
+            # consistent, easy-to-audit convention across sites. This is
+            # a lab-only placeholder needing real allocation logic (the
+            # same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
+            # EnvNAT66ShardSID's own doc comment both flag today) before
+            # production.
+            - name: GALACTIC_NAT66_SHARD_SID
+              value: "2001:db8:ff01:1:e001::"
+            # Lab-only placeholder masquerade source address, same
+            # "operator-supplied, no in-cluster derivation yet" status as
+            # GALACTIC_GATEWAY_SRV6_ADDRESS (see
+            # internal/config/gateway.go's doc comment). 2001:db8:9966::/32
+            # is a new documentation-range (RFC 3849) block reserved here
+            # for NAT66 shard public addresses specifically, picked to
+            # avoid colliding with any address already in use elsewhere
+            # in this topology (transit mesh: 2001:db8:0:*::/64 and
+            # 2001:db8:1:*::/64; SRv6 locators: 2001:db8:ff0X::/48; the
+            # ns60 ingress VIP: 2001:db8:6060::1) -- "9966" as a mnemonic
+            # for "NAT66". ::1 here is dfw's shard (shard 1 of 3).
+            - name: GALACTIC_NAT66_SHARD_PUB_ADDR
+              value: "2001:db8:9966:1::1"

--- a/deploy/containerlab/resources/galactic-nat66/iad/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/iad/kustomization.yaml
@@ -1,0 +1,16 @@
+# iad's instantiation of ../base as this site's NAT66 shard, reusing the
+# already-existing iad-worker node (see node-patch.yaml and ../README.md)
+# rather than a new dedicated "nat66"-labeled node. Mirrors
+# resources/galactic-router/iad/'s per-site pattern (no rename needed the
+# way resources/galactic-gateway/iad-gateway{1,2}/ require: dfw/iad/sjc
+# are three separate clusters, so "galactic-nat66" never collides with
+# itself the way two DaemonSets in the same iad cluster would).
+namespace: galactic-system
+resources:
+  - ../base
+  - nat66shard.yaml
+patches:
+  - path: node-patch.yaml
+    target:
+      kind: DaemonSet
+      name: galactic-nat66

--- a/deploy/containerlab/resources/galactic-nat66/iad/nat66shard.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/iad/nat66shard.yaml
@@ -1,0 +1,17 @@
+# Sample NAT66Shard for iad-worker, this cluster's own shard node --
+# alongside node-patch.yaml the same way resources/galactic-gateway/
+# iad-gateway1/networkgateway.yaml sits alongside its own node-patch.yaml.
+# Status is left empty: NAT66ShardReconciler (running inside the
+# galactic-nat66 process on iad-worker itself, per node-patch.yaml's
+# GALACTIC_NAT66_SHARD_SID/_SHARD_PUB_ADDR) fills in
+# status.shardAddress/status.shardSID from its own config at startup --
+# this object only needs to exist and target the right node.
+apiVersion: network.datumapis.com/v1alpha1
+kind: NAT66Shard
+metadata:
+  name: iad-worker-nat66
+  namespace: galactic-system
+spec:
+  targetRef:
+    kind: Node
+    name: iad-worker

--- a/deploy/containerlab/resources/galactic-nat66/iad/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/iad/node-patch.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-nat66
+spec:
+  template:
+    spec:
+      # config/galactic-nat66/base/daemonset.yaml's own affinity requires
+      # galactic.datumapis.com/node: nat66 -- a dedicated node role this
+      # lab has never introduced (see AGENTS.md's "Node labels" note:
+      # every site worker here is labeled galactic.datumapis.com/node:
+      # edge). Per the redesign plan's own §8 suggestion, this lab reuses
+      # iad-worker itself as a shard rather than adding a new dedicated
+      # nat66-labeled node, so this patch replaces the whole affinity
+      # block to match iad-worker's real "edge" label plus a
+      # kubernetes.io/hostname pin -- otherwise the base's own affinity
+      # would never match any node in this cluster and the DaemonSet
+      # would sit at zero replicas forever. iad-worker (worker-index 1)
+      # is the plain tenant worker, not iad-worker2/iad-worker-control
+      # (the route reflector) or iad-gateway1/iad-gateway2 (the tainted
+      # gateway-role nodes) -- see gvpc.clab.yaml and README.md's node
+      # table. GALACTIC_NAT66_SHARD_SID/_SHARD_PUB_ADDR below must be
+      # unique per shard node (see config/galactic-nat66/kustomization.
+      # yaml's doc comment), so dfw/iad/sjc are three separate per-node
+      # overlays rather than one overlay matching all three site workers
+      # with identical env -- mirrors resources/galactic-gateway/
+      # iad-gateway1/'s identical per-node-overlay rationale.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.datumapis.com/node
+                    operator: In
+                    values:
+                      - edge
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - iad-worker
+      containers:
+        - name: galactic-nat66
+          env:
+            # eth1 is this lab's dedicated transit-fabric-facing uplink on
+            # every node (see resources/galactic-cni/daemonset-patch.yaml's
+            # comment) -- the same interface internal/plumbing/ebpf/
+            # nat66prog's XDP program attaches to.
+            - name: GALACTIC_NAT66_UPLINK_INTERFACE
+              value: eth1
+            # uFMT 48+16 uSID over iad's own locator (2001:db8:ff03::/48,
+            # see resources/galactic-router/iad/bgprouter.yaml's
+            # srv6Locator), nodeID=1 -- reusing iad-worker's own already-
+            # registered node identity (its BGPRouter's nodeID) rather
+            # than minting a new one, since this shard runs on that exact
+            # physical node, not a separate dedicated node the way
+            # iad-gateway1/iad-gateway2 are (those are nodeID=2/3 on this
+            # same locator -- see resources/galactic-gateway/
+            # iad-gateway{1,2}/bgprouter.yaml). Function=End.DT46 (0xE),
+            # matching resources/galactic-gateway/iad-gateway1/
+            # node-patch.yaml's convention, even though this address is
+            # never actually looked up through function_table/vrf_table
+            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
+            # doc comment says it's advertised as a plain /128
+            # node-reachability route "no VRFID/Function" -- the uFMT
+            # encoding here is only to keep the address inside iad's
+            # locator block without colliding with any real tenant VRF
+            # SID. Argument=1, deliberately NOT 0: iad-gateway1/
+            # iad-gateway2 already claim Argument=0 on this same locator
+            # (nodeID=2 and nodeID=3 respectively) -- since nodeID
+            # differs, Argument=0 at nodeID=1 would not actually collide
+            # with either of those two addresses bit-for-bit, but reusing
+            # 0 here anyway would be easy to misread as "the same
+            # reserved slot the gateway nodes use," so this shard's SID
+            # is deliberately given its own reserved Argument (1) instead
+            # -- a lab-only placeholder needing real allocation logic
+            # (the same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
+            # EnvNAT66ShardSID's own doc comment both flag today) before
+            # production.
+            - name: GALACTIC_NAT66_SHARD_SID
+              value: "2001:db8:ff03:1:e001::"
+            # Lab-only placeholder masquerade source address, same
+            # "operator-supplied, no in-cluster derivation yet" status as
+            # GALACTIC_GATEWAY_SRV6_ADDRESS (see
+            # internal/config/gateway.go's doc comment). 2001:db8:9966::/32
+            # is a new documentation-range (RFC 3849) block reserved here
+            # for NAT66 shard public addresses specifically, picked to
+            # avoid colliding with any address already in use elsewhere
+            # in this topology (transit mesh: 2001:db8:0:*::/64 and
+            # 2001:db8:1:*::/64; SRv6 locators: 2001:db8:ff0X::/48; the
+            # ns60 ingress VIP: 2001:db8:6060::1) -- "9966" as a mnemonic
+            # for "NAT66". ::2 here is iad's shard (shard 2 of 3).
+            - name: GALACTIC_NAT66_SHARD_PUB_ADDR
+              value: "2001:db8:9966:2::1"

--- a/deploy/containerlab/resources/galactic-nat66/sjc/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/sjc/kustomization.yaml
@@ -1,0 +1,16 @@
+# sjc's instantiation of ../base as this site's NAT66 shard, reusing the
+# already-existing sjc-worker node (see node-patch.yaml and ../README.md)
+# rather than a new dedicated "nat66"-labeled node. Mirrors
+# resources/galactic-router/sjc/'s per-site pattern (no rename needed the
+# way resources/galactic-gateway/iad-gateway{1,2}/ require: dfw/iad/sjc
+# are three separate clusters, so "galactic-nat66" never collides with
+# itself the way two DaemonSets in the same iad cluster would).
+namespace: galactic-system
+resources:
+  - ../base
+  - nat66shard.yaml
+patches:
+  - path: node-patch.yaml
+    target:
+      kind: DaemonSet
+      name: galactic-nat66

--- a/deploy/containerlab/resources/galactic-nat66/sjc/nat66shard.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/sjc/nat66shard.yaml
@@ -1,0 +1,17 @@
+# Sample NAT66Shard for sjc-worker, this cluster's own shard node --
+# alongside node-patch.yaml the same way resources/galactic-gateway/
+# iad-gateway1/networkgateway.yaml sits alongside its own node-patch.yaml.
+# Status is left empty: NAT66ShardReconciler (running inside the
+# galactic-nat66 process on sjc-worker itself, per node-patch.yaml's
+# GALACTIC_NAT66_SHARD_SID/_SHARD_PUB_ADDR) fills in
+# status.shardAddress/status.shardSID from its own config at startup --
+# this object only needs to exist and target the right node.
+apiVersion: network.datumapis.com/v1alpha1
+kind: NAT66Shard
+metadata:
+  name: sjc-worker-nat66
+  namespace: galactic-system
+spec:
+  targetRef:
+    kind: Node
+    name: sjc-worker

--- a/deploy/containerlab/resources/galactic-nat66/sjc/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/sjc/node-patch.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: galactic-nat66
+spec:
+  template:
+    spec:
+      # config/galactic-nat66/base/daemonset.yaml's own affinity requires
+      # galactic.datumapis.com/node: nat66 -- a dedicated node role this
+      # lab has never introduced (see AGENTS.md's "Node labels" note:
+      # every site worker here is labeled galactic.datumapis.com/node:
+      # edge). Per the redesign plan's own §8 suggestion, this lab reuses
+      # sjc-worker itself as a shard rather than adding a new dedicated
+      # nat66-labeled node, so this patch replaces the whole affinity
+      # block to match sjc-worker's real "edge" label plus a
+      # kubernetes.io/hostname pin -- otherwise the base's own affinity
+      # would never match any node in this cluster and the DaemonSet
+      # would sit at zero replicas forever. GALACTIC_NAT66_SHARD_SID/
+      # _SHARD_PUB_ADDR below must be unique per shard node (see
+      # config/galactic-nat66/kustomization.yaml's doc comment), so
+      # dfw/iad/sjc are three separate per-node overlays rather than one
+      # overlay matching all three site workers with identical env --
+      # mirrors resources/galactic-gateway/iad-gateway1/'s identical
+      # per-node-overlay rationale.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+                  - key: galactic.datumapis.com/node
+                    operator: In
+                    values:
+                      - edge
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - sjc-worker
+      containers:
+        - name: galactic-nat66
+          env:
+            # eth1 is this lab's dedicated transit-fabric-facing uplink on
+            # every node (see resources/galactic-cni/daemonset-patch.yaml's
+            # comment) -- the same interface internal/plumbing/ebpf/
+            # nat66prog's XDP program attaches to.
+            - name: GALACTIC_NAT66_UPLINK_INTERFACE
+              value: eth1
+            # uFMT 48+16 uSID over sjc's own locator (2001:db8:ff02::/48,
+            # see resources/galactic-router/sjc/bgprouter.yaml's
+            # srv6Locator), nodeID=1 -- reusing sjc-worker's own already-
+            # registered node identity (its BGPRouter's nodeID) rather
+            # than minting a new one, since this shard runs on that exact
+            # physical node, not a separate dedicated node the way
+            # iad-gateway1/iad-gateway2 are. Function=End.DT46 (0xE),
+            # matching resources/galactic-gateway/iad-gateway1/
+            # node-patch.yaml's convention, even though this address is
+            # never actually looked up through function_table/vrf_table
+            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
+            # doc comment says it's advertised as a plain /128
+            # node-reachability route "no VRFID/Function" -- the uFMT
+            # encoding here is only to keep the address inside sjc's
+            # locator block without colliding with any real tenant VRF
+            # SID. Argument=1, NOT 0: sjc has no other node sharing this
+            # locator, so 0 would not literally collide here either, but
+            # 1 is used on all three shards for one consistent,
+            # easy-to-audit convention across sites (see
+            # resources/galactic-nat66/iad/node-patch.yaml's fuller
+            # rationale, where the distinction actually matters). This is
+            # a lab-only placeholder needing real allocation logic (the
+            # same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
+            # EnvNAT66ShardSID's own doc comment both flag today) before
+            # production.
+            - name: GALACTIC_NAT66_SHARD_SID
+              value: "2001:db8:ff02:1:e001::"
+            # Lab-only placeholder masquerade source address, same
+            # "operator-supplied, no in-cluster derivation yet" status as
+            # GALACTIC_GATEWAY_SRV6_ADDRESS (see
+            # internal/config/gateway.go's doc comment). 2001:db8:9966::/32
+            # is a new documentation-range (RFC 3849) block reserved here
+            # for NAT66 shard public addresses specifically, picked to
+            # avoid colliding with any address already in use elsewhere
+            # in this topology (transit mesh: 2001:db8:0:*::/64 and
+            # 2001:db8:1:*::/64; SRv6 locators: 2001:db8:ff0X::/48; the
+            # ns60 ingress VIP: 2001:db8:6060::1) -- "9966" as a mnemonic
+            # for "NAT66". ::3 here is sjc's shard (shard 3 of 3).
+            - name: GALACTIC_NAT66_SHARD_PUB_ADDR
+              value: "2001:db8:9966:3::1"

--- a/docs/agents/ARCHITECTURE-GATEWAY.md
+++ b/docs/agents/ARCHITECTURE-GATEWAY.md
@@ -1,12 +1,14 @@
 # Architecture — galactic-gateway
 
-> The edge XDP NAT+LB gateway control plane: a controller-runtime process
-> that loads and attaches an XDP Full-NAT (DNAT+SNAT) load-balancing
-> program to a dedicated gateway node's public uplink and drives it from
-> `NetworkGateway`/`NetworkRule` CRDs, publishing an Active-Active BGP
-> local-preference model over the existing tenant EVPN mesh.
+> The edge XDP Maglev/DSR (Direct Server Return) load-balancing gateway
+> control plane: a controller-runtime process that loads and attaches an
+> anycast consistent-hash L4 load-balancing program to a dedicated gateway
+> node's public uplink and drives it from `NetworkGateway`/`NetworkRule`
+> CRDs. Every gateway node advertises every VIP identically over the
+> existing tenant EVPN mesh — there is no primary/secondary node, no BGP
+> local-preference split, and no address rewriting anywhere in the datapath.
 
-_Last updated: 2026-08-13_
+_Last updated: 2026-08-17_
 
 This document covers `galactic-gateway` and the `NetworkGateway`/
 `NetworkRule` reconcilers only. See
@@ -14,9 +16,16 @@ This document covers `galactic-gateway` and the `NetworkGateway`/
 (`galactic-router`, co-located in the same pod on gateway-role nodes) and
 [ARCHITECTURE-CNI.md](ARCHITECTURE-CNI.md) for the CNI attach chain that
 produces the `BGPAdvertisement`/`BGPRouter` CRDs this binary's own
-uSID-resolution code reads. This file, together with those two, supersedes
-the former monolithic `ARCHITECTURE.md` — see [AGENTS.md](../../AGENTS.md)
-for which document to start from for a given task.
+uSID-resolution code reads. A third, separate `galactic-nat66` binary (out
+of this document's scope) provides sharded stateful NAT66 egress for
+VPC-attached workloads reaching the internet — see `cmd/galactic-nat66`,
+`internal/plumbing/ebpf/nat66prog`, and the `NAT66Shard` reconciler
+(`internal/controller/nat66shard_controller.go`, which registers with
+`galactic-router`'s manager, not this binary's) rather than this file for
+egress. This file,
+together with the other two architecture docs, supersedes the former
+monolithic `ARCHITECTURE.md` — see [AGENTS.md](../../AGENTS.md) for which
+document to start from for a given task.
 
 ---
 
@@ -34,28 +43,66 @@ other down with it. Tenant BGP itself (the embedded GoBGP server, the
 reconcilers) still runs in the co-located `galactic-router` container,
 unmodified — see [ARCHITECTURE-ROUTER.md](ARCHITECTURE-ROUTER.md).
 
-This design is a deliberate pivot away from an earlier, rejected approach
-(internally called `gwprog`) that tunneled tenant traffic to gateway nodes
-over Geneve and drove a TC-BPF program keyed by `(VNI, 5-tuple)`. That
-design was abandoned after live testing ruled out driving LoxiLB directly
-and found native XDP unavailable specifically on Geneve tunnel devices. The
-current design instead attaches XDP directly to the gateway node's public
-interface: no tunnel, no per-tenant Geneve provisioning, and — because the
-outer SRv6 header is pushed straight from the program's own `rule_table`
-rather than a kernel VRF route — no VRF dependency and no exposure to the
-GoBGP bugs that forced every earlier per-VPC gateway design to colocate
-with the workload's own VRF.
+The load-balancing design itself is **DSR (Direct Server Return) over a
+Maglev consistent-hash ring**, replacing an earlier Full-NAT (DNAT+SNAT)
+design entirely — a breaking change with no migration path, not a second
+mode alongside the old one. The defining simplification: this datapath does
+**no address or port rewriting at all**. A client's packet travels inside
+the SRv6 encapsulation byte-for-byte unmodified all the way to the backend;
+the backend replies to the client *directly* (bypassing the gateway node on
+the return path entirely), which is DSR's whole premise. Every gateway node
+the datapath is loaded on advertises every VIP **identically** via BGP —
+anycast, not primary/secondary — and Maglev's consistent-hash ring (not BGP
+local-preference) decides which node's backend set actually answers a given
+flow, and which specific backend within that node's set. Because every
+gateway node builds the byte-identical Maglev table from the byte-identical
+`(VIP, backend list)` input, a flow's packets landing on a different gateway
+node mid-connection (ECMP, BGP reconvergence) still resolve to the same
+backend.
+
+Consequences that follow directly from dropping rewriting:
+
+- No `conn_table`/flow state of any kind, and nothing to garbage-collect
+  beyond the eBPF verifier's own bookkeeping — DSR is fully stateless.
+  Full-NAT needed a flow table to remember which backend/SNAT port a flow
+  was assigned; Maglev/DSR re-derives the same answer from the same input
+  on every packet.
+- No return/decap branch in the XDP program — DSR never sees reply
+  traffic through this node at all, so there is nothing to un-DNAT/un-SNAT.
+- No L3/L4 checksum touch anywhere in the datapath — the packet's own
+  checksum is already correct for its own, completely unmodified content.
+- No Active-Active BGP local-preference model, no primary/secondary node
+  election, and no per-node self-address to publish — every gateway node's
+  route is equally preferred by construction (a distinct Route
+  Distinguisher per originating node keeps every node's identical-prefix
+  advertisement alive as an independent, non-competing route rather than
+  one silently replacing another — see the go/no-go anycast spike,
+  `internal/runtime/gobgp/anycast_spike_test.go`).
+
+This design is also a deliberate pivot away from a still-earlier, rejected
+approach (internally called `gwprog`) that tunneled tenant traffic to
+gateway nodes over Geneve and drove a TC-BPF program keyed by `(VNI,
+5-tuple)`. That design was abandoned after live testing ruled out driving
+LoxiLB directly and found native XDP unavailable specifically on Geneve
+tunnel devices. The current design instead attaches XDP directly to the
+gateway node's public interface: no tunnel, no per-tenant Geneve
+provisioning, and — because the outer SRv6 header is pushed straight from
+the program's own `vip_table` rather than a kernel VRF route — no VRF
+dependency and no exposure to the GoBGP bugs that forced every earlier
+per-VPC gateway design to colocate with the workload's own VRF.
 
 ### The two CRDs
 
-| CRD              | Scope                                                                | Written by                                                                                                                                     | Purpose                                                                                                                                                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `NetworkGateway` | Namespaced, one per gateway node (`spec.targetRef.name` = node name) | Operator, once per gateway node (see [worked example](#worked-containerlab-example) below)                                                     | Node-scoped root object, mirroring `BGPRouter`'s pattern. `status.sRv6Address` is this node's Full-NAT SNAT source, published by `NetworkGatewayReconciler`.                                                                                                 |
-| `NetworkRule`    | Namespaced, tenant-writable                                          | Tenant, via an admission webhook that verifies VPC/VPCAttachment ownership (**webhook not yet deployed in this repo** — see Known Constraints) | Ingress load-balancing spec: `vpcRef`/`vpcAttachmentRef` (opaque tenant identifiers), `vipAddresses` (1–8, IPv4/IPv6), `protocol` (`tcp`/`udp`), `port`, `backends` (1–64 `address:port` pairs). `status.primaryNode` is assigned exactly once, at creation. |
+| CRD              | Scope                                                                | Written by                                                                                                                                     | Purpose                                                                                                                                                                                                                                        |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NetworkGateway` | Namespaced, one per gateway node (`spec.targetRef.name` = node name) | Operator, once per gateway node (see [worked example](#worked-containerlab-example) below)                                                     | Node-scoped root object, mirroring `BGPRouter`'s pattern. Identifies which nodes participate in the anycast mesh and surfaces each node's engine health via `status.conditions`. Carries **no** self-address field — DSR rewrites nothing, so there is no SNAT source to publish. |
+| `NetworkRule`    | Namespaced, tenant-writable                                          | Tenant, via an admission webhook that verifies VPC/VPCAttachment ownership (**webhook not yet deployed in this repo** — see Known Constraints) | Ingress load-balancing spec: `vpcRef`/`vpcAttachmentRef` (opaque tenant identifiers), `vipAddresses` (1–8, IPv4/IPv6), `protocol` (`tcp`/`udp`), `port`, `backends` (1–64 `address:port` pairs). Served by every `NetworkGateway` in the namespace identically — there is **no** `status.primaryNode` field. |
 
 Both are defined in `go.datum.net/network`'s `api/v1alpha1` package
 (`gateway_types.go`, `rule_types.go`) — the same external CRD module the
-BGP-family types live in.
+BGP-family types live in. Both types' own doc comments describe this
+DSR/anycast model directly (they were rewritten alongside this redesign,
+not left describing the old Full-NAT behavior).
 
 ---
 
@@ -73,16 +120,29 @@ galactic/
 │   │                        #   ARCHITECTURE-ROUTER.md) but registers only with
 │   │                        #   galactic-gateway's own manager
 │   ├── config/              # GatewayConfig (internal/config/gateway.go):
-│   │                        #   node name, ports, public interface, SRv6 address
+│   │                        #   node name, ports, public interface, SRv6
+│   │                        #   encap-source address
 │   ├── gateway/              # Engine, Datapath/QuotaEnforcer/TelemetryEmitter
-│   │                        #   interfaces + real implementations, Active-Active
-│   │                        #   placement/local-pref, crash recovery
+│   │                        #   interfaces + real implementations, crash
+│   │                        #   recovery — no VRF/Geneve state, no
+│   │                        #   primary/secondary placement
+│   ├── maglev/               # Pure-Go Maglev consistent-hash lookup table
+│   │                        #   (internal/maglev/table.go), shared in spirit
+│   │                        #   (not by import) with galactic-nat66's own
+│   │                        #   independent shard-placement ring
 │   └── plumbing/ebpf/
-│       ├── edgeprog/         # Compiled XDP program (edgenat.c) + bpf2go bindings
-│       ├── edgemap/          # rule_table/rule_stats_table/gw_config_table read/write API
-│       └── edgeattach/       # Load + XDP-attach the compiled program to one interface
+│       ├── edgeprog/         # Compiled XDP program (edgedsr.c, program
+│       │                     #   edge_lb) + bpf2go bindings
+│       ├── edgemap/          # vip_table/vip_stats_table/encap_config_table
+│       │                     #   read/write API (viptable.go)
+│       ├── edgeattach/       # Load + XDP-attach the compiled program to one
+│       │                     #   interface
+│       ├── edgemetrics/      # Pull-based Prometheus collector reading
+│       │                     #   vip_table/vip_stats_table/drop_reasons live
+│       └── edgepreflight/    # Startup kernel-capability check for this
+│                             #   datapath's own requirement list
 ├── config/
-│   ├── gateway/
+│   ├── galactic-gateway/
 │   │   ├── serviceaccount.yaml  # Applied cluster-wide, idempotent
 │   │   ├── rbac.yaml            # Applied cluster-wide, idempotent
 │   │   ├── kustomization.yaml   # Covers only the two files above — deliberately
@@ -90,7 +150,7 @@ galactic/
 │   │   └── base/
 │   │       ├── daemonset.yaml   # Two-container pod: galactic-router + galactic-gateway
 │   │       └── kustomization.yaml
-│   └── fabric/               # (not gateway-specific, but fabric-router must also
+│   └── fabric-router/        # (not gateway-specific, but fabric-router must also
 │                              #   run on gateway-role nodes — see ARCHITECTURE-CNI.md
 │                              #   and root CLAUDE.md's config/fabric-router/ note)
 ├── deploy/containerlab/resources/
@@ -99,14 +159,15 @@ galactic/
     └── galactic-gateway/    # galactic-gateway production image
 ```
 
-`config/galactic-gateway/base/` is **not** included in `config/galactic-gateway/`'s own
-kustomization and is **not** applied as-is — the same exemption
-`config/fabric-router/` documents in root `AGENTS.md`, for the same reason:
-`GALACTIC_GATEWAY_SRV6_ADDRESS` must be unique per gateway node and has no
-generic default (see [publishSelfAddress](#status-and-self-address-publish)
-below). It's designed to be instantiated once per gateway node by a further
-overlay that pins it to one node (`kubernetes.io/hostname`) and sets that
-node's own public-interface/SRv6-address values.
+`config/galactic-gateway/base/` is **not** included in
+`config/galactic-gateway/`'s own kustomization and is **not** applied
+as-is — the same exemption `config/fabric-router/` documents in root
+`CLAUDE.md`, for the same reason: `GALACTIC_GATEWAY_SRV6_ADDRESS` must be
+unique per gateway node and has no generic default (see [SRv6 encap-source
+address](#srv6-encap-source-address) below). It's designed to be
+instantiated once per gateway node by a further overlay that pins it to one
+node (`kubernetes.io/hostname`) and sets that node's own
+public-interface/SRv6-address values.
 
 ### Worked ContainerLab example
 
@@ -118,8 +179,7 @@ the `iad` cluster. Each node's overlay directory (`iad-gateway1/`,
 - `node-patch.yaml` — pins the DaemonSet to one node via
   `kubernetes.io/hostname` and sets `GALACTIC_GATEWAY_PUBLIC_INTERFACE`
   (`eth1` in this lab) and `GALACTIC_GATEWAY_SRV6_ADDRESS` (a distinct uFMT
-  48+16 uSID per node, computed at Argument 0 — see
-  [Argument-0 reservation](#argument-0-reservation) below).
+  48+16 uSID per node).
 - `bgprouter.yaml`/`bgppeer.yaml` — this node's tenant `BGPRouter`/`BGPPeer`
   (the co-located `galactic-router` container's own config).
 - `networkgateway.yaml` — the `NetworkGateway` object itself (just
@@ -139,87 +199,105 @@ See [docs/architecture/](../architecture/) for C4 context/container diagrams cov
 `NetworkGatewayReconciler.Reconcile` runs the aggregate, List-driven pass
 that converges this node's whole gateway engine:
 
-1. **Publish self-address.** `publishSelfAddress` writes `status.sRv6Address`
-   (operator-supplied via `GALACTIC_GATEWAY_SRV6_ADDRESS`, already the value
-   the running datapath was configured with at startup) and ensures a
-   `/128` `l2vpn/evpn` `BGPAdvertisement` exists distributing it — a plain
-   node-reachability route, no VRFID/Function.
-2. **Assemble desired state.** Lists every accepted, non-deleting
-   `NetworkRule` in the namespace (both primary- and secondary-assigned —
-   Active-Active means every gateway node serves every rule), resolves each
-   backend's SRv6 uSID via `usidresolver.go`'s `buildBackendSIDIndex`, and
-   converges `gateway.Engine` toward the result.
-3. **Wire BGP.** Reconciles one `BGPAdvertisement` per rule per non-empty
+1. **Assemble desired state.** Lists every accepted, non-deleting
+   `NetworkRule` in the namespace — under the DSR anycast model every
+   gateway node in a PoP serves every accepted rule identically, so there
+   is no primary/secondary subset to filter on — resolves each backend's
+   SRv6 uSID via `usidresolver.go`'s `buildBackendSIDIndex`, and converges
+   `gateway.Engine` toward the result.
+2. **Wire BGP.** Reconciles one `BGPAdvertisement` per rule per non-empty
    VIP address family, name-qualified by node (`<rule>-<node>-v4`/`-v6` —
    required, not cosmetic, since every gateway node computes the same rule
-   independently), with `Spec.LocalPreference` from
-   `gateway.LocalPreference`. This reuses the existing `l2vpn/evpn` Type-5
-   IP-Prefix advertisement path end-to-end unmodified — no changes were
-   needed in `internal/reconcile` or `internal/runtime/gobgp` to support it.
-4. **Crash recovery.** Runs `Engine.ReconcileOrphans` (see
+   independently). This reuses the existing `l2vpn/evpn` Type-5 IP-Prefix
+   advertisement path end-to-end unmodified. `VRFID`/`Function` are left
+   unset (these routes need no SRv6 decap behavior of their own — a
+   different Route Distinguisher per originating node, not a decap
+   Function, is what keeps every node's route alive as an independent,
+   non-competing path). **No `LocalPreference` is set** — every gateway
+   node's route is equally preferred by construction, unlike the removed
+   Full-NAT design's primary/secondary local-pref split.
+3. **Crash recovery.** Runs `Engine.ReconcileOrphans` (see
    [Crash recovery](#crash-recovery) below).
 
 `NetworkRuleReconciler.Reconcile` separately owns two **per-object**
 lifecycle pieces the aggregate pass above is the wrong place for:
-`status.primaryNode` assignment (exactly once, at creation — see
-[Placement](#placement-and-local-preference) below) and the finalizer-guarded
-teardown ordering on deletion (withdraw the rule's `BGPAdvertisement`s
-*before* releasing NAT/conntrack state, so an in-flight flow is never
-blackholed through a translation whose route has already disappeared).
+`status.conditions`'s `Accepted` condition (`updateAcceptedCondition` — set
+once gateway nodes exist for the namespace; no `primary_node`-style
+assignment exists anymore, since DSR has no primary node to assign) and the
+finalizer-guarded teardown ordering on deletion (withdraw the rule's
+`BGPAdvertisement`s *before* releasing quota/reservation state, so an
+in-flight flow is never blackholed through a route that has already
+disappeared while the datapath still thinks it owns it).
 
 Every gateway node's own process runs both reconcilers, unconditionally, on
 every `NetworkGateway`/`NetworkRule` in the namespace, with no leader
 election anywhere in this codebase — safe because the reconcile logic is
 either idempotent (finalizer add/remove, `BGPAdvertisement` create/delete)
 or a pure function of inputs every gateway node observes identically
-(`AssignPrimaryNode`, `LocalPreference`). A rule carries no
+(`vip_table` registration, the Maglev table itself). A rule carries no
 `gatewayRef`, so both reconcilers watch the *other* CRD type and broadcast
 to every object in the namespace on change (`ruleToGatewayRequests`,
 `gatewayToRuleRequests`) rather than targeting a specific object.
 
-### Packet path (`internal/plumbing/ebpf/edgeprog/edgenat.c`)
+### Packet path (`internal/plumbing/ebpf/edgeprog/edgedsr.c`, program `edge_lb`)
 
 IPv6-only, phase 1 scope (plain TCP/UDP, no extension headers). One XDP
 program, one attach point per gateway node — the node's single public/
-underlay-facing uplink interface. Direction is decided by matching the
-packet's outer IPv6 destination against this node's own configured
-`gw_addr` (`gw_config_table`), the same "is this mine" pattern
-`internal/plumbing/ebpf/prog/usid.c` uses for the SRv6 uSID datapath (see
-[ARCHITECTURE-CNI.md](ARCHITECTURE-CNI.md)), just against a single address
-instead of a locator/function/argument hierarchy.
+underlay-facing uplink interface. Unlike the removed Full-NAT `edgenat.c`,
+there is no "is this a reply to me" direction check at all — DSR never
+sees reply traffic through this node, so the program has exactly one
+branch, not two.
 
-1. **Parse** the outer Ethernet + IPv6 header. Not IPv6, or unparseable —
-   `XDP_PASS` (falls through to the kernel stack, e.g. BGP/SSH to the node
-   itself).
-2. **Return branch** (`daddr == gw_addr`, outer `nexthdr == 41`, plain
-   IPv6-in-IPv6, no SRH): this is a reply this node SNAT'd on the way out.
-   Strip the outer header, look up `conn_table` by the revealed inner
-   packet's reverse 5-tuple, un-SNAT/un-DNAT back to the client's original
-   view, fix the L4 checksum via `bpf_csum_diff` (XDP has no
-   `__sk_buff`-based checksum helpers), resolve the L2 next-hop via
-   `bpf_fib_lookup`, `XDP_TX`. No `conn_table` hit — drop, not pass-through
-   (this address is claimed).
-3. **Forward branch** (everything else, TCP/UDP only — anything else
-   `XDP_PASS`): match `(proto, dst port, dst addr)` against `rule_table`
-   (keyed by VIP+port only, no tenant dimension — a VIP is globally unique
-   by construction). No match — `XDP_PASS`. A `conn_table` hit on the
-   forward key reuses the already-assigned backend/SNAT port (a flow's
-   translation never changes mid-connection even if the rule's backend list
-   changes later). A miss on a TCP SYN or any UDP packet allocates: pick a
-   backend by `hash(client_addr,client_port) % backend_count`, claim a SNAT
-   port by probing candidate ports and inserting the *reverse* `conn_table`
-   row with `BPF_NOEXIST` (the atomic claim and the sole liveness/reuse
-   mechanism — `conn_table` is `BPF_MAP_TYPE_LRU_HASH`, self-evicting, no
-   separate GC). DNAT to the backend, SNAT to `gw_addr:allocated-port`, fix
-   the checksum, push a fresh 40-byte outer IPv6 header addressed to the
-   backend's own worker-node SRv6 uSID (`rule_table`'s per-backend field,
-   resolved by the Go control plane — see
-   [uSID resolution](#usid-resolution-for-backends) below), resolve the L2
-   next-hop, `XDP_TX`.
+1. **Parse** the outer Ethernet + IPv6 header, then the L4 header (TCP or
+   UDP only). Not IPv6, unparseable, or not TCP/UDP — `XDP_PASS` (falls
+   through to the kernel stack, e.g. BGP/SSH to the node itself). Only the
+   source/destination port are ever read; nothing is rewritten, so there is
+   no pointer-to-field resolution the way a rewrite would need.
+2. **Match** `(proto, dst port, dst addr)` against `vip_table` (keyed
+   identically to the removed `rule_table` — a VIP is globally unique by
+   construction, no tenant dimension). No match — `XDP_PASS` (not one of
+   this gateway's VIPs).
+3. **Claimed past this point** — every subsequent failure is a drop, not a
+   pass-through (this gateway owns this VIP+port+protocol). Bump
+   `vip_stats_table`'s hit counters (packets/bytes/last-seen), lazily
+   creating the row on first match. An empty backend list drops
+   (`DROP_REASON_EMPTY_BACKEND_LIST`).
+4. **Maglev lookup.** Hash the client's own `(address, port)` and look up
+   the precomputed Maglev table (`vip_table`'s own `maglev_table` field,
+   populated by the Go control plane's `internal/maglev.Table` — see
+   `edgemap`'s doc comment) to get a backend index, deterministically and
+   statelessly: every gateway node computes the identical index for the
+   identical flow from the identical `(VIP, backend list)` input, which is
+   what makes this design safe under anycast/ECMP — a flow's packets
+   landing on a different gateway node mid-connection still resolve to the
+   same backend.
+5. **Push** a fresh 40-byte outer IPv6 header addressed to the chosen
+   backend's own worker-node SRv6 uSID (`vip_table`'s per-backend field,
+   resolved by the Go control plane the same way any other cross-node
+   SRv6 destination is — see
+   [uSID resolution](#usid-resolution-for-backends) below), sourced from
+   this node's own `encap_config_table` entry (this node's plain
+   SRv6-reachable address — never a NAT/SNAT source and never compared
+   against anything on a receive path, since there is no return path
+   through this node at all). Resolve the L2 next-hop via
+   `bpf_fib_lookup` and `XDP_TX` back out this same interface. The inner
+   packet travels completely unmodified — this is DSR's entire premise:
+   no DNAT, no SNAT, no checksum touch anywhere.
 
-See `edgenat.c`'s own header comment for the full byte-level walkthrough,
+See `edgedsr.c`'s own header comment for the full byte-level walkthrough,
 including the `EDGE_BARRIER_VAR` eBPF-verifier bounds-narrowing gotcha
-carried over from `gwprog`.
+carried over unchanged from the removed `edgenat.c`, and two real
+wire-format bugs found and fixed in `push_outer_header` (inherited
+unchanged from `edgenat.c`, not introduced by this rewrite): the pushed
+outer IPv6 header's version nibble was left zeroed instead of set to `6`,
+and the outer header's `payload_len` undercounted the inner IPv6 header's
+own 40 bytes (a call site passed `ip6->payload_len` directly instead of
+`sizeof(ip6hdr) + payload_len`). Both were invisible on the SRv6 uSID
+decap path (`usid.c`'s decap reads fixed offsets unconditionally, without
+validating either field) but would have caused any version- or
+length-validating intermediate hop or receiver to reject every packet this
+datapath ever pushed — found via live-kernel investigation, not
+`BPF_PROG_TEST_RUN`, and covered by regression tests in `edgedsr_test.go`.
 
 ---
 
@@ -242,16 +320,16 @@ to resolve backend uSIDs).
 2. Start a gRPC health server, explicitly forced to `NOT_SERVING` at
    startup rather than the default-`SERVING` `grpchealth.NewServer()`
    behavior — flipped to `SERVING` only once the datapath is attached and
-   the rule table reachable (see [#360](#known-constraints) below for why
+   the vip table reachable (see [#360](#known-constraints) below for why
    this ordering was fixed deliberately).
 3. RBAC pre-flight (`checkWatchPermissions`).
-4. `setupGatewayDatapath` (`cmd/galactic-gateway/gateway.go`) — load and
-   attach the XDP program, register the Prometheus metrics collector.
-   Unlike the pre-split `cmd/galactic-router`'s identically-named function
-   (now removed), `PublicInterface`/`SRv6Address` are both required, not a
-   jointly-optional pair with a `NoopDatapath{}` fallback — the config
-   validator already rejected either being empty before `runCmd` was ever
-   reached.
+4. `setupGatewayDatapath` (`cmd/galactic-gateway/gateway.go`) — configure
+   the required IPv6-forwarding sysctls on the public interface (see
+   [Configuration](#configuration) below), load and attach the XDP program,
+   register the Prometheus metrics collector. `PublicInterface`/
+   `SRv6Address` are both required, not a jointly-optional pair with a
+   `NoopDatapath{}` fallback — the config validator already rejected either
+   being empty before `runCmd` was ever reached.
 5. Construct real (not stubbed) `gateway.NodeQuotaEnforcer` and
    `gateway.PrometheusTelemetryEmitter`, wire `gateway.NewEngine`.
 6. Register `NetworkGatewayReconciler` and `NetworkRuleReconciler`.
@@ -259,10 +337,23 @@ to resolve backend uSIDs).
 
 ### `cmd/galactic-gateway/gateway.go` — datapath setup
 
-`setupGatewayDatapath` loads `edgeprog.EdgenatObjects`
+`setupGatewayDatapath` first calls
+`sysctl.ConfigureFIBLookupUplinkSysctls(publicInterface)` — required for
+`bpf_fib_lookup()` (`edgedsr.c`'s `push_outer_header`) to ever succeed on
+this interface: without it the kernel returns
+`BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup, correctly refusing to
+resolve a forwarding route on an interface not configured as a router. This
+was found via live-kernel investigation of a pre-existing containerlab
+veth/XDP_TX blocker — the sysctl gap, not `XDP_TX` itself, was what
+actually prevented every gateway node's `bpf_fib_lookup` from ever
+succeeding in that lab (see [Known Constraints](#known-constraints) below
+for the related, lab-only `XDP_TX` observability quirk this investigation
+also turned up). It then loads `edgeprog.EdgedsrObjects`
 (`edgeattach.Load`), attaches it to `PublicInterface`
 (`edgeattach.Attach` — native XDP driver mode only, no generic/SKB-mode
-fallback), and constructs a `gateway.KernelDatapath` over it.
+fallback), and constructs a `gateway.KernelDatapath` over it, writing this
+node's SRv6 encap-source address into `encap_config_table` once at
+construction time.
 
 The loaded objects and the returned `link.Link` are stashed in a
 package-level `gatewayDatapathKeepAlive` var rather than ever being
@@ -272,8 +363,8 @@ finalizer that silently closes the underlying fd once nothing reachable
 points at it, and the first time this path ran against a real interface
 with nothing pinning `objs`/the link, the XDP attachment was silently GC'd
 and detached mid-run — every control-plane signal (pod healthy, `ApplyRule`
-succeeding, `rule_stats_table` metrics populated) still looked completely normal
-while ingress traffic quietly stopped being intercepted at all.
+succeeding, `vip_stats_table` metrics populated) still looked completely
+normal while ingress traffic quietly stopped being intercepted at all.
 
 ---
 
@@ -281,13 +372,13 @@ while ingress traffic quietly stopped being intercepted at all.
 
 ### GatewayConfig environment variables (`internal/config/gateway.go`)
 
-| Variable                            | Required | Default | Description                                                                                                                               |
-| ----------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `GALACTIC_GATEWAY_NODE_NAME`        | Yes      | —       | Kubernetes node name                                                                                                                      |
-| `GALACTIC_GATEWAY_PUBLIC_INTERFACE` | Yes      | —       | Public/underlay-facing uplink interface the XDP program attaches to                                                                       |
-| `GALACTIC_GATEWAY_SRV6_ADDRESS`     | Yes      | —       | This node's own SRv6-reachable IPv6 address, used as the Full-NAT SNAT source; must be a native IPv6 address (rejected if IPv4 or 4-in-6) |
-| `GALACTIC_GATEWAY_METRICS_PORT`     | No       | `8081`  | Prometheus metrics port                                                                                                                   |
-| `GALACTIC_GATEWAY_GRPC_HEALTH_PORT` | No       | `5181`  | gRPC health check port                                                                                                                    |
+| Variable                            | Required | Default | Description                                                                                                                                        |
+| ----------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GALACTIC_GATEWAY_NODE_NAME`        | Yes      | —       | Kubernetes node name                                                                                                                                |
+| `GALACTIC_GATEWAY_PUBLIC_INTERFACE` | Yes      | —       | Public/underlay-facing uplink interface the XDP program attaches to                                                                                 |
+| `GALACTIC_GATEWAY_SRV6_ADDRESS`     | Yes      | —       | This node's own plain SRv6-reachable IPv6 address, used as the DSR outer-header encap source (`encap_config_table`) — never a NAT/SNAT source and never compared against anything on a receive path; must be a native IPv6 address (rejected if IPv4 or 4-in-6) |
+| `GALACTIC_GATEWAY_METRICS_PORT`     | No       | `8081`  | Prometheus metrics port                                                                                                                             |
+| `GALACTIC_GATEWAY_GRPC_HEALTH_PORT` | No       | `5181`  | gRPC health check port                                                                                                                              |
 
 All three required fields are enforced by `GatewayConfig.Validate` at
 startup, not deferred to a later, less obvious kernel-datapath error — a
@@ -309,6 +400,20 @@ pod's port table:
 | `galactic-router` (this pod's tenant-BGP side) | `9179`  | `5179`      |
 | `galactic-gateway`                             | `8081`  | `5181`      |
 
+### SRv6 encap-source address
+
+`GALACTIC_GATEWAY_SRV6_ADDRESS` is this gateway node's own plain
+SRv6-reachable address, used purely as the source of every outer header
+this node's `edge_lb` program pushes — unlike the removed Full-NAT design's
+identically-named field, it is never a NAT/SNAT source, never has
+return-path significance (DSR has no return path through this node at
+all), and is never published to any CRD status (`NetworkGatewayStatus`
+carries no self-address field — see [The two CRDs](#the-two-crds) above).
+It is operator-supplied per gateway node today, with no in-cluster
+mechanism deriving it automatically from a node's own `BGPRouter`
+locator/node-ID; see the [worked example](#worked-containerlab-example) for
+how a real deployment picks this value.
+
 ### Two-container pod (`config/galactic-gateway/base/daemonset.yaml`)
 
 One `ServiceAccount` (`galactic-gateway`) for both containers — a
@@ -318,9 +423,9 @@ needs (the trimmed BGP-only `galactic-router` ClusterRole *plus* this
 binary's own, see [RBAC](#rbac) below).
 
 | Container          | Capabilities                  | Why                                                                                                                                                                                                                                                                                                                          |
-| ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `galactic-router`  | `NET_ADMIN`                   | Same as the plain `tenant`/`tenant-control` roles — no BPF/PERFMON, since gateway-specific eBPF is confined to the other container now                                                                                                                                                                                       |
-| `galactic-gateway` | `NET_ADMIN`, `BPF`, `PERFMON` | `BPF` for the `bpf()` syscalls (program/map creation); `PERFMON` because the verifier only allows pointer+scalar arithmetic on packet data/data_end (the DNAT/SNAT header rewrites) when the loading process is `perfmon_capable()` — without it, even a `root` container gets "pointer arithmetic ... prohibited for !root" |
+| `galactic-gateway` | `NET_ADMIN`, `BPF`, `PERFMON` | `BPF` for the `bpf()` syscalls (program/map creation); `PERFMON` because the verifier only allows pointer+scalar arithmetic on packet data/data_end when the loading process is `perfmon_capable()` — without it, even a `root` container gets "pointer arithmetic ... prohibited for !root" |
 
 Both containers mount host paths: `galactic-router` mounts
 `/var/run/netns` read-only (GC's netns-liveness check, see
@@ -359,60 +464,154 @@ not a supported configuration).
 
 | Package                                                 | Binary           | Responsibility                                                                                                                                                                                  | Owns state                           |
 | ------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `internal/config` (`gateway.go`)                        | galactic-gateway | `GatewayConfig`: node name, ports, public interface, SRv6 address; three-tier CLI/env/default precedence via viper                                                                              | No                                   |
-| `internal/controller` (`networkgateway_controller.go`)  | galactic-gateway | `NetworkGatewayReconciler`: self-address publish, desired-state assembly, BGP wiring, orphan-crash recovery                                                                                     | No                                   |
-| `internal/controller` (`networkrule_controller.go`)     | galactic-gateway | `NetworkRuleReconciler`: finalizer-guarded teardown ordering, one-time `primary_node` assignment                                                                                                | No                                   |
-| `internal/controller` (`usidresolver.go`)               | galactic-gateway | `backendSIDIndex`: resolves a `NetworkRule` backend address to the worker node's SRv6 uSID by matching against `BGPAdvertisement`/`BGPRouter` CRDs                                              | No                                   |
+| `internal/config` (`gateway.go`)                        | galactic-gateway | `GatewayConfig`: node name, ports, public interface, SRv6 encap-source address; three-tier CLI/env/default precedence via viper                                                                 | No                                   |
+| `internal/controller` (`networkgateway_controller.go`)  | galactic-gateway | `NetworkGatewayReconciler`: desired-state assembly, BGP wiring, orphan-crash recovery                                                                                                            | No                                   |
+| `internal/controller` (`networkrule_controller.go`)     | galactic-gateway | `NetworkRuleReconciler`: finalizer-guarded teardown ordering, `Accepted`-condition maintenance (`updateAcceptedCondition`)                                                                       | No                                   |
+| `internal/controller` (`usidresolver.go`)               | galactic-gateway | `backendSIDIndex`: resolves a `NetworkRule` backend address to the worker node's SRv6 uSID by matching against `BGPAdvertisement`/`BGPRouter`/`BGPVRFInstance` CRDs, verifying tenant ownership  | No                                   |
 | `internal/gateway` (`engine.go`)                        | galactic-gateway | `Engine`: mutex-guarded convergence loop ("apply everything in desired, remove everything not in desired"), mirroring `GoBGPRuntime`'s shape                                                    | Yes (active-rule map)                |
-| `internal/gateway` (`types.go`)                         | galactic-gateway | `DesiredRule`/`DesiredBackend`/`EngineState`/`EngineStatus`/`RuleStatus` — the engine's own representation, assembled by the controllers above                                                  | No                                   |
-| `internal/gateway` (`datapath.go`, `kerneldatapath.go`) | galactic-gateway | `Datapath`/`QuotaEnforcer`/`TelemetryEmitter` interfaces; `KernelDatapath`, the real `Datapath` backed by `edgemap.RuleTable` over a loaded `edgeprog.EdgenatObjects`; `NoopDatapath` for tests | Yes (`ruleKeysByName` bookkeeping)   |
-| `internal/gateway` (`quota.go`)                         | galactic-gateway | `NodeQuotaEnforcer` — real, coarse node-level admission caps (max rules/tenant, max total `rule_table` entries); `NoopQuotaEnforcer` for tests                                                  | Yes (in-memory reservation counters) |
-| `internal/gateway` (`telemetry.go`)                     | galactic-gateway | `PrometheusTelemetryEmitter` — primary/secondary placement gauge + control-plane-drop counter; `NoopTelemetryEmitter` for tests                                                                 | Yes (Prometheus metric state)        |
-| `internal/gateway` (`placement.go`, `localpref.go`)     | galactic-gateway | `AssignPrimaryNode` (`hash(vpcRef) % gateway-node-count`), `LocalPreference` (pure lookup) — the Active-Active BGP model's primitives                                                           | No                                   |
-| `internal/gateway` (`recovery.go`, `diff.go`)           | galactic-gateway | `Engine.ReconcileOrphans` (crash recovery) and `diffRuleKeys` (the pure key-set diff both `Reconcile`/`ReconcileOrphans` build on)                                                              | No                                   |
-| `internal/plumbing/ebpf/edgeprog`                       | galactic-gateway | Compiled XDP program (`edgenat.c`) + bpf2go-generated Go bindings (`EdgenatObjects`)                                                                                                            | No                                   |
-| `internal/plumbing/ebpf/edgemap`                        | galactic-gateway | `RuleTable`: `rule_table`/`rule_stats_table`/`gw_config_table` read/write API, `Generation`/`Reconcile` crash-safety mechanism                                                                  | Yes (via `KernelTable`)              |
+| `internal/gateway` (`types.go`)                         | galactic-gateway | `DesiredRule`/`DesiredBackend`/`EngineState`/`EngineStatus`/`RuleStatus` — the engine's own representation, assembled by the controllers above; `DesiredBackend` implements `internal/maglev.Backend` | No                              |
+| `internal/gateway` (`datapath.go`, `kerneldatapath.go`) | galactic-gateway | `Datapath`/`QuotaEnforcer`/`TelemetryEmitter` interfaces; `KernelDatapath`, the real `Datapath` backed by `edgemap.VIPTable` over a loaded `edgeprog.EdgedsrObjects`, building a `internal/maglev.Table` per rule; `NoopDatapath` for tests | Yes (`vipKeysByName` bookkeeping) |
+| `internal/gateway` (`quota.go`)                         | galactic-gateway | `NodeQuotaEnforcer` — real, coarse node-level admission caps (max rules/tenant, max total `vip_table` entries); `NoopQuotaEnforcer` for tests                                                    | Yes (in-memory reservation counters) |
+| `internal/gateway` (`telemetry.go`)                     | galactic-gateway | `PrometheusTelemetryEmitter` — control-plane-drop counter only (no primary/secondary placement gauge — see Key Design Decisions); `NoopTelemetryEmitter` for tests                               | Yes (Prometheus metric state)        |
+| `internal/gateway` (`recovery.go`, `diff.go`)           | galactic-gateway | `Engine.ReconcileOrphans` (crash recovery) and `diffRuleKeys` (the pure key-set diff both `Reconcile`/`ReconcileOrphans` build on)                                                               | No                                   |
+| `internal/maglev` (`table.go`)                          | galactic-gateway, galactic-nat66 | Pure-Go Maglev consistent-hash lookup table (`New`/`Lookup`/`Backends`) — one `*Table` built per ring; shared in design, not by import, with `galactic-nat66`'s independent shard-placement ring | No                        |
+| `internal/plumbing/ebpf/edgeprog`                       | galactic-gateway | Compiled XDP program (`edgedsr.c`, program `edge_lb`) + bpf2go-generated Go bindings (`EdgedsrObjects`)                                                                                          | No                                   |
+| `internal/plumbing/ebpf/edgemap`                        | galactic-gateway | `VIPTable`: `vip_table`/`vip_stats_table` read/write API, `Generation`/`Reconcile` crash-safety mechanism                                                                                        | Yes (via `KernelTable`)              |
 | `internal/plumbing/ebpf/edgeattach`                     | galactic-gateway | Load + native-XDP-only attach of the compiled program to one interface                                                                                                                          | Yes (pinned maps, held link)         |
+| `internal/plumbing/ebpf/edgemetrics`                    | galactic-gateway | Pull-based `prometheus.Collector` reading `vip_table`/`vip_stats_table`/`drop_reasons` live at every scrape                                                                                      | No                                   |
+| `internal/plumbing/ebpf/edgepreflight`                  | galactic-gateway | Startup kernel-capability check (`BPF_PROG_TYPE_XDP`, `BPF_MAP_TYPE_HASH`, kernel BTF, `bpf_xdp_adjust_head`) — no partial pass, no degraded fallback                                            | No                                   |
 
 ---
 
 ## External Dependencies
 
 | Dependency                            | Version           | Purpose                                                                                                                                                                                                                                                                                             |
-| ------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------------------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `github.com/cilium/ebpf`              | v0.22.0           | XDP program load/attach/map bindings (`edgeprog`/`edgemap`/`edgeattach`) — the same library version `internal/plumbing/ebpf` (the CNI chain's TC-BPF uSID datapath, see [ARCHITECTURE-CNI.md](ARCHITECTURE-CNI.md)) uses, but a fully separate program/map/attach surface with no shared map layout |
-| `go.datum.net/network`                | bumped frequently | `NetworkGateway`/`NetworkRule` CRD API types, plus the BGP-family types this binary reads (`BGPAdvertisement`, `BGPRouter`)                                                                                                                                                                         |
+| `go.datum.net/network`                | bumped frequently | `NetworkGateway`/`NetworkRule` CRD API types, plus the BGP-family types this binary reads (`BGPAdvertisement`, `BGPRouter`, `BGPVRFInstance`)                                                                                                                                                       |
 | `sigs.k8s.io/controller-runtime`      | v0.24.1           | Full manager + reconciler framework — like `galactic-router`, not a bare client like the CNI chain                                                                                                                                                                                                  |
-| `github.com/prometheus/client_golang` | v1.24.1           | `PrometheusTelemetryEmitter`'s gauge/counter metrics, plus `edgemetrics`'s pull-based `rule_stats_table`/`conn_table`/`drop_reasons` collector                                                                                                                                                      |
-| `github.com/spf13/cobra`              | v1.10.2           | CLI command/flag handling                                                                                                                                                                                                                                                                           |
-| `google.golang.org/grpc`              | v1.82.0           | gRPC health server (default `:5181`)                                                                                                                                                                                                                                                                |
-| `k8s.io/api`, `k8s.io/client-go`      | v0.36.0           | Kubernetes client, `SelfSubjectAccessReview` (RBAC pre-flight)                                                                                                                                                                                                                                      |
+| `github.com/prometheus/client_golang` | v1.24.1           | `PrometheusTelemetryEmitter`'s control-plane-drop counter, plus `edgemetrics`'s pull-based `vip_table`/`vip_stats_table`/`drop_reasons` collector                                                                                                                                                   |
+| `github.com/spf13/cobra`              | v1.10.2           | CLI command/flag handling                                                                                                                                                                                                                                                                            |
+| `google.golang.org/grpc`              | v1.83.0           | gRPC health server (default `:5181`)                                                                                                                                                                                                                                                                 |
+| `k8s.io/api`, `k8s.io/client-go`      | v0.36.3           | Kubernetes client, `SelfSubjectAccessReview` (RBAC pre-flight)                                                                                                                                                                                                                                       |
 
 ---
 
 ## Key Design Decisions
 
-- **No VRF/Geneve dependency.** The outer SRv6 header is pushed straight from `rule_table` (resolved via `edgemap`) rather than a kernel VRF route, so this datapath has no VRF dependency and no exposure to the GoBGP EVPN-decode bugs that forced every earlier per-VPC gateway design to colocate with the workload's own VRF. `Engine`/`KernelDatapath` hold no VRF/Geneve state at all — no `vrfLinkNames` map, no `SetVRFLink` method, unlike the rejected `gwprog` predecessor.
-- **Active-Active BGP model, not active-passive failover.** Both gateway nodes in a PoP always advertise every rule they hold; `AssignPrimaryNode` (`hash(vpcRef) % gateway-node-count`, sorted node list for determinism) only decides which node advertises at the higher local-preference (`PrimaryLocalPref = 100` vs. `SecondaryLocalPref = 50`). Failover is ordinary BGP reconvergence, not a controller-driven health check — the secondary path is always live, just less preferred.
-- **`primary_node` is assigned exactly once, never recomputed.** `NetworkRuleReconciler.assignPrimaryNode` explicitly skips re-assignment once `status.primaryNode` is set. Recomputing it on a later reconcile (e.g. after a gateway node is added/removed) would generally produce a different assignment for the same `vpcRef` and flip which node is primary for a live VIP — an avoidable traffic flap.
-- **No tenant dimension in the datapath.** `rule_table` is keyed by `(proto, VIP port, VIP address)` only — a VIP is globally unique by construction, so no tenant/VPC field is needed to disambiguate ingress traffic. `DesiredRule.VPCRef`/`VPCAttachmentRef` are carried through purely for telemetry labeling and admission-webhook auditing, never consulted by the datapath itself.
-- **uSID resolution for backends.** There is no exported "IP → uSID" query anywhere else in this codebase (`internal/runtime/gobgp/monitor.go` decodes EVPN Prefix-SID attributes purely internally, for local kernel route installation only). `usidresolver.go`'s `backendSIDIndex` mirrors `internal/reconcile/reconcile.go`'s `resolveSRv6SID` instead of embedding a second GoBGP speaker: list `BGPRouter`/`BGPAdvertisement` CRDs once per reconcile, match a backend's address against advertised prefixes, combine the matching advertisement's VRFID/Function with its router's SRv6Locator/NodeID via `srv6.ComputeSID`. **Known limitation:** matching is by address containment only, with no tenant-identity check (`BGPAdvertisement` carries no VPCRef/VPCAttachmentRef to disambiguate against) — two tenants advertising overlapping private address space would resolve ambiguously. A pre-existing gap in the address model, not introduced by this resolver, and out of scope to close here.
-- **Argument-0 reservation.** A gateway node's own `SRv6Address` is a uFMT 48+16 uSID at the reserved Argument value `0` (`uformat.go`'s `ArgumentMin`) — reserved specifically so it is never registered into any tenant's `vrf_table`. `srv6.ComputeSID` unconditionally rejects `argument==0` (that guard exists for tenant-VRF SID derivation, where 0 must never be assigned), so deriving this value needs a second, narrower encode path bypassing that guard — genuinely new work this phase does not build. Today `SRv6Address` is supplied via operator config (`GALACTIC_GATEWAY_SRV6_ADDRESS`) instead of computed in-cluster; `publishSelfAddress`'s only job is to publish that already-authoritative value into the CRD and into BGP, so there is exactly one source of truth rather than two that could drift. See the [worked example](#worked-containerlab-example) for how a real deployment picks this value today.
-- **Quota/telemetry are real but deliberately coarse.** `NodeQuotaEnforcer` enforces two node-level admission caps entirely from control-plane state already held by `Engine` (no eBPF map read required): max `NetworkRule`s per tenant, and total `rule_table` rows across every tenant vs. the map's fixed capacity. It deliberately does **not** do per-flow/conntrack rate limiting — `conn_table`'s key carries no tenant dimension (by design, see above), and a meaningful bandwidth/packet-rate quota needs a time-windowed rate rather than `rule_stats_table`'s cumulative, never-reset packet/byte counters. Real rate-based enforcement needs live traffic data this repo does not have yet. `PrometheusTelemetryEmitter` similarly covers only what `Engine`'s own call sites uniquely know (primary/secondary placement, control-plane-level rejections before a rule ever reaches the datapath) — `rule_stats_table`/`conn_table`'s own per-packet counters are exposed separately by `edgemetrics`'s pull-based collector.
-- **Per-rule hit counters live in their own map (`rule_stats_table`), not `rule_table`.** They used to be fields on `rule_table`'s own value, and `edgemap.RuleTable.Register` carried them forward with a Lookup-then-Put read-modify-write on every re-registration (`Engine.Reconcile` re-registers every desired rule on every pass, not just changed ones) so that rewriting a rule's backend list wouldn't also zero its counters. Any datapath increment landing between that Lookup and Put was silently discarded, undercounting `galactic_edgenat_rule_*` by an amount that scaled with traffic rate and resync frequency (issue #361). Splitting the counters into a separate map, keyed identically but populated lazily by the datapath itself (never by `Register`), closes the race instead of narrowing it — `Register` now only ever writes `rule_table`'s backend list/`Generation` and has nothing left to race.
-- **Generation-based crash recovery, not a Geneve-interface scan.** `Engine.ReconcileOrphans` delegates to `edgemap.RuleTable.Reconcile`'s `Generation`-cutoff mechanism: a caller must capture `Engine.DatapathGeneration()` *before* listing the `NetworkRule` CRDs that become the live set, so a rule created between the snapshot and the list is never mistaken for an orphan. `rule_table` state (not a kernel interface) is the only thing this design can leak on a crash — unlike the rejected Geneve-based predecessor, which had to scan interfaces.
-- **Native XDP only, no generic-mode fallback.** `edgeattach.Attach` always requests `link.XDPDriverMode` and errors rather than silently retrying in `link.XDPGenericMode` (SKB mode) if the interface's driver doesn't support it — accepting generic mode silently would defeat the reason this design chose XDP over TC-BPF in the first place.
-- **`galactic-router` carries no gateway-role code anymore.** Splitting the edge gateway out of `galactic-router` into its own binary means a crash in the XDP-loading, BPF/PERFMON-capable container never takes down the tenant BGP session on the same node, and vice versa. See [ARCHITECTURE-ROUTER.md](ARCHITECTURE-ROUTER.md) for what's left in that binary.
+- **DSR (Direct Server Return), not Full-NAT.** The datapath does no
+  address/port rewriting at all: a client's packet is pushed inside an SRv6
+  outer header toward the chosen backend's worker node completely
+  unmodified, and the backend replies to the client directly. This is a
+  breaking replacement of the earlier Full-NAT (DNAT+SNAT) design, not a
+  second mode alongside it — no migration path, per the redesign's
+  explicit decision to drop Full-NAT rather than grow a second personality.
+  Everything else in this section follows from that one choice.
+- **Anycast, not Active-Active BGP local-preference.** Every gateway node
+  in a PoP advertises every accepted rule's VIPs at equal BGP preference —
+  there is no `AssignPrimaryNode`/`LocalPreference` primitive anywhere in
+  this codebase anymore (`internal/gateway/placement.go` and
+  `localpref.go`, and their tests, were deleted outright as part of this
+  rewrite). A distinct Route Distinguisher per originating node (RFC 4364
+  §4.3.2, `internal/runtime/gobgp/paths.go`'s `deriveRD`) is what keeps
+  every node's identical-prefix advertisement alive as an independent,
+  non-competing route instead of BGP collapsing them to one best path — see
+  the go/no-go anycast spike, `internal/runtime/gobgp/anycast_spike_test.go`.
+- **Maglev, not `hash(client) % backend_count`.** `internal/maglev.Table`
+  gives every gateway node the byte-identical lookup table for the
+  byte-identical `(VIP, backend list)` input, with no coordination or RPC
+  between nodes — this is what makes it safe for ECMP/BGP reconvergence to
+  move a flow's packets to a different gateway node mid-connection and
+  still land on the same backend. It also bounds backend-set-change
+  disruption to roughly `1/N` of flows (N = backend count) rather than
+  reshuffling everything, unlike a plain modulo scheme.
+- **No VRF/Geneve dependency.** The outer SRv6 header is pushed straight
+  from `vip_table` (resolved via `edgemap`) rather than a kernel VRF route,
+  so this datapath has no VRF dependency and no exposure to the GoBGP
+  EVPN-decode bugs that forced every earlier per-VPC gateway design to
+  colocate with the workload's own VRF. `Engine`/`KernelDatapath` hold no
+  VRF/Geneve state at all.
+- **No tenant dimension in the datapath.** `vip_table` is keyed by `(proto,
+  VIP port, VIP address)` only — a VIP is globally unique by construction,
+  so no tenant/VPC field is needed to disambiguate ingress traffic.
+  `DesiredRule.VPCRef`/`VPCAttachmentRef` are carried through purely for
+  telemetry labeling and admission-webhook auditing, never consulted by the
+  datapath itself.
+- **uSID resolution for backends.** There is no exported "IP → uSID" query
+  anywhere else in this codebase (`internal/runtime/gobgp/monitor.go`
+  decodes EVPN Prefix-SID attributes purely internally, for local kernel
+  route installation only). `usidresolver.go`'s `backendSIDIndex` mirrors
+  `internal/reconcile/reconcile.go`'s `resolveSRv6SID` instead of embedding
+  a second GoBGP speaker: list `BGPRouter`/`BGPAdvertisement`/
+  `BGPVRFInstance` CRDs once per reconcile, match a backend's address
+  against advertised prefixes, and — unlike an earlier version of this
+  resolver — **verify tenant ownership** of the match
+  (`verifyTenantOwnership`) via the calling rule's own `VPCRef` and the
+  deterministic `BGPVRFInstance` name `galactic-bgp` writes
+  (`crdnames.BGPVRFInstanceName`), before trusting it: two tenants
+  advertising overlapping (e.g. colliding ULA) address space would
+  otherwise resolve ambiguously, silently routing a packet into the wrong
+  tenant's VRF rather than merely picking an ambiguous-but-harmless match.
+- **SRv6 encap-source address has no in-cluster derivation mechanism.**
+  `GALACTIC_GATEWAY_SRV6_ADDRESS` is operator-supplied per gateway node
+  today; nothing in this repo yet computes it automatically from a node's
+  own `BGPRouter` locator/node-ID. Unlike the removed Full-NAT design, this
+  value is never published to any CRD status — there is no reconcile step
+  analogous to the old `publishSelfAddress` at all, since DSR rewrites
+  nothing and so has no SNAT source that needs advertising as a
+  node-reachability route.
+- **Quota/telemetry are real but deliberately coarse.** `NodeQuotaEnforcer`
+  enforces two node-level admission caps entirely from control-plane state
+  already held by `Engine` (no eBPF map read required): max `NetworkRule`s
+  per tenant, and total `vip_table` rows across every tenant vs. the map's
+  fixed capacity. It deliberately does **not** do per-flow rate limiting —
+  `vip_table`'s key carries no tenant dimension (by design, see above), and
+  a meaningful bandwidth/packet-rate quota needs a time-windowed rate
+  rather than `vip_stats_table`'s cumulative, never-reset packet/byte
+  counters. `PrometheusTelemetryEmitter` similarly covers only what
+  `Engine`'s own call sites uniquely know (control-plane-level rejections
+  before a rule ever reaches the datapath) — `vip_table`/`vip_stats_table`'s
+  own per-packet counters are exposed separately by `edgemetrics`'s
+  pull-based collector.
+- **Per-VIP hit counters live in their own map (`vip_stats_table`), not
+  `vip_table`.** The removed Full-NAT predecessor's `rule_table`/
+  `rule_stats_table` split already established this convention (issue
+  #361: a control-plane `Register` read-modify-write racing the datapath's
+  own per-packet increments silently discarded whichever landed second).
+  `vip_table`/`vip_stats_table` keep the same split: `Register` is a blind
+  overwrite of `vip_table` alone and never touches `vip_stats_table`, which
+  `edgedsr.c` alone populates, lazily, on a VIP's first matching packet —
+  so re-registering a VIP (e.g. every controller reconcile pass) can never
+  race, and therefore never lose, the datapath's own increments.
+- **Generation-based crash recovery, not a Geneve-interface scan.**
+  `Engine.ReconcileOrphans` delegates to `edgemap.VIPTable.Reconcile`'s
+  `Generation`-cutoff mechanism: a caller must capture
+  `Engine.DatapathGeneration()` *before* listing the `NetworkRule` CRDs
+  that become the live set, so a rule created between the snapshot and the
+  list is never mistaken for an orphan. `vip_table` state (not a kernel
+  interface) is the only thing this design can leak on a crash — DSR keeps
+  no flow/conntrack state at all to garbage-collect beyond that.
+- **Native XDP only, no generic-mode fallback.** `edgeattach.Attach` always
+  requests `link.XDPDriverMode` and errors rather than silently retrying in
+  `link.XDPGenericMode` (SKB mode) if the interface's driver doesn't
+  support it — accepting generic mode silently would defeat the reason
+  this design chose XDP over TC-BPF in the first place.
+- **`galactic-router` carries no gateway-role code anymore.** Splitting the
+  edge gateway out of `galactic-router` into its own binary means a crash
+  in the XDP-loading, BPF/PERFMON-capable container never takes down the
+  tenant BGP session on the same node, and vice versa. See
+  [ARCHITECTURE-ROUTER.md](ARCHITECTURE-ROUTER.md) for what's left in that
+  binary.
 
 ---
 
 ## Testing
 
-| Layer           | Command                               | Framework                       | Scope                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| --------------- | ------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unit            | `task test:unit`                      | `go test -race`                 | `internal/config` (`gateway_test.go`), `internal/controller` (`networkgateway_controller_test.go`, `networkrule_controller_test.go`, `usidresolver_test.go`), `internal/gateway` (`engine_test.go`, `diff_test.go`, `kerneldatapath_test.go`, `localpref_test.go`, `placement_test.go`, `quota_test.go`, `recovery_test.go`, `telemetry_test.go`), `internal/plumbing/ebpf/edgemap` (`ruletable_test.go`, in-memory fake `Table`, no kernel required) |
-| Kernel-required | `task test:unit` (root/CAP_BPF gated) | `go test` + `BPF_PROG_TEST_RUN` | `internal/plumbing/ebpf/edgeprog/edgenat_test.go` — exercises the compiled program directly; `internal/plumbing/ebpf/edgeattach/attach_test.go`                                                                                                                                                                                                                                                                                                       |
-| E2E             | —                                     | —                               | **Not yet covered.** `deploy/containerlab/`'s `iad-gateway1`/`iad-gateway2` nodes are a manifests-and-live-pod canary, not a scripted e2e test — see Known Constraints.                                                                                                                                                                                                                                                                               |
+| Layer           | Command                               | Framework                       | Scope                                                                                                                                                                                                                                                                                                                                    |
+| --------------- | -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit            | `task test:unit`                      | `go test -race`                 | `internal/config` (`gateway_test.go`), `internal/controller` (`networkgateway_controller_test.go`, `networkrule_controller_test.go`, `usidresolver_test.go`), `internal/gateway` (`engine_test.go`, `diff_test.go`, `kerneldatapath_test.go`, `quota_test.go`, `recovery_test.go`, `telemetry_test.go`), `internal/maglev` (`table_test.go`), `internal/plumbing/ebpf/edgemap` (`viptable_test.go`, in-memory fake `Table`, no kernel required), `internal/plumbing/ebpf/edgemetrics` (`collector_test.go`), `internal/plumbing/ebpf/edgepreflight` (`preflight_test.go`, `kernel_prober_test.go`) |
+| Kernel-required | `task test:unit` (root/CAP_BPF gated) | `go test` + `BPF_PROG_TEST_RUN` | `internal/plumbing/ebpf/edgeprog/edgedsr_test.go` — exercises the compiled program directly, including the version-nibble/payload_len regression tests; `internal/plumbing/ebpf/edgeattach/attach_test.go`                                                                                                                                |
+| E2E             | —                                     | —                                | **Not yet covered.** `deploy/containerlab/`'s `iad-gateway1`/`iad-gateway2` nodes are a manifests-and-live-pod canary, not a scripted e2e test — see Known Constraints.                                                                                                                                                                    |
 
 ---
 
@@ -445,13 +644,14 @@ since that base's DaemonSet runs both images in one pod.
 
 ## Known Constraints
 
-- **No e2e coverage yet.** The gateway canary in `deploy/containerlab/` validates manifests and a live pod/eBPF attach, but predates any live underlay BGP peering that would deliver real traffic through it — see the `gatewayDatapathKeepAlive` incident described in [Entry Points](#cmd-galactic-gateway-gateway-go--datapath-setup) above, which was only discovered because ingress traffic silently stopped being intercepted, not caught by any test.
-- **No `NetworkRule` admission webhook is deployed in this repo.** The CRD's own doc comment and `NetworkRuleReconciler`'s doc comment both describe an admission webhook that verifies VPC/VPCAttachment ownership before setting the `Accepted` condition — no `ValidatingWebhookConfiguration` exists in `config/` yet (`config/webhook/` doesn't exist). `assignPrimaryNode` currently sets `Accepted=True` unconditionally once gateway nodes exist for the namespace, not gated on any ownership check.
-- **The uSID backend resolver has no tenant-identity check** (see [uSID resolution](#usid-resolution-for-backends) above) — two tenants advertising overlapping private address space resolve ambiguously. Pre-existing gap in the address model, not unique to this resolver.
-- **`SRv6Address` (and, per the design plan, a second reserved Argument value for future egress use) has no in-cluster derivation mechanism.** Both are operator-supplied per gateway node today; nothing in this repo yet computes them automatically from a node's own `BGPRouter` locator/node-ID at the reserved Argument value. See [Argument-0 reservation](#argument-0-reservation) above.
-- **The uSID TC-BPF/XDP FIB-lookup PMTUD gap applies here too.** When `bpf_fib_lookup()` returns `BPF_FIB_LKUP_RET_FRAG_NEEDED`, `edgenat.c` counts `DROP_REASON_FIB_FRAG_NEEDED` and drops rather than emitting an ICMPv6 Packet Too Big — the same accepted gap `internal/plumbing/ebpf/prog/usid.c` has for the SRv6 uSID datapath (see [ARCHITECTURE-CNI.md#known-constraints](ARCHITECTURE-CNI.md#known-constraints)), not yet scheduled to be closed on either side.
-- **Egress (NAT masquerade for outbound tenant traffic) is planned, not implemented.** Today's gateway only handles ingress (external client → VIP → tenant backend); there is no path for a VPC-attached workload to reach the general internet. See `docs/plans/edge-gateway-nat-masquerade-egress.md` for the design-in-progress (status: planning only, no implementation started) — it proposes a second XDP personality (`handle_egress_forward`/`handle_egress_return`), a new `NetworkEgressPolicy` CRD, and flags the open questions (default-route ownership, IPv4 scope, anti-spoofing trust boundary) that block starting real implementation.
-- **conn_table/rule_table have no active GC beyond LRU self-eviction.** By design (see Key Design Decisions above) — this is a deliberate, not accidental, scope boundary carried over from the rejected `gwprog` predecessor's identical choice.
+- **No e2e coverage yet.** The gateway canary in `deploy/containerlab/` validates manifests and a live pod/eBPF attach, but predates any live underlay BGP peering that would deliver real traffic through it — see the `gatewayDatapathKeepAlive` incident described in [Entry Points](#cmd-galactic-gatewaygateway-go--datapath-setup) above, which was only discovered because ingress traffic silently stopped being intercepted, not caught by any test.
+- **No `NetworkRule` admission webhook is deployed in this repo.** The CRD's own doc comment and `NetworkRuleReconciler`'s doc comment both describe an admission webhook that verifies VPC/VPCAttachment ownership before setting the `Accepted` condition — no `ValidatingWebhookConfiguration` exists in `config/` yet (`config/webhook/` doesn't exist). `updateAcceptedCondition` currently sets `Accepted=True` unconditionally once gateway nodes exist for the namespace, not gated on any ownership check.
+- **The uSID backend resolver's tenant-ownership check depends on `BGPVRFInstance` naming staying deterministic.** `verifyTenantOwnership` closes the ambiguous-match gap an earlier version of this resolver had, but it is only as strong as `crdnames.BGPVRFInstanceName(vpc, nodeName)` staying the exact name `galactic-bgp` writes — a divergence between the two would fail closed (a real backend never resolving) rather than open (a wrong-tenant resolve), which is the safer failure direction but still worth knowing about when either side of that naming contract changes.
+- **`GALACTIC_GATEWAY_SRV6_ADDRESS` has no in-cluster derivation mechanism.** It is operator-supplied per gateway node today; nothing in this repo yet computes it automatically from a node's own `BGPRouter` locator/node-ID. See [SRv6 encap-source address](#srv6-encap-source-address) above.
+- **The uSID TC-BPF/XDP FIB-lookup PMTUD gap applies here too.** When `bpf_fib_lookup()` returns `BPF_FIB_LKUP_RET_FRAG_NEEDED`, `edgedsr.c` counts `DROP_REASON_FIB_FRAG_NEEDED` and drops rather than emitting an ICMPv6 Packet Too Big — the same accepted gap `internal/plumbing/ebpf/prog/usid.c` has for the SRv6 uSID datapath (see [ARCHITECTURE-CNI.md#known-constraints](ARCHITECTURE-CNI.md#known-constraints)), not yet scheduled to be closed on either side.
+- **`bpf_fib_lookup()` requires IPv6 forwarding sysctls on the public uplink, not just XDP driver support.** `setupGatewayDatapath` calls `sysctl.ConfigureFIBLookupUplinkSysctls` before attaching the datapath — without `net.ipv6.conf.<iface>.forwarding` and `net.ipv6.conf.all.forwarding` both set, the kernel returns `BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup regardless of anything this program does, which `edgedsr.c`'s own drop-reason accounting cannot distinguish from a generic FIB lookup failure. Found via live-kernel investigation of a pre-existing containerlab veth/XDP_TX blocker: the sysctl gap, not `XDP_TX` itself, was the actual cause. A related, lab-only characteristic the same investigation turned up: native `XDP_TX` on a veth pair only promotes a frame into the peer's normal receive stack (visible to `tcpdump`) if the peer *also* runs an XDP program — otherwise delivery uses a raw fast-path invisible to normal tools. This does not apply to a real physical NIC uplink in production, where there is no "peer's own XDP program" question to begin with.
+- **`vip_table` has no active GC beyond crash-recovery reconcile.** By design (see Key Design Decisions above) — DSR keeps no flow state to leak in the first place, unlike the removed Full-NAT predecessor's `conn_table`, which relied on `BPF_MAP_TYPE_LRU_HASH` self-eviction for the same purpose.
+- **Egress is out of this binary's scope, not unimplemented.** An earlier plan (`docs/plans/865-edge-gateway-nat66-egress.md`) proposed adding a second, egress-masquerading XDP personality to this same program and process; that approach was superseded by a separate, sharded stateful NAT66 tier (`galactic-nat66`, its own binary — see `cmd/galactic-nat66` and `internal/controller/nat66shard_controller.go`) rather than built here. `NetworkRule`/this datapath remain ingress-only: external client → VIP → tenant backend.
 
 ---
 
@@ -460,27 +660,28 @@ since that base's DaemonSet runs both images in one pod.
 **Where to start for each concern:**
 
 | Concern                                                                                            | Start here                                                                                               |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| Node-scoped aggregate reconcile (self-address, desired-state assembly, BGP wiring, crash recovery) | `internal/controller/networkgateway_controller.go:Reconcile`                                             |
-| Per-object lifecycle (finalizer teardown ordering, one-time primary_node assignment)               | `internal/controller/networkrule_controller.go:Reconcile`, `assignPrimaryNode`, `reconcileDelete`        |
-| Backend address → SRv6 uSID resolution                                                             | `internal/controller/usidresolver.go:buildBackendSIDIndex`, `resolveUSID`                                |
-| Engine convergence loop                                                                            | `internal/gateway/engine.go:Reconcile`, `applyRuleLocked`, `removeRuleLocked`                            |
-| Real datapath implementation (rule_table read/write)                                               | `internal/gateway/kerneldatapath.go:ApplyRule`, `RemoveRule`                                             |
-| Active-Active placement                                                                            | `internal/gateway/placement.go:AssignPrimaryNode`, `internal/gateway/localpref.go:LocalPreference`       |
-| Crash recovery (orphaned rule_table state)                                                         | `internal/gateway/recovery.go`, `internal/plumbing/ebpf/edgemap/ruletable.go`'s `Generation`/`Reconcile` |
-| Quota enforcement                                                                                  | `internal/gateway/quota.go:NodeQuotaEnforcer.CheckAndReserve`                                            |
-| XDP packet path                                                                                    | `internal/plumbing/ebpf/edgeprog/edgenat.c` (start with its own header comment)                          |
-| Datapath load/attach lifecycle                                                                     | `internal/plumbing/ebpf/edgeattach/attach.go`, `cmd/galactic-gateway/gateway.go:setupGatewayDatapath`    |
-| Startup sequencing / gRPC health ordering                                                          | `cmd/galactic-gateway/root.go:runCmd`                                                                    |
+| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Node-scoped aggregate reconcile (desired-state assembly, BGP wiring, crash recovery)               | `internal/controller/networkgateway_controller.go:Reconcile`                                             |
+| Per-object lifecycle (finalizer teardown ordering, `Accepted`-condition maintenance)                 | `internal/controller/networkrule_controller.go:Reconcile`, `updateAcceptedCondition`, `reconcileDelete`  |
+| Backend address → SRv6 uSID resolution (with tenant-ownership verification)                        | `internal/controller/usidresolver.go:buildBackendSIDIndex`, `resolveUSID`, `verifyTenantOwnership`       |
+| Engine convergence loop                                                                             | `internal/gateway/engine.go:Reconcile`, `applyRuleLocked`, `removeRuleLocked`                            |
+| Real datapath implementation (vip_table read/write, Maglev table construction)                      | `internal/gateway/kerneldatapath.go:ApplyRule`, `RemoveRule`, `buildMaglevTable`                          |
+| Maglev consistent-hash ring                                                                          | `internal/maglev/table.go:New`, `Lookup`, `Backends`                                                      |
+| Crash recovery (orphaned vip_table state)                                                           | `internal/gateway/recovery.go`, `internal/plumbing/ebpf/edgemap/viptable.go`'s `Generation`/`Reconcile`  |
+| Quota enforcement                                                                                    | `internal/gateway/quota.go:NodeQuotaEnforcer.CheckAndReserve`                                             |
+| XDP packet path                                                                                      | `internal/plumbing/ebpf/edgeprog/edgedsr.c` (start with its own header comment)                          |
+| Datapath load/attach lifecycle                                                                       | `internal/plumbing/ebpf/edgeattach/attach.go`, `cmd/galactic-gateway/gateway.go:setupGatewayDatapath`    |
+| Startup sequencing / gRPC health ordering                                                            | `cmd/galactic-gateway/root.go:runCmd`                                                                    |
 
 **Stable vs. frequently changed:**
-- Stable: `internal/gateway/placement.go`, `localpref.go` (pure functions, unaffected by any datapath change), `internal/plumbing/ebpf/edgemap` (mirrors `usidmap`'s already-settled crash-safety pattern)
-- Active: `internal/gateway/quota.go`/`telemetry.go` (real but coarse — see Key Design Decisions; likely to grow richer enforcement), `internal/plumbing/ebpf/edgeprog/edgenat.c` (the egress masquerade plan below would add a second personality here)
-- Planning only, not yet built: egress/NAT-masquerade (`docs/plans/edge-gateway-nat-masquerade-egress.md`), the `NetworkRule` admission webhook
+- Stable: `internal/maglev/table.go` (a settled, well-tested algorithm — Google's published Maglev construction), `internal/plumbing/ebpf/edgemap` (mirrors `usidmap`'s already-settled crash-safety pattern)
+- Active: `internal/gateway/quota.go`/`telemetry.go` (real but coarse — see Key Design Decisions; likely to grow richer enforcement)
+- Out of scope here, but related and evolving: `galactic-nat66`'s sharded stateful NAT66 egress tier (`cmd/galactic-nat66`, a separate binary, its own Maglev ring built from this same `internal/maglev` package for shard placement rather than backend selection), the `NetworkRule` admission webhook
 
 **Non-obvious patterns:**
 - `gatewayDatapathKeepAlive` (`cmd/galactic-gateway/gateway.go`) intentionally never calls `Close` on the loaded eBPF objects or the XDP `link.Link` — see that var's doc comment for the live incident this guards against (silent GC-triggered detach with every control-plane signal still looking healthy).
 - Every gateway node reconciles every `NetworkGateway`/`NetworkRule` in the namespace — there is no leader election and no per-node filtering predicate on the watch itself; filtering happens inside `Reconcile` (`gw.Spec.TargetRef.Name != r.NodeName` early-return) and via `isGatewayNode`/broadcast watch mappers, not via `SetupWithManager` predicates.
-- `BGPAdvertisement` names for gateway-originated routes are node-qualified (`<rule>-<node>-v4`/`-v6`, or `<gateway>-selfaddr`) specifically because Active-Active means every gateway node computes the same rule independently — omitting the node qualifier caused two nodes to race to create/update one shared object, confirmed live (`AlreadyExists` forever on the second node, only the first node's route ever advertised).
+- `BGPAdvertisement` names for gateway-originated routes are node-qualified (`<rule>-<node>-v4`/`-v6`) specifically because the anycast model means every gateway node computes the same rule independently — omitting the node qualifier caused two nodes to race to create/update one shared object, confirmed live (`AlreadyExists` forever on the second node, only the first node's route ever advertised) under the earlier Full-NAT design and never reintroduced here.
 - A deleted `NetworkGateway` reconcile can't just call `Engine.Stop()` unconditionally — every gateway node's process reconciles every `NetworkGateway` in the namespace, so a *sibling* node's deletion reaches this reconciler too. `isGatewayNode` re-checks whether *this* node still has its own `NetworkGateway` before stopping the engine (issue #364).
 - Advertisement failures during `Reconcile` are collected, not returned immediately — one bad rule's BGP-wiring failure must not stop the rest of the pass, but a node that converged its engine while failing to publish any route must still report `AdvertisementFailed`, not `EngineHealthy` (issue #365) — see `readyConditionFor`.
+- `withdrawNodeAdvertisements` matches only the `-v4`/`-v6` rule-advertisement name suffixes now — an earlier, Full-NAT-era version of this function also withdrew a `-selfaddr` self-address route; DSR's anycast model has no self-address to publish at all, so that name pattern no longer applies (see this file's package doc comment in `networkgateway_controller.go`).

--- a/docs/plans/865-edge-gateway-nat66-egress.md
+++ b/docs/plans/865-edge-gateway-nat66-egress.md
@@ -2,7 +2,15 @@
 
 - **Issue:** [datum-cloud/enhancements#865](https://github.com/datum-cloud/enhancements/issues/865) — "NAT66 (NPTv6) for VPC Peering and External Attachments on Galactic VPC" (title predates a body rewrite; the current body describes stateful ULA→GUA NAT66, matching this plan — see §0 for why that's *not* the NPTv6 the title still names).
 - **Builds on:** the edge XDP NAT+LB gateway's existing ingress design (`internal/gateway/doc.go`, `internal/plumbing/ebpf/edgeprog/doc.go`, the design plan those two doc comments cite).
-- **Status:** planning only — no implementation started.
+- **Status:** **superseded — abandon, not implement.** The Full-NAT edge
+  gateway this plan builds on (`edgenat.c`, `internal/gateway`'s
+  primary/secondary Active-Active model) has been replaced by a DSR
+  Maglev L4LB with no egress personality of its own; stateful NAT66 moves
+  to its own standalone sharded tier instead. See
+  [`dsr-maglev-nptv6-nat66-gateway-redesign.md`](dsr-maglev-nptv6-nat66-gateway-redesign.md)
+  §6 for the full disposition (verdict: abandon this stack's datapath
+  design, not salvage it) and §3 for the tier that replaces it. This
+  document is kept for historical context only — do not build against it.
 
 ## 0. Terminology
 

--- a/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
+++ b/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
@@ -1,0 +1,479 @@
+# Implementation Plan — DSR/Maglev Gateway + Per-VRF NPTv6 + Sharded NAT66
+
+- **Issue:** none yet — this redesign was scoped and implemented directly
+  (branch `feat/dsr-maglev-gateway` here, `feat/dsr-maglev-crds` in
+  `go.datum.net/network`) without opening a tracking issue first, per an
+  explicit instruction to leave GitHub untouched while this work was in
+  flight. File one before merging, and rename this doc to the conventional
+  `docs/plans/NNN-*.md` at that point (matching `405`/`408`/`865` and
+  friends) rather than carrying the unnumbered filename forward.
+- **Supersedes:** [`865-edge-gateway-nat66-egress.md`](865-edge-gateway-nat66-egress.md)
+  (`datum-cloud/enhancements#865`) — see §6 for the disposition of that
+  stack's branches/PRs. **Not closed or deleted as part of this work** —
+  same "don't touch GitHub" instruction above applies to the old PRs
+  (`galactic#380`/`381`/`383`/`385`/`386`) and branches
+  (`feat/865-egress-phase-a` through `-phase-e`); do that as an explicit,
+  separate, outward-facing step later.
+- **Status:** **implementation complete, committed locally, not yet a
+  PR.** All three components below are implemented, integrated, and
+  verified (`go build`/`go vet`/`golangci-lint`/`go test`, including the
+  kernel-required suite via `sudo -n go test`, all clean across the whole
+  repo). Originally a kitt notebook design doc
+  (`~/.vaults/notebook/projects/galactic/dsr-maglev-nptv6-nat66-design.md`);
+  promoted here per this repo's own `docs/plans/NNN-*.md` convention once
+  implementation was done, per the note in that doc's own §8.
+
+## 0. Core architectural constraint
+
+`galactic-gateway` is a true Maglev-style consistent-hash L4 LB operating
+in DSR (Direct Server Return) mode:
+
+- The LB does **no address rewriting**. It picks a backend via consistent
+  hashing on the 5-tuple, encapsulates the untouched original packet
+  (SRv6) toward the backend's worker node. No DNAT, no port translation,
+  no connection table on the LB path at all.
+- The backend node binds the VIP on loopback (component 1) and replies
+  **directly to the client** — reply traffic never re-enters
+  `galactic-gateway`.
+- Consequence: nothing stateful (conntrack, PAT) can live on the
+  consistent-hash selection stage, because DSR guarantees that stage never
+  sees return traffic. NPTv6 (stateless, checksum-neutral, per-tenant) can
+  live there; stateful NAT66 cannot and gets its own tier (component 3).
+
+This is a significant *simplification* over the Full-NAT datapath it
+replaces: the old `edgenat.c` had a whole ingress-return branch
+(`handle_return`) that existed solely to route Full-NAT replies back to
+the SNAT'ing node. DSR deletes that branch outright — the gateway's XDP
+program (`edgedsr.c`) only ever needs a forward path.
+
+**Anycast, not primary/secondary.** Every gateway node the datapath is
+loaded on advertises every VIP identically via BGP — no
+`LocalPreference`, no primary-node election
+(`AssignPrimaryNode`/`LocalPreference`/`placement.go`/`localpref.go` are
+deleted outright). Maglev's consistent-hash ring, not BGP local-pref,
+decides which node's backend set actually answers a given flow.
+
+**Go/no-go spike run 2026-08-17 — anycast premise confirmed, GO.** The
+rejected predecessor design avoided colocating a gateway in a tenant VRF
+specifically to dodge two named GoBGP issues (`monitor.go`'s
+`processEVPNPath` skipping local paths before RT match; `rtIndex` being
+1:1 not fan-out). Both are scoped to advertisements carrying a
+VRFID/Function (tenant-VRF SEG6 kernel-route install) — a VIP/self-address
+advertisement carries neither, so it never reaches that code path. What
+actually governs anycast survival is `paths.go`'s `deriveRD`: a
+VRFID-less advertisement's RD falls back to `routerID:0`, distinct per
+node — and per RFC 4364 §4.3.2/EVPN's identical convention, routes with
+different RDs are never best-path competitors, full stop. Proved
+empirically against gobgp v4.8.0 as actually driven by this codebase's
+own `buildEVPNPaths` — `internal/runtime/gobgp/anycast_spike_test.go`:
+two advertisements with the identical VIP prefix and two router IDs
+produce two independent, both-`Best=true`, independently-withdrawable
+paths; the same-router-ID negative control collapses to one, proving the
+positive result isn't a methodology false-positive.
+
+**Remaining, still-open gap this spike does not cover:** how the VIP gets
+announced to the actual external border/internet at all — this design
+(like the Full-NAT gateway it replaces) never specified that mechanism.
+Whatever bridges it (FRR redistribution, a `fabric-vip`-style component,
+or something else) must propagate *every* qualifying gateway node's
+route, not collapse to "the best one" the way the old local-pref
+primary/secondary model deliberately did. Flagged in §5, not resolved
+here.
+
+## 0.1 Hard requirement — must work for both veth and tap backends
+
+**Non-negotiable, cutting across every component below:** a backend can
+be a container (`galactic-veth`/`internal/cni`) or a VM
+(`galactic-tap`/`internal/cnitap` — the actual VPC/SRv6-dataplane VM
+attach plugin, **not** `vmtap-cni`/`internal/vmtap`, an unrelated
+Unikraft/kraftlet mechanism that is unused in any deployment and
+scheduled for removal from this repo) — this design must work for both.
+The existing SRv6 uSID ingress decap program
+(`internal/plumbing/ebpf/prog/usid.c`) already forks on this at its final
+delivery step for a real kernel-level reason: a veth attachment's egress
+interface has a peer living in a *different* netns (`bpf_redirect_peer`);
+a tap attachment never moves its interface out of the node's own netns,
+so it needs plain `bpf_redirect` instead.
+
+**Where this needed no new work:** backend resolution (`usidresolver.go`)
+is purely address+VRF based; final local delivery is the existing
+`usid_ingress` step 9 redirect, already correct for both kinds; NAT66's
+forward leg receives already-encapsulated traffic via the tenant VRF's
+ordinary default route, agnostic to originating workload kind.
+
+**Where this was a real fork, resolved by a new mechanism (component
+1):** binding a VIP on the node's own `galactic-vip0` doesn't get the
+address in front of whatever actually has to answer on it. For a veth/pod
+backend, the answering process lives in the pod's own netns, reached
+across the veth pair — `internal/cni`'s `cmdAdd` already reaches into
+that netns, so extending it to also assign the VIP there is plausible,
+buildable work. For a tap/VM backend, there is categorically **no
+guest-side configuration capability anywhere in this repo**, by design —
+`internal/cnitap`'s own `cmdAdd` doc comment states the boundary
+explicitly: "no host-device delegation, no guest interface, no netns IP
+configuration. The VM manages its own interface entirely."
+
+**Resolution: don't bind anything in the guest at all; make the VIP
+invisible to it instead.** The guest doesn't need to know about the VIP
+if the host transparently substitutes addresses (and, when a VM backs
+more than one rule/port, the port too) at the tap boundary — a genuine
+NAT-style address/port rewrite with a real (if cheap) checksum fixup via
+`bpf_l4_csum_replace` (available because both `usid_ingress`/`usid_egress`
+are TC-BPF, with a real `struct __sk_buff` — unlike `edgedsr.c`'s XDP
+context). This is **not** literally NPTv6-at-/128: RFC 6296's
+checksum-neutral trick needs an untouched Interface Identifier and an
+"elsewhere in the address" to fold the checksum delta into, and at a full
+/128 substitution (with the port possibly changing too) there is no
+"elsewhere" left — so this is a variant of "the same table/attach-point
+infrastructure" as NPTv6, not "the same math."
+
+Concretely, this needed one genuinely new piece of eBPF plumbing shared
+with component 2: **`usid_egress`, a new TC-BPF program attached at TC
+*ingress* of the tenant's own host-side veth (or tap device)** — the same
+interface `usid_ingress`'s own step 9 already redirects *to*, matching
+the standard "from-container" interception pattern. This attach point,
+not a shared physical uplink, is correct because by the time a tenant's
+outbound packet reaches the shared uplink, `RouteEgressAdd`'s own SEG6
+encap route has already pushed an outer header whose destination encodes
+the **remote** peer's identity, not the local sending VRF's — nothing to
+key a per-sender-VRF lookup on there without decoding the tenant's own
+(ambiguous, possibly-colliding) inner ULA source address. At the
+per-attachment ingress point instead, VRF identity is resolved via a new
+`ifindex_vrf_table` (key = `skb->ifindex` → `{block, argument}`),
+registered once per attachment at CNI ADD time and unregistered at DEL
+time — decoupled from the actual translation tables (`nptv6_table`,
+`vip_xlat_table`, both keyed by the same `(block, argument)` `vrf_table`
+already uses). `usid_egress` translates the packet's *source* (ULA→public
+outbound, or VIP-substitution outbound); `usid_ingress` gains the
+mirrored lookup after its own step 7 (strip) and before step 8 (FIB
+lookup), translating the packet's *destination* (public→ULA inbound, or
+VIP-substitution inbound) using the `(block, argument)` already resolved
+locally from steps 2–6.
+
+**Honest limitation, not oversold:** the guest application itself has no
+way to *learn* its own VIP at the socket/API level (no `getsockname()`
+visibility) unless told out-of-band (DNS, cloud-init metadata). A
+container backend that explicitly binds the VIP on its own loopback
+doesn't have this gap.
+
+## 1. Component 1 — Loopback VIP binding automation (backend nodes)
+
+**Package:** `internal/plumbing/vip`. Mirrors `internal/plumbing/vrf`'s
+shape (idempotent create/delete over netlink) and reuses `loaddr`'s
+detection precedent for what already lives on `lo`.
+
+```go
+package vip
+
+// Bind idempotently assigns vip to the node's dedicated VIP interface
+// (galactic-vip0, a dummy link this package owns exclusively — not lo,
+// since lo already carries the SRv6 locator address loaddr.Detect reads).
+func Bind(vip net.IP) error
+
+// Unbind idempotently removes vip. No-op (not an error) if already absent.
+func Unbind(vip net.IP) error
+
+// Verify confirms vip is actually live: present in the interface's address
+// list AND resolvable as a local (RTN_LOCAL) route via the kernel's own
+// route table — not just "AddrAdd returned nil".
+func Verify(vip net.IP) error
+```
+
+`galactic-vip0` is created lazily the first time `Bind` runs on a node.
+Binding/unbinding is driven by `ServiceVIPBinding` (namespaced, one per
+`(nodeName, vip)` pair), reconciled by `ServiceVIPBindingReconciler`
+inside `galactic-router`'s tenant role (not a new binary — this only
+needs `NET_ADMIN` + netlink, which tenant-mode `galactic-router` already
+has). `EgressKindTap` bindings take a different path — no loopback bind at
+all, instead a `vip_xlat_table` registration for the transparent tap-VIP
+substitution described in §0.1. `cmd/galactic-router` also gains a `vip
+bind|unbind|verify <addr>` CLI subcommand for manual/debug use, backed
+directly by the `vip` package.
+
+## 2. Component 2 — Per-VRF NPTv6 (RFC 6296)
+
+**Package:** `internal/plumbing/nptv6` (pure Go, no kernel dependency —
+mirrors `internal/plumbing/srv6`'s split between pure computation and the
+netlink/eBPF wiring that consumes it).
+
+```go
+package nptv6
+
+// Mapping is one tenant VRF's stateless prefix translation.
+type Mapping struct {
+	ULAPrefix    *net.IPNet
+	PublicPrefix *net.IPNet // same prefix length as ULAPrefix
+}
+
+// Adjustment precomputes the RFC 6296 §3.6 checksum-neutral adjustment
+// value for a Mapping, control-plane side, once.
+func (m Mapping) Adjustment() (uint16, error)
+
+// Translate applies m to addr (either direction — RFC 6296 translation is
+// symmetric).
+func Translate(m Mapping, addr net.IP, outbound bool) (net.IP, error)
+```
+
+Test vectors are pinned against RFC 6296 §3.6's own published worked
+example.
+
+**Scoping is the whole point:** the eBPF-side table
+(`internal/plumbing/ebpf/nptv6map`, mirroring `edgemap`'s
+Register/Reconcile/Generation crash-safety convention) is keyed **by
+VRFID**, never by address — resolved by the existing SRv6 uSID decap
+program before a packet is delivered into a tenant's VRF. Two tenants
+with colliding ULA prefixes get two independent `nptv6map` rows, never a
+single shared/global table.
+
+**Lifecycle:** `BGPVRFInstance.Spec` gains an optional `NPTv6
+*NPTv6Spec{ULAPrefix, PublicPrefix}`. `BGPRouterReconciler`'s
+`updateVRFInstanceStatuses` reports `ConditionNPTv6Configured`,
+validating spec (parseable CIDRs, matching prefix lengths,
+`nptv6.Mapping`'s own supported-length rules) — config validity only,
+since that reconciler has no access back to `nptv6_table`'s live kernel
+state from a different container. `gc.SweepEBPFNPTv6Table` is
+`nptv6_table`'s *only* writer, run from `internal/installer.Run` inside
+the CNI "run" container (the only container with `/sys/fs/bpf` +
+`CAP_BPF`): it both registers every currently-live NPTv6 mapping from
+`BGPVRFInstance` specs and reconciles stale entries away on every GC
+tick.
+
+## 3. Component 3 — Sharded stateful NAT66 tier
+
+**New, standalone component**, deliberately not folded into
+`galactic-gateway`'s XDP program, since its whole reason to exist is
+*not* sharing state or a hash ring with the backend-selection LB tier.
+`cmd/galactic-nat66` (new binary, own DaemonSet, own eBPF program/maps:
+`internal/plumbing/ebpf/nat66prog` + `nat66map`, mirroring the
+`edgeprog`/`edgemap`/`edgeattach` three-way split).
+
+### 3.1 Generic consistent-hash ring (shared with the LB tier's own use)
+
+`internal/maglev` (pure Go, no kernel/CRD dependency) implements Google's
+Maglev consistent-hash table (`New(backends, tableSize)`,
+`(*Table).Lookup(key)`), unit-tested including the paper's own
+disruption-bound property. Used by **both** `galactic-gateway`'s
+backend-selection ring (replacing a naive `hash % backend_count`, which
+reshuffles ~100% of flows on any backend-list change — Maglev bounds
+that to ~1/N, which is also what makes multi-node anycast-safe: every
+gateway node computes the identical table from the identical backend
+list) and component 3's shard-placement ring — a **separate `Table`
+instance**, never sharing a ring with the LB's own.
+
+### 3.2 Shard placement (outbound / translation leg)
+
+A new flow's shard assignment is chosen via a `maglev.Table` built over
+`(tenant VRFID, backend addr:port, dest addr:port)` — load-distributed,
+minimally disrupted when a shard node is added/removed.
+
+### 3.3 Return-leg routing — self-routing by construction
+
+Rather than requiring every node to hash a reply packet against a
+replicated shard-placement table, **each shard owns a dedicated,
+BGP-advertised public IPv6 address** (a `/128` advertisement, no
+VRFID/Function). A flow's allocated public port lives within *that*
+shard's own address, so ordinary unicast SRv6/BGP routing delivers a
+reply to the correct shard with **zero hashing on the return path** — the
+destination address already names the owner, satisfying the same
+property (any node can determine the owning shard from the tuple alone)
+more simply than recomputing a hash per reply packet.
+
+*Scale note:* this spends one public /128 per shard — cheap on this
+fabric's IPv6 addressing, would not generalize to a scarce-public-IPv4
+deployment; revisit with a shared-pool-plus-hash design if/when IPv4
+egress is ever in scope.
+
+### 3.4 Per-shard state
+
+`nat66map`'s `conn_table`: `BPF_MAP_TYPE_LRU_HASH`, self-evicting, no
+separate GC. Forward key `(proto, tenant_arg, backend_addr:port →
+dest_addr:port)`; reverse key `(proto, dest_addr:port →
+shard_addr:masq_port)`. `tenant_arg` (a VRFID) guards against two tenants
+presenting the same backend ULA colliding on the forward key. **Each
+shard owns its table exclusively** — no shared state, no cross-shard
+lookup, by construction.
+
+### 3.5 Minimal-disruption test under shard-set changes
+
+Synthesize N flows, hash each against a `maglev.Table` built from shard
+set S, record assignments; build a second table from S ± one node;
+re-hash the same N flows; assert the reassigned fraction is bounded
+(~1/|S|, allow some slack — the classic Maglev disruption-bound test).
+Separately: a reply packet keyed only by `(dest_addr:port,
+shard_addr:masq_port)` resolves to the exact shard that allocated it,
+purely from already-in-place-by-construction routing (§3.3) — this half
+needs no re-test under shard changes at all, since it was never
+hash-dependent.
+
+## 4. Ties between components
+
+- Component 1 (VIP binding) is what makes DSR possible at all — without
+  it, a backend has nothing to source replies from.
+- Component 2 (NPTv6) can sit in the same forward path as the LB's
+  consistent-hash selection because it's stateless — applied per-packet,
+  after VRF/tenant identity is already resolved, no conflict with DSR.
+- Component 3 (NAT66) is deliberately kept off that path entirely — a
+  tenant's *egress* traffic never touches the ingress LB's hash ring; a
+  different traffic pattern needing its own ring, its own state, its own
+  tier.
+
+## 5. Explicitly out of scope / open
+
+- **Closed during implementation — the gateway's backend-address→SID
+  resolver's missing tenant-identity check.** `usidresolver.go`'s
+  `buildBackendSIDIndex`/`resolveUSID` used to match a rule's backend
+  address against advertised prefixes by containment only — two tenants
+  with a backend at the identical ULA address, both configured on
+  different rules, resolved ambiguously. Fixed with zero CRD schema
+  changes: `resolveUSID` now takes the calling rule's `VPCRef` and
+  cross-checks each candidate advertisement's `(RouterRef, VRFID)` against
+  the specific `BGPVRFInstance` that VPC actually owns on that node,
+  named deterministically via `crdnames.BGPVRFInstanceName(vpc,
+  nodeName)`. A candidate whose owning VRF instance doesn't exist or
+  whose VRFID doesn't match is never trusted, regardless of prefix
+  containment.
+- `galactic-router` transit-mode interaction — unscoped, not assumed.
+- **External VIP announcement mechanism.** Nothing in this repo (old
+  design or this one) specifies how a VIP prefix reaches the actual
+  internet-facing border. Whatever does (FRR redistribution, a
+  `fabric-vip`-style component, or something else) must forward every
+  gateway node's independent route for a VIP, not pick "the best one."
+  Needs its own design pass before this redesign can be considered
+  complete end-to-end.
+- IPv4 for component 3 (see §3.3 scale note).
+- Anti-spoofing / trust boundary for egress traffic entering
+  `galactic-nat66` — deserves its own security pass before real traffic.
+- Public IPv6 prefix provisioning/allocation for component 3's per-shard
+  addresses — operator-supplied for phase 1, no in-cluster derivation yet
+  (matches this repo's existing precedent for gateway `SRv6Address`-style
+  values elsewhere).
+
+## 6. Removal scope — dead stateful-NAT code superseded by this design
+
+The `#865` stack built stateful egress NAT66 as a *second personality
+bolted onto the old Full-NAT `edgenat.c`* (`egress_config_table`/
+`egress_conn_table`, `handle_egress_forward`/`handle_egress_return`,
+`tenant_arg` = `BGPVRFInstance.Spec.VRFID` reused directly in the
+datapath key). None of that host program exists in this design —
+`galactic-gateway`'s XDP program is forward-only DSR (§0), with no
+egress personality of its own at all, and stateful NAT66 lives in its own
+standalone tier (component 3) with its own hash ring, own maps, own
+per-shard state, and self-routing return path (§3.3) instead of a
+per-gateway-node `tenant_arg`-keyed conn table. **Verdict: abandon, not
+salvage.**
+
+Concretely dead: branches `feat/865-egress-phase-a` through `-phase-e`
+(local and `origin`); PRs `galactic#380`/`381`/`383`/`385`/`386` (should
+be closed as superseded, not merged); `network#15`'s
+`NetworkEgressPolicy`/`NetworkGatewayStatus.EgressAddress`/`EgressSID`
+CRD additions (worth a second look for a simple per-VPC "egress enabled"
+toggle CRD, but their shape was designed around the old
+personality-on-the-gateway model — needs redesign, not reuse, when
+component 3's control-plane CRD is actually scoped).
+
+**Explicitly not done as part of this implementation:** deleting pushed
+branches and closing PRs that may have active reviewers is a distinct,
+outward-facing action from the code/design work above, and per explicit
+instruction was left alone — do it as its own deliberate step, with its
+own go-ahead, separately from this plan.
+
+## 7. Phased delivery (all phases below are done)
+
+0. ~~Remove the dead `#865` stack~~ — **left untouched on GitHub, on
+   purpose** (see §6's last paragraph); the local code superseding it is
+   in place regardless.
+1. **Component 1** (VIP bind/unbind/verify + CLI) — done.
+2. **`internal/maglev`** — done.
+3. **Component 2** (NPTv6) — done.
+4. **`galactic-gateway` DSR rewrite** — done: Full-NAT forward/return
+   logic replaced with DNAT-free consistent-hash forward-only,
+   `internal/maglev` wired in for backend selection,
+   `AssignPrimaryNode`/`LocalPreference`/self-address-advertisement
+   deleted (anycast makes them unnecessary).
+5. **Component 3** (`galactic-nat66`) — done: new binary, depends on
+   `internal/maglev` and the shard-address-advertisement mechanism from
+   step 4.
+
+## 8. Containerlab validation
+
+`deploy/containerlab/` has real, reusable scaffolding for every component
+here (the `ns10`/`ns20`/`ns30`/`ns40`/`ns60` tenant fixtures, the
+`iad-gateway1`/`iad-gateway2` gateway-role nodes) — this section is
+grounded in what actually exists, not a green-field lab design. **Not yet
+done** — the two items below are the concrete remaining work before this
+redesign can claim containerlab validation beyond manifests:
+
+**Known blocker, root-caused during implementation — two stacked
+issues, not one.** The lab's own `README.md` used to describe "real
+end-to-end ingress traffic through the datapath still doesn't reach a
+backend in this topology — it currently stops on a veth-specific
+`XDP_TX` behavior," attributed to the lab environment generically.
+Live-kernel investigation found it is actually two separate, stacked
+issues:
+
+1. **IPv6 forwarding sysctls not enabled** — `bpf_fib_lookup()` (used
+   identically by `edgedsr.c`'s and `nat66.c`'s `push_outer_header`)
+   returned `BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup, since the
+   kernel correctly refuses to resolve a route on an interface not
+   configured as a router. **Fixed:**
+   `sysctl.ConfigureFIBLookupUplinkSysctls` now sets both
+   `net.ipv6.conf.<iface>.forwarding` and `net.ipv6.conf.all.forwarding`
+   (empirically confirmed both are required together) from both
+   `cmd/galactic-gateway` and `cmd/galactic-nat66` startup.
+2. **veth's native `XDP_TX` fast path is invisible to normal observation
+   unless the peer also runs an XDP program.** A frame `XDP_TX`'d on one
+   veth leg is only promoted into the peer's normal receive stack
+   (visible to tcpdump/AF_PACKET) if the peer interface *also* has an
+   XDP program attached — otherwise delivery uses a raw fast-path queue
+   nothing but another XDP program on that peer can see. **Not fixable
+   in this datapath's own code** — a genuine veth/kernel characteristic
+   that doesn't apply to a real physical NIC uplink in production, only
+   to this lab's veth-pair simulation of one. Document as a lab-only
+   caveat when this section's live-traffic validation is actually run,
+   not carried forward as an unexplained blocker.
+
+**Bonus find while chasing the above with a strict external observer
+(tcpdump) instead of just `BPF_PROG_TEST_RUN`:** two real,
+previously-undiscovered wire-format bugs in `push_outer_header`,
+inherited unchanged from the removed `edgenat.c` into both `edgedsr.c`
+and `nat66.c` — the pushed outer IPv6 header's version nibble was left
+zeroed instead of set to 6, and `payload_len` undercounted the outer
+header's declared length by the inner IPv6 header's own 40 bytes. Both
+fixed in both C programs, with regression-guard test assertions added.
+
+**Second known gap: no tap/VM fixture exists in this lab at all.** Every
+tenant fixture is a plain k8s `Deployment` (container/veth backend);
+§0.1's veth-vs-tap requirement can only be validated for the veth half in
+this lab as it stands. The tap half needs a new fixture built on
+`galactic-tap`/`internal/cnitap`'s existing attach path before it's
+testable at all.
+
+### Per-component validation, reusing real lab fixtures (not yet run)
+
+- **Component 1 (VIP binding).** veth case: validate against `ns60`'s
+  existing backend pod. tap/VM case: per §0.1's resolution, this is the
+  transparent `usid_ingress`/`usid_egress` translation, proven against a
+  real VM once a tap fixture exists.
+- **Component 2 (NPTv6).** `ns10` (`fd20` ULA, already 3-site) is the
+  ready-made base case; add a second tenant on the same ULA range (a new
+  `ns70`-style fixture) to prove overlapping-prefix disambiguation live.
+- **Phase 4 (`galactic-gateway` DSR rewrite).** Reuses
+  `resources/galactic-gateway/{base,iad,iad-gateway1,iad-gateway2}`
+  unchanged and the `ns60` fixture unchanged. Two things to prove, now
+  that the sysctl blocker is fixed: (1) a real client → VIP → backend →
+  direct-reply round-trip, asserting the reply's source address; (2) the
+  anycast spike's finding against real BGP — both `iad-gateway1`/
+  `iad-gateway2` routes reaching a third site independently.
+- **Component 3 / phase 5 (`galactic-nat66` shard tier).** Reuse the
+  three existing site workers as a 3-shard DaemonSet. Validate the
+  minimal-disruption property (§3.5) against real node removal:
+  drain/cordon one worker, confirm only that worker's own flows
+  reassign, confirm the reply-routing self-addressing (§3.3) survives the
+  shard-set change unchanged.
+
+### New verification tasks (naming matches existing `verify:*` convention)
+
+`verify:vip-binding`, `verify:nptv6`, `verify:dsr-gateway` (extends
+`verify:gateway` past "CRDs exist" now that the sysctl blocker is fixed),
+`verify:nat66-sharding`. Each should be addable to `task verify`'s
+existing aggregate the same way `verify:ns10`..`verify:ns40` already are.

--- a/internal/config/nat66.go
+++ b/internal/config/nat66.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// --- NAT66 defaults ---------------------------------------------------
+
+const (
+	// DefaultNAT66MetricsPort/DefaultNAT66GRPCHealthPort are the next
+	// unused values past every other hostNetwork: true galactic-* process
+	// already running on a node: fabric-router's BGP listener (179),
+	// galactic-router's grpc-health/metrics (5179/9179), galactic-cni's
+	// (5180/9180), and galactic-gateway's (5181/8081 -- see
+	// internal/config/gateway.go's own doc comment for why that pair
+	// isn't a clean continuation of the 517x/917x pattern). galactic-nat66
+	// is deployed on its own dedicated, hostNetwork: true shard nodes
+	// (config/galactic-nat66/base/daemonset.yaml) -- disjoint from
+	// galactic-gateway's own gateway-role nodes -- but a node's role
+	// labels are not mutually exclusive by construction, so these still
+	// avoid every value already claimed above rather than assuming no
+	// overlap will ever happen.
+	DefaultNAT66MetricsPort    = 9182
+	DefaultNAT66GRPCHealthPort = 5182
+)
+
+// --- NAT66 environment variable keys ------------------------------------
+
+const (
+	EnvNAT66NodeName       = "GALACTIC_NAT66_NODE_NAME"
+	EnvNAT66MetricsPort    = "GALACTIC_NAT66_METRICS_PORT"
+	EnvNAT66GRPCHealthPort = "GALACTIC_NAT66_GRPC_HEALTH_PORT"
+
+	// EnvNAT66UplinkInterface names this shard's single fabric-facing
+	// uplink interface -- the interface
+	// internal/plumbing/ebpf/nat66prog's XDP program attaches to. Required:
+	// galactic-nat66 only ever runs as a dedicated NAT66 shard, so there is
+	// no "not this role, skip the datapath" case to support, mirroring
+	// config.EnvGatewayPublicInterface's identical reasoning.
+	EnvNAT66UplinkInterface = "GALACTIC_NAT66_UPLINK_INTERFACE"
+
+	// EnvNAT66ShardSID is this shard's own SRv6 uSID
+	// (network.datumapis.com/v1alpha1's NAT66ShardStatus.ShardSID) --
+	// the outer destination a tenant's egress packet is encapsulated
+	// toward. Required -- see EnvNAT66UplinkInterface. Operator-supplied
+	// today (no in-cluster derivation mechanism yet -- the same gap
+	// BGPRouter.Spec.SRv6Locator/NodeID assignment and
+	// GALACTIC_GATEWAY_SRV6_ADDRESS both have today; see
+	// docs/agents/ARCHITECTURE-GATEWAY.md's "Argument-0 reservation"
+	// section for the established precedent this follows).
+	EnvNAT66ShardSID = "GALACTIC_NAT66_SHARD_SID"
+
+	// EnvNAT66ShardPubAddr is this shard's own publicly-routable
+	// masquerade source address (NAT66ShardStatus.ShardAddress) -- every
+	// flow this shard NATs is SNAT'd to an address:port within it.
+	// Required -- see EnvNAT66UplinkInterface.
+	EnvNAT66ShardPubAddr = "GALACTIC_NAT66_SHARD_PUB_ADDR"
+)
+
+// --- NAT66Config ---------------------------------------------------------
+
+// NAT66Config resolves galactic-nat66 configuration with three-tier
+// precedence: CLI flag > env var > compiled-in default. Create once via
+// NewNAT66Config(), call BindFlags() to layer CLI flags, then read the
+// exported fields.
+type NAT66Config struct {
+	v      *viper.Viper
+	prefix string
+
+	// Resolved fields.
+	NodeName       string
+	MetricsPort    int
+	GRPCHealthPort int
+
+	// UplinkInterface/ShardSID/ShardPubAddr configure the NAT66 egress
+	// shard datapath -- see EnvNAT66UplinkInterface's doc comment. All
+	// three required; NAT66Config.Validate rejects any being empty.
+	UplinkInterface string
+	ShardSID        string
+	ShardPubAddr    string
+}
+
+// NewNAT66Config creates a NAT66 config resolver with the GALACTIC_NAT66
+// env prefix and AutomaticEnv enabled. Exported fields are populated from
+// env vars and defaults; call BindFlags() to layer CLI overrides.
+func NewNAT66Config() *NAT66Config {
+	v := viper.New()
+	v.SetEnvPrefix("GALACTIC_NAT66")
+	v.AutomaticEnv()
+
+	v.SetDefault(KeyNodeName, "")
+	v.SetDefault(KeyMetricsPort, DefaultNAT66MetricsPort)
+	v.SetDefault(KeyGRPCHealthPort, DefaultNAT66GRPCHealthPort)
+	v.SetDefault("uplink_interface", "")
+	v.SetDefault("shard_sid", "")
+	v.SetDefault("shard_pub_addr", "")
+
+	cfg := &NAT66Config{
+		v:      v,
+		prefix: "GALACTIC_NAT66",
+	}
+	cfg.readFields()
+	return cfg
+}
+
+// BindFlags binds Cobra/pflag flags to the config resolver and re-reads
+// the exported fields. Each flag is bound to a Viper key using the key
+// argument.
+func (c *NAT66Config) BindFlags(flags *pflag.FlagSet) {
+	bindings := []struct {
+		flag string
+		key  string
+	}{
+		{FlagNodeName, KeyNodeName},
+		{FlagMetricsPort, KeyMetricsPort},
+		{FlagGRPCHealthPort, KeyGRPCHealthPort},
+		{"nat66-uplink-interface", "uplink_interface"},
+		{"nat66-shard-sid", "shard_sid"},
+		{"nat66-shard-pub-addr", "shard_pub_addr"},
+	}
+	for _, b := range bindings {
+		if flags.Changed(b.flag) {
+			c.v.Set(b.key, flags.Lookup(b.flag).Value.String())
+		} else {
+			//nolint:errcheck // controlled keys, BindPFlag cannot fail here
+			c.v.BindPFlag(b.key, flags.Lookup(b.flag))
+		}
+	}
+	c.readFields()
+}
+
+// readFields populates the exported fields from the current Viper state.
+func (c *NAT66Config) readFields() {
+	c.NodeName = c.v.GetString(KeyNodeName)
+	c.MetricsPort = c.v.GetInt(KeyMetricsPort)
+	c.GRPCHealthPort = c.v.GetInt(KeyGRPCHealthPort)
+	c.UplinkInterface = c.v.GetString("uplink_interface")
+	c.ShardSID = c.v.GetString("shard_sid")
+	c.ShardPubAddr = c.v.GetString("shard_pub_addr")
+}
+
+// validateShardAddr parses and range-checks a shard identity address
+// (ShardSID or ShardPubAddr), rejecting anything that isn't a native
+// IPv6 address -- caught eventually anyway by
+// internal/plumbing/ebpf/nat66map's identical check, but late: only once
+// setupNat66Datapath has already loaded and attached the eBPF datapath.
+// Reject it here instead, at startup, with a message that names the
+// actual field rather than surfacing as a deeper, less obvious
+// kernel-datapath error -- mirrors GatewayConfig.Validate's identical
+// SRv6Address check.
+func validateShardAddr(field, value string) error {
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return fmt.Errorf("%s %q is not a valid IP address: %w", field, value, err)
+	}
+	if !addr.Is6() || addr.Is4In6() {
+		return fmt.Errorf("%s %q must be a native IPv6 address, not IPv4", field, value)
+	}
+	return nil
+}
+
+// Validate checks that the required configuration fields are set.
+func (c *NAT66Config) Validate() error {
+	if c.NodeName == "" {
+		return fmt.Errorf("node name is required (use --node-name flag or %s env var)", EnvNAT66NodeName)
+	}
+	if c.UplinkInterface == "" {
+		return fmt.Errorf(
+			"uplink interface is required (use --nat66-uplink-interface flag or %s env var)", EnvNAT66UplinkInterface)
+	}
+	if c.ShardSID == "" {
+		return fmt.Errorf(
+			"shard SID is required (use --nat66-shard-sid flag or %s env var)", EnvNAT66ShardSID)
+	}
+	if err := validateShardAddr("shard SID", c.ShardSID); err != nil {
+		return err
+	}
+	if c.ShardPubAddr == "" {
+		return fmt.Errorf(
+			"shard public address is required (use --nat66-shard-pub-addr flag or %s env var)", EnvNAT66ShardPubAddr)
+	}
+	if err := validateShardAddr("shard public address", c.ShardPubAddr); err != nil {
+		return err
+	}
+	if c.MetricsPort < 1 || c.MetricsPort > 65535 {
+		return errors.New("metrics port must be between 1 and 65535")
+	}
+	if c.GRPCHealthPort < 1 || c.GRPCHealthPort > 65535 {
+		return errors.New("grpc health port must be between 1 and 65535")
+	}
+	return nil
+}

--- a/internal/config/nat66_test.go
+++ b/internal/config/nat66_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	testNAT66NodeName = "test-nat66-node"
+	testNAT66Iface    = "eth1"
+	testNAT66ShardSID = "fc00:1:2::1"
+	testNAT66ShardPub = "2001:db8:9999::1"
+)
+
+func TestNAT66ConfigDefaults(t *testing.T) {
+	cfg := NewNAT66Config()
+
+	if cfg.MetricsPort != DefaultNAT66MetricsPort {
+		t.Errorf("MetricsPort = %d, want %d", cfg.MetricsPort, DefaultNAT66MetricsPort)
+	}
+	if cfg.GRPCHealthPort != DefaultNAT66GRPCHealthPort {
+		t.Errorf("GRPCHealthPort = %d, want %d", cfg.GRPCHealthPort, DefaultNAT66GRPCHealthPort)
+	}
+	if cfg.NodeName != "" {
+		t.Errorf("NodeName = %q, want empty", cfg.NodeName)
+	}
+	if cfg.UplinkInterface != "" {
+		t.Errorf("UplinkInterface = %q, want empty", cfg.UplinkInterface)
+	}
+	if cfg.ShardSID != "" {
+		t.Errorf("ShardSID = %q, want empty", cfg.ShardSID)
+	}
+	if cfg.ShardPubAddr != "" {
+		t.Errorf("ShardPubAddr = %q, want empty", cfg.ShardPubAddr)
+	}
+}
+
+func TestNAT66ConfigEnvOverride(t *testing.T) {
+	t.Setenv(EnvNAT66NodeName, testEnvNode)
+	t.Setenv(EnvNAT66MetricsPort, "9090")
+	t.Setenv(EnvNAT66GRPCHealthPort, "9091")
+	t.Setenv(EnvNAT66UplinkInterface, testNAT66Iface)
+	t.Setenv(EnvNAT66ShardSID, testNAT66ShardSID)
+	t.Setenv(EnvNAT66ShardPubAddr, testNAT66ShardPub)
+
+	cfg := NewNAT66Config()
+
+	if cfg.NodeName != testEnvNode {
+		t.Errorf("NodeName = %q, want %q", cfg.NodeName, testEnvNode)
+	}
+	if cfg.MetricsPort != 9090 {
+		t.Errorf("MetricsPort = %d, want 9090", cfg.MetricsPort)
+	}
+	if cfg.GRPCHealthPort != 9091 {
+		t.Errorf("GRPCHealthPort = %d, want 9091", cfg.GRPCHealthPort)
+	}
+	if cfg.UplinkInterface != testNAT66Iface {
+		t.Errorf("UplinkInterface = %q, want %q", cfg.UplinkInterface, testNAT66Iface)
+	}
+	if cfg.ShardSID != testNAT66ShardSID {
+		t.Errorf("ShardSID = %q, want %q", cfg.ShardSID, testNAT66ShardSID)
+	}
+	if cfg.ShardPubAddr != testNAT66ShardPub {
+		t.Errorf("ShardPubAddr = %q, want %q", cfg.ShardPubAddr, testNAT66ShardPub)
+	}
+}
+
+func TestNAT66ConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		wantErr string
+	}{
+		{
+			name: testCaseMissingNodeName,
+			envVars: map[string]string{
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+			},
+			wantErr: testErrNodeNameRequired,
+		},
+		{
+			name: "missing uplink interface",
+			envVars: map[string]string{
+				EnvNAT66NodeName:     testNAT66NodeName,
+				EnvNAT66ShardSID:     testNAT66ShardSID,
+				EnvNAT66ShardPubAddr: testNAT66ShardPub,
+			},
+			wantErr: "uplink interface is required",
+		},
+		{
+			name: "missing shard SID",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+			},
+			wantErr: "shard SID is required",
+		},
+		{
+			name: "unparseable shard SID",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        "not-an-ip-address",
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+			},
+			wantErr: "is not a valid IP address",
+		},
+		{
+			name: "ipv4 shard SID is wrong family",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testIPv4Addr,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+			},
+			wantErr: testErrMustBeNativeIPv6,
+		},
+		{
+			name: "missing shard public address",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+			},
+			wantErr: "shard public address is required",
+		},
+		{
+			name: "ipv4 shard public address is wrong family",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+				EnvNAT66ShardPubAddr:    testIPv4Addr,
+			},
+			wantErr: testErrMustBeNativeIPv6,
+		},
+		{
+			name: testCaseInvalidMetricsPort,
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+				EnvNAT66MetricsPort:     "0",
+			},
+			wantErr: testErrMetricsPortRange,
+		},
+		{
+			name: testCaseInvalidGRPCHealthPort,
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+				EnvNAT66GRPCHealthPort:  "0",
+			},
+			wantErr: testErrGRPCHealthPortRange,
+		},
+		{
+			name: "valid config",
+			envVars: map[string]string{
+				EnvNAT66NodeName:        testNAT66NodeName,
+				EnvNAT66UplinkInterface: testNAT66Iface,
+				EnvNAT66ShardSID:        testNAT66ShardSID,
+				EnvNAT66ShardPubAddr:    testNAT66ShardPub,
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+			cfg := NewNAT66Config()
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("Validate() = nil, want error containing %q", tc.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() = %q, want error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/controller/nat66shard_controller.go
+++ b/internal/controller/nat66shard_controller.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// NAT66DatapathHealth reports whether this node's NAT66 egress XDP
+// datapath (internal/plumbing/ebpf/nat66prog, loaded and attached by
+// cmd/galactic-nat66's setupNat66Datapath) is currently attached and
+// serving traffic -- the interface NAT66ShardReconciler uses to decide
+// whether to set its Ready condition True, mirroring GatewayEngine's
+// interface-seam pattern in networkgateway_controller.go for
+// test-fakeability.
+type NAT66DatapathHealth interface {
+	// Attached reports whether the datapath is loaded and attached.
+	Attached() bool
+}
+
+const (
+	// reasonNAT66DatapathAttached is the Ready condition reason once the
+	// datapath is confirmed attached.
+	reasonNAT66DatapathAttached = "DatapathAttached"
+
+	// reasonNAT66DatapathNotAttached is the Ready condition reason while
+	// the datapath is not yet (or no longer) attached.
+	reasonNAT66DatapathNotAttached = "DatapathNotAttached"
+)
+
+// NAT66ShardReconciler reconciles the single NAT66Shard object for this
+// node (spec.targetRef.name == NodeName), mirroring
+// NetworkGatewayReconciler's node-scoped root-object pattern -- but much
+// simpler: there is no rule/backend desired-state assembly here at all.
+// This reconciler's only job is to publish Status.ShardAddress/
+// Status.ShardSID, echoing back the operator-configured values this
+// node's own cmd/galactic-nat66 process was started with (ShardAddress/
+// ShardSID below -- plain strings, not re-derived from anything), and set
+// a Ready condition once the datapath is confirmed attached.
+type NAT66ShardReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	NodeName string
+
+	// ShardAddress/ShardSID are this node's own operator-configured NAT66
+	// shard identity (config.NAT66Config.ShardPubAddr/ShardSID,
+	// already the values the running datapath was configured with -- see
+	// cmd/galactic-nat66's setupNat66Datapath). This reconciler publishes
+	// them, it does not compute them -- same division of responsibility
+	// as NetworkGatewayReconciler.SRv6Address/publishSelfAddress.
+	ShardAddress string
+	ShardSID     string
+
+	// Datapath reports whether this node's NAT66 datapath is currently
+	// attached -- see NAT66DatapathHealth's doc comment.
+	Datapath NAT66DatapathHealth
+}
+
+// Reconcile reconciles a single NAT66Shard.
+func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	shard := &bgpv1alpha1.NAT66Shard{}
+	if err := r.Get(ctx, req.NamespacedName, shard); err != nil {
+		if apierrors.IsNotFound(err) {
+			// No finalizer, no cross-node cleanup to perform: unlike
+			// NetworkGateway (whose deletion must withdraw BGPAdvertisements
+			// other nodes may still be depending on), a NAT66Shard carries no
+			// other object this reconciler is responsible for tearing down.
+			// There is simply nothing left to reconcile once the object is
+			// gone.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get NAT66Shard %s: %w", req.NamespacedName, err)
+	}
+
+	// Node check: skip shards that don't target this node, mirroring
+	// NetworkGatewayReconciler's identical targetRef.Name check.
+	if shard.Spec.TargetRef.Name != r.NodeName {
+		return ctrl.Result{}, nil
+	}
+
+	if !shard.DeletionTimestamp.IsZero() {
+		// Nothing to tear down beyond the object itself -- see the NotFound
+		// branch above for why this reconciler owns no other resource's
+		// lifecycle.
+		return ctrl.Result{}, nil
+	}
+
+	shardCopy := shard.DeepCopy()
+	shardCopy.Status.ObservedGeneration = shard.Generation
+	if r.ShardAddress != "" {
+		shardCopy.Status.ShardAddress = r.ShardAddress
+	}
+	if r.ShardSID != "" {
+		shardCopy.Status.ShardSID = r.ShardSID
+	}
+	setNAT66ShardCondition(shardCopy, r.readyCondition())
+
+	if err := r.Status().Update(ctx, shardCopy); err != nil {
+		logger.Error(err, "update NAT66Shard status", "nat66Shard", req.NamespacedName)
+		return ctrl.Result{}, fmt.Errorf("update NAT66Shard %s status: %w", req.NamespacedName, err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// readyCondition computes the Ready condition from the datapath's current
+// attachment state. A nil Datapath (not expected in production --
+// cmd/galactic-nat66 always wires a real one -- but guarded against for
+// test/defensive-programming reasons the same way GatewayEngine's own
+// callers never pass nil) is treated as not attached, not as a panic.
+func (r *NAT66ShardReconciler) readyCondition() metav1.Condition {
+	if r.Datapath != nil && r.Datapath.Attached() {
+		return metav1.Condition{
+			Type:    bgpv1alpha1.ConditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  reasonNAT66DatapathAttached,
+			Message: "NAT66 egress datapath is attached and serving traffic",
+		}
+	}
+	return metav1.Condition{
+		Type:    bgpv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  reasonNAT66DatapathNotAttached,
+		Message: "NAT66 egress datapath is not yet attached",
+	}
+}
+
+// SetupWithManager registers the NAT66ShardReconciler with the manager.
+func (r *NAT66ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&bgpv1alpha1.NAT66Shard{}).
+		Named("nat66shard").
+		Complete(r)
+}

--- a/internal/controller/nat66shard_controller_test.go
+++ b/internal/controller/nat66shard_controller_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	testNAT66Namespace   = "galactic-system"
+	testNAT66NodeA       = "node-a"
+	testNAT66NodeB       = "node-b"
+	testNAT66ShardName   = "node-a"
+	testNAT66ShardAddr   = "2001:db8:9999::1"
+	testNAT66ShardSIDVal = "fc00:1:2::1"
+)
+
+// fakeDatapathHealth is a NAT66DatapathHealth test double whose Attached
+// return value is directly settable.
+type fakeDatapathHealth struct {
+	attached bool
+}
+
+func (f *fakeDatapathHealth) Attached() bool { return f.attached }
+
+func nat66TestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	utilruntime.Must(bgpv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+// newNAT66Shard builds the fixture NAT66Shard object (always named
+// testNAT66ShardName, matching every reconcileReq call below) targeting
+// nodeName.
+func newNAT66Shard(nodeName string) *bgpv1alpha1.NAT66Shard {
+	return &bgpv1alpha1.NAT66Shard{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNAT66Namespace, Name: testNAT66ShardName},
+		Spec: bgpv1alpha1.NAT66ShardSpec{
+			TargetRef: bgpv1alpha1.TargetRef{Kind: "Node", Name: nodeName},
+		},
+	}
+}
+
+// nat66ReconcilerParams bundles newNAT66Reconciler's arguments so the
+// per-test call sites don't overflow the line-length limit.
+type nat66ReconcilerParams struct {
+	client   client.Client
+	scheme   *runtime.Scheme
+	nodeName string
+	addr     string
+	sid      string
+	datapath NAT66DatapathHealth
+}
+
+func newNAT66Reconciler(p nat66ReconcilerParams) *NAT66ShardReconciler {
+	return &NAT66ShardReconciler{
+		Client:       p.client,
+		Scheme:       p.scheme,
+		NodeName:     p.nodeName,
+		ShardAddress: p.addr,
+		ShardSID:     p.sid,
+		Datapath:     p.datapath,
+	}
+}
+
+func reconcileReq(name string) ctrl.Request {
+	return ctrl.Request{NamespacedName: client.ObjectKey{Namespace: testNAT66Namespace, Name: name}}
+}
+
+func TestNAT66ShardReconciler_NotFoundIsANoop(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq("does-not-exist")); err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil for a NotFound object", err)
+	}
+}
+
+func TestNAT66ShardReconciler_SkipsShardForAnotherNode(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeB)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+	if got.Status.ShardAddress != "" {
+		t.Errorf("Status.ShardAddress = %q, want untouched empty string (shard targets another node)",
+			got.Status.ShardAddress)
+	}
+	if len(got.Status.Conditions) != 0 {
+		t.Errorf("Status.Conditions = %+v, want untouched empty slice (shard targets another node)",
+			got.Status.Conditions)
+	}
+}
+
+func TestNAT66ShardReconciler_PublishesStatusWhenAttached(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+	if got.Status.ShardAddress != testNAT66ShardAddr {
+		t.Errorf("Status.ShardAddress = %q, want %q", got.Status.ShardAddress, testNAT66ShardAddr)
+	}
+	if got.Status.ShardSID != testNAT66ShardSIDVal {
+		t.Errorf("Status.ShardSID = %q, want %q", got.Status.ShardSID, testNAT66ShardSIDVal)
+	}
+	if got.Status.ObservedGeneration != shard.Generation {
+		t.Errorf("Status.ObservedGeneration = %d, want %d", got.Status.ObservedGeneration, shard.Generation)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, bgpv1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("Ready condition not set")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Ready condition status = %v, want True", cond.Status)
+	}
+	if cond.Reason != reasonNAT66DatapathAttached {
+		t.Errorf("Ready condition reason = %q, want %q", cond.Reason, reasonNAT66DatapathAttached)
+	}
+}
+
+func TestNAT66ShardReconciler_ReadyFalseWhenNotAttached(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: false},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+
+	cond := meta.FindStatusCondition(got.Status.Conditions, bgpv1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("Ready condition not set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready condition status = %v, want False", cond.Status)
+	}
+	if cond.Reason != reasonNAT66DatapathNotAttached {
+		t.Errorf("Ready condition reason = %q, want %q", cond.Reason, reasonNAT66DatapathNotAttached)
+	}
+}
+
+func TestNAT66ShardReconciler_NilDatapathIsNotAttached(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: nil,
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+	cond := meta.FindStatusCondition(got.Status.Conditions, bgpv1alpha1.ConditionTypeReady)
+	if cond == nil {
+		t.Fatal("Ready condition not set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Ready condition status = %v, want False for a nil Datapath", cond.Status)
+	}
+}
+
+func TestNAT66ShardReconciler_DeletingShardIsANoop(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	shard.Finalizers = []string{"test.datum.net/keep"} // required for the fake client to accept a deletion timestamp
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+
+	if err := c.Delete(context.Background(), shard); err != nil {
+		t.Fatalf("delete shard: %v", err)
+	}
+
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+	if got.Status.ShardAddress != "" {
+		t.Errorf("Status.ShardAddress = %q, want untouched empty string for a terminating shard", got.Status.ShardAddress)
+	}
+}
+
+func TestNAT66ShardReconciler_EmptyConfiguredValuesLeaveStatusUntouched(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	shard.Status.ShardAddress = testNAT66ShardAddr
+	shard.Status.ShardSID = testNAT66ShardSIDVal
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+
+	// A reconciler started with empty ShardAddress/ShardSID (shouldn't
+	// happen in production -- config.NAT66Config.Validate requires both --
+	// but must not clobber a previously-published value with an empty
+	// string if it somehow does).
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: "", sid: "", datapath: &fakeDatapathHealth{attached: true},
+	})
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.NAT66Shard{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get shard after reconcile: %v", err)
+	}
+	if got.Status.ShardAddress != testNAT66ShardAddr {
+		t.Errorf("Status.ShardAddress = %q, want untouched %q", got.Status.ShardAddress, testNAT66ShardAddr)
+	}
+	if got.Status.ShardSID != testNAT66ShardSIDVal {
+		t.Errorf("Status.ShardSID = %q, want untouched %q", got.Status.ShardSID, testNAT66ShardSIDVal)
+	}
+}

--- a/internal/plumbing/ebpf/nat66attach/attach.go
+++ b/internal/plumbing/ebpf/nat66attach/attach.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66attach
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+// PinDir is the default bpffs directory every nat66prog map is pinned
+// under -- deliberately distinct from every other datapath's own PinDir
+// in this codebase (internal/plumbing/ebpf/attach.PinDir,
+// internal/plumbing/ebpf/edgeattach.PinDir), so this datapath is fully
+// independent under bpffs even where map names don't actually collide.
+const PinDir = "/sys/fs/bpf/galactic-nat66"
+
+// Load loads nat66prog's compiled object with every map pinned under
+// pinDir. A map already pinned there from a previous process is reused
+// as-is; see internal/plumbing/ebpf/edgeattach.Load's identical doc
+// comment for the full rationale (schema-mismatch recreation, pin-by-name
+// semantics) -- not repeated here, since it applies unchanged. See doc.go
+// for why, unlike edgeattach.Load, there is no kernel preflight check
+// here.
+func Load(pinDir string) (*nat66prog.Nat66Objects, error) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		return nil, fmt.Errorf("nat66attach: remove memlock rlimit: %w", err)
+	}
+	if err := os.MkdirAll(pinDir, 0o755); err != nil {
+		return nil, fmt.Errorf("nat66attach: create bpf map pin directory %q: %w", pinDir, err)
+	}
+
+	spec, err := nat66prog.LoadNat66()
+	if err != nil {
+		return nil, fmt.Errorf("nat66attach: load compiled nat66 collection spec: %w", err)
+	}
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinByName
+	}
+
+	var loaded nat66prog.Nat66Objects
+	opts := &ebpf.CollectionOptions{Maps: ebpf.MapOptions{PinPath: pinDir}}
+	loadErr := spec.LoadAndAssign(&loaded, opts)
+	if loadErr != nil && errors.Is(loadErr, ebpf.ErrMapIncompatible) {
+		// Every map here is either control-plane-owned and reconstructable
+		// (shard_config_table is rewritten once at process startup by
+		// cmd/galactic-nat66's setupNat66Datapath) or datapath-owned and
+		// self-managed (nat66_conn_table is an LRU that self-evicts;
+		// drop_reasons is a pure counter array) -- a stale pin from an
+		// older, incompatible map layout is safe to recreate rather than
+		// fatal.
+		slog.Warn("nat66attach: pinned eBPF map incompatible with the newly compiled map spec, recreating "+
+			"(control-plane state will repopulate at next startup)", "pinDir", pinDir, "err", loadErr)
+		if unpinErr := unpinIncompatibleMaps(spec, pinDir); unpinErr != nil {
+			return nil, fmt.Errorf("nat66attach: recreate incompatible pinned maps: %w", unpinErr)
+		}
+		loadErr = spec.LoadAndAssign(&loaded, opts)
+	}
+	if loadErr != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(loadErr, &ve) {
+			return nil, fmt.Errorf("nat66attach: verifier rejected nat66_ingress program:\n%w", ve)
+		}
+		return nil, fmt.Errorf("nat66attach: load and pin nat66 objects: %w", loadErr)
+	}
+	return &loaded, nil
+}
+
+// unpinIncompatibleMaps mirrors internal/plumbing/ebpf/edgeattach's
+// identical helper -- see that function's doc comment.
+func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
+	var errs []error
+	for name := range spec.Maps {
+		path := filepath.Join(pinDir, name)
+		m, err := ebpf.LoadPinnedMap(path, nil)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("load pinned map %q for recreation: %w", name, err))
+			continue
+		}
+		if err := m.Unpin(); err != nil {
+			errs = append(errs, fmt.Errorf("unpin stale map %q: %w", name, err))
+		}
+		_ = m.Close()
+	}
+	return errors.Join(errs...)
+}
+
+// Attach attaches program (nat66prog.Nat66Objects.Nat66Ingress) to
+// ifaceName's XDP hook in native (driver) mode, returning the resulting
+// link.Link for the caller to hold open and Close on shutdown -- see
+// doc.go for why native mode is required, not merely preferred, and why no
+// pinning or Watch-style re-attachment is needed here.
+func Attach(program *ebpf.Program, ifaceName string) (link.Link, error) {
+	if program == nil {
+		return nil, errors.New("nat66attach: program is nil")
+	}
+
+	iface, err := netlink.LinkByName(ifaceName)
+	if err != nil {
+		return nil, fmt.Errorf("nat66attach: find link %q: %w", ifaceName, err)
+	}
+
+	xdpLink, err := link.AttachXDP(link.XDPOptions{
+		Program:   program,
+		Interface: iface.Attrs().Index,
+		Flags:     link.XDPDriverMode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"nat66attach: attach XDP program to %q in native/driver mode: %w "+
+				"(this program requires native XDP support -- generic/SKB mode is not attempted, "+
+				"see this package's doc comment)",
+			ifaceName, err,
+		)
+	}
+	return xdpLink, nil
+}

--- a/internal/plumbing/ebpf/nat66attach/attach_test.go
+++ b/internal/plumbing/ebpf/nat66attach/attach_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66attach
+
+import (
+	"fmt"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN/CAP_SYS_ADMIN) to load/attach BPF programs " +
+			"and create a test network namespace; re-run via sudo")
+	}
+}
+
+// TestAttach_NilProgramIsError covers Attach's defensive nil-program
+// guard directly, without needing root.
+func TestAttach_NilProgramIsError(t *testing.T) {
+	if _, err := Attach(nil, "eth0"); err == nil {
+		t.Error("Attach(nil program, ...) error = nil, want an error")
+	}
+}
+
+// TestLoadAttach_SurvivesRestartWithMapsIntact is the real, root-gated
+// exit criterion: program load/attach survives a simulated process
+// restart with pinned maps intact. Unlike a TC-BPF filter (which persists
+// in the kernel independent of any process), an unpinned XDP bpf_link
+// detaches when its owning process's file descriptor closes -- so
+// simulating "restart" here means explicitly Close()ing the first
+// attach's link before re-attaching, not just calling Attach twice in a
+// row (see doc.go).
+//
+// Uses a veth pair, not a dummy interface: dummy's driver, like geneve's,
+// does not implement ndo_bpf, so it cannot accept a native-mode XDP attach
+// at all -- same finding internal/plumbing/ebpf/edgeattach's identical
+// test documents.
+func TestLoadAttach_SurvivesRestartWithMapsIntact(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-nat66-test-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	const ifaceName = "nat66test0"
+	const peerName = "nat66test1"
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		handle, err := netlink.NewHandle()
+		if err != nil {
+			return err
+		}
+		defer handle.Close() //nolint:errcheck // best-effort cleanup
+
+		veth := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}, PeerName: peerName}
+		if err := handle.LinkAdd(veth); err != nil {
+			return fmt.Errorf("add veth pair: %w", err)
+		}
+		link, err := handle.LinkByName(ifaceName)
+		if err != nil {
+			return err
+		}
+		return handle.LinkSetUp(link)
+	})
+	if err != nil {
+		t.Fatalf("setup veth interface: %v", err)
+	}
+
+	cfg := nat66prog.Nat66ShardConfig{
+		ShardSid:     netip.MustParseAddr("fc00:1:2::1").As16(),
+		ShardPubAddr: netip.MustParseAddr("2001:db8:9999::1").As16(),
+	}
+
+	// --- pre-restart: first load, attach, and populate a map entry. ---
+	var firstLink interface{ Close() error }
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("load: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		l, err := Attach(objs.Nat66Ingress, ifaceName)
+		if err != nil {
+			return fmt.Errorf("attach: %w", err)
+		}
+		firstLink = l
+
+		if err := objs.ShardConfigTable.Put(uint32(0), cfg); err != nil {
+			return fmt.Errorf("populate shard_config_table: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("pre-restart load/attach/populate: %v", err)
+	}
+
+	// Simulate the old process exiting: close its XDP link so the
+	// interface has no attached program, exactly like a real process
+	// restart would leave it.
+	if err := firstLink.Close(); err != nil {
+		t.Fatalf("close pre-restart link: %v", err)
+	}
+
+	// --- simulate a container restart: fresh Load+Attach against the
+	// same pinDir/interface, as a brand new process would do. ---
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("reload after restart: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		l, err := Attach(objs.Nat66Ingress, ifaceName)
+		if err != nil {
+			return fmt.Errorf("re-attach after restart: %w", err)
+		}
+		defer func() { _ = l.Close() }()
+
+		var got nat66prog.Nat66ShardConfig
+		if err := objs.ShardConfigTable.Lookup(uint32(0), &got); err != nil {
+			return fmt.Errorf("lookup shard_config_table entry after restart: %w", err)
+		}
+		if got != cfg {
+			return fmt.Errorf("shard_config_table entry after restart = %+v, want %+v", got, cfg)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("post-restart verification: %v", err)
+	}
+}

--- a/internal/plumbing/ebpf/nat66attach/doc.go
+++ b/internal/plumbing/ebpf/nat66attach/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package nat66attach loads internal/plumbing/ebpf/nat66prog's compiled XDP
+// program and attaches it to one interface -- one NAT66 shard's own
+// fabric-facing uplink -- mirroring internal/plumbing/ebpf/edgeattach's
+// mechanics almost verbatim (pinned maps, verifier-error unwrapping,
+// incompatible-map recreation on a schema change; native-driver-mode-only
+// XDP attach with no generic-mode fallback). See edgeattach's own doc
+// comment for the full rationale behind each of those choices -- it
+// applies unchanged here, this package is not repeating it.
+//
+// # No kernel preflight check here
+//
+// Unlike edgeattach.Load, this package's Load does not run a kernel
+// preflight check before loading: internal/plumbing/ebpf/edgepreflight is
+// scoped specifically to edgeprog's own map types (its own doc comment
+// lists BPF_MAP_TYPE_HASH, not BPF_MAP_TYPE_LRU_HASH -- nat66_conn_table's
+// actual type), and internal/plumbing/ebpf/preflight is scoped to the SRv6
+// uSID TC-BPF datapath. Neither is a correct fit, and inventing a third,
+// nat66-specific preflight package is out of scope for this phase --
+// LoadAndAssign's own verifier-error unwrapping already surfaces "this
+// kernel can't load this program" clearly at load time, just later than a
+// dedicated preflight check would.
+//
+// # One attach target, no Watch-style re-attachment
+//
+// Same as edgeattach: this program has exactly one attach target (a fixed,
+// operator-configured interface name, config.NAT66Config.UplinkInterface),
+// attached once at process startup by cmd/galactic-nat66. There is no
+// external network event this package needs to notice on its own.
+package nat66attach

--- a/internal/plumbing/ebpf/nat66map/conntable.go
+++ b/internal/plumbing/ebpf/nat66map/conntable.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+// beU16 converts v between host and big-endian ("network") representation
+// by a full 2-byte swap -- its own inverse, so this same function is used
+// for both directions. Required because nat66prog's generated Go structs
+// store a C __be16 field as a plain uint16, and cilium/ebpf's BTF-based
+// marshalling writes it using the host's native (little-endian, on every
+// architecture this repo targets) byte order with no swap of its own. This
+// duplicates edgemap's identically-named helper rather than importing it --
+// see doc.go for why this package does not depend on edgemap.
+func beU16(v uint16) uint16 {
+	return v<<8 | v>>8
+}
+
+// ConnKey identifies one nat66_conn_table row -- see nat66.c's struct
+// conn_key doc comment for the forward/reverse row layout this mirrors.
+// TenantArg is host-order (nat66.c's read_argument already returns it in
+// host order, not wire order, so unlike Sport/Dport it needs no beU16
+// swap); Sport/Dport are the packet's own wire-order (__be16) ports.
+type ConnKey struct {
+	Proto     uint8
+	TenantArg uint16
+	Sport     uint16
+	Dport     uint16
+	Saddr     netip.Addr
+	Daddr     netip.Addr
+}
+
+// ConnEntry is one fully decoded nat66_conn_table row, decoupled from
+// nat66prog.Nat66ConnValue's cilium/ebpf/BTF-generated field layout.
+type ConnEntry struct {
+	ConnKey
+
+	// BackendAddr/BackendPort are the tenant backend's own facing
+	// address/port -- present in both the forward and reverse row's value
+	// (nat66.c's struct conn_value comment).
+	BackendAddr netip.Addr
+	BackendPort uint16
+
+	// DestAddr/DestPort are the internet destination's own address/port.
+	DestAddr netip.Addr
+	DestPort uint16
+
+	// ShardPort is this shard's own allocated masquerade port for this
+	// flow.
+	ShardPort uint16
+
+	// BackendUSID is the tenant backend's own worker-node SRv6 uSID, used
+	// to re-encapsulate a reply back toward it (handle_return).
+	BackendUSID netip.Addr
+
+	// Proto is the value's own copy of the protocol, read back
+	// independently of ConnKey.Proto (both are always equal by
+	// construction -- nat66.c never writes them differently -- exposed
+	// separately only because Nat66ConnValue carries its own field).
+	Proto uint8
+}
+
+// ConnTable is the read-only accessor for nat66_conn_table -- see doc.go
+// for why this package never writes to it. Get/List exist purely for
+// observability/metrics (e.g. a future admin CLI or diagnostics endpoint);
+// nothing in this codebase's control plane depends on reading it today.
+type ConnTable struct {
+	table Table
+}
+
+// NewConnTable wraps table as a ConnTable. Production callers pass a
+// KernelTable wrapping a loaded *nat66prog.Nat66Objects's Nat66ConnTable
+// map; tests pass a fake Table.
+func NewConnTable(table Table) *ConnTable {
+	return &ConnTable{table: table}
+}
+
+func toWireConnKey(key ConnKey) (nat66prog.Nat66ConnKey, error) {
+	if err := validateAddr("conn key source address", key.Saddr); err != nil {
+		return nat66prog.Nat66ConnKey{}, err
+	}
+	if err := validateAddr("conn key destination address", key.Daddr); err != nil {
+		return nat66prog.Nat66ConnKey{}, err
+	}
+	return nat66prog.Nat66ConnKey{
+		Proto:     key.Proto,
+		TenantArg: key.TenantArg,
+		Sport:     beU16(key.Sport),
+		Dport:     beU16(key.Dport),
+		Saddr:     key.Saddr.As16(),
+		Daddr:     key.Daddr.As16(),
+	}, nil
+}
+
+func fromWireConnKey(wireKey nat66prog.Nat66ConnKey) ConnKey {
+	return ConnKey{
+		Proto:     wireKey.Proto,
+		TenantArg: wireKey.TenantArg,
+		Sport:     beU16(wireKey.Sport),
+		Dport:     beU16(wireKey.Dport),
+		Saddr:     netip.AddrFrom16(wireKey.Saddr),
+		Daddr:     netip.AddrFrom16(wireKey.Daddr),
+	}
+}
+
+func fromWireConnValue(key ConnKey, value nat66prog.Nat66ConnValue) ConnEntry {
+	return ConnEntry{
+		ConnKey:     key,
+		BackendAddr: netip.AddrFrom16(value.BackendAddr),
+		BackendPort: beU16(value.BackendPort),
+		DestAddr:    netip.AddrFrom16(value.DestAddr),
+		DestPort:    beU16(value.DestPort),
+		ShardPort:   beU16(value.ShardPort),
+		BackendUSID: netip.AddrFrom16(value.BackendUsid),
+		Proto:       value.Proto,
+	}
+}
+
+// Get reads the nat66_conn_table entry for key, reporting whether it
+// exists.
+func (t *ConnTable) Get(key ConnKey) (ConnEntry, bool, error) {
+	wireKey, err := toWireConnKey(key)
+	if err != nil {
+		return ConnEntry{}, false, fmt.Errorf("nat66map: nat66_conn_table: get %+v: %w", key, err)
+	}
+
+	var value nat66prog.Nat66ConnValue
+	if err := t.table.Lookup(wireKey, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return ConnEntry{}, false, nil
+		}
+		return ConnEntry{}, false, fmt.Errorf("nat66map: nat66_conn_table: get %+v: %w", key, err)
+	}
+	return fromWireConnValue(key, value), true, nil
+}
+
+// List returns every entry currently in nat66_conn_table, in unspecified
+// order. Since this is an LRU-evicting map under live traffic, the result
+// is only ever a point-in-time snapshot -- a row present in one List call
+// may be gone (evicted, or aged out) by the next.
+func (t *ConnTable) List() ([]ConnEntry, error) {
+	var (
+		entries []ConnEntry
+		rawKey  nat66prog.Nat66ConnKey
+		value   nat66prog.Nat66ConnValue
+	)
+	it := t.table.Iterate()
+	for it.Next(&rawKey, &value) {
+		key := fromWireConnKey(rawKey)
+		entries = append(entries, fromWireConnValue(key, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("nat66map: nat66_conn_table: list: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/plumbing/ebpf/nat66map/conntable_test.go
+++ b/internal/plumbing/ebpf/nat66map/conntable_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"net/netip"
+	"sort"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+func testConnKey() ConnKey {
+	return ConnKey{
+		Proto:     17,
+		TenantArg: 0x123,
+		Sport:     40000,
+		Dport:     443,
+		Saddr:     netip.MustParseAddr("fd20:60::5"),
+		Daddr:     netip.MustParseAddr("2001:db8:9998::1"),
+	}
+}
+
+func testConnEntry() ConnEntry {
+	return ConnEntry{
+		ConnKey:     testConnKey(),
+		BackendAddr: netip.MustParseAddr("fd20:60::5"),
+		BackendPort: 40000,
+		DestAddr:    netip.MustParseAddr("2001:db8:9998::1"),
+		DestPort:    443,
+		ShardPort:   35000,
+		BackendUSID: netip.MustParseAddr("fc00:3:4::a1b2"),
+		Proto:       17,
+	}
+}
+
+// connValueFromEntry is the inverse of fromWireConnValue -- test-only,
+// since ConnTable itself is deliberately read-only (see doc.go) and
+// exposes no Put/Register method to seed test data through.
+func connValueFromEntry(e ConnEntry) nat66prog.Nat66ConnValue {
+	return nat66prog.Nat66ConnValue{
+		BackendAddr: e.BackendAddr.As16(),
+		BackendPort: beU16(e.BackendPort),
+		DestAddr:    e.DestAddr.As16(),
+		DestPort:    beU16(e.DestPort),
+		ShardPort:   beU16(e.ShardPort),
+		BackendUsid: e.BackendUSID.As16(),
+		Proto:       e.Proto,
+	}
+}
+
+// putEntry writes e directly through the wire conversion helpers.
+func putEntry(t *testing.T, table Table, e ConnEntry) {
+	t.Helper()
+	wireKey, err := toWireConnKey(e.ConnKey)
+	if err != nil {
+		t.Fatalf("toWireConnKey: %v", err)
+	}
+	if err := table.Put(wireKey, connValueFromEntry(e)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+}
+
+func TestConnTable_GetHit(t *testing.T) {
+	fake := newFakeTable()
+	entry := testConnEntry()
+	putEntry(t, fake, entry)
+
+	table := NewConnTable(fake)
+	got, ok, err := table.Get(entry.ConnKey)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got != entry {
+		t.Errorf("Get() = %+v, want %+v", got, entry)
+	}
+}
+
+func TestConnTable_GetMiss(t *testing.T) {
+	table := NewConnTable(newFakeTable())
+	got, ok, err := table.Get(testConnKey())
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if ok {
+		t.Errorf("Get() ok = true, want false for an absent key; got %+v", got)
+	}
+}
+
+func TestConnTable_GetRejectsIPv4Key(t *testing.T) {
+	table := NewConnTable(newFakeTable())
+	key := testConnKey()
+	key.Saddr = netip.MustParseAddr("203.0.113.1")
+
+	_, _, err := table.Get(key)
+	if err == nil {
+		t.Fatal("Get() error = nil, want an error for a non-native-IPv6 key address")
+	}
+}
+
+func TestConnTable_List(t *testing.T) {
+	fake := newFakeTable()
+
+	first := testConnEntry()
+	second := testConnEntry()
+	second.Sport = 40001
+	second.ShardPort = 35001
+
+	putEntry(t, fake, first)
+	putEntry(t, fake, second)
+
+	table := NewConnTable(fake)
+	entries, err := table.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List() returned %d entries, want 2", len(entries))
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Sport < entries[j].Sport })
+	if entries[0] != first {
+		t.Errorf("entries[0] = %+v, want %+v", entries[0], first)
+	}
+	if entries[1] != second {
+		t.Errorf("entries[1] = %+v, want %+v", entries[1], second)
+	}
+}
+
+func TestConnTable_ListEmpty(t *testing.T) {
+	table := NewConnTable(newFakeTable())
+	entries, err := table.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("List() = %d entries, want 0 on an empty table", len(entries))
+	}
+}

--- a/internal/plumbing/ebpf/nat66map/doc.go
+++ b/internal/plumbing/ebpf/nat66map/doc.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package nat66map implements the read/write API for
+// internal/plumbing/ebpf/nat66prog's two control-plane-facing maps
+// (shard_config_table, a single-entry write target this shard's own
+// operator-supplied identity is stamped into; drop_reasons, a per-CPU
+// counter array) plus a read-only accessor for nat66_conn_table, the
+// datapath's own self-managed LRU flow-state table.
+//
+// # nat66_conn_table is never written here
+//
+// nat66_conn_table (a BPF_MAP_TYPE_LRU_HASH) is written ONLY by
+// nat66.c's own handle_forward/handle_return -- it allocates masquerade
+// ports, claims rows via BPF_NOEXIST, and self-evicts under memory
+// pressure with no GC needed, entirely inside the datapath. This mirrors
+// the identical "never write conn_table, only read for observability"
+// boundary internal/plumbing/ebpf/edgemap's now-removed edgenat.c-era
+// ruletable.go doc comment described for that program's own conn_table:
+// ConnTable in this package exposes Get/List only, no Register/Unregister/
+// Reconcile at all -- there is no control-plane liveness set to reconcile
+// this table against in the first place.
+//
+// # shard_config_table is the one thing the control plane does write
+//
+// shard_config_table (a single-entry BPF_MAP_TYPE_ARRAY, key uint32(0))
+// carries this shard's own identity -- shard_sid and shard_pub_addr,
+// both operator-supplied (see internal/config.NAT66Config) -- and is
+// written exactly once, at process startup, by cmd/galactic-nat66's
+// setupNat66Datapath. ShardConfigTable's Set/Get mirror
+// internal/plumbing/ebpf/edgemap/doc.go's own reasoning for why
+// encap_config_table (edgeprog's analogous single-entry map) doesn't get a
+// dedicated wrapper there: unlike that case, this package does give
+// shard_config_table one, because unlike edgeprog's encap_config_table
+// (a single field, written directly by internal/gateway.NewKernelDatapath)
+// this map's value has two fields and benefits from the same
+// netip.Addr-typed, validated API every other table in this codebase's
+// eBPF map layer already offers -- see internal/plumbing/ebpf/prog's own
+// locator_table/vrf_table wrappers (internal/plumbing/ebpf/usidmap) for the
+// precedent this package follows instead.
+//
+// # Reusing usidmap's or edgemap's Table/KernelTable/Iterator? No.
+//
+// nat66prog.nat66.c is its own standalone datapath -- no map or key layout
+// shared with usid.c (usidmap) or edgedsr.c (edgemap) -- so, following
+// edgemap's own doc comment's precedent for why it does not import
+// usidmap's identical interface, this package declares its own Table/
+// KernelTable/Iterator (table.go) rather than importing either.
+//
+// # Testability
+//
+// Every table type here is built against the Table interface (table.go),
+// not directly against *ebpf.Map: KernelTable adapts a real, loaded map
+// (e.g. nat66prog.Nat66Objects.ShardConfigTable) for production use, while
+// this package's own tests substitute an in-memory fake to exercise every
+// code path without a kernel or root privileges.
+package nat66map

--- a/internal/plumbing/ebpf/nat66map/dropreasons.go
+++ b/internal/plumbing/ebpf/nat66map/dropreasons.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"fmt"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+// DropReasonsReader abstracts drop_reasons's per-CPU lookup (a
+// BPF_MAP_TYPE_PERCPU_ARRAY keyed by drop reason index) down to the one
+// operation this package needs, so tests can substitute an in-memory fake
+// instead of a real, kernel-loaded map -- same interface shape as
+// internal/plumbing/ebpf/edgemetrics.DropReasonsReader and
+// internal/plumbing/ebpf/metrics's identical type. *ebpf.Map already
+// satisfies this interface structurally.
+type DropReasonsReader interface {
+	Lookup(key, valueOut any) error
+}
+
+// SumDropReason reads drop_reasons[index] (one per-CPU counter slice) and
+// returns the sum across every CPU -- the per-CPU-array summing idiom
+// internal/plumbing/ebpf/prog's test helpers and
+// internal/plumbing/ebpf/edgemetrics.Collector.collectDrops both already
+// use, duplicated here rather than imported for the same "no shared
+// datapath" reasoning doc.go gives for Table/KernelTable/Iterator.
+func SumDropReason(reader DropReasonsReader, index uint32) (uint64, error) {
+	var perCPU []uint64
+	if err := reader.Lookup(index, &perCPU); err != nil {
+		return 0, fmt.Errorf("nat66map: drop_reasons: lookup[%d]: %w", index, err)
+	}
+	var total uint64
+	for _, v := range perCPU {
+		total += v
+	}
+	return total, nil
+}
+
+// DropReasonTotals reads every drop reason index
+// (nat66prog.DropReasonNat66Count of them) and returns the per-CPU-summed
+// total for each, keyed by its DropReasonNat66* index -- the shape a
+// Prometheus collector (or any other caller) reads a full snapshot from in
+// one call rather than looping SumDropReason itself.
+func DropReasonTotals(reader DropReasonsReader) (map[uint32]uint64, error) {
+	totals := make(map[uint32]uint64, nat66prog.DropReasonNat66Count)
+	for i := range nat66prog.DropReasonNat66Count {
+		total, err := SumDropReason(reader, i)
+		if err != nil {
+			return nil, fmt.Errorf("nat66map: drop_reasons: totals: %w", err)
+		}
+		totals[i] = total
+	}
+	return totals, nil
+}

--- a/internal/plumbing/ebpf/nat66map/dropreasons_test.go
+++ b/internal/plumbing/ebpf/nat66map/dropreasons_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"errors"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+func TestSumDropReason(t *testing.T) {
+	reader := &fakeDropReasonsReader{
+		perCPU: map[uint32][]uint64{
+			nat66prog.DropReasonNat66NoReturnConn: {3, 0, 1, 2},
+		},
+	}
+
+	got, err := SumDropReason(reader, nat66prog.DropReasonNat66NoReturnConn)
+	if err != nil {
+		t.Fatalf("SumDropReason() error = %v", err)
+	}
+	if got != 6 {
+		t.Errorf("SumDropReason() = %d, want 6 (sum across every CPU)", got)
+	}
+}
+
+func TestSumDropReason_AbsentIndexIsZero(t *testing.T) {
+	reader := &fakeDropReasonsReader{perCPU: map[uint32][]uint64{}}
+
+	got, err := SumDropReason(reader, nat66prog.DropReasonNat66PatExhausted)
+	if err != nil {
+		t.Fatalf("SumDropReason() error = %v", err)
+	}
+	if got != 0 {
+		t.Errorf("SumDropReason() = %d, want 0 for an index with no counters yet", got)
+	}
+}
+
+func TestSumDropReason_LookupError(t *testing.T) {
+	wantErr := errors.New("simulated map lookup failure")
+	reader := &fakeDropReasonsReader{err: wantErr}
+
+	_, err := SumDropReason(reader, nat66prog.DropReasonNat66NoReturnConn)
+	if err == nil {
+		t.Fatal("SumDropReason() error = nil, want the wrapped lookup failure")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("SumDropReason() error = %v, want it to wrap %v", err, wantErr)
+	}
+}
+
+func TestDropReasonTotals(t *testing.T) {
+	reader := &fakeDropReasonsReader{
+		perCPU: map[uint32][]uint64{
+			nat66prog.DropReasonNat66NoReturnConn:     {1, 1},
+			nat66prog.DropReasonNat66MalformedReturn:  {2, 2},
+			nat66prog.DropReasonNat66PatExhausted:     {0, 0},
+			nat66prog.DropReasonNat66MalformedForward: {3, 0},
+			nat66prog.DropReasonNat66FibNoNeigh:       {0, 0},
+			nat66prog.DropReasonNat66FibUnreachable:   {0, 0},
+			nat66prog.DropReasonNat66FibFragNeeded:    {0, 0},
+			nat66prog.DropReasonNat66FibLookupFailed:  {5, 0},
+			nat66prog.DropReasonNat66AdjustHeadFailed: {0, 0},
+		},
+	}
+
+	totals, err := DropReasonTotals(reader)
+	if err != nil {
+		t.Fatalf("DropReasonTotals() error = %v", err)
+	}
+	if len(totals) != int(nat66prog.DropReasonNat66Count) {
+		t.Fatalf("DropReasonTotals() returned %d entries, want %d", len(totals), nat66prog.DropReasonNat66Count)
+	}
+	if totals[nat66prog.DropReasonNat66NoReturnConn] != 2 {
+		t.Errorf("totals[no_return_conn] = %d, want 2", totals[nat66prog.DropReasonNat66NoReturnConn])
+	}
+	if totals[nat66prog.DropReasonNat66MalformedReturn] != 4 {
+		t.Errorf("totals[malformed_return] = %d, want 4", totals[nat66prog.DropReasonNat66MalformedReturn])
+	}
+	if totals[nat66prog.DropReasonNat66FibLookupFailed] != 5 {
+		t.Errorf("totals[fib_lookup_failed] = %d, want 5", totals[nat66prog.DropReasonNat66FibLookupFailed])
+	}
+}
+
+func TestDropReasonTotals_LookupError(t *testing.T) {
+	wantErr := errors.New("simulated map lookup failure")
+	reader := &fakeDropReasonsReader{err: wantErr}
+
+	_, err := DropReasonTotals(reader)
+	if err == nil {
+		t.Fatal("DropReasonTotals() error = nil, want the wrapped lookup failure")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("DropReasonTotals() error = %v, want it to wrap %v", err, wantErr)
+	}
+}

--- a/internal/plumbing/ebpf/nat66map/faketable_test.go
+++ b/internal/plumbing/ebpf/nat66map/faketable_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"reflect"
+
+	"github.com/cilium/ebpf"
+)
+
+// fakeTable is an in-memory Table implementation used across this
+// package's tests, keyed by `any` (rather than usidmap's fakeTable, which
+// assumes every key is a uint64) since this package's two tables use two
+// different key types: shard_config_table's fixed uint32(0) and
+// nat66_conn_table's nat66prog.Nat66ConnKey struct. It stores each value as
+// the concrete Go struct Put was given, copying into/out of callers'
+// pointer arguments via reflection to mirror *ebpf.Map's own copy-in/
+// copy-out semantics for Put/Lookup/Delete/Iterate, without needing a
+// kernel, BTF, or root privileges.
+type fakeTable struct {
+	entries map[any]any
+	order   []any // insertion order, for deterministic Iterate/List in tests
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[any]any)}
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	if _, exists := f.entries[key]; !exists {
+		f.order = append(f.order, key)
+	}
+	f.entries[key] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	if _, ok := f.entries[key]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, key)
+	for i, kk := range f.order {
+		if kk == key {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }
+
+var _ Table = (*fakeTable)(nil)
+
+// fakeDropReasonsReader is an in-memory DropReasonsReader for
+// dropreasons_test.go, keyed by drop-reason index with a fixed per-CPU
+// slice per index -- enough to exercise SumDropReason/DropReasonTotals'
+// summing logic without a kernel.
+type fakeDropReasonsReader struct {
+	perCPU map[uint32][]uint64
+	err    error
+}
+
+func (f *fakeDropReasonsReader) Lookup(key, valueOut any) error {
+	if f.err != nil {
+		return f.err
+	}
+	k := key.(uint32) //nolint:forcetypeassert // test-only fake, always called with uint32
+	*valueOut.(*[]uint64) = f.perCPU[k]
+	return nil
+}

--- a/internal/plumbing/ebpf/nat66map/shardconfig.go
+++ b/internal/plumbing/ebpf/nat66map/shardconfig.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
+)
+
+// shardConfigKey is shard_config_table's single, fixed key (nat66.c's
+// `__u32 cfg_key = 0`) -- this map is a BPF_MAP_TYPE_ARRAY with
+// max_entries=1, so there is exactly one valid key, ever.
+const shardConfigKey uint32 = 0
+
+// ShardConfig is shard_config_table's fully decoded single row: this
+// shard's own operator-supplied identity (internal/config.NAT66Config's
+// ShardSID/ShardPubAddr, already validated there). See nat66.c's header
+// comment for what each address is used for.
+type ShardConfig struct {
+	// ShardSID is this shard's own SRv6 uSID (uFMT 48+16) -- the outer
+	// destination a tenant's egress packet is encapsulated toward, and the
+	// re-encap source handle_return uses on the way back.
+	ShardSID netip.Addr
+
+	// ShardPubAddr is this shard's own publicly-routable masquerade source
+	// address -- every flow this shard NATs is SNAT'd to an address:port
+	// within it.
+	ShardPubAddr netip.Addr
+}
+
+// ShardConfigTable is the read/write API for shard_config_table.
+type ShardConfigTable struct {
+	table Table
+}
+
+// NewShardConfigTable wraps table as a ShardConfigTable. Production callers
+// pass a KernelTable wrapping a loaded *nat66prog.Nat66Objects's
+// ShardConfigTable map; tests pass a fake Table.
+func NewShardConfigTable(table Table) *ShardConfigTable {
+	return &ShardConfigTable{table: table}
+}
+
+// validateAddr rejects anything that isn't a native IPv6 address --
+// phase 1 is IPv6-only, matching every other table in this codebase's own
+// convention (e.g. edgemap.toWireKey's identical check).
+func validateAddr(field string, addr netip.Addr) error {
+	if !addr.Is6() || addr.Is4In6() {
+		return fmt.Errorf("%s %s is not a native IPv6 address (phase 1 is IPv6-only)", field, addr)
+	}
+	return nil
+}
+
+// Set writes (or overwrites) shard_config_table's single entry with cfg.
+// This is a blind overwrite, not a read-modify-write: shard_config_table
+// carries no counters or other datapath-owned fields to preserve across a
+// re-write (unlike, e.g., edgemap.VIPTable's own vip_table/vip_stats_table
+// split -- see that package's Register doc comment for the race a
+// read-modify-write would otherwise risk here; shard_config_table has no
+// such risk because it has nothing the datapath itself increments).
+func (t *ShardConfigTable) Set(cfg ShardConfig) error {
+	if err := validateAddr("shard SID", cfg.ShardSID); err != nil {
+		return fmt.Errorf("nat66map: shard_config_table: set: %w", err)
+	}
+	if err := validateAddr("shard public address", cfg.ShardPubAddr); err != nil {
+		return fmt.Errorf("nat66map: shard_config_table: set: %w", err)
+	}
+
+	value := nat66prog.Nat66ShardConfig{
+		ShardSid:     cfg.ShardSID.As16(),
+		ShardPubAddr: cfg.ShardPubAddr.As16(),
+	}
+	if err := t.table.Put(shardConfigKey, value); err != nil {
+		return fmt.Errorf("nat66map: shard_config_table: set: %w", err)
+	}
+	return nil
+}
+
+// Get reads shard_config_table's single entry, reporting whether it has
+// been written yet (nat66_ingress fails open -- XDP_PASS, not claimed --
+// on every packet until it has, per nat66.c's header comment).
+func (t *ShardConfigTable) Get() (ShardConfig, bool, error) {
+	var value nat66prog.Nat66ShardConfig
+	if err := t.table.Lookup(shardConfigKey, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return ShardConfig{}, false, nil
+		}
+		return ShardConfig{}, false, fmt.Errorf("nat66map: shard_config_table: get: %w", err)
+	}
+	return ShardConfig{
+		ShardSID:     netip.AddrFrom16(value.ShardSid),
+		ShardPubAddr: netip.AddrFrom16(value.ShardPubAddr),
+	}, true, nil
+}

--- a/internal/plumbing/ebpf/nat66map/shardconfig_test.go
+++ b/internal/plumbing/ebpf/nat66map/shardconfig_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func TestShardConfigTable_SetAndGet(t *testing.T) {
+	table := NewShardConfigTable(newFakeTable())
+
+	cfg := ShardConfig{
+		ShardSID:     netip.MustParseAddr("fc00:1:2::1"),
+		ShardPubAddr: netip.MustParseAddr("2001:db8:9999::1"),
+	}
+	if err := table.Set(cfg); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	got, ok, err := table.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true after Set")
+	}
+	if got != cfg {
+		t.Errorf("Get() = %+v, want %+v", got, cfg)
+	}
+}
+
+func TestShardConfigTable_GetBeforeSet(t *testing.T) {
+	table := NewShardConfigTable(newFakeTable())
+
+	got, ok, err := table.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if ok {
+		t.Errorf("Get() ok = true, want false before any Set; got %+v", got)
+	}
+}
+
+func TestShardConfigTable_SetOverwrites(t *testing.T) {
+	table := NewShardConfigTable(newFakeTable())
+
+	first := ShardConfig{
+		ShardSID:     netip.MustParseAddr("fc00:1:2::1"),
+		ShardPubAddr: netip.MustParseAddr("2001:db8:9999::1"),
+	}
+	second := ShardConfig{
+		ShardSID:     netip.MustParseAddr("fc00:3:4::1"),
+		ShardPubAddr: netip.MustParseAddr("2001:db8:8888::1"),
+	}
+
+	if err := table.Set(first); err != nil {
+		t.Fatalf("Set(first) error = %v", err)
+	}
+	if err := table.Set(second); err != nil {
+		t.Fatalf("Set(second) error = %v", err)
+	}
+
+	got, ok, err := table.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got != second {
+		t.Errorf("Get() = %+v, want %+v (second Set must overwrite the first)", got, second)
+	}
+}
+
+func TestShardConfigTable_SetRejectsIPv4(t *testing.T) {
+	table := NewShardConfigTable(newFakeTable())
+
+	tests := []struct {
+		name string
+		cfg  ShardConfig
+	}{
+		{
+			name: "ipv4 shard SID",
+			cfg: ShardConfig{
+				ShardSID:     netip.MustParseAddr("203.0.113.1"),
+				ShardPubAddr: netip.MustParseAddr("2001:db8:9999::1"),
+			},
+		},
+		{
+			name: "ipv4 shard pub addr",
+			cfg: ShardConfig{
+				ShardSID:     netip.MustParseAddr("fc00:1:2::1"),
+				ShardPubAddr: netip.MustParseAddr("203.0.113.1"),
+			},
+		},
+		{
+			name: "4-in-6 shard SID",
+			cfg: ShardConfig{
+				ShardSID:     netip.MustParseAddr("::ffff:203.0.113.1"),
+				ShardPubAddr: netip.MustParseAddr("2001:db8:9999::1"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := table.Set(tc.cfg)
+			if err == nil {
+				t.Fatal("Set() error = nil, want an error for a non-native-IPv6 address")
+			}
+			if !strings.Contains(err.Error(), "not a native IPv6 address") {
+				t.Errorf("Set() error = %q, want it to mention the IPv6-only requirement", err)
+			}
+		})
+	}
+}

--- a/internal/plumbing/ebpf/nat66map/table.go
+++ b/internal/plumbing/ebpf/nat66map/table.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package nat66map
+
+import "github.com/cilium/ebpf"
+
+// Table is the minimal map-operation surface every table type in this
+// package is written against, instead of directly against *ebpf.Map. Its
+// method set matches *ebpf.Map's own Put/Lookup/Delete/Iterate closely
+// enough that KernelTable (below) is a one-line adapter; this package's own
+// tests substitute a fake, in-memory implementation to exercise
+// shard-config/read-accessor logic without a kernel or root privileges --
+// see doc.go for why this is its own declaration rather than an import of
+// edgemap's or usidmap's identical interface.
+type Table interface {
+	// Put creates or overwrites the map entry at key with value.
+	Put(key, value any) error
+
+	// Lookup reads the map entry at key into valueOut. It returns
+	// ebpf.ErrKeyNotExist (or, for a fake Table, an error satisfying
+	// errors.Is(err, ebpf.ErrKeyNotExist)) if key is absent.
+	Lookup(key, valueOut any) error
+
+	// Delete removes the map entry at key. It returns ebpf.ErrKeyNotExist
+	// (see Lookup) if key is already absent.
+	Delete(key any) error
+
+	// Iterate returns an Iterator walking every entry currently in the
+	// map, in unspecified order -- matching *ebpf.Map.Iterate's own
+	// documented behavior.
+	Iterate() Iterator
+}
+
+// Iterator matches *ebpf.MapIterator's own Next/Err method set.
+type Iterator interface {
+	// Next decodes the next key/value pair into keyOut/valueOut and
+	// reports whether one was available. Callers must check Err after Next
+	// returns false to distinguish "iteration finished" from "an error
+	// interrupted iteration."
+	Next(keyOut, valueOut any) bool
+
+	// Err returns the first error encountered during iteration, if any.
+	Err() error
+}
+
+// KernelTable adapts a real, loaded *ebpf.Map -- e.g.
+// nat66prog.Nat66Objects's ShardConfigTable/Nat66ConnTable/DropReasons map
+// fields, once loaded by internal/plumbing/ebpf/nat66attach -- to the
+// Table interface every table type in this package is written against.
+type KernelTable struct {
+	Map *ebpf.Map
+}
+
+func (k KernelTable) Put(key, value any) error       { return k.Map.Put(key, value) }
+func (k KernelTable) Lookup(key, valueOut any) error { return k.Map.Lookup(key, valueOut) }
+func (k KernelTable) Delete(key any) error           { return k.Map.Delete(key) }
+func (k KernelTable) Iterate() Iterator              { return k.Map.Iterate() }


### PR DESCRIPTION
## Summary

The sharded NAT66 eBPF program landed a few PRs back with nothing to run it. This adds the third binary, `galactic-nat66`, and its `NAT66Shard` controller, publishing shard identity and Ready status. It also rewrites `ARCHITECTURE-GATEWAY.md` for the DSR/Maglev/anycast model and updates the containerlab manifests to deploy the new binary end to end.

## Test plan

- [ ] `task test`
- [ ] `task test:e2e`