### PR TITLE
fix: Stabilize the gateway after wiring the datapath and controllers together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ internal/plumbing/ebpf/nat66prog/nat66_bpfel.o
 internal/plumbing/ebpf/nat66prog/nat66_bpfeb.go
 internal/plumbing/ebpf/nat66prog/nat66_bpfeb.o
 
+# Same convention as above, for the containerlab-only pass-through XDP
+# program (deploy/containerlab/Taskfile.yaml's build:lab-xdp-passthrough,
+# node_files/common/xdp-passthrough.c's own doc comment).
+deploy/containerlab/node_files/common/xdp-passthrough.o
+
 # ============================================================
 # Kubernetes / controller-runtime / kubebuilder
 # ============================================================

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -88,12 +88,13 @@ tasks:
       - task: build:binaries
 
   build:ebpf:
-    desc: Regenerate the eBPF uSID and edge gateway NAT/LB datapaths (requires clang)
+    desc: Regenerate the eBPF uSID, edge gateway DSR, and NAT66 datapaths (requires clang)
     run: once
     deps: [require-clang]
     cmds:
       - go generate ./internal/plumbing/ebpf/prog/...
       - go generate ./internal/plumbing/ebpf/edgeprog/...
+      - go generate ./internal/plumbing/ebpf/nat66prog/...
 
   require-clang:
     internal: true
@@ -141,6 +142,7 @@ tasks:
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-route ./cmd/galactic-route
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-router ./cmd/galactic-router
       - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-gateway ./cmd/galactic-gateway
+      - go build -ldflags "{{.LDFLAGS}}" -o bin/galactic-nat66 ./cmd/galactic-nat66
       - go build -ldflags "{{.LDFLAGS}}" -o bin/vmtap-cni ./cmd/vmtap-cni
       - GOBIN={{.LOCALBIN}} go install github.com/containernetworking/plugins/plugins/main/host-device@v1.9.1
 

--- a/cmd/galactic-gateway/root.go
+++ b/cmd/galactic-gateway/root.go
@@ -105,6 +105,19 @@ func runCmd(cfg *config.GatewayConfig) error {
 		grpcSrv.GracefulStop()
 	}()
 
+	// Register field indexes. NetworkGatewayReconciler.resolveBGPRouterForNode
+	// (networkgateway_controller.go) lists BGPRouters by BGPRouterByTargetName
+	// -- an index, not a real API field, so it only resolves if something on
+	// this process's own manager registered it first. cmd/galactic-router
+	// registers it via the same call for its own, separate manager; galactic-
+	// gateway is a distinct binary/process/manager and never did, so every
+	// NetworkGateway reconcile here failed outright ("Index with name
+	// field:.spec.targetRef.name does not exist") until this call was added --
+	// found via a live containerlab deploy's own reconciler error loop.
+	if err := controller.RegisterIndexes(ctx, mgr); err != nil {
+		return fmt.Errorf("register field indexes: %w", err)
+	}
+
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 

--- a/containers/galactic-cni/Dockerfile
+++ b/containers/galactic-cni/Dockerfile
@@ -1,3 +1,16 @@
+# "network" is an empty stage by default -- overridden with a real
+# go.datum.net/network checkout via `docker build --build-context
+# network=<path-to-network-repo> ...` whenever go.mod carries a local
+# `replace go.datum.net/network => ../network` directive (this repo's own
+# convention for developing against unpublished network CRD changes before
+# they're tagged -- see go.mod's own comment on that line). Copied to
+# /network below, exactly matching what that relative replace path resolves
+# to from /workspace/go.mod inside this build. Harmless when no such
+# replace directive exists and no override is passed: go.mod then has
+# nothing under /network to resolve, so an empty directory there is never
+# read.
+FROM scratch AS network
+
 # Build the galactic CNI plugin
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
@@ -14,6 +27,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+# Local cross-repo development: satisfies go.mod's `replace
+# go.datum.net/network => ../network`, when present -- see the "network"
+# stage's own comment above for where this comes from.
+COPY --from=network / /network
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/containers/galactic-gateway/Dockerfile
+++ b/containers/galactic-gateway/Dockerfile
@@ -1,3 +1,16 @@
+# "network" is an empty stage by default -- overridden with a real
+# go.datum.net/network checkout via `docker build --build-context
+# network=<path-to-network-repo> ...` whenever go.mod carries a local
+# `replace go.datum.net/network => ../network` directive (this repo's own
+# convention for developing against unpublished network CRD changes before
+# they're tagged -- see go.mod's own comment on that line). Copied to
+# /network below, exactly matching what that relative replace path resolves
+# to from /workspace/go.mod inside this build. Harmless when no such
+# replace directive exists and no override is passed: go.mod then has
+# nothing under /network to resolve, so an empty directory there is never
+# read.
+FROM scratch AS network
+
 # Build the galactic-gateway binary
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
@@ -13,6 +26,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+# Local cross-repo development: satisfies go.mod's `replace
+# go.datum.net/network => ../network`, when present -- see the "network"
+# stage's own comment above for where this comes from.
+COPY --from=network / /network
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/containers/galactic-nat66/Dockerfile
+++ b/containers/galactic-nat66/Dockerfile
@@ -1,3 +1,16 @@
+# "network" is an empty stage by default -- overridden with a real
+# go.datum.net/network checkout via `docker build --build-context
+# network=<path-to-network-repo> ...` whenever go.mod carries a local
+# `replace go.datum.net/network => ../network` directive (this repo's own
+# convention for developing against unpublished network CRD changes before
+# they're tagged -- see go.mod's own comment on that line). Copied to
+# /network below, exactly matching what that relative replace path resolves
+# to from /workspace/go.mod inside this build. Harmless when no such
+# replace directive exists and no override is passed: go.mod then has
+# nothing under /network to resolve, so an empty directory there is never
+# read.
+FROM scratch AS network
+
 # Build the galactic-nat66 binary
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
@@ -13,6 +26,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+# Local cross-repo development: satisfies go.mod's `replace
+# go.datum.net/network => ../network`, when present -- see the "network"
+# stage's own comment above for where this comes from.
+COPY --from=network / /network
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/containers/galactic-router/Dockerfile
+++ b/containers/galactic-router/Dockerfile
@@ -1,3 +1,16 @@
+# "network" is an empty stage by default -- overridden with a real
+# go.datum.net/network checkout via `docker build --build-context
+# network=<path-to-network-repo> ...` whenever go.mod carries a local
+# `replace go.datum.net/network => ../network` directive (this repo's own
+# convention for developing against unpublished network CRD changes before
+# they're tagged -- see go.mod's own comment on that line). Copied to
+# /network below, exactly matching what that relative replace path resolves
+# to from /workspace/go.mod inside this build. Harmless when no such
+# replace directive exists and no override is passed: go.mod then has
+# nothing under /network to resolve, so an empty directory there is never
+# read.
+FROM scratch AS network
+
 # Build the galactic router binary
 FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
@@ -13,6 +26,10 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+# Local cross-repo development: satisfies go.mod's `replace
+# go.datum.net/network => ../network`, when present -- see the "network"
+# stage's own comment above for where this comes from.
+COPY --from=network / /network
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -39,17 +39,25 @@ dedicated nodes, same idea as `iad-worker-control`'s taint: no tenant pods land 
 DaemonSets with a blanket toleration (`fabric-router`, `galactic-gateway1`/`-gateway2` — each a
 two-container pod, `galactic-router` + `galactic-gateway`).
 They never run `galactic-cni` (config/galactic-cni's affinity is edge-only) or a route-reflector.
-**Underlay BGP peering on their `tr3` uplinks is now wired** (`node_files/tr3/frr.conf`,
+**Underlay BGP peering on their `tr3` uplinks is wired** (`node_files/tr3/frr.conf`,
 plus two `BGPPeer` objects in `resources/galactic-control/iad/` for the route reflector side)
-and the full fabric converges. Real end-to-end ingress traffic through the datapath is not yet
-live-validated here — this used to be attributed to a generic veth `XDP_TX` behavior, but
-root-causing found two stacked issues: IPv6 forwarding sysctls weren't enabled (now fixed,
-`sysctl.ConfigureFIBLookupUplinkSysctls`), and veth's native `XDP_TX` fast path stays invisible
-to tcpdump/AF_PACKET unless the peer interface also runs an XDP program — a genuine veth/kernel
-characteristic of this lab's veth-pair uplink simulation, not a code bug and not a production
-concern. See the redesign plan's
-[§8](../../docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md#8-containerlab-validation) and
-`resources/galactic-gateway/`.
+and the full fabric converges. Real end-to-end ingress traffic through the datapath is now
+**live-validated** — three stacked issues were found and fixed along the way, not one: (1)
+IPv6 forwarding sysctls weren't enabled (fixed, `sysctl.ConfigureFIBLookupUplinkSysctls`);
+(2) veth's native `XDP_TX` fast path does not deliver a frame to the peer interface's normal
+receive stack at all unless the peer *also* runs an XDP program — confirmed live via a real
+destination-side packet counter, not just `tcpdump` invisibility (stronger than this section
+used to claim: "invisible to `tcpdump`, no delivery impact" was wrong, not merely imprecise).
+Worked around for this lab specifically, not by converting `edgedsr.c`'s production datapath
+from XDP to TC (a real gateway's public uplink is a physical NIC, where this veth-specific
+behavior doesn't apply, and XDP's throughput advantage is exactly why that datapath uses it):
+`task deploy:lab-xdp-passthrough` loads a trivial pass-through XDP program on `tr3`'s
+`eth6`/`eth7` (`node_files/common/xdp-passthrough.c`), already wired into `task deploy`.
+(3) `vip_xlat_table`'s veth-kind delivery gap and its identical-VIP/backend-port key
+collision, both fixed in galactic. See the redesign plan's
+[§8](../../docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md#8-containerlab-validation) for
+the full account, including the still-open, unrelated NAT66/default-egress gap this validation
+surfaced but did not fix, and `resources/galactic-gateway/`.
 
 `dfw`, `iad`, and `sjc` are the three Kind cluster names — not separate ContainerLab
 topology nodes. Each cluster's `control-plane`/`worker` nodes above are its members.

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -33,20 +33,30 @@ tasks:
     cmds:
       - docker build --network=host --build-arg FRR_VERSION={{.FRR_VERSION}} -t {{.FABRIC_ROUTER_IMAGE}} -f ../../containers/fabric-router/Dockerfile ../..
 
+  # --build-context network=../../../network satisfies go.mod's local
+  # `replace go.datum.net/network => ../network` (see that line's own
+  # comment) inside each Dockerfile's "network" build stage -- see
+  # containers/galactic-{router,gateway,cni}/Dockerfile's own comment on
+  # that stage for the full mechanism. ../../../network is this Taskfile's
+  # own cwd (deploy/containerlab) relative to the network repo checked out
+  # as galactic's sibling; harmless to pass even once that replace
+  # directive is eventually removed, since the Dockerfile's "network"
+  # stage is unused by go.mod at that point regardless of what's passed
+  # here.
   "build:galactic-router":
     desc: Build the galactic-router container image
     cmds:
-      - docker build --network=host -t galactic-router:latest -f ../../containers/galactic-router/Dockerfile ../..
+      - docker build --network=host --build-context network=../../../network -t galactic-router:latest -f ../../containers/galactic-router/Dockerfile ../..
 
   "build:galactic-gateway":
     desc: Build the galactic-gateway container image
     cmds:
-      - docker build --network=host -t galactic-gateway:latest -f ../../containers/galactic-gateway/Dockerfile ../..
+      - docker build --network=host --build-context network=../../../network -t galactic-gateway:latest -f ../../containers/galactic-gateway/Dockerfile ../..
 
   "build:galactic-cni":
     desc: Build the galactic-cni installer image
     cmds:
-      - docker build --network=host -t galactic-cni:latest -f ../../containers/galactic-cni/Dockerfile ../..
+      - docker build --network=host --build-context network=../../../network -t galactic-cni:latest -f ../../containers/galactic-cni/Dockerfile ../..
 
   deploy:
     desc: Build images and deploy the full lab end-to-end

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -64,6 +64,7 @@ tasks:
     cmds:
       - task: "deploy:clusters"
       - task: "deploy:topology"
+      - task: "deploy:lab-xdp-passthrough"
       - task: "deploy:rename-control"
       - task: "deploy:images"
       - task: "deploy:system"
@@ -93,6 +94,50 @@ tasks:
       - docker rename iad-worker2 iad-worker-control
       - docker rename iad-worker3 iad-gateway1
       - docker rename iad-worker4 iad-gateway2
+
+  require-clang:
+    internal: true
+    run: once
+    cmds:
+      - |
+        if ! command -v clang >/dev/null 2>&1; then
+          echo "ERROR: clang not found on PATH." >&2
+          echo "node_files/common/xdp-passthrough.o is compiled from" >&2
+          echo "xdp-passthrough.c via clang -target bpf, not committed to" >&2
+          echo "git (matching this repo's own bpf2go-output convention) --" >&2
+          echo "clang is required to deploy this lab. Install, e.g.:" >&2
+          echo "  Fedora/RHEL: sudo dnf install clang llvm" >&2
+          echo "  Debian/Ubuntu: sudo apt install clang llvm" >&2
+          exit 1
+        fi
+
+  "build:lab-xdp-passthrough":
+    desc: Compile the lab-only pass-through XDP program (see node_files/common/xdp-passthrough.c)
+    deps: [require-clang]
+    cmds:
+      - clang -O2 -g -target bpf -c node_files/common/xdp-passthrough.c -o node_files/common/xdp-passthrough.o
+
+  "deploy:lab-xdp-passthrough":
+    desc: >-
+      Load the pass-through XDP program on tr3's gateway-facing links
+      (eth6/eth7) -- makes those veth links behave like a real gateway's
+      physical NIC uplink for edgedsr.c's XDP_TX redirect (see
+      xdp-passthrough.c's own doc comment). Idempotent: `ip link set ...
+      xdp obj` replaces whatever program (if any) is already attached.
+    deps: [build:lab-xdp-passthrough]
+    vars:
+      # tr3 is a real containerlab-managed node (kind: linux), unlike the
+      # Kind-cluster nodes elsewhere in this Taskfile (kind: ext-container,
+      # which keep their bare Kind-assigned names) -- containerlab prefixes
+      # its own nodes' container names with "clab-{{.LAB}}-".
+      TR3_CONTAINER: "clab-{{.LAB}}-tr3"
+    cmds:
+      - docker cp node_files/common/xdp-passthrough.o {{.TR3_CONTAINER}}:/xdp-passthrough.o
+      # -force: without it, `ip link set ... xdp obj` errors "XDP program
+      # already attached" on any re-run instead of replacing it (verified
+      # live) -- needed for this task to actually be idempotent.
+      - docker exec {{.TR3_CONTAINER}} ip -force link set dev eth6 xdp obj /xdp-passthrough.o sec xdp
+      - docker exec {{.TR3_CONTAINER}} ip -force link set dev eth7 xdp obj /xdp-passthrough.o sec xdp
 
   "load-image":
     internal: true

--- a/deploy/containerlab/gvpc.clab.yaml
+++ b/deploy/containerlab/gvpc.clab.yaml
@@ -254,19 +254,30 @@ topology:
     # galactic-gateway/). tr3 (iad's transit router) already
     # consumed eth1/eth2/eth3 for the TR mesh and eth4/eth5 for
     # iad-worker/iad-worker2, so these take the next free ports. BGP
-    # peering on these links is now configured (node_files/tr3/frr.conf,
-    # plus two BGPPeer objects in resources/galactic-control/iad/ for the
-    # route reflector side) and the fabric fully converges over them, but
-    # real end-to-end ingress traffic through the datapath is not yet
-    # live-validated here -- two stacked issues, not the generic
-    # veth-specific XDP_TX behavior this comment used to attribute it
-    # to: (1) IPv6 forwarding sysctls weren't enabled (now fixed,
-    # sysctl.ConfigureFIBLookupUplinkSysctls), and (2) veth's native
-    # XDP_TX fast path stays invisible to tcpdump/AF_PACKET unless the
-    # peer interface also runs an XDP program -- a genuine veth/kernel
-    # characteristic of this lab's veth-pair uplink simulation, not a
-    # code bug and not a production concern. See the redesign plan's
-    # §8 (docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md).
+    # peering on these links is configured (node_files/tr3/frr.conf, plus
+    # two BGPPeer objects in resources/galactic-control/iad/ for the route
+    # reflector side), the fabric converges over them, and real
+    # end-to-end ingress traffic through the datapath is now
+    # live-validated (docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md's
+    # §8) -- three stacked issues found and fixed along the way, not one:
+    # (1) IPv6 forwarding sysctls weren't enabled (fixed,
+    # sysctl.ConfigureFIBLookupUplinkSysctls); (2) veth's native XDP_TX
+    # fast path does not deliver a frame to the peer interface's normal
+    # receive stack at all unless the peer *also* runs an XDP program --
+    # confirmed live via a real destination-side packet counter, not just
+    # tcpdump invisibility (a stronger finding than this comment used to
+    # carry: "invisible to tcpdump, no delivery impact" was wrong, not
+    # merely imprecise) -- worked around for this lab specifically by
+    # `task deploy:lab-xdp-passthrough` loading a trivial pass-through XDP
+    # program on tr3's eth6/eth7 (node_files/common/xdp-passthrough.c),
+    # rather than converting edgedsr.c's own production datapath from XDP
+    # to TC, since a real gateway's public uplink is a physical NIC where
+    # this veth-specific behavior doesn't apply and native XDP_TX's
+    # throughput advantage is exactly why that datapath uses XDP at all;
+    # (3) `vip_xlat_table`'s veth-kind delivery gap and its identical-port
+    # key collision, both fixed in galactic (see that redesign plan's §8
+    # for the full account, including the still-separate, still-open
+    # NAT66/default-egress gap this validation surfaced but did not fix).
     #
     # mtu: 1500 on both ends, unlike every other link in this topology
     # (which gets containerlab's jumbo-frame veth default, ~9500) --

--- a/deploy/containerlab/node_files/common/xdp-passthrough.c
+++ b/deploy/containerlab/node_files/common/xdp-passthrough.c
@@ -1,0 +1,63 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// xdp-passthrough.c is a trivial, always-XDP_PASS eBPF program that exists
+// for exactly one reason: on a veth pair, the kernel's native XDP_TX fast
+// path only promotes a redirected frame into the peer interface's normal
+// receive stack if the peer *also* has an XDP program attached -- without
+// one, the frame is queued through a raw fast path nothing but another XDP
+// program on that peer can see, and in this lab's multi-hop topology it
+// never actually arrives anywhere (confirmed live: with no XDP program on
+// the peer, the receiving node's own eBPF datapath counters for the
+// affected traffic stay at exactly zero; attaching this program is what
+// makes them move).
+//
+// edgedsr.c (the edge DSR/Maglev gateway datapath) uses XDP_TX -- back out
+// the same interface a client's packet arrived on -- deliberately: on a
+// real gateway node's public uplink, a genuine physical NIC, this is
+// exactly the same high-throughput pattern real production XDP-based DSR
+// load balancers use (this design intentionally does not use TC for that
+// datapath -- see docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md's
+// §8 for why converting production code to TC was rejected in favor of
+// this lab-only workaround instead). This program's only job is making
+// this lab's veth-pair simulation of that uplink behave the way a real NIC
+// already does, on whichever node sits on the *other* end of a link facing
+// a gateway-role node's public interface -- currently tr3's eth6/eth7 (see
+// gvpc.clab.yaml's own comment on those links) -- so that link behaves
+// like a physical wire instead of exposing a veth-specific kernel
+// limitation. Not applied anywhere else in this topology: usid_ingress/
+// usid_egress (usid.c) are already TC-BPF, not XDP, so ordinary tenant
+// traffic never needed this.
+//
+// Built by deploy/containerlab/Taskfile.yaml's build:lab-xdp-passthrough
+// task (clang -target bpf); not go:generate'd or wrapped in bpf2go
+// bindings like every other program in this repo, since nothing ever
+// needs to read a map from it or drive it from Go -- it is loaded purely
+// via `ip link set ... xdp obj ... sec xdp`, the same as this Taskfile's
+// own deploy:lab-xdp-passthrough task does. The compiled .o is gitignored,
+// matching this repo's established convention of never committing eBPF
+// build output (see internal/plumbing/ebpf/prog/doc.go).
+
+#define SEC(name) __attribute__((section(name), used))
+
+// A local, minimal stand-in for struct xdp_md (from linux/bpf.h) -- not
+// actually read by this program, but required so the function signature
+// matches what the "xdp" program type expects.
+struct xdp_md {
+	unsigned int data;
+	unsigned int data_end;
+	unsigned int data_meta;
+	unsigned int ingress_ifindex;
+	unsigned int rx_queue_index;
+	unsigned int egress_ifindex;
+};
+
+SEC("xdp")
+int xdp_passthrough(struct xdp_md *ctx)
+{
+	(void) ctx;
+	return 2; // XDP_PASS
+}
+
+char _license[] SEC("license") = "GPL";

--- a/deploy/containerlab/resources/galactic-gateway/iad/servicevipbinding-ns60.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad/servicevipbinding-ns60.yaml
@@ -11,13 +11,15 @@
 #
 # egressKind: veth, since ns60's backend is a plain container Deployment
 # (veth attach, not a tap/VM backend) -- see ServiceVIPBinding's own doc
-# comment for the veth/tap fork. backendAddress/backendPort are omitted:
-# per that same doc comment, both are ignored for the veth kind (a veth
-# binding's backend answers on vipAddress itself once bound, via
-# internal/plumbing/vip's galactic-vip0 dummy-interface bind) -- they
-# exist on the spec only for the tap case, where there is no fixture in
-# this lab yet (see the redesign plan's §8, "no tap/VM fixture exists in
-# this lab at all").
+# comment for the veth/tap fork. backendAddress/backendPort now match
+# networkrule-ns60.yaml's own backend entry exactly (fd20:60:ff03::100:0:80)
+# -- required for veth too, not just tap: a decapsulated ingress packet is
+# delivered into vpc60's own VRF routing table, which has no route to
+# vipAddress at all (only bound on the node's own root-namespace
+# galactic-vip0 interface, outside that VRF) -- found live in this exact
+# lab. galactic's ServiceVIPBindingReconciler now registers the same
+# vip_xlat_table substitution tap already used, closing that gap; see its
+# own doc comment for the full story.
 apiVersion: network.datumapis.com/v1alpha1
 kind: ServiceVIPBinding
 metadata:
@@ -30,4 +32,6 @@ spec:
   vipAddress: 2001:db8:6060::1
   port: 80
   protocol: tcp
+  backendAddress: fd20:60:ff03::100:0
+  backendPort: 80
   egressKind: veth

--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -16,6 +16,17 @@ source "${SCRIPT_DIR}/lib.sh"
 NETWORK_SHA=$(awk '$1 == "go.datum.net/network" {print $2}' "${SCRIPT_DIR}/../../../go.mod" | sed 's/.*-//')
 NETWORK_CRD_URL="https://raw.githubusercontent.com/datum-cloud/network/${NETWORK_SHA}/config/crd"
 
+# go.mod's own local `replace go.datum.net/network => ../network` (see that
+# line's comment) resolves from the galactic repo root, i.e. one level
+# above SCRIPT_DIR's ../../.. -- same relative path the containerlab
+# Taskfile's --build-context network=../../../network and scripts/ci.sh's
+# --build-context network=../network use for the identical reason (both
+# from their own, different, working directories). Used below for CRDs
+# that exist only on that local, unpublished branch (network_crds_local) --
+# NETWORK_CRD_URL above can't serve them since GitHub only has the SHA
+# go.mod's require line pins, which predates them.
+NETWORK_LOCAL_CRD_DIR="${SCRIPT_DIR}/../../../../network/config/crd"
+
 # VPC/VPCAttachment CRDs come from the separate companion VPC operator,
 # datum-cloud/cloud. Nothing in this repo's Go code imports it (the CNI
 # plugin only reads VPC/VPCAttachment identifiers as plain JSON fields off
@@ -34,6 +45,26 @@ network_crds=(
   network.datumapis.com_networkrules.yaml
 )
 
+# ServiceVIPBinding is the DSR/Maglev redesign's own CRD (design plan §1),
+# added on network's local feat/dsr-maglev-crds branch alongside this
+# repo's feat/dsr-maglev-gateway -- never pushed, so it doesn't exist at
+# NETWORK_SHA on GitHub the way network_crds above does. Missing this
+# breaks two different things, discovered live in this lab: (1)
+# resources/galactic-gateway/iad/servicevipbinding-ns60.yaml fails
+# deploy-galactic-router.sh's apply_k of that directory with kubectl's
+# "ensure CRDs are installed first" (the DaemonSet/BGP resources in the
+# same kustomization still get applied, but the script's overall exit
+# code still goes non-zero); (2), the more serious one -- galactic-router's
+# manager registers a ServiceVIPBinding watch unconditionally, on every
+# site, so without this CRD it crash-loops everywhere on "failed to wait
+# for servicevipbinding caches to sync ... timed out" and never starts any
+# controller at all, not just the ones this redesign added. Installed on
+# every site, matching network_crds' own blanket per-site loop, for that
+# second reason -- (1) alone would only need iad.
+network_crds_local=(
+  network.datumapis.com_servicevipbindings.yaml
+)
+
 cloud_crds=(
   cloud.datumapis.com_vpcs.yaml
   cloud.datumapis.com_vpcattachments.yaml
@@ -50,6 +81,9 @@ for site in dfw sjc iad; do
   # hiccups (rate-limits, cold CDN cache) instead of failing the deploy.
   for crd in "${network_crds[@]}"; do
     curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused "${NETWORK_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -
+  done
+  for crd in "${network_crds_local[@]}"; do
+    docker exec -i "${node}" kubectl apply -f - < "${NETWORK_LOCAL_CRD_DIR}/${crd}"
   done
   for crd in "${cloud_crds[@]}"; do
     curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused "${CLOUD_CRD_URL}/${crd}" | docker exec -i "${node}" kubectl apply -f -

--- a/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
+++ b/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
@@ -403,13 +403,14 @@ grounded in what actually exists, not a green-field lab design. **Not yet
 done** — the two items below are the concrete remaining work before this
 redesign can claim containerlab validation beyond manifests:
 
-**Known blocker, root-caused during implementation — two stacked
-issues, not one.** The lab's own `README.md` used to describe "real
-end-to-end ingress traffic through the datapath still doesn't reach a
-backend in this topology — it currently stops on a veth-specific
+**Known blocker, root-caused and fixed during implementation — three
+stacked issues, not one.** The lab's own `README.md` used to describe
+"real end-to-end ingress traffic through the datapath still doesn't reach
+a backend in this topology — it currently stops on a veth-specific
 `XDP_TX` behavior," attributed to the lab environment generically.
-Live-kernel investigation found it is actually two separate, stacked
-issues:
+Live-kernel investigation, and a full end-to-end validation run
+(2026-08-18) that finally drove real traffic through ns60's gateway
+canary, found and fixed three separate, stacked issues:
 
 1. **IPv6 forwarding sysctls not enabled** — `bpf_fib_lookup()` (used
    identically by `edgedsr.c`'s and `nat66.c`'s `push_outer_header`)
@@ -420,17 +421,53 @@ issues:
    `net.ipv6.conf.<iface>.forwarding` and `net.ipv6.conf.all.forwarding`
    (empirically confirmed both are required together) from both
    `cmd/galactic-gateway` and `cmd/galactic-nat66` startup.
-2. **veth's native `XDP_TX` fast path is invisible to normal observation
-   unless the peer also runs an XDP program.** A frame `XDP_TX`'d on one
-   veth leg is only promoted into the peer's normal receive stack
-   (visible to tcpdump/AF_PACKET) if the peer interface *also* has an
-   XDP program attached — otherwise delivery uses a raw fast-path queue
-   nothing but another XDP program on that peer can see. **Not fixable
-   in this datapath's own code** — a genuine veth/kernel characteristic
-   that doesn't apply to a real physical NIC uplink in production, only
-   to this lab's veth-pair simulation of one. Document as a lab-only
-   caveat when this section's live-traffic validation is actually run,
-   not carried forward as an unexplained blocker.
+2. **veth's native `XDP_TX` fast path does not deliver a frame to the
+   peer interface's normal receive stack at all, not merely invisibly,
+   unless the peer also runs an XDP program.** This corrects the
+   original diagnosis above: it was believed (based on `tcpdump`
+   observation alone) that the frame still arrived, just unobserved.
+   Confirmed live via the destination node's own eBPF datapath packet
+   counter (not `tcpdump`): with no peer XDP program, the counter stayed
+   at exactly zero through every attempt; attaching one made it move
+   immediately. **Not fixable in this datapath's own code** — a genuine
+   veth/kernel characteristic that doesn't apply to a real physical NIC
+   uplink in production (where `edgedsr.c`'s `XDP_TX`-back-out-the-same-
+   interface pattern is exactly how real production XDP-based DSR load
+   balancers, e.g. Katran, are built) — but it *is* fixable, and fixed,
+   at the lab level: `task deploy:lab-xdp-passthrough`
+   (`deploy/containerlab/Taskfile.yaml`, wired into `task deploy`) loads
+   a trivial pass-through XDP program
+   (`node_files/common/xdp-passthrough.c`) on `tr3`'s `eth6`/`eth7` --
+   the links facing `iad-gateway1`/`iad-gateway2`'s public interfaces --
+   making that veth pair behave the way a real NIC already does, rather
+   than converting `edgedsr.c` itself to TC and giving up XDP's
+   throughput advantage in production to work around a testing-only
+   artifact. `usid_ingress`/`usid_egress` (`usid.c`) never hit this at
+   all: they're already `SEC("tc")`, not XDP, which is exactly why
+   ordinary tenant traffic (ns10/ns20/etc.) always worked fine.
+3. **`vip_xlat_table`'s veth-kind delivery gap, and a key collision that
+   fix immediately exposed.** `vip.Bind` alone never delivered anything
+   to a VRF-isolated backend pod (it only binds the VIP outside any
+   tenant VRF); fixing that by having veth also use `vip_xlat_table`'s
+   substitution (previously tap-only) then exposed a second bug -- the
+   map's key couldn't distinguish an ingress row from an egress row when
+   the VIP port and backend port coincide (ns60's own binding: port 80
+   both ways). Both fixed on `feat/dsr-maglev-gateway`
+   (commits `a0e1677`, `d76e799`), with regression tests at both the Go
+   and kernel-verifier level.
+
+**Still not a full end-to-end success, for a fourth, separate,
+already-known reason:** with all three of the above fixed, `iad-worker`'s
+own datapath counters proved the *entire forward chain* works (gateway
+match → Maglev backend select → `XDP_TX` redirect → SRv6 transit →
+backend uSID decap → `vip_xlat_table` translation → VRF delivery). A full
+client-facing `curl` still doesn't complete, because the tenant VRF
+(`vrf60`) has no egress route at all -- not a DSR/gateway bug, but the
+pre-existing, already-tracked gap that `resources/galactic-nat66/`'s
+sharded egress tier (§3 above) was built but deliberately never wired
+into this lab's `gvpc.clab.yaml`/`Taskfile.yaml` bring-up (see that
+directory's own `README.md`). No tenant pod in this lab can reply to any
+external address today, independent of this redesign's own correctness.
 
 **Bonus find while chasing the above with a strict external observer
 (tcpdump) instead of just `BPF_PROG_TEST_RUN`:** two real,

--- a/internal/controller/indexer.go
+++ b/internal/controller/indexer.go
@@ -35,8 +35,11 @@ const (
 	BGPRouterByTargetName = ".spec.targetRef.name"
 )
 
-// RegisterIndexes registers all field indexes required by galactic-router controllers.
-// It must be called before starting the manager.
+// RegisterIndexes registers all field indexes required by galactic-router's
+// and galactic-gateway's controllers (e.g. NetworkGatewayReconciler's own
+// BGPRouterByTargetName lookup) against mgr's cache. Each binary runs its
+// own separate manager/cache, so this must be called once per process --
+// it must be called before starting the manager.
 func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	cache := mgr.GetCache()
 

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -515,6 +515,38 @@ func (r *NetworkGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return ruleToGatewayRequests(ctx, r.Client, obj)
 			}),
 		).
+		// buildBackendSIDIndex (via buildDesiredRule) resolves each rule's
+		// backend uSID from BGPRouter/BGPAdvertisement/BGPVRFInstance, but
+		// none of those were ever watched -- only NetworkRule/NetworkGateway
+		// themselves. A backend whose owning BGPAdvertisement doesn't exist
+		// yet at reconcile time (a real, observed startup race: this
+		// reconciler's own initial reconcile can run before
+		// NetworkRuleReconciler/galactic-router have created and
+		// re-reconciled it) permanently fails that rule with "no
+		// BGPAdvertisement owned by VPC ... found" -- buildDesiredRule's
+		// error is logged and the rule is skipped, not requeued, and
+		// nothing the reconciler *does* watch ever changes afterward, so
+		// the rule stays broken until something unrelated (a NetworkRule
+		// edit, a pod restart) happens to trigger another reconcile. These
+		// three watches close that gap the same way NetworkRule's own
+		// watch does: broadcast to every NetworkGateway in the namespace,
+		// since any of them could be the one whose backend resolution was
+		// waiting on this exact object.
+		Watches(&bgpv1alpha1.BGPRouter{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return broadcastToGatewayRequests(ctx, r.Client, obj.GetNamespace(), "BGPRouter", obj.GetName())
+			}),
+		).
+		Watches(&bgpv1alpha1.BGPAdvertisement{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return broadcastToGatewayRequests(ctx, r.Client, obj.GetNamespace(), "BGPAdvertisement", obj.GetName())
+			}),
+		).
+		Watches(&bgpv1alpha1.BGPVRFInstance{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return broadcastToGatewayRequests(ctx, r.Client, obj.GetNamespace(), "BGPVRFInstance", obj.GetName())
+			}),
+		).
 		Named("networkgateway").
 		Complete(r)
 }
@@ -531,11 +563,22 @@ func ruleToGatewayRequests(ctx context.Context, c client.Client, obj client.Obje
 	if !ok {
 		return nil
 	}
+	return broadcastToGatewayRequests(ctx, c, rule.Namespace, "NetworkRule", rule.Name)
+}
+
+// broadcastToGatewayRequests lists every NetworkGateway in namespace and
+// returns a reconcile request for each — the shared primitive
+// ruleToGatewayRequests and SetupWithManager's BGPRouter/BGPAdvertisement/
+// BGPVRFInstance watches all build on. sourceKind/sourceName are for the
+// list-failure log line only.
+func broadcastToGatewayRequests(
+	ctx context.Context, c client.Client, namespace, sourceKind, sourceName string,
+) []ctrlreconcile.Request {
 	logger := log.FromContext(ctx)
 
 	gwList := &bgpv1alpha1.NetworkGatewayList{}
-	if err := c.List(ctx, gwList, client.InNamespace(rule.Namespace)); err != nil {
-		logger.Error(err, "list NetworkGateways for NetworkRule change", "networkRule", rule.Name)
+	if err := c.List(ctx, gwList, client.InNamespace(namespace)); err != nil {
+		logger.Error(err, "list NetworkGateways for change", "sourceKind", sourceKind, "sourceName", sourceName)
 		return nil
 	}
 	reqs := make([]ctrlreconcile.Request, 0, len(gwList.Items))

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -668,6 +668,64 @@ func TestNetworkGatewayReconciler_WithdrawsAdvertisementsOnOwnDeletion(t *testin
 	}
 }
 
+// TestBroadcastToGatewayRequests_ListsEveryGatewayInNamespace covers the
+// primitive SetupWithManager's BGPRouter/BGPAdvertisement/BGPVRFInstance
+// watches build on (added to close a real startup race: buildBackendSIDIndex
+// resolving a rule's backend before its owning BGPAdvertisement existed
+// permanently failed that rule, since none of BGPRouter/BGPAdvertisement/
+// BGPVRFInstance were watched before -- only a later, unrelated reconcile
+// trigger happened to paper over it). One request per NetworkGateway in the
+// given namespace, none for a different namespace.
+func TestBroadcastToGatewayRequests_ListsEveryGatewayInNamespace(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gwA := newTestGateway(testNodeGWA)
+	gwB := newTestGateway(testNodeGWB)
+	otherNS := &bgpv1alpha1.NetworkGateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "gw-c"},
+		Spec:       bgpv1alpha1.NetworkGatewaySpec{TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: "gw-c"}},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gwA, gwB, otherNS).Build()
+
+	reqs := broadcastToGatewayRequests(context.Background(), fakeClient, testNamespace, "BGPAdvertisement", "some-adv")
+
+	if len(reqs) != 2 {
+		t.Fatalf("got %d requests, want 2 (one per NetworkGateway in %q, none from other-ns)", len(reqs), testNamespace)
+	}
+	got := map[string]bool{}
+	for _, r := range reqs {
+		if r.Namespace != testNamespace {
+			t.Errorf("request namespace = %q, want %q", r.Namespace, testNamespace)
+		}
+		got[r.Name] = true
+	}
+	if !got[testNodeGWA] || !got[testNodeGWB] {
+		t.Errorf("requests = %v, want both %q and %q", reqs, testNodeGWA, testNodeGWB)
+	}
+}
+
+func TestRuleToGatewayRequests_UsesRuleNamespace(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	gw := newTestGateway(testNodeGWA)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gw).Build()
+	rule := newTestRule(testRuleName, testVPCRef, testVIP)
+
+	reqs := ruleToGatewayRequests(context.Background(), fakeClient, rule)
+
+	if len(reqs) != 1 || reqs[0].Name != testNodeGWA {
+		t.Errorf("reqs = %v, want exactly one request for %q", reqs, testNodeGWA)
+	}
+}
+
+// TestRuleToGatewayRequests_WrongTypeReturnsNil covers
+// EnqueueRequestsFromMapFunc's contract: the map function is only ever
+// called with the watched type, but a defensive type assertion (rather
+// than a panic-inducing cast) is what makes that safe to rely on.
+func TestRuleToGatewayRequests_WrongTypeReturnsNil(t *testing.T) {
+	if reqs := ruleToGatewayRequests(context.Background(), nil, &bgpv1alpha1.NetworkGateway{}); reqs != nil {
+		t.Errorf("reqs = %v, want nil for a non-NetworkRule object", reqs)
+	}
+}
+
 func TestPrefixesByFamily(t *testing.T) {
 	vips := []netip.Addr{netip.MustParseAddr(testVIP), netip.MustParseAddr("2001:db8::1")}
 	v4, v6 := prefixesByFamily(vips)

--- a/internal/controller/servicevipbinding_controller.go
+++ b/internal/controller/servicevipbinding_controller.go
@@ -53,7 +53,8 @@ var (
 )
 
 // VIPTranslationTable is the interface ServiceVIPBindingReconciler drives
-// for EgressKindTap bindings, satisfied by *vipxlatmap.VipXlatTable in
+// for both EgressKindVeth and EgressKindTap bindings (see
+// registerVIPTranslation), satisfied by *vipxlatmap.VipXlatTable in
 // production and a fake in tests -- the same interface-seam pattern
 // GatewayEngine (networkgateway_controller.go) provides for *gateway.Engine.
 type VIPTranslationTable interface {
@@ -69,27 +70,53 @@ type VIPTranslationTable interface {
 // this node (spec.targetRef.name == NodeName) -- the backend-side half of
 // the DSR/Maglev gateway redesign (see ServiceVIPBinding's own doc
 // comment). It branches on Spec.EgressKind exactly like usid.c's own
-// vrf_table egress_kind field does:
+// vrf_table egress_kind field does, but both branches now converge on the
+// same delivery mechanism:
 //
-//   - EgressKindVeth calls internal/plumbing/vip.Bind/Unbind/Verify.
 //   - EgressKindTap calls VIPTranslationTable's Register/Unregister methods
 //     (vip_xlat_table's two independent rows -- see
 //     internal/plumbing/ebpf/vipxlatmap's package doc comment), after
 //     resolving this node's own uSID Block and the tenant VRF's Argument
-//     via resolveTapVIPContext.
+//     via resolveVIPBindingContext.
+//   - EgressKindVeth does the *same* vip_xlat_table registration (see
+//     registerVIPTranslation), plus internal/plumbing/vip.Bind/Unbind/Verify.
 //
-// VIPTranslationTable is nil-safe for veth-only tests/deployments (e.g. a
-// node with no eBPF uSID datapath loaded at all): a nil table only matters
-// once a tap-kind binding is actually reconciled, at which point it fails
-// with a clear, actionable error rather than a nil-pointer panic.
+// # Why veth needs vip_xlat_table too, not just vip.Bind
+//
+// vip.Bind only assigns the VIP to a plain dummy interface in the node's
+// *root* network namespace -- not enslaved to any tenant VRF (see
+// internal/plumbing/vip's own doc comment). But a DSR-forwarded ingress
+// packet is decapsulated by usid_ingress and delivered into the owning
+// tenant's *own* VRF routing table, which has no route to an address that
+// only exists on a root-namespace interface outside that VRF entirely.
+// Found live in containerlab: a NetworkRule's VIP reported fully
+// Advertised/Ready, the edge datapath's own metrics showed it matching and
+// forwarding every packet with zero drops, and the connection still never
+// completed -- traced to exactly this: iad-worker's own vrf60 routing
+// table had a route for the backend pod's real address but none at all for
+// the VIP. vip_xlat_table's ingress row rewrites the packet's destination
+// from VIP to the backend's real, already-routed address *before* that VRF
+// lookup happens (usid.c's own comment on this step: "translate the inner
+// packet's destination before the FIB lookup ... so the lookup resolves
+// against the tenant's real, routed address") -- exactly the missing
+// piece, and usid_ingress applies it unconditionally whenever a matching
+// vip_xlat_table row exists, regardless of egress_kind; only the control
+// plane was ever kind-gated. vip.Bind is kept alongside it for veth (not
+// replaced): it still gives the node itself a locally-verifiable answer on
+// the VIP (see vip.Verify), which registerVIPTranslation alone would not.
+//
+// VIPTranslationTable is nil-safe for tests that never reconcile a live
+// binding: a nil table only matters once one actually is, at which point
+// it fails with a clear, actionable error rather than a nil-pointer panic.
 type ServiceVIPBindingReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
 	NodeName string
 
-	// VIPTranslationTable is the tap-branch's kernel-map handle. See the
-	// type doc comment above for its nil-safety contract.
+	// VIPTranslationTable is the kernel-map handle both EgressKindVeth and
+	// EgressKindTap now drive (see the type doc comment above). See its own
+	// nil-safety contract there.
 	VIPTranslationTable VIPTranslationTable
 }
 
@@ -157,8 +184,10 @@ func (r *ServiceVIPBindingReconciler) reconcileBind(ctx context.Context, binding
 	return nil
 }
 
-// applyBind performs the actual veth bind or tap registration for binding,
-// branching on Spec.EgressKind.
+// applyBind performs the actual veth or tap binding for binding, branching
+// on Spec.EgressKind. Both kinds now register the same vip_xlat_table rows
+// (see registerVIPTranslation and the type doc comment above); veth
+// additionally does the root-namespace vip.Bind/Verify.
 func (r *ServiceVIPBindingReconciler) applyBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
 	switch binding.Spec.EgressKind {
 	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
@@ -172,21 +201,25 @@ func (r *ServiceVIPBindingReconciler) applyBind(ctx context.Context, binding *bg
 		if err := vipVerifyFn(vipAddr); err != nil {
 			return fmt.Errorf("vip.Verify: %w", err)
 		}
-		return nil
+		return r.registerVIPTranslation(ctx, binding)
 	case bgpv1alpha1.ServiceVIPBindingEgressKindTap:
-		return r.applyTapBind(ctx, binding)
+		return r.registerVIPTranslation(ctx, binding)
 	default:
 		return fmt.Errorf("unknown egressKind %q", binding.Spec.EgressKind)
 	}
 }
 
-// applyTapBind registers both vip_xlat_table rows (ingress and egress) for
-// a tap-kind binding, after resolving this node's own uSID Block and the
-// owning tenant VRF's Argument (resolveTapVIPContext).
-func (r *ServiceVIPBindingReconciler) applyTapBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
+// registerVIPTranslation registers both vip_xlat_table rows (ingress and
+// egress) for binding, after resolving this node's own uSID Block and the
+// owning tenant VRF's Argument (resolveVIPBindingContext). Shared by both
+// EgressKindVeth and EgressKindTap -- see ServiceVIPBindingReconciler's own
+// doc comment for why veth needs this too, not just tap.
+func (r *ServiceVIPBindingReconciler) registerVIPTranslation(
+	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
+) error {
 	if r.VIPTranslationTable == nil {
-		return errors.New("vip_xlat_table is not available on this node (eBPF uSID datapath not loaded); " +
-			"cannot bind a tap-kind ServiceVIPBinding")
+		return fmt.Errorf("vip_xlat_table is not available on this node (eBPF uSID datapath not loaded); "+
+			"cannot bind a %s-kind ServiceVIPBinding", binding.Spec.EgressKind)
 	}
 
 	vipAddr := net.ParseIP(binding.Spec.VIPAddress)
@@ -195,7 +228,8 @@ func (r *ServiceVIPBindingReconciler) applyTapBind(ctx context.Context, binding 
 	}
 	backendAddr := net.ParseIP(binding.Spec.BackendAddress)
 	if backendAddr == nil {
-		return fmt.Errorf("invalid backendAddress %q (required for egressKind tap)", binding.Spec.BackendAddress)
+		return fmt.Errorf("invalid backendAddress %q (required for both egressKind veth and tap)",
+			binding.Spec.BackendAddress)
 	}
 	backendAddrIP, err := netip.ParseAddr(binding.Spec.BackendAddress)
 	if err != nil {
@@ -207,9 +241,9 @@ func (r *ServiceVIPBindingReconciler) applyTapBind(ctx context.Context, binding 
 		return err
 	}
 
-	block, argument, err := resolveTapVIPContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
+	block, argument, err := resolveVIPBindingContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
 	if err != nil {
-		return fmt.Errorf("resolve VRF context for tap VIP binding: %w", err)
+		return fmt.Errorf("resolve VRF context for VIP binding: %w", err)
 	}
 
 	vipPort := uint16(binding.Spec.Port)            //nolint:gosec // kubebuilder-validated 1-65535
@@ -252,36 +286,49 @@ func (r *ServiceVIPBindingReconciler) reconcileDelete(
 	return ctrl.Result{}, nil
 }
 
-// applyUnbind performs the actual veth unbind or tap unregistration for
-// binding, branching on Spec.EgressKind.
+// applyUnbind performs the actual veth or tap unbind for binding, branching
+// on Spec.EgressKind. Both kinds now unregister the same vip_xlat_table
+// rows (see unregisterVIPTranslation); veth additionally does the
+// root-namespace vip.Unbind. For veth, both are attempted even if one
+// fails, and any errors are joined -- mirroring unregisterVIPTranslation's
+// own "attempt every candidate even if one fails" convention -- so a
+// failure in one mechanism never silently skips tearing down the other.
 func (r *ServiceVIPBindingReconciler) applyUnbind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
 	switch binding.Spec.EgressKind {
 	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
-		vipAddr := net.ParseIP(binding.Spec.VIPAddress)
-		if vipAddr == nil {
-			return nil // already-invalid address; nothing meaningful to unbind
+		var errs []error
+		if err := r.unregisterVIPTranslation(ctx, binding); err != nil {
+			errs = append(errs, err)
 		}
-		return vipUnbindFn(vipAddr)
+		if vipAddr := net.ParseIP(binding.Spec.VIPAddress); vipAddr != nil {
+			if err := vipUnbindFn(vipAddr); err != nil {
+				errs = append(errs, err)
+			}
+		} // else: already-invalid address; nothing meaningful for vip.Unbind to do
+		return errors.Join(errs...)
 	case bgpv1alpha1.ServiceVIPBindingEgressKindTap:
-		if r.VIPTranslationTable == nil {
-			return errors.New(
-				"vip_xlat_table is not available on this node; cannot unregister a tap-kind ServiceVIPBinding")
-		}
-		return r.applyTapUnbind(ctx, binding)
+		return r.unregisterVIPTranslation(ctx, binding)
 	default:
 		return nil
 	}
 }
 
-// applyTapUnbind removes both vip_xlat_table rows for a tap-kind binding.
-// Both directions are attempted even if resolving the VRF context or the
-// first Unregister call fails, and any errors are joined together --
-// mirroring usidmap.VRFTable.Reconcile's own "attempt every candidate even
-// if one fails" convention -- so a partial failure never silently leaves
-// the other row behind unregistered.
-func (r *ServiceVIPBindingReconciler) applyTapUnbind(
+// unregisterVIPTranslation removes both vip_xlat_table rows for binding.
+// Shared by both EgressKindVeth and EgressKindTap -- see
+// ServiceVIPBindingReconciler's own doc comment. Both directions are
+// attempted even if resolving the VRF context or the first Unregister call
+// fails, and any errors are joined together -- mirroring
+// usidmap.VRFTable.Reconcile's own "attempt every candidate even if one
+// fails" convention -- so a partial failure never silently leaves the
+// other row behind unregistered.
+func (r *ServiceVIPBindingReconciler) unregisterVIPTranslation(
 	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
 ) error {
+	if r.VIPTranslationTable == nil {
+		return fmt.Errorf("vip_xlat_table is not available on this node; cannot unregister a %s-kind ServiceVIPBinding",
+			binding.Spec.EgressKind)
+	}
+
 	proto, err := ipProtocolNumber(binding.Spec.Protocol)
 	if err != nil {
 		return err
@@ -292,9 +339,9 @@ func (r *ServiceVIPBindingReconciler) applyTapUnbind(
 		return fmt.Errorf("parse backendAddress %q: %w", binding.Spec.BackendAddress, err)
 	}
 
-	block, argument, err := resolveTapVIPContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
+	block, argument, err := resolveVIPBindingContext(ctx, r.Client, binding.Namespace, r.NodeName, backendAddrIP.Unmap())
 	if err != nil {
-		return fmt.Errorf("resolve VRF context for tap VIP unbind: %w", err)
+		return fmt.Errorf("resolve VRF context for VIP unbind: %w", err)
 	}
 
 	vipPort := uint16(binding.Spec.Port)            //nolint:gosec // kubebuilder-validated 1-65535
@@ -324,7 +371,7 @@ func ipProtocolNumber(proto bgpv1alpha1.NetworkRuleProtocol) (uint8, error) {
 	}
 }
 
-// resolveTapVIPContext resolves this node's own uSID Block (from its
+// resolveVIPBindingContext resolves this node's own uSID Block (from its
 // BGPRouter's SRv6Locator) and the owning tenant VRF's Argument (from the
 // BGPVRFInstance whose VRFID is associated with a BGPAdvertisement whose
 // advertised prefix contains backendAddr) -- the (block, argument) pair
@@ -365,7 +412,7 @@ func ipProtocolNumber(proto bgpv1alpha1.NetworkRuleProtocol) (uint8, error) {
 // object), replace this address-containment heuristic with a direct
 // lookup -- see crdnames.BGPVRFInstanceName(vpc, nodeName) for the
 // deterministic name that lookup would use.
-func resolveTapVIPContext(
+func resolveVIPBindingContext(
 	ctx context.Context, c client.Client, namespace, nodeName string, backendAddr netip.Addr,
 ) (block uint64, argument uint16, err error) {
 	idx, err := buildBackendSIDIndex(ctx, c, namespace)
@@ -440,7 +487,7 @@ func resolveTapVIPContext(
 		return 0, 0, fmt.Errorf(
 			"ambiguous VRF ownership for backend address %s on node %q: %d candidate VRFIDs %v all advertise a "+
 				"containing prefix, and ServiceVIPBinding carries no VPCRef/VRFRef to disambiguate "+
-				"(see resolveTapVIPContext's doc comment); refusing to guess",
+				"(see resolveVIPBindingContext's doc comment); refusing to guess",
 			backendAddr, nodeName, len(matches), matches)
 	}
 }

--- a/internal/controller/servicevipbinding_controller_test.go
+++ b/internal/controller/servicevipbinding_controller_test.go
@@ -147,13 +147,26 @@ func TestServiceVIPBindingReconciler_NotMineIsIgnored(t *testing.T) {
 	}
 }
 
+// newVethTestBinding returns a veth-kind ServiceVIPBinding targeting
+// testComputeNodeName with BackendAddress overridden to testBackendAddr --
+// veth now needs vip_xlat_table registration too (see
+// ServiceVIPBindingReconciler's own doc comment), which requires a backend
+// address resolvable against newBackendFixtures' advertised prefix, the
+// same fixtures the tap tests already use.
+func newVethTestBinding() *bgpv1alpha1.ServiceVIPBinding {
+	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testComputeNodeName)
+	binding.Spec.BackendAddress = testBackendAddr
+	return binding
+}
+
 func TestServiceVIPBindingReconciler_VethBindSuccess(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newVethTestBinding()
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
-		WithObjects(binding).
+		WithObjects(router, adv, vrf, binding).
 		Build()
 
 	var boundAddr net.IP
@@ -163,13 +176,21 @@ func TestServiceVIPBindingReconciler_VethBindSuccess(t *testing.T) {
 		func(net.IP) error { return nil },
 	)
 
-	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	table := &fakeVIPTable{}
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName, VIPTranslationTable: table}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
 	}
 
 	if boundAddr == nil || !boundAddr.Equal(net.ParseIP(testVIPBindingVIPAddr)) {
 		t.Errorf("vip.Bind called with %v, want %s", boundAddr, testVIPBindingVIPAddr)
+	}
+	// The actual fix: veth must ALSO register vip_xlat_table rows, not just
+	// vip.Bind -- see ServiceVIPBindingReconciler's own doc comment for why
+	// vip.Bind alone never delivered anything to a VRF-isolated backend pod.
+	if len(table.ingressCalls) != 1 || len(table.egressCalls) != 1 {
+		t.Fatalf("ingressCalls=%d egressCalls=%d, want 1 each (veth must register vip_xlat_table too)",
+			len(table.ingressCalls), len(table.egressCalls))
 	}
 
 	got := &bgpv1alpha1.ServiceVIPBinding{}
@@ -184,9 +205,35 @@ func TestServiceVIPBindingReconciler_VethBindSuccess(t *testing.T) {
 	}
 }
 
+// TestServiceVIPBindingReconciler_VethNilTableFails mirrors
+// TestServiceVIPBindingReconciler_TapNilTableFails: veth now needs
+// VIPTranslationTable too, not just for tap.
+func TestServiceVIPBindingReconciler_VethNilTableFails(t *testing.T) {
+	scheme := newRuleTestScheme(t)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newVethTestBinding()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
+		WithObjects(router, adv, vrf, binding).
+		Build()
+
+	stubVIPFns(t,
+		func(net.IP) error { return nil },
+		func(net.IP) error { return nil },
+		func(net.IP) error { return nil },
+	)
+
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName} // no VIPTranslationTable
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err == nil {
+		t.Fatal("Reconcile: expected an error binding a veth-kind ServiceVIPBinding with no VIPTranslationTable")
+	}
+}
+
 func TestServiceVIPBindingReconciler_VethUnbindOnDelete(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newVethTestBinding()
 	controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
 	now := metav1.Now()
 	binding.DeletionTimestamp = &now
@@ -194,7 +241,7 @@ func TestServiceVIPBindingReconciler_VethUnbindOnDelete(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
-		WithObjects(binding).
+		WithObjects(router, adv, vrf, binding).
 		Build()
 
 	var unboundAddr net.IP
@@ -204,13 +251,18 @@ func TestServiceVIPBindingReconciler_VethUnbindOnDelete(t *testing.T) {
 		func(net.IP) error { return nil },
 	)
 
-	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	table := &fakeVIPTable{}
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName, VIPTranslationTable: table}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err != nil {
 		t.Fatalf("Reconcile: unexpected error: %v", err)
 	}
 
 	if unboundAddr == nil || !unboundAddr.Equal(net.ParseIP(testVIPBindingVIPAddr)) {
 		t.Errorf("vip.Unbind called with %v, want %s", unboundAddr, testVIPBindingVIPAddr)
+	}
+	if len(table.unregIngress) != 1 || len(table.unregEgress) != 1 {
+		t.Fatalf("unregIngress=%d unregEgress=%d, want 1 each (veth must unregister vip_xlat_table too)",
+			len(table.unregIngress), len(table.unregEgress))
 	}
 
 	// Removing the last finalizer from an object that already carries a
@@ -228,10 +280,12 @@ func TestServiceVIPBindingReconciler_VethUnbindOnDelete(t *testing.T) {
 // "finalizer add/remove ordering" requirement: a failing unbind/unregister
 // must never let the finalizer be removed, so the object stays present
 // (blocking deletion, and retried) rather than silently leaking host/kernel
-// state.
+// state. VIPTranslationTable is a working fake here so only vip.Unbind's
+// own failure is under test.
 func TestServiceVIPBindingReconciler_FinalizerKeptWhenUnbindFails(t *testing.T) {
 	scheme := newRuleTestScheme(t)
-	binding := newTestServiceVIPBinding(bgpv1alpha1.ServiceVIPBindingEgressKindVeth, testVIPBindingNode)
+	router, adv, vrf := newBackendFixtures(testVPCRef)
+	binding := newVethTestBinding()
 	controllerutil.AddFinalizer(binding, serviceVIPBindingFinalizer)
 	now := metav1.Now()
 	binding.DeletionTimestamp = &now
@@ -239,7 +293,7 @@ func TestServiceVIPBindingReconciler_FinalizerKeptWhenUnbindFails(t *testing.T) 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&bgpv1alpha1.ServiceVIPBinding{}).
-		WithObjects(binding).
+		WithObjects(router, adv, vrf, binding).
 		Build()
 
 	stubVIPFns(t,
@@ -248,7 +302,8 @@ func TestServiceVIPBindingReconciler_FinalizerKeptWhenUnbindFails(t *testing.T) 
 		func(net.IP) error { return nil },
 	)
 
-	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testVIPBindingNode}
+	table := &fakeVIPTable{}
+	r := &ServiceVIPBindingReconciler{Client: fakeClient, NodeName: testComputeNodeName, VIPTranslationTable: table}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: bindingKey()}); err == nil {
 		t.Fatal("Reconcile: expected an error when vip.Unbind fails")
 	}
@@ -356,15 +411,15 @@ func TestServiceVIPBindingReconciler_TapNilTableFails(t *testing.T) {
 	}
 }
 
-func TestResolveTapVIPContext_Success(t *testing.T) {
+func TestResolveVIPBindingContext_Success(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	router, adv, vrf := newBackendFixtures(testVPCRef)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
 
-	block, argument, err := resolveTapVIPContext(
+	block, argument, err := resolveVIPBindingContext(
 		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr(testBackendAddr))
 	if err != nil {
-		t.Fatalf("resolveTapVIPContext: unexpected error: %v", err)
+		t.Fatalf("resolveVIPBindingContext: unexpected error: %v", err)
 	}
 	if argument != uint16(testBackendVRFID) {
 		t.Errorf("argument = %d, want %d", argument, testBackendVRFID)
@@ -374,22 +429,22 @@ func TestResolveTapVIPContext_Success(t *testing.T) {
 	}
 }
 
-func TestResolveTapVIPContext_NoMatchingVRF(t *testing.T) {
+func TestResolveVIPBindingContext_NoMatchingVRF(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	router, adv, vrf := newBackendFixtures(testVPCRef)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf).Build()
 
-	if _, _, err := resolveTapVIPContext(
+	if _, _, err := resolveVIPBindingContext(
 		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr("192.0.2.1")); err == nil {
-		t.Fatal("resolveTapVIPContext: expected an error for an address with no matching advertised prefix")
+		t.Fatal("resolveVIPBindingContext: expected an error for an address with no matching advertised prefix")
 	}
 }
 
-// TestResolveTapVIPContext_AmbiguousFailsClosed covers the documented
+// TestResolveVIPBindingContext_AmbiguousFailsClosed covers the documented
 // ambiguity: two local BGPVRFInstances on the same node both advertise a
 // prefix containing the same backend address (e.g. two tenants using the
-// same ULA range) -- resolveTapVIPContext must fail rather than guess.
-func TestResolveTapVIPContext_AmbiguousFailsClosed(t *testing.T) {
+// same ULA range) -- resolveVIPBindingContext must fail rather than guess.
+func TestResolveVIPBindingContext_AmbiguousFailsClosed(t *testing.T) {
 	scheme := newRuleTestScheme(t)
 	router, adv, vrf := newBackendFixtures(testVPCRef)
 
@@ -417,9 +472,9 @@ func TestResolveTapVIPContext_AmbiguousFailsClosed(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, adv, vrf, adv2, vrf2).Build()
 
-	_, _, err := resolveTapVIPContext(
+	_, _, err := resolveVIPBindingContext(
 		context.Background(), fakeClient, testNamespace, testComputeNodeName, netip.MustParseAddr(testBackendAddr))
 	if err == nil {
-		t.Fatal("resolveTapVIPContext: expected a fail-closed error for ambiguous VRF ownership")
+		t.Fatal("resolveVIPBindingContext: expected a fail-closed error for ambiguous VRF ownership")
 	}
 }

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -431,23 +431,40 @@ struct nptv6_value {
 // since the two directions substitute in opposite directions and are
 // looked up via different fields of the same packet.
 //
-// pad2 exists only to eliminate the struct's own trailing alignment
-// padding: block's __u64 alignment rounds this struct up to 16 bytes, but
-// block+argument+proto+pad+port only account for 14 of them, leaving 2
-// bytes of compiler-inserted tail padding no initializer touches. C99
-// zero-initializes an *omitted named member* (like pad, above) but says
-// nothing about true structural padding, and clang's BPF backend does not
-// zero it -- bpf_map_lookup_elem() then reads all 16 key bytes and the
-// verifier rejects the two never-written ones as "invalid read from
-// stack" (caught live via a real containerlab deploy, both vkey
-// initializers below only ever set block/argument/proto/port). Naming the
+// direction disambiguates those two rows when their ports coincide -- a
+// common, unremarkable case (e.g. a binding that keeps port 80 on both the
+// VIP and the backend), not a rare one, and one this struct originally had
+// no way to handle: (block, argument, proto, port) alone collapses the
+// ingress row (keyed on the VIP port) and the egress row (keyed on the
+// backend port) into the *same* map entry whenever those two ports match,
+// so registering the second row silently overwrote the first -- found live
+// in containerlab, where ns60's binding uses port 80 both ways and the
+// ingress row (VIP -> backend) never survived RegisterEgress's later
+// write, leaving every packet correctly matched by the edge gateway but
+// silently undeliverable at the backend. usid_ingress always sets
+// direction to USID_VIP_XLAT_DIR_INGRESS on the key it builds;
+// usid_egress always sets USID_VIP_XLAT_DIR_EGRESS -- see vipxlatmap.go's
+// mirroring register()/unregister() split for the control-plane side.
+//
+// The trailing pad2 exists only to eliminate the struct's own compiler-
+// inserted alignment padding: block's __u64 alignment rounds this struct
+// up to 16 bytes, but block+argument+proto+direction+port only account for
+// 14 of them, leaving 2 bytes no initializer touches. C99 zero-initializes
+// an *omitted named member* (like direction, when a caller doesn't set it)
+// but says nothing about true structural padding, and clang's BPF backend
+// does not zero it -- bpf_map_lookup_elem() then reads all 16 key bytes
+// and the verifier rejects the two never-written ones as "invalid read
+// from stack" (caught live via a real containerlab deploy). Naming the
 // last 2 bytes as a real member makes them a normal omitted-member zero,
 // not padding.
+#define USID_VIP_XLAT_DIR_INGRESS 0
+#define USID_VIP_XLAT_DIR_EGRESS 1
+
 struct vip_xlat_key {
 	__u64 block;
 	__u16 argument;
 	__u8 proto;
-	__u8 pad;
+	__u8 direction;
 	__be16 port;
 	__u16 pad2;
 };
@@ -1025,6 +1042,7 @@ int usid_ingress(struct __sk_buff *skb)
 				struct vip_xlat_key vkey = {
 					.block = block, .argument = argument,
 					.proto = inner6->nexthdr, .port = ports->dest,
+					.direction = USID_VIP_XLAT_DIR_INGRESS,
 				};
 				struct vip_xlat_value *vv = bpf_map_lookup_elem(&vip_xlat_table, &vkey);
 
@@ -1237,6 +1255,7 @@ int usid_egress(struct __sk_buff *skb)
 			struct vip_xlat_key vkey = {
 				.block = iv->block, .argument = iv->argument,
 				.proto = ip6->nexthdr, .port = ports->source,
+				.direction = USID_VIP_XLAT_DIR_EGRESS,
 			};
 			struct vip_xlat_value *vv = bpf_map_lookup_elem(&vip_xlat_table, &vkey);
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -430,12 +430,26 @@ struct nptv6_value {
 // each ServiceVIPBinding writes one row under each key (vip_xlat.go),
 // since the two directions substitute in opposite directions and are
 // looked up via different fields of the same packet.
+//
+// pad2 exists only to eliminate the struct's own trailing alignment
+// padding: block's __u64 alignment rounds this struct up to 16 bytes, but
+// block+argument+proto+pad+port only account for 14 of them, leaving 2
+// bytes of compiler-inserted tail padding no initializer touches. C99
+// zero-initializes an *omitted named member* (like pad, above) but says
+// nothing about true structural padding, and clang's BPF backend does not
+// zero it -- bpf_map_lookup_elem() then reads all 16 key bytes and the
+// verifier rejects the two never-written ones as "invalid read from
+// stack" (caught live via a real containerlab deploy, both vkey
+// initializers below only ever set block/argument/proto/port). Naming the
+// last 2 bytes as a real member makes them a normal omitted-member zero,
+// not padding.
 struct vip_xlat_key {
 	__u64 block;
 	__u16 argument;
 	__u8 proto;
 	__u8 pad;
 	__be16 port;
+	__u16 pad2;
 };
 
 // struct vip_xlat_value is vip_xlat_table's value: unlike nptv6_value, this

--- a/internal/plumbing/ebpf/prog/usid_test.go
+++ b/internal/plumbing/ebpf/prog/usid_test.go
@@ -1007,6 +1007,107 @@ func TestUsidIngress_VIPXlatRewritesAddrPortAndChecksum(t *testing.T) {
 	}
 }
 
+// TestUsidIngress_VIPXlatSurvivesIdenticalPortEgressRow is the kernel-level
+// regression test for the bug found live in containerlab: a binding that
+// keeps the *same* port number on both the VIP and the backend (ns60's own
+// binding uses port 80 both ways) used to collapse the ingress and egress
+// rows into one map entry, since (block, argument, proto, port) alone was
+// the whole key -- struct vip_xlat_key's Direction field is what now keeps
+// them distinct. This test populates *both* rows at the identical port (as
+// vip_xlat.go's RegisterIngress/RegisterEgress genuinely would for such a
+// binding) and proves usid_ingress still resolves its own (Direction =
+// USID_VIP_XLAT_DIR_INGRESS) row correctly rather than reading back the
+// coexisting egress row's value.
+func TestUsidIngress_VIPXlatSurvivesIdenticalPortEgressRow(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	usid := testUSID{block: baseUSID.block, nodeID: baseUSID.nodeID, function: uformat.FunctionEndDT46, argument: 0x654}
+	if err := objs.LocatorTable.Put(usid.locatorKey(t), UsidLocatorValue{Generation: 1}); err != nil {
+		t.Fatalf("populate locator_table: %v", err)
+	}
+	if err := objs.FunctionTable.Put(usid.functionKey(t), UsidFunctionValue{Behavior: 1}); err != nil {
+		t.Fatalf("populate function_table: %v", err)
+	}
+	const bogusVRFTableID = 0x2C2C2C
+	if err := objs.VrfTable.Put(usid.vrfKey(), UsidVrfValue{VrfTableId: bogusVRFTableID}); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+
+	vip := netip.MustParseAddr("2001:db8:6060::1")
+	backend := netip.MustParseAddr("fd20:60:ff03::100:0")
+	const port = 80 // deliberately identical on both sides, unlike the test above
+
+	ingressKey := UsidVipXlatKey{
+		Block: usid.block, Argument: usid.argument, Proto: 17, /* UDP */
+		Direction: usidVIPXlatDirIngress, Port: bswap16(port),
+	}
+	if err := objs.VipXlatTable.Put(ingressKey, UsidVipXlatValue{
+		Addr: backend.As16(), Port: bswap16(port),
+	}); err != nil {
+		t.Fatalf("populate vip_xlat_table (ingress row): %v", err)
+	}
+	// The coexisting egress row RegisterEgress would also write for this
+	// same binding -- same (block, argument, proto, port), opposite
+	// direction and value. If Direction didn't distinguish them, this Put
+	// would have overwritten the ingress row above.
+	egressKey := UsidVipXlatKey{
+		Block: usid.block, Argument: usid.argument, Proto: 17,
+		Direction: usidVIPXlatDirEgress, Port: bswap16(port),
+	}
+	if err := objs.VipXlatTable.Put(egressKey, UsidVipXlatValue{
+		Addr: vip.As16(), Port: bswap16(port),
+	}); err != nil {
+		t.Fatalf("populate vip_xlat_table (egress row): %v", err)
+	}
+
+	innerSrc := netip.MustParseAddr("2001:db8:ffff::1")
+	const clientPort = 54321
+	payload := []byte("hello")
+
+	udp := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint16(udp[0:2], clientPort)
+	binary.BigEndian.PutUint16(udp[2:4], port)
+	binary.BigEndian.PutUint16(udp[4:6], uint16(len(udp)))
+	copy(udp[8:], payload)
+	origCsum := udp6Checksum(innerSrc.As16(), vip.As16(), udp)
+	binary.BigEndian.PutUint16(udp[6:8], origCsum)
+
+	pkt := buildPacketWithUDPInner(t, usid.addr(t), netip.MustParseAddr("2001:db8::1"), innerSrc, vip, udp)
+
+	ret, out, err := objs.UsidIngress.Test(pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != tcActShot {
+		t.Fatalf("verdict = %d, want TC_ACT_SHOT (%d)", ret, tcActShot)
+	}
+
+	const daddrOffset = ethHeaderLen + 24
+	const udpOffset = ethHeaderLen + ip6HeaderLen
+	var gotDaddr [16]byte
+	copy(gotDaddr[:], out[daddrOffset:daddrOffset+16])
+	if wantDaddr := backend.As16(); gotDaddr != wantDaddr {
+		t.Errorf("daddr after vip_xlat = %x, want %x (backend address) -- got the egress row's value instead, "+
+			"meaning Direction failed to keep the two rows apart", gotDaddr, wantDaddr)
+	}
+	gotDstPort := binary.BigEndian.Uint16(out[udpOffset+2 : udpOffset+4])
+	if gotDstPort != port {
+		t.Errorf("UDP dest port after vip_xlat = %d, want %d", gotDstPort, port)
+	}
+}
+
+// usidVIPXlatDirIngress/usidVIPXlatDirEgress mirror usid.c's
+// USID_VIP_XLAT_DIR_INGRESS/USID_VIP_XLAT_DIR_EGRESS -- bpf2go generates no
+// symbol for a #define, so tests that need to populate vip_xlat_table with
+// an explicit direction (anything beyond the ingress-direction default a
+// zero-value UsidVipXlatKey already produces) name the raw values here
+// once, rather than each hard-coding a bare 0/1.
+const (
+	usidVIPXlatDirIngress = 0
+	usidVIPXlatDirEgress  = 1
+)
+
 // bswap16 is netip.Addr-adjacent test glue: UsidVipXlatKey/Value's Port
 // fields are __be16 (network/big-endian) on the C side; bpf2go generates
 // them as a plain uint16 Go field with no automatic byte-swap, so tests

--- a/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
+++ b/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
@@ -4,12 +4,20 @@
 
 // Package vipxlatmap implements the read/write API for the eBPF uSID
 // datapath's vip_xlat_table map (usid.c's struct vip_xlat_key/
-// vip_xlat_value) -- the DSR/Maglev redesign's tap-backend VIP-boundary
-// substitution (design plan §0.1, §2). It is the ServiceVIPBinding
-// reconciler's (internal/controller/servicevipbinding_controller.go)
-// EgressKindTap counterpart to internal/plumbing/vip's veth-branch
-// Bind/Unbind/Verify, mirroring internal/plumbing/ebpf/usidmap's own
-// Register/Unregister/Get/List/Reconcile shape for vrf_table.
+// vip_xlat_value) -- the DSR/Maglev redesign's VIP-boundary substitution
+// (design plan §0.1, §2), originally built for the tap-backend case but
+// now driven by ServiceVIPBindingReconciler
+// (internal/controller/servicevipbinding_controller.go) for EgressKindVeth
+// too: a decapsulated ingress packet is delivered into the owning
+// tenant's own VRF routing table, which has no route to a veth binding's
+// address on internal/plumbing/vip's root-namespace dummy interface --
+// found live in containerlab (see ServiceVIPBindingReconciler's own doc
+// comment) -- and this package's ingress row, run unconditionally by
+// usid_ingress whenever a matching entry exists, rewrites the destination
+// to the backend's real, already-routed address before that VRF lookup
+// happens, closing exactly that gap. Mirrors
+// internal/plumbing/ebpf/usidmap's own Register/Unregister/Get/List/
+// Reconcile shape for vrf_table.
 //
 // # Two independent rows per binding
 //
@@ -179,12 +187,31 @@ func addrTo16(addr net.IP) ([16]byte, error) {
 	return a.As16(), nil
 }
 
+// directionIngress/directionEgress mirror usid.c's
+// USID_VIP_XLAT_DIR_INGRESS/USID_VIP_XLAT_DIR_EGRESS -- the byte value the
+// kernel key's Direction field must carry so usid_ingress's and
+// usid_egress's own, direction-fixed key constructions ever find the row
+// each is looking for. Needed because (block, argument, proto, port) alone
+// is not always unique: a binding that keeps the same port number on both
+// the VIP and the backend (an unremarkable, common case, not a rare one --
+// found live in containerlab, ns60's binding uses port 80 both ways) would
+// otherwise collapse the ingress and egress rows into the same map entry,
+// silently losing whichever was registered first. This package's own
+// exported API stays direction-implicit (RegisterIngress/RegisterEgress/
+// UnregisterIngress/UnregisterEgress/GetIngress/GetEgress each hard-code
+// the direction their own name implies) -- only the kernel key construction
+// below needs the actual byte value.
+const (
+	directionIngress = uint8(0)
+	directionEgress  = uint8(1)
+)
+
 // register is the shared primitive RegisterIngress/RegisterEgress build
 // their (key, value) pair around. keyPort is the port this row's kernel key
 // is composed with (direction-dependent -- see the package doc comment);
 // valAddr/valPort are the rewrite target this row substitutes in.
 func (t *VipXlatTable) register(
-	block uint64, argument uint16, proto uint8, keyPort uint16, valAddr net.IP, valPort uint16,
+	direction uint8, block uint64, argument uint16, proto uint8, keyPort uint16, valAddr net.IP, valPort uint16,
 ) error {
 	if err := uformat.ValidateBlock(block); err != nil {
 		return fmt.Errorf("vipxlatmap: vip_xlat_table: register: %w", err)
@@ -207,10 +234,11 @@ func (t *VipXlatTable) register(
 	}
 
 	key := prog.UsidVipXlatKey{
-		Block:    block,
-		Argument: argument,
-		Proto:    proto,
-		Port:     hostToNetwork16(keyPort),
+		Block:     block,
+		Argument:  argument,
+		Proto:     proto,
+		Direction: direction,
+		Port:      hostToNetwork16(keyPort),
 	}
 	value := prog.UsidVipXlatValue{
 		Addr: rawAddr,
@@ -248,7 +276,7 @@ func (t *VipXlatTable) RegisterIngress(
 	if _, err := addrTo16(vipAddr); err != nil {
 		return fmt.Errorf("vipxlatmap: vip_xlat_table: register ingress: vip address: %w", err)
 	}
-	return t.register(block, argument, proto, vipPort, backendAddr, backendPort)
+	return t.register(directionIngress, block, argument, proto, vipPort, backendAddr, backendPort)
 }
 
 // RegisterEgress writes vip_xlat_table's egress-direction row for one
@@ -265,18 +293,19 @@ func (t *VipXlatTable) RegisterEgress(
 	if _, err := addrTo16(backendAddr); err != nil {
 		return fmt.Errorf("vipxlatmap: vip_xlat_table: register egress: backend address: %w", err)
 	}
-	return t.register(block, argument, proto, backendPort, vipAddr, vipPort)
+	return t.register(directionEgress, block, argument, proto, backendPort, vipAddr, vipPort)
 }
 
-// unregister removes the vip_xlat_table entry keyed by (block, argument,
-// proto, port), if present. Not an error if already absent, mirroring
-// usidmap.VRFTable.Unregister's identical idempotency contract.
-func (t *VipXlatTable) unregister(block uint64, argument uint16, proto uint8, port uint16) error {
+// unregister removes the vip_xlat_table entry keyed by (direction, block,
+// argument, proto, port), if present. Not an error if already absent,
+// mirroring usidmap.VRFTable.Unregister's identical idempotency contract.
+func (t *VipXlatTable) unregister(direction uint8, block uint64, argument uint16, proto uint8, port uint16) error {
 	key := prog.UsidVipXlatKey{
-		Block:    block,
-		Argument: argument,
-		Proto:    proto,
-		Port:     hostToNetwork16(port),
+		Block:     block,
+		Argument:  argument,
+		Proto:     proto,
+		Direction: direction,
+		Port:      hostToNetwork16(port),
 	}
 	if err := t.table.Delete(key); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
@@ -294,13 +323,13 @@ func (t *VipXlatTable) unregister(block uint64, argument uint16, proto uint8, po
 // UnregisterIngress removes the ingress-direction row RegisterIngress
 // would have written for (block, argument, proto, vipPort).
 func (t *VipXlatTable) UnregisterIngress(block uint64, argument uint16, proto uint8, vipPort uint16) error {
-	return t.unregister(block, argument, proto, vipPort)
+	return t.unregister(directionIngress, block, argument, proto, vipPort)
 }
 
 // UnregisterEgress removes the egress-direction row RegisterEgress would
 // have written for (block, argument, proto, backendPort).
 func (t *VipXlatTable) UnregisterEgress(block uint64, argument uint16, proto uint8, backendPort uint16) error {
-	return t.unregister(block, argument, proto, backendPort)
+	return t.unregister(directionEgress, block, argument, proto, backendPort)
 }
 
 // decodeEntry converts a raw kernel key/value pair into an Entry, attaching
@@ -327,16 +356,30 @@ func (t *VipXlatTable) decodeEntry(key prog.UsidVipXlatKey, value prog.UsidVipXl
 	}
 }
 
-// Get reads the vip_xlat_table entry for (block, argument, proto, port),
-// reporting whether it exists. port is whichever key a caller wants to
-// inspect -- the VIP port for an ingress-direction row, or the backend port
-// for an egress-direction row.
-func (t *VipXlatTable) Get(block uint64, argument uint16, proto uint8, port uint16) (Entry, bool, error) {
+// GetIngress reads the ingress-direction vip_xlat_table entry for (block,
+// argument, proto, vipPort) -- the row RegisterIngress would have written --
+// reporting whether it exists.
+func (t *VipXlatTable) GetIngress(block uint64, argument uint16, proto uint8, vipPort uint16) (Entry, bool, error) {
+	return t.get(directionIngress, block, argument, proto, vipPort)
+}
+
+// GetEgress reads the egress-direction vip_xlat_table entry for (block,
+// argument, proto, backendPort) -- the row RegisterEgress would have
+// written -- reporting whether it exists.
+func (t *VipXlatTable) GetEgress(block uint64, argument uint16, proto uint8, backendPort uint16) (Entry, bool, error) {
+	return t.get(directionEgress, block, argument, proto, backendPort)
+}
+
+// get is GetIngress/GetEgress's shared primitive.
+func (t *VipXlatTable) get(
+	direction uint8, block uint64, argument uint16, proto uint8, port uint16,
+) (Entry, bool, error) {
 	key := prog.UsidVipXlatKey{
-		Block:    block,
-		Argument: argument,
-		Proto:    proto,
-		Port:     hostToNetwork16(port),
+		Block:     block,
+		Argument:  argument,
+		Proto:     proto,
+		Direction: direction,
+		Port:      hostToNetwork16(port),
 	}
 	var value prog.UsidVipXlatValue
 	if err := t.table.Lookup(key, &value); err != nil {
@@ -401,8 +444,17 @@ func (t *VipXlatTable) Reconcile(live map[Key]struct{}, cutoff uint64) (removed 
 		if e.Generation >= cutoff {
 			continue
 		}
-		if err := t.unregister(e.Block, e.Argument, e.Proto, e.Port); err != nil {
-			errs = append(errs, fmt.Errorf("vipxlatmap: vip_xlat_table: reconcile: delete stale entry %+v: %w", e.Key, err))
+		// Key carries no Direction (List's own doc comment: a raw entry
+		// alone can't tell an ingress row from an egress row) -- try both;
+		// unregister is a no-op for whichever direction was never actually
+		// registered at this exact (block, argument, proto, port), so this
+		// never deletes anything that didn't already match e.
+		delErr := errors.Join(
+			t.unregister(directionIngress, e.Block, e.Argument, e.Proto, e.Port),
+			t.unregister(directionEgress, e.Block, e.Argument, e.Proto, e.Port),
+		)
+		if delErr != nil {
+			errs = append(errs, fmt.Errorf("vipxlatmap: vip_xlat_table: reconcile: delete stale entry %+v: %w", e.Key, delErr))
 			continue
 		}
 		removed = append(removed, e)

--- a/internal/plumbing/ebpf/vipxlatmap/vipxlat_test.go
+++ b/internal/plumbing/ebpf/vipxlatmap/vipxlat_test.go
@@ -29,7 +29,7 @@ func TestVipXlatTable_RegisterIngressAndGet(t *testing.T) {
 		t.Fatalf("RegisterIngress: unexpected error: %v", err)
 	}
 
-	entry, ok, err := vt.Get(testBlock, 0x654, ProtoUDP, vipPort)
+	entry, ok, err := vt.GetIngress(testBlock, 0x654, ProtoUDP, vipPort)
 	if err != nil {
 		t.Fatalf("Get: unexpected error: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestVipXlatTable_RegisterEgressAndGet(t *testing.T) {
 		t.Fatalf("RegisterEgress: unexpected error: %v", err)
 	}
 
-	entry, ok, err := vt.Get(testBlock, 0x654, ProtoTCP, backendPort)
+	entry, ok, err := vt.GetEgress(testBlock, 0x654, ProtoTCP, backendPort)
 	if err != nil {
 		t.Fatalf("Get: unexpected error: %v", err)
 	}
@@ -104,11 +104,11 @@ func TestVipXlatTable_IngressAndEgressRowsAreSwapped(t *testing.T) {
 		t.Fatalf("table has %d entries after both registrations, want %d (two independent rows)", got, want)
 	}
 
-	ingress, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, vipPort)
+	ingress, ok, err := vt.GetIngress(testBlock, 0x1, ProtoTCP, vipPort)
 	if err != nil || !ok {
 		t.Fatalf("Get(ingress key): ok=%v err=%v", ok, err)
 	}
-	egress, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, backendPort)
+	egress, ok, err := vt.GetEgress(testBlock, 0x1, ProtoTCP, backendPort)
 	if err != nil || !ok {
 		t.Fatalf("Get(egress key): ok=%v err=%v", ok, err)
 	}
@@ -133,10 +133,69 @@ func TestVipXlatTable_IngressAndEgressRowsAreSwapped(t *testing.T) {
 	}
 }
 
+// TestVipXlatTable_IngressAndEgressSurviveIdenticalPort is the regression
+// test for the bug found live in containerlab: a binding that keeps the
+// *same* port number on both the VIP and the backend (an unremarkable,
+// common case -- e.g. ns60's own binding uses port 80 both ways) used to
+// collapse into a single map entry, since (block, argument, proto, port)
+// alone was the whole key and both rows share that exact tuple when the
+// ports coincide. RegisterEgress's write silently overwrote
+// RegisterIngress's row, so a client's request matched and forwarded fine
+// at the edge gateway (metrics showed zero drops) but was never
+// deliverable at the backend at all. struct vip_xlat_key's new Direction
+// field is what keeps these two rows distinct even here.
+func TestVipXlatTable_IngressAndEgressSurviveIdenticalPort(t *testing.T) {
+	vt, ft := newTestTable(constClock(1))
+
+	vip := net.ParseIP("2001:db8:6060::1")
+	backend := net.ParseIP("fd20:60:ff03::100:0")
+	const port = 80 // deliberately identical on both sides
+
+	if err := vt.RegisterIngress(testBlock, 0x1, ProtoTCP, vip, port, backend, port); err != nil {
+		t.Fatalf("RegisterIngress: unexpected error: %v", err)
+	}
+	if err := vt.RegisterEgress(testBlock, 0x1, ProtoTCP, backend, port, vip, port); err != nil {
+		t.Fatalf("RegisterEgress: unexpected error: %v", err)
+	}
+
+	if got, want := ft.len(), 2; got != want {
+		t.Fatalf("table has %d entries after both registrations with identical ports, want %d "+
+			"(RegisterEgress must not overwrite RegisterIngress's row)", ft.len(), want)
+	}
+
+	ingress, ok, err := vt.GetIngress(testBlock, 0x1, ProtoTCP, port)
+	if err != nil || !ok {
+		t.Fatalf("GetIngress: ok=%v err=%v, want the row RegisterIngress wrote to still be present", ok, err)
+	}
+	if !ingress.Addr.Equal(backend) || ingress.RewritePort != port {
+		t.Errorf("ingress row value = %s:%d, want %s:%d (backend) -- got the egress row's value instead, "+
+			"meaning it was overwritten", ingress.Addr, ingress.RewritePort, backend, port)
+	}
+
+	egress, ok, err := vt.GetEgress(testBlock, 0x1, ProtoTCP, port)
+	if err != nil || !ok {
+		t.Fatalf("GetEgress: ok=%v err=%v, want the row RegisterEgress wrote to still be present", ok, err)
+	}
+	if !egress.Addr.Equal(vip) || egress.RewritePort != port {
+		t.Errorf("egress row value = %s:%d, want %s:%d (VIP)", egress.Addr, egress.RewritePort, vip, port)
+	}
+
+	// Unregistering one direction must not remove the other.
+	if err := vt.UnregisterIngress(testBlock, 0x1, ProtoTCP, port); err != nil {
+		t.Fatalf("UnregisterIngress: unexpected error: %v", err)
+	}
+	if got, want := ft.len(), 1; got != want {
+		t.Fatalf("table has %d entries after UnregisterIngress, want %d (the egress row must survive)", got, want)
+	}
+	if _, ok, err := vt.GetEgress(testBlock, 0x1, ProtoTCP, port); err != nil || !ok {
+		t.Errorf("GetEgress after UnregisterIngress: ok=%v err=%v, want the egress row to still be present", ok, err)
+	}
+}
+
 func TestVipXlatTable_GetMissingEntry(t *testing.T) {
 	vt, _ := newTestTable(constClock(1))
 
-	_, ok, err := vt.Get(testBlock, 0x1, ProtoTCP, 443)
+	_, ok, err := vt.GetIngress(testBlock, 0x1, ProtoTCP, 443)
 	if err != nil {
 		t.Fatalf("Get: unexpected error: %v", err)
 	}

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -77,12 +77,9 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	if gateway == nil || gateway.IsUnspecified() {
 		return fmt.Errorf("refusing to install seg6 encap route for %s: gateway %s is not a usable SRv6 SID", prefix, gateway)
 	}
-	routes, err := netlink.RouteGet(gateway)
+	linkIndex, nextHop, err := resolveNextHop(gateway)
 	if err != nil {
-		return fmt.Errorf("no route to gateway %s: %w", gateway, err)
-	}
-	if len(routes) == 0 {
-		return fmt.Errorf("no route to gateway %s", gateway)
+		return err
 	}
 	encap := &netlink.SEG6Encap{
 		Mode:     seg6IptunModeEncapRed,
@@ -92,9 +89,9 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 		Dst:       prefix,
 		Table:     int(tableID),
 		Encap:     encap,
-		LinkIndex: routes[0].LinkIndex,
+		LinkIndex: linkIndex,
 	}
-	if nextHop := routes[0].Gw; len(nextHop) > 0 {
+	if len(nextHop) > 0 {
 		if prefix.IP.To4() != nil {
 			// IPv4 VPC prefix, IPv6 next-hop: cross-family, must use Via.
 			route.Via = &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: nextHop}
@@ -106,11 +103,95 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	return netlink.RouteReplace(route)
 }
 
+// resolveNextHop resolves gateway's real, immediate next-hop -- the exact
+// link plus (unless gateway is itself on-link) the concrete address the
+// kernel would actually forward through right now -- via netlink.RouteGet.
+//
+// This flattening matters because IPv6 route installation does not recurse
+// through an indirect gateway on its own: passing gateway straight through
+// as a route's Gw with no LinkIndex set fails with "no route to host"
+// whenever gateway is only reachable via its own separate route (e.g.
+// through a link-local next-hop) rather than being on-link itself --
+// confirmed empirically live in containerlab, where every BGP next-hop
+// used as a plain gateway (RouteMainAdd, below) is exactly this indirect
+// shape. Both RouteEgressAdd and RouteMainAdd need gateway flattened into
+// one concrete hop before installing anything, for the same reason.
+func resolveNextHop(gateway net.IP) (linkIndex int, nextHop net.IP, err error) {
+	routes, err := netlink.RouteGet(gateway)
+	if err != nil {
+		return 0, nil, fmt.Errorf("no route to gateway %s: %w", gateway, err)
+	}
+	if len(routes) == 0 {
+		return 0, nil, fmt.Errorf("no route to gateway %s", gateway)
+	}
+	return routes[0].LinkIndex, routes[0].Gw, nil
+}
+
 // RouteEgressDel removes the SEG6 encap route for prefix from routing table tableID.
 func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
 	return netlink.RouteDel(&netlink.Route{
 		Dst:   prefix,
 		Table: int(tableID),
 		Encap: &netlink.SEG6Encap{},
+	})
+}
+
+// RouteMainAdd installs a plain route for prefix in routing table tableID,
+// forwarding to gateway via ordinary recursive next-hop resolution -- no
+// SEG6 encapsulation, unlike RouteEgressAdd.
+//
+// This exists for EVPN Type 5 paths that carry no Route Target extended
+// community at all (see matchTableID in internal/runtime/gobgp/monitor.go):
+// NetworkGatewayReconciler's anycast ingress-VIP advertisements are the one
+// case today, deliberately left VRFID/Function-less because they name no
+// tenant VRF (that reconciler's own package doc comment). Their EVPN path
+// therefore carries no Prefix-SID either, so gateway here is always the
+// path's plain BGP next-hop -- a real, already fabric-reachable node
+// address (how else could this path's own BGP session exist), not a uSID
+// decap SID. Wrapping the packet in another SEG6/IPv6-in-IPv6 header toward
+// that address the way RouteEgressAdd does for a tenant VRF prefix would
+// only make it undeliverable: nothing there is listening for that
+// encapsulation the way usid_ingress listens for a real uSID SID's traffic.
+// Ordinary recursive forwarding is what an anycast route actually needs.
+//
+// gateway must be a real address for the same reason RouteEgressAdd
+// requires one: an unspecified gateway would silently blackhole prefix
+// behind a route to nowhere.
+func RouteMainAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
+	if gateway == nil || gateway.IsUnspecified() {
+		return fmt.Errorf("refusing to install route for %s: gateway %s is not a usable next-hop", prefix, gateway)
+	}
+	linkIndex, nextHop, err := resolveNextHop(gateway)
+	if err != nil {
+		return err
+	}
+	route := &netlink.Route{
+		Dst:       prefix,
+		Table:     int(tableID),
+		LinkIndex: linkIndex,
+	}
+	if len(nextHop) > 0 {
+		if prefix.IP.To4() != nil {
+			route.Via = &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: nextHop}
+		} else {
+			route.Gw = nextHop
+		}
+	} else {
+		// gateway itself is on-link (RouteGet found no further next-hop of
+		// its own) -- unlike RouteEgressAdd's SEG6 encap case, where the
+		// segment list alone already fully specifies the destination, a
+		// plain route needs an explicit gateway here or the kernel would
+		// treat prefix itself as directly reachable on this link.
+		route.Gw = gateway
+	}
+	return netlink.RouteReplace(route)
+}
+
+// RouteMainDel removes the plain route for prefix from routing table
+// tableID -- RouteMainAdd's counterpart, mirroring RouteEgressDel.
+func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
+	return netlink.RouteDel(&netlink.Route{
+		Dst:   prefix,
+		Table: int(tableID),
 	})
 }

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -175,3 +175,202 @@ func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 		})
 	}
 }
+
+// TestRouteMainAddRejectsUnspecifiedGateway mirrors
+// TestRouteEgressAddRejectsUnspecifiedGateway for RouteMainAdd's identical
+// guard.
+func TestRouteMainAddRejectsUnspecifiedGateway(t *testing.T) {
+	_, prefix, err := net.ParseCIDR("2001:db8:6060::1/128")
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		gateway net.IP
+	}{
+		{name: "nil gateway", gateway: nil},
+		{name: "IPv4 zero", gateway: net.IPv4zero},
+		{name: "IPv6 zero", gateway: net.IPv6unspecified},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := RouteMainAdd(prefix, tt.gateway, 0); err == nil {
+				t.Errorf("RouteMainAdd(%v) = nil error, want an error rejecting the unusable gateway", tt.gateway)
+			}
+		})
+	}
+}
+
+// TestRouteMainAdd_InstallsPlainRouteNoEncap installs a RouteMainAdd route
+// against a real kernel routing table and asserts it lands as a plain
+// gateway route with no SEG6 (or any other) encapsulation attached --
+// the entire point of RouteMainAdd over RouteEgressAdd (see its own doc
+// comment). Also exercises RouteMainDel as the add/delete round trip.
+func TestRouteMainAdd_InstallsPlainRouteNoEncap(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		ifaceName = "srv6mtest0"
+		ifaceAddr = "2001:db8:2::1/64"
+		gateway   = "2001:db8:2::2" // on-link next-hop, no encap SID involved
+		vipPrefix = "2001:db8:6060::1/128"
+		table     = 0 // main table -- see matchTableID's own doc comment
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy link: %w", err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			return fmt.Errorf("set link up: %w", err)
+		}
+		addr, err := netlink.ParseAddr(ifaceAddr)
+		if err != nil {
+			return fmt.Errorf("parse addr: %w", err)
+		}
+		return netlink.AddrAdd(dummy, addr)
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, prefix, err := net.ParseCIDR(vipPrefix)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", vipPrefix, err)
+	}
+	gw := net.ParseIP(gateway)
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return RouteMainAdd(prefix, gw, table)
+	})
+	if err != nil {
+		t.Fatalf("RouteMainAdd(%s) = %v, want success", vipPrefix, err)
+	}
+
+	var installed *netlink.Route
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == prefix.String() {
+				installed = &routes[i]
+				return nil
+			}
+		}
+		return fmt.Errorf("no route to %s found in table %d", prefix, table)
+	})
+	if err != nil {
+		t.Fatalf("verify installed route: %v", err)
+	}
+	if installed.Encap != nil {
+		t.Errorf("installed route for %s has Encap %+v, want no encapsulation at all", vipPrefix, installed.Encap)
+	}
+	if installed.Gw == nil || !installed.Gw.Equal(gw) {
+		t.Errorf("installed route for %s has Gw %v, want %v", vipPrefix, installed.Gw, gw)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return RouteMainDel(prefix, table)
+	})
+	if err != nil {
+		t.Fatalf("RouteMainDel(%s) = %v, want success", vipPrefix, err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == prefix.String() {
+				return fmt.Errorf("route to %s still present in table %d after RouteMainDel", prefix, table)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("verify deleted route: %v", err)
+	}
+}
+
+// TestRouteMainAdd_ResolvesIndirectGateway is the regression test for the
+// bug found live in containerlab: RouteMainAdd originally passed gateway
+// straight through as a route's plain Gw with no LinkIndex, which fails
+// with "no route to host" whenever gateway is only reachable via its own
+// separate route rather than being on-link itself -- exactly the shape of
+// a real EVPN path's BGP next-hop (reached through a link-local next-hop,
+// not directly on the receiving node's own subnet). RouteEgressAdd already
+// handled this via netlink.RouteGet (see resolveNextHop); RouteMainAdd
+// initially didn't. Mirrors TestRouteEgressAdd_InstallsForBothPrefixFamilies'
+// own multi-hop setup.
+func TestRouteMainAdd_ResolvesIndirectGateway(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		ifaceName     = "srv6mtest1"
+		ifaceAddr     = "2001:db8:3::1/64"
+		gatewayRoute  = "2001:db8:9::9/128" // reachable via ifaceAddr's subnet
+		onLinkNextHop = "2001:db8:3::2"     // on-link next-hop for gatewayRoute
+		gateway       = "2001:db8:9::9"     // NOT on-link -- reached indirectly
+		vipPrefix     = "2001:db8:6060::1/128"
+		table         = 0
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy link: %w", err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			return fmt.Errorf("set link up: %w", err)
+		}
+		addr, err := netlink.ParseAddr(ifaceAddr)
+		if err != nil {
+			return fmt.Errorf("parse addr: %w", err)
+		}
+		if err := netlink.AddrAdd(dummy, addr); err != nil {
+			return fmt.Errorf("add addr: %w", err)
+		}
+		_, gwDst, err := net.ParseCIDR(gatewayRoute)
+		if err != nil {
+			return fmt.Errorf("parse gateway route: %w", err)
+		}
+		return netlink.RouteAdd(&netlink.Route{
+			LinkIndex: dummy.Attrs().Index,
+			Dst:       gwDst,
+			Gw:        net.ParseIP(onLinkNextHop),
+		})
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	_, prefix, err := net.ParseCIDR(vipPrefix)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", vipPrefix, err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return RouteMainAdd(prefix, net.ParseIP(gateway), table)
+	})
+	if err != nil {
+		t.Fatalf("RouteMainAdd(%s) via indirect gateway %s = %v, want success", vipPrefix, gateway, err)
+	}
+}

--- a/internal/plumbing/vip/vip.go
+++ b/internal/plumbing/vip/vip.go
@@ -2,12 +2,23 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package vip manages loopback-style VIP binding on backend nodes — the
-// backend-side half of the DSR/Maglev gateway redesign's veth/container
-// case (design plan §0.1, §1): a backend node binds a service VIP to its
-// own dedicated dummy interface so the backend can answer a client
-// directly, without the reply ever passing back through galactic-gateway.
-// Requires CAP_NET_ADMIN, mirroring internal/plumbing/vrf.
+// Package vip manages loopback-style VIP binding on backend nodes -- one
+// half of the DSR/Maglev gateway redesign's veth/container case (design
+// plan §0.1, §1): a backend node binds a service VIP to its own dedicated
+// dummy interface, letting the node itself verifiably answer on that
+// address (see Verify) without the reply ever passing back through
+// galactic-gateway. Requires CAP_NET_ADMIN, mirroring internal/plumbing/vrf.
+//
+// This alone does not deliver anything to a VRF-isolated backend pod,
+// though: the dummy interface lives in the node's root network namespace,
+// not enslaved to any tenant VRF, and a DSR-forwarded ingress packet is
+// decapsulated straight into the owning tenant's own VRF routing table --
+// which has no route to an address that only exists outside it. The other
+// half, internal/plumbing/ebpf/vipxlatmap's vip_xlat_table translation
+// (originally built for the tap case only), now also runs for veth for
+// exactly this reason -- see
+// internal/controller.ServiceVIPBindingReconciler's own doc comment for
+// the live containerlab finding that surfaced this gap.
 package vip
 
 import (

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -106,17 +106,24 @@ func (r *GoBGPRuntime) processEVPNPath(path *apiutil.Path, logPrefix string) {
 		return
 	}
 
-	tableID, ok := r.matchTableID(path.Attrs)
+	install, ok := r.matchTableID(path.Attrs)
 	if !ok {
 		return
 	}
+	tableID := install.tableID
 
 	prefix := addrToIPNet(ipPrefix.IPPrefix, int(ipPrefix.IPPrefixLength))
 
 	if path.Withdrawal {
-		slog.Info(logPrefix+": withdrawing route", "prefix", prefix, "table", tableID)
-		if delErr := srv6.RouteEgressDel(prefix, tableID); delErr != nil {
-			slog.Error(logPrefix+": RouteEgressDel failed", "prefix", prefix, "table", tableID, "err", delErr)
+		slog.Info(logPrefix+": withdrawing route", "prefix", prefix, "table", tableID, "plain", install.plain)
+		var delErr error
+		if install.plain {
+			delErr = srv6.RouteMainDel(prefix, tableID)
+		} else {
+			delErr = srv6.RouteEgressDel(prefix, tableID)
+		}
+		if delErr != nil {
+			slog.Error(logPrefix+": route delete failed", "prefix", prefix, "table", tableID, "err", delErr)
 		}
 		return
 	}
@@ -137,32 +144,77 @@ func (r *GoBGPRuntime) processEVPNPath(path *apiutil.Path, logPrefix string) {
 		}
 	}
 
-	slog.Info(logPrefix+": installing route", "prefix", prefix, "gw", gw, "table", tableID)
-	if addErr := srv6.RouteEgressAdd(prefix, gw, tableID); addErr != nil {
-		slog.Error(logPrefix+": RouteEgressAdd failed", "prefix", prefix, "gw", gw, "table", tableID, "err", addErr)
+	slog.Info(logPrefix+": installing route", "prefix", prefix, "gw", gw, "table", tableID, "plain", install.plain)
+	var addErr error
+	if install.plain {
+		addErr = srv6.RouteMainAdd(prefix, gw, tableID)
+	} else {
+		addErr = srv6.RouteEgressAdd(prefix, gw, tableID)
+	}
+	if addErr != nil {
+		slog.Error(logPrefix+": route install failed", "prefix", prefix, "gw", gw, "table", tableID, "err", addErr)
 	}
 }
 
-// matchTableID looks up the kernel VRF table that imports one of the
-// extended communities on attrs, via the RT index maintained by applyVRFs.
-// It returns false if no configured VRF imports any route target on the
-// path. This is an O(1)-per-community lookup, not an O(#VRFs) scan, so it
-// stays cheap even with thousands of VRFs on the node.
-func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (uint32, bool) {
+// routeInstall is matchTableID's result: which kernel table processEVPNPath
+// should install path's route into, and which of srv6's two installers to
+// use -- RouteEgressAdd's SEG6 encap (a VRF-scoped tenant path, whose gw
+// always resolves to a real uSID decap SID) or RouteMainAdd's plain
+// next-hop route (plain is true; see RouteMainAdd's own doc comment for
+// why an RT-less path needs this instead).
+type routeInstall struct {
+	tableID uint32
+	plain   bool
+}
+
+// matchTableID resolves how to install one EVPN Type 5 path's route.
+//
+// A path carrying at least one Route Target extended community is a
+// tenant VRF route: matchTableID looks up the kernel VRF table that
+// imports one of those RTs, via the RT index maintained by applyVRFs, and
+// returns false if no VRF configured on this node imports any RT on the
+// path (a VRF this node doesn't participate in -- correctly skipped, not
+// installed anywhere). This is an O(1)-per-community lookup, not an
+// O(#VRFs) scan, so it stays cheap even with thousands of VRFs on the node.
+//
+// A path carrying no Route Target community at all is not VRF-scoped by
+// construction (buildEVPNPaths in paths.go only attaches the extended
+// communities attribute "if len(rts) > 0") -- e.g.
+// NetworkGatewayReconciler's anycast ingress-VIP advertisements, which
+// leave VRFID/Function unset for exactly this reason (that reconciler's
+// own package doc comment). Such a path is installed into the kernel's
+// main routing table (table ID 0, which both the kernel and this
+// vishvananda/netlink call resolve to RT_TABLE_MAIN when left unset) via
+// RouteMainAdd's plain routing, not RouteEgressAdd's SEG6 encap -- see that
+// function's own doc comment for why. This previously silently dropped
+// every anycast VIP path on every node in the mesh (found live: a
+// containerlab NetworkGateway/NetworkRule canary's VIP was never reachable
+// from any other site, even once BGP itself and the DSR/Maglev datapath
+// were both working correctly) -- gated on the absence of any RT
+// altogether, not merely a lookup miss, so a genuine unrecognized-VRF path
+// still correctly falls through to false above rather than being installed
+// into main by accident.
+func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeInstall, bool) {
 	r.rtIndexMu.RLock()
 	defer r.rtIndexMu.RUnlock()
+
+	var sawRouteTarget bool
 	for _, attr := range attrs {
 		ec, ok := attr.(*bgp.PathAttributeExtendedCommunities)
 		if !ok {
 			continue
 		}
 		for _, community := range ec.Value {
+			sawRouteTarget = true
 			if tableID, ok := r.rtIndex[community.String()]; ok {
-				return tableID, true
+				return routeInstall{tableID: tableID}, true
 			}
 		}
 	}
-	return 0, false
+	if !sawRouteTarget {
+		return routeInstall{plain: true}, true
+	}
+	return routeInstall{}, false
 }
 
 // vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{node}"

--- a/internal/runtime/gobgp/monitor_test.go
+++ b/internal/runtime/gobgp/monitor_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gobgp
+
+import (
+	"testing"
+
+	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+)
+
+// extCommAttr builds a PathAttributeExtendedCommunities attribute from
+// route-target strings, mirroring buildEVPNPaths' own construction in
+// paths.go.
+func extCommAttr(t *testing.T, rts ...string) bgp.PathAttributeInterface {
+	t.Helper()
+	parsed, err := parseRouteTargets(rts)
+	if err != nil {
+		t.Fatalf("parseRouteTargets(%v): %v", rts, err)
+	}
+	return bgp.NewPathAttributeExtendedCommunities(parsed)
+}
+
+// TestMatchTableID_VRFScopedPath covers the pre-existing behavior: a path
+// carrying a Route Target this node has a configured VRF for resolves to
+// that VRF's table, tagged for RouteEgressAdd's SEG6 encap (plain=false).
+func TestMatchTableID_VRFScopedPath(t *testing.T) {
+	r := &GoBGPRuntime{rtIndex: map[string]uint32{testRT100: 42}}
+
+	got, ok := r.matchTableID([]bgp.PathAttributeInterface{extCommAttr(t, testRT100)})
+	if !ok {
+		t.Fatalf("matchTableID() ok = false, want true (RT %s is configured)", testRT100)
+	}
+	if got.tableID != 42 {
+		t.Errorf("tableID = %d, want 42", got.tableID)
+	}
+	if got.plain {
+		t.Errorf("plain = true, want false (VRF-scoped path must use RouteEgressAdd's SEG6 encap)")
+	}
+}
+
+// TestMatchTableID_UnknownVRFSkipped covers a path carrying Route Targets,
+// none of which match any VRF configured on this node: it must be skipped
+// entirely (ok=false), not installed into main by accident -- the whole
+// reason matchTableID gates the RT-less case on the *absence* of any RT,
+// not merely a lookup miss.
+func TestMatchTableID_UnknownVRFSkipped(t *testing.T) {
+	r := &GoBGPRuntime{rtIndex: map[string]uint32{testRT100: 42}}
+
+	_, ok := r.matchTableID([]bgp.PathAttributeInterface{extCommAttr(t, testRT200)})
+	if ok {
+		t.Errorf("matchTableID() ok = true, want false (RT %s matches no configured VRF)", testRT200)
+	}
+}
+
+// TestMatchTableID_RTLessPathUsesMainTable covers the fix: a path with no
+// Route Target extended community at all -- e.g. NetworkGatewayReconciler's
+// anycast ingress-VIP advertisements (buildEVPNPaths never attaches the
+// attribute when adv.Communities is empty) -- must resolve to the main
+// table (0) via RouteMainAdd's plain routing (plain=true), not be silently
+// dropped. This is the exact bug found live in containerlab: an ns60
+// NetworkRule's VIP BGPAdvertisement reported Advertised/Ready, but no
+// receiving node anywhere in the mesh ever installed a route for it.
+func TestMatchTableID_RTLessPathUsesMainTable(t *testing.T) {
+	r := &GoBGPRuntime{rtIndex: map[string]uint32{testRT100: 42}}
+
+	got, ok := r.matchTableID(nil)
+	if !ok {
+		t.Fatalf("matchTableID(nil attrs) ok = false, want true (no RT at all must resolve to main table)")
+	}
+	if !got.plain {
+		t.Errorf("plain = false, want true (RT-less path must use RouteMainAdd, not SEG6 encap)")
+	}
+	if got.tableID != 0 {
+		t.Errorf("tableID = %d, want 0 (main table)", got.tableID)
+	}
+}
+
+// TestMatchTableID_NoExtendedCommunitiesAttributeAtAll covers the same
+// RT-less case as TestMatchTableID_RTLessPathUsesMainTable, but via attrs
+// containing other, unrelated path attributes rather than none at all --
+// the realistic shape of an actual EVPN path (which always carries Origin
+// and MpReachNLRI, see buildEVPNPaths).
+func TestMatchTableID_NoExtendedCommunitiesAttributeAtAll(t *testing.T) {
+	r := &GoBGPRuntime{rtIndex: map[string]uint32{testRT100: 42}}
+
+	attrs := []bgp.PathAttributeInterface{
+		bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP),
+	}
+	got, ok := r.matchTableID(attrs)
+	if !ok {
+		t.Fatalf("matchTableID() ok = false, want true")
+	}
+	if !got.plain || got.tableID != 0 {
+		t.Errorf("routeInstall = %+v, want {tableID:0 plain:true}", got)
+	}
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -140,10 +140,17 @@ EOF
     # go.datum.net/network => ../network` (see that line's own comment)
     # inside the Dockerfile's "network" build stage -- see
     # containers/galactic-cni/Dockerfile's own comment on that stage for
-    # the full mechanism. Harmless to pass once that replace directive is
-    # eventually removed, since the stage goes unused by go.mod at that
-    # point regardless of what's passed here.
-    docker build --build-context network=../network -t "$IMG" -f containers/galactic-cni/Dockerfile .
+    # the full mechanism. Only passed when ../network actually exists:
+    # docker eagerly stats every --build-context path before looking at
+    # the Dockerfile at all, so passing it unconditionally broke CI's
+    # single-repo checkout (no sibling ../network there) even with no
+    # replace directive active -- it's the *Dockerfile* stage that's
+    # harmless to leave unused, not this flag.
+    BUILD_ARGS=()
+    if [ -d ../network ]; then
+      BUILD_ARGS+=(--build-context "network=../network")
+    fi
+    docker build "${BUILD_ARGS[@]}" -t "$IMG" -f containers/galactic-cni/Dockerfile .
 
     echo "--- Loading image into cluster"
     kind load docker-image "$IMG" --name "$CLUSTER_NAME"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -136,7 +136,14 @@ spec:
 EOF
 
     echo "--- Building image: $IMG"
-    docker build -t "$IMG" -f containers/galactic-cni/Dockerfile .
+    # --build-context network=../network satisfies go.mod's local `replace
+    # go.datum.net/network => ../network` (see that line's own comment)
+    # inside the Dockerfile's "network" build stage -- see
+    # containers/galactic-cni/Dockerfile's own comment on that stage for
+    # the full mechanism. Harmless to pass once that replace directive is
+    # eventually removed, since the stage goes unused by go.mod at that
+    # point regardless of what's passed here.
+    docker build --build-context network=../network -t "$IMG" -f containers/galactic-cni/Dockerfile .
 
     echo "--- Loading image into cluster"
     kind load docker-image "$IMG" --name "$CLUSTER_NAME"


### PR DESCRIPTION
## Summary

Bringing up the previous five PRs together in containerlab surfaced several integration bugs: a Docker build that couldn't resolve the local network module replace, an eBPF struct padding the verifier rejected, a missing field index on the gateway's own manager, EVPN anycast paths landing in the wrong routing table, and a VIP-translation table that conflated ingress and egress rows. This PR is that batch of fixes, each confirmed against the failure it closes.

## Test plan

- [ ] `task ci`