### PR TITLE
feat: Route tenant VRF egress to NAT66 shards

### DIFF
--- a/cmd/galactic-nat66/main.go
+++ b/cmd/galactic-nat66/main.go
@@ -32,7 +32,9 @@ const (
 	networkAPIGroup   = "network.datumapis.com"
 	networkAPIVersion = "v1alpha1"
 
-	resourceNAT66Shards = "nat66shards"
+	resourceNAT66Shards       = "nat66shards"
+	resourceBGPAdvertisements = "bgpadvertisements"
+	resourceBGPRouters        = "bgprouters"
 )
 
 func main() {
@@ -42,16 +44,20 @@ func main() {
 	}
 }
 
-// checkWatchPermissions issues a SelfSubjectAccessReview for nat66shards,
-// checking the watch verb. If the review denies the request the informer
-// cache will never sync and NAT66ShardReconciler will be silently
-// blocked; this logs a clear, actionable message at startup so the
-// problem is immediately obvious. Mirrors cmd/galactic-gateway/main.go's
-// identically-named function, scoped to this binary's own single
-// resource: unlike galactic-gateway's NetworkGatewayReconciler,
-// NAT66ShardReconciler reads no other CRD (no BGPRouter/BGPAdvertisement
-// lookup -- see internal/controller/nat66shard_controller.go's own doc
-// comment for why this reconciler is deliberately much simpler).
+// checkWatchPermissions issues a SelfSubjectAccessReview for each resource
+// NAT66ShardReconciler now touches, checking the watch verb. If a review
+// denies the request the informer cache will never sync and the
+// reconciler will be silently blocked; this logs a clear, actionable
+// message at startup so the problem is immediately obvious. Mirrors
+// cmd/galactic-gateway/main.go's identically-named function.
+//
+// bgprouters/bgpadvertisements are new here: NAT66ShardReconciler's own
+// doc comment used to describe this binary as reading no other CRD at
+// all, but applyShardAdvertisement (nat66shard_controller.go) now looks
+// up this node's BGPRouter and creates/updates/deletes a BGPAdvertisement
+// for Status.ShardSID -- the same RBAC surface
+// cmd/galactic-gateway/main.go's own checkWatchPermissions already checks
+// for NetworkGatewayReconciler's identical pattern.
 func checkWatchPermissions(mgr ctrl.Manager) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {
@@ -64,23 +70,35 @@ func checkWatchPermissions(mgr ctrl.Manager) {
 
 	logger := ctrl.Log.WithName("rbac-preflight")
 
-	review := &authorizationv1.SelfSubjectAccessReview{
-		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-			ResourceAttributes: &authorizationv1.ResourceAttributes{
-				Verb:     "watch",
-				Group:    networkAPIGroup,
-				Version:  networkAPIVersion,
-				Resource: resourceNAT66Shards,
+	resources := []struct {
+		group    string
+		version  string
+		resource string
+	}{
+		{group: networkAPIGroup, version: networkAPIVersion, resource: resourceNAT66Shards},
+		{group: networkAPIGroup, version: networkAPIVersion, resource: resourceBGPAdvertisements},
+		{group: networkAPIGroup, version: networkAPIVersion, resource: resourceBGPRouters},
+	}
+
+	for _, r := range resources {
+		review := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Verb:     "watch",
+					Group:    r.group,
+					Version:  r.version,
+					Resource: r.resource,
+				},
 			},
-		},
+		}
+		if err := c.Create(ctx, review); err != nil {
+			logger.Error(err, "RBAC pre-flight: failed to submit access review for "+r.resource, "verb", "watch")
+			continue
+		}
+		if review.Status.Allowed {
+			continue
+		}
+		logger.Error(nil, "missing watch RBAC for "+r.resource,
+			"verb", "watch", "detail", "informer cache will not sync; add resource to ServiceAccount ClusterRole and restart")
 	}
-	if err := c.Create(ctx, review); err != nil {
-		logger.Error(err, "RBAC pre-flight: failed to submit access review for "+resourceNAT66Shards, "verb", "watch")
-		return
-	}
-	if review.Status.Allowed {
-		return
-	}
-	logger.Error(nil, "missing watch RBAC for "+resourceNAT66Shards,
-		"verb", "watch", "detail", "informer cache will not sync; add resource to ServiceAccount ClusterRole and restart")
 }

--- a/cmd/galactic-nat66/root.go
+++ b/cmd/galactic-nat66/root.go
@@ -101,6 +101,29 @@ func runCmd(cfg *config.NAT66Config) error {
 		grpcSrv.GracefulStop()
 	}()
 
+	// Register the one field index NAT66ShardReconciler.applyShardAdvertisement
+	// (nat66shard_controller.go) needs: BGPRouterByTargetName, to find the
+	// BGPRouter it advertises its shard SID through -- an index, not a
+	// real API field, so it only resolves if something on this process's
+	// own manager registered it first.
+	//
+	// Deliberately controller.RegisterBGPRouterTargetIndex, not the full
+	// controller.RegisterIndexes cmd/galactic-router and cmd/galactic-gateway
+	// call for their own managers: RegisterIndexes touches BGPPeer/
+	// BGPPolicy/BGPAdvertisement/BGPVRFInstance/BGPRouter, and
+	// controller-runtime's cache starts a live informer for every type any
+	// IndexField call touches immediately, regardless of whether this
+	// binary's own reconciler ever reads it again. Calling the full
+	// function here failed live at manager startup with "bgppolicies...is
+	// forbidden ... at the cluster scope": config/galactic-nat66/rbac.yaml
+	// only grants nat66shards/bgpadvertisements/bgprouters, on purpose (see
+	// that file's own "grant exactly what is used" principle) -- the
+	// narrower function keeps that principle intact instead of widening
+	// this binary's RBAC to match a function it doesn't need in full.
+	if err := controller.RegisterBGPRouterTargetIndex(ctx, mgr); err != nil {
+		return fmt.Errorf("register field indexes: %w", err)
+	}
+
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 

--- a/config/galactic-nat66/rbac.yaml
+++ b/config/galactic-nat66/rbac.yaml
@@ -2,12 +2,16 @@
 # only what NAT66ShardReconciler (internal/controller/nat66shard_controller.go)
 # actually touches.
 #
-# Unlike galactic-gateway's own RBAC (config/galactic-gateway/rbac.yaml),
-# this binary reads no other CRD at all: NAT66ShardReconciler's own doc
-# comment describes it as deliberately much simpler than
-# NetworkGatewayReconciler -- no rule/backend desired-state assembly, no
-# BGPRouter/BGPAdvertisement lookup, no BGPAdvertisement wiring. It only
-# gets/lists/watches its own NAT66Shard object and updates its status.
+# bgprouters (get/list/watch) plus full CRUD on bgpadvertisements are
+# included even though this binary runs no BGP client of its own:
+# NAT66ShardReconciler.applyShardAdvertisement looks up this node's own
+# BGPRouter and creates/updates/deletes the /128 BGPAdvertisement that
+# makes Status.ShardSID actually reachable fabric-wide -- exactly the
+# same shape config/galactic-gateway/rbac.yaml already grants
+# NetworkGatewayReconciler for its own VIP advertisements, and exactly
+# what NAT66ShardStatus.ShardSID's own doc comment in datum-cloud/network
+# promises ("advertised into BGP... so every other node learns a kernel
+# SEG6 route toward it").
 #
 # networkegresspolicies is deliberately NOT granted here: NAT66ShardReconciler
 # never reads or writes that CRD (it belongs to the earlier, now-superseded
@@ -28,6 +32,14 @@ rules:
     resources:
       - nat66shards/status
     verbs: ["get", "update", "patch"]
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - bgpadvertisements
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - bgprouters
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/containerlab/README.md
+++ b/deploy/containerlab/README.md
@@ -56,8 +56,15 @@ behavior doesn't apply, and XDP's throughput advantage is exactly why that datap
 (3) `vip_xlat_table`'s veth-kind delivery gap and its identical-VIP/backend-port key
 collision, both fixed in galactic. See the redesign plan's
 [§8](../../docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md#8-containerlab-validation) for
-the full account, including the still-open, unrelated NAT66/default-egress gap this validation
-surfaced but did not fix, and `resources/galactic-gateway/`.
+the full account, and `resources/galactic-gateway/`.
+
+The NAT66/default-egress gap that validation surfaced (no tenant VRF had
+any route out at all) is now closed: `task deploy:galactic-nat66` stands
+up the sharded NAT66 tier on the three existing site workers as shards
+(`resources/galactic-nat66/`), and every CNI ADD now installs a default
+route toward those shards' advertised SIDs
+(`internal/plumbing/srv6.EgressDefaultRouteAdd`, `internal/cnibgp`) --
+see `resources/galactic-nat66/README.md` for the full mechanism.
 
 `dfw`, `iad`, and `sjc` are the three Kind cluster names — not separate ContainerLab
 topology nodes. Each cluster's `control-plane`/`worker` nodes above are its members.

--- a/deploy/containerlab/Taskfile.yaml
+++ b/deploy/containerlab/Taskfile.yaml
@@ -22,6 +22,7 @@ tasks:
       - "build:galactic-router"
       - "build:galactic-gateway"
       - "build:galactic-cni"
+      - "build:galactic-nat66"
 
   "build:node":
     desc: Build the Kind node image
@@ -58,6 +59,11 @@ tasks:
     cmds:
       - docker build --network=host --build-context network=../../../network -t galactic-cni:latest -f ../../containers/galactic-cni/Dockerfile ../..
 
+  "build:galactic-nat66":
+    desc: Build the galactic-nat66 sharded egress datapath image
+    cmds:
+      - docker build --network=host --build-context network=../../../network -t galactic-nat66:latest -f ../../containers/galactic-nat66/Dockerfile ../..
+
   deploy:
     desc: Build images and deploy the full lab end-to-end
     deps: [build, host-setup]
@@ -71,6 +77,7 @@ tasks:
       - task: "deploy:cni"
       - task: "deploy:fabric"
       - task: "deploy:galactic-router"
+      - task: "deploy:galactic-nat66"
       - task: "deploy:scenarios"
 
   "deploy:clusters":
@@ -194,6 +201,12 @@ tasks:
         vars: {IMAGE: galactic-cni:latest, NODE: sjc-worker}
       - task: load-image
         vars: {IMAGE: galactic-cni:latest, NODE: dfw-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-nat66:latest, NODE: iad-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-nat66:latest, NODE: sjc-worker}
+      - task: load-image
+        vars: {IMAGE: galactic-nat66:latest, NODE: dfw-worker}
 
   "deploy:system":
     desc: Install CRDs, namespace, and RBAC
@@ -238,6 +251,11 @@ tasks:
     cmds:
       - ./scripts/deploy-galactic-router.sh
 
+  "deploy:galactic-nat66":
+    desc: Install the sharded NAT66 egress DaemonSet and NAT66Shard objects
+    cmds:
+      - ./scripts/deploy-galactic-nat66.sh
+
   "deploy:scenarios":
     desc: Deploy all VPC test scenarios
     cmds:
@@ -281,6 +299,7 @@ tasks:
       - task: "verify:srv6"
       - task: "verify:evpn"
       - task: "verify:gateway"
+      - task: "verify:nat66-sharding"
       - task: "verify:scenarios"
 
   "verify:bgp-transit":
@@ -338,6 +357,16 @@ tasks:
     cmds:
       - docker exec iad-control-plane kubectl get networkgateways,networkrules -n galactic-system
       - docker exec iad-control-plane kubectl get daemonset -n galactic-system -l app.kubernetes.io/name=galactic-gateway
+
+  "verify:nat66-sharding":
+    desc: Verify each site's NAT66Shard is Ready and its shard SID is advertised
+    cmds:
+      - |
+        for site in dfw sjc iad; do
+          echo "--- ${site} ---"
+          docker exec ${site}-control-plane kubectl get nat66shards -n galactic-system -o wide
+          docker exec ${site}-control-plane kubectl get bgpadvertisements -n galactic-system
+        done
 
   "verify:scenarios":
     desc: Verify ping across all VPC test scenarios

--- a/deploy/containerlab/gvpc.clab.yaml
+++ b/deploy/containerlab/gvpc.clab.yaml
@@ -243,10 +243,32 @@ topology:
         - node_files/tr4/frr.conf:/etc/frr/frr.conf:ro
 
   links:
-    # Cluster worker uplinks
+    # Cluster worker uplinks. mtu: 1500 on dfw-worker/sjc-worker/iad-worker's
+    # own links (unlike containerlab's jumbo-frame veth default, ~9500,
+    # which iad-worker2/tr3:eth4 below keeps -- it never runs
+    # galactic-nat66) -- required for the same -ERANGE reason the gateway
+    # node links below already document in detail: galactic-nat66's own
+    # XDP program (nat66attach.go, also native/driver-mode-only) attaches
+    # to this exact interface (eth1, shared with the TC-BPF SRv6 uSID
+    # datapath, which has no such restriction), and every tenant worker is
+    # now also a NAT66 shard (design plan §8's "reuse the three site
+    # workers as shards"). Confirmed live: galactic-nat66 crash-looped on
+    # dfw-worker/sjc-worker/iad-worker with exactly this ERANGE
+    # ("veth: Peer MTU is too large to set XDP") until these three links
+    # were dropped to 1500, mirroring iad-worker3/iad-worker4's own fix
+    # below. Accepted trade-off, not risk-free: ordinary tenant SRv6
+    # traffic (ns10/ns20/ns30/ns40) previously had headroom up to the
+    # jumbo default; a packet whose SRv6-encapsulated size would have
+    # landed between 1500 and 9500 bytes now needs source
+    # fragmentation/PMTU handling instead of transiting whole. Every
+    # existing scenario test uses small ping payloads well under 1500 and
+    # is unaffected.
     - endpoints: ["dfw-worker:eth1", "tr1:eth1"]
+      mtu: 1500
     - endpoints: ["sjc-worker:eth1", "tr2:eth1"]
+      mtu: 1500
     - endpoints: ["iad-worker:eth1", "tr3:eth5"]
+      mtu: 1500
     - endpoints: ["iad-worker2:eth1", "tr3:eth4"]
 
     # Gateway node uplinks (edge XDP Maglev/DSR DaemonSet; see

--- a/deploy/containerlab/resources/galactic-cni/daemonset-patch.yaml
+++ b/deploy/containerlab/resources/galactic-cni/daemonset-patch.yaml
@@ -9,6 +9,19 @@ spec:
         - name: install-cni
           image: galactic-cni:latest
           imagePullPolicy: Never
+          env:
+            # Fabric-wide NAT66 shard membership list (design plan §3,
+            # internal/plumbing/srv6.EgressDefaultRouteAdd's own doc
+            # comment) -- the same three shard SIDs
+            # resources/galactic-nat66/{dfw,sjc,iad}/node-patch.yaml
+            # configure each shard with, shared identically across every
+            # site here since this list is currently operator-supplied,
+            # not learned in-cluster (see EnvCNINAT66ShardSIDs's own doc
+            # comment). Written into the static conflist by
+            # internal/installer.Bootstrap (this init container), read
+            # back by internal/cnibgp at every CNI ADD.
+            - name: GALACTIC_CNI_NAT66_SHARD_SIDS
+              value: "2001:db8:ff01:9:e001::,2001:db8:ff02:9:e001::,2001:db8:ff03:9:e001::"
       containers:
         - name: credential-refresh
           image: galactic-cni:latest

--- a/deploy/containerlab/resources/galactic-nat66/README.md
+++ b/deploy/containerlab/resources/galactic-nat66/README.md
@@ -1,4 +1,4 @@
-# galactic-nat66 lab overlay (3-shard, not yet wired up)
+# galactic-nat66 lab overlay (3-shard, now wired up)
 
 What's here: a per-site containerlab overlay for `galactic-nat66`, the
 sharded NAT66 egress datapath control plane (`config/galactic-nat66/`),
@@ -11,7 +11,7 @@ built on the same base/per-node-overlay shape
   `config/galactic-nat66/base` itself isn't ("all three of
   `GALACTIC_NAT66_UPLINK_INTERFACE`/`_SHARD_SID`/`_SHARD_PUB_ADDR` are
   required and must be unique per shard node").
-- `dfw/`, `iad/`, `sjc/` — one per-site overlay each, per the redesign
+- `dfw/`, `sjc/`, `iad/` — one per-site overlay each, per the redesign
   plan's own §8 suggestion to reuse the three existing site workers
   (`dfw-worker`, `iad-worker`, `sjc-worker`) as a 3-shard DaemonSet rather
   than inventing new lab topology. Each pins the DaemonSet to that site's
@@ -30,15 +30,36 @@ lab topology, no new containerlab nodes), and the exact
 base/per-node-overlay/patch shape `resources/galactic-gateway/` already
 established.
 
-What this is **not**: none of this is wired into `gvpc.clab.yaml` or
-`Taskfile.yaml` yet — no bring-up target applies it, no image build step
-adds `galactic-nat66` to the Kind image load sequence, and no
-`ClusterRoleBinding` from `config/galactic-nat66/` is applied anywhere in
-this lab today. That's a deliberate, separate integration decision (new
-`task deploy:galactic-nat66`/`task verify:nat66-sharding` targets, per the
-redesign plan's §8), not done here. These manifests are self-consistent
-and buildable (verified with `kubectl kustomize` against a locally staged
-copy of `config/galactic-nat66/base`'s nested `nat66/` directory — see
-`base/kustomization.yaml`'s doc comment for why that directory isn't
-checked into git) but standing them up live is out of scope for this
-pass.
+## Wired up
+
+This is now applied by `task deploy:galactic-nat66`
+(`deploy/containerlab/Taskfile.yaml`'s `scripts/deploy-galactic-nat66.sh`),
+part of the main `task deploy` chain, right after `deploy:galactic-router`
+and before `deploy:scenarios` — deliberately in that order, since a tenant
+pod's own CNI ADD now installs a default egress route toward these three
+shard SIDs (`internal/plumbing/srv6.EgressDefaultRouteAdd`, called from
+`internal/cnibgp`) and would fail outright if the shards' own SIDs weren't
+reachable yet. `task build`/`task deploy:images` build and load
+`galactic-nat66:latest` the same way the other lab images are; RBAC
+(`config/galactic-nat66/{serviceaccount,rbac}.yaml`) is applied by
+`scripts/deploy-system.sh` alongside `galactic-cni`/`galactic-router`'s
+own, and `NAT66Shard`/`BGPVRFInstance` (the latter for NPTv6's own
+`nptv6` field) are installed from the local `../network` checkout by that
+same script — see its own comments for why.
+
+Each shard's `Status.ShardSID` is advertised as a plain, RT-less `/128`
+BGPAdvertisement by `NAT66ShardReconciler`
+(`internal/controller/nat66shard_controller.go`) — the same shape
+`NetworkGatewayReconciler` uses for its own ingress VIP — so every other
+node in the mesh learns a real kernel route to it via the existing
+RT-less-EVPN main-table import path
+(`internal/runtime/gobgp/monitor.go`'s `matchTableID`/`RouteMainAdd`).
+`GALACTIC_CNI_NAT66_SHARD_SIDS` (set identically on every site's
+`galactic-cni` DaemonSet, `resources/galactic-cni/daemonset-patch.yaml`)
+carries the fabric-wide membership list every tenant node needs to build
+its own default route — operator-supplied in this phase, not learned
+in-cluster; see that env var's own doc comment
+(`internal/config/cni.go`) for why.
+
+`task verify:nat66-sharding` checks each site's `NAT66Shard` status and
+`BGPAdvertisement` list.

--- a/deploy/containerlab/resources/galactic-nat66/base/kustomization.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/base/kustomization.yaml
@@ -1,15 +1,9 @@
 # Mirrors resources/galactic-gateway/base/'s pattern exactly, pointed at
-# config/galactic-nat66/base instead of config/galactic-gateway/base: "nat66"
-# is meant to be copied onto the node at deploy time by a
-# copy_nat66_config-style helper (see scripts/deploy-galactic-router.sh's
-# copy_router_gateway_config for the equivalent, already-written gateway
-# helper), nested here so this kustomization's "nat66" resource reference
-# resolves. That helper does not exist yet -- this whole directory is not
-# wired into any deploy script or Taskfile target (see ../README.md) -- so
-# applying this kustomization today requires manually copying
-# config/galactic-nat66/base's contents to
-# resources/galactic-nat66/base/nat66/ first (or docker cp'ing it, same
-# idea copy_router_gateway_config automates for galactic-gateway).
+# config/galactic-nat66/base instead of config/galactic-gateway/base:
+# "nat66" is copied onto the node at deploy time by
+# scripts/deploy-galactic-nat66.sh's copy_nat66_config helper (mirroring
+# scripts/deploy-galactic-router.sh's copy_router_gateway_config), nested
+# here so this kustomization's "nat66" resource reference resolves.
 # config/galactic-nat66/base is self-contained (its own full
 # single-container DaemonSet spec, not a patch onto some other config/
 # base), so there is no separate "base" resource to nest alongside it here

--- a/deploy/containerlab/resources/galactic-nat66/dfw/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/dfw/node-patch.yaml
@@ -48,30 +48,40 @@ spec:
               value: eth1
             # uFMT 48+16 uSID over dfw's own locator (2001:db8:ff01::/48,
             # see resources/galactic-router/dfw/bgprouter.yaml's
-            # srv6Locator), nodeID=1 -- reusing dfw-worker's own already-
-            # registered node identity (its BGPRouter's nodeID) rather
-            # than minting a new one, since this shard runs on that exact
-            # physical node, not a separate dedicated node the way
-            # iad-gateway1/iad-gateway2 are. Function=End.DT46 (0xE),
-            # matching resources/galactic-gateway/iad-gateway1/
-            # node-patch.yaml's convention, even though this address is
-            # never actually looked up through function_table/vrf_table
-            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
-            # doc comment says it's advertised as a plain /128
-            # node-reachability route "no VRFID/Function" -- the uFMT
-            # encoding here is only to keep the address inside dfw's
-            # locator block without colliding with any real tenant VRF
-            # SID. Argument=1, NOT 0: dfw has no other node sharing this
-            # locator (unlike iad, where iad-gateway1/2 already claim
-            # Argument=0 at nodeID=2/3), so 0 would not literally collide
-            # here either, but 1 is used on all three shards for one
-            # consistent, easy-to-audit convention across sites. This is
-            # a lab-only placeholder needing real allocation logic (the
-            # same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
-            # EnvNAT66ShardSID's own doc comment both flag today) before
-            # production.
+            # srv6Locator), nodeID=9 -- a dedicated Node-ID reserved for
+            # this shard, deliberately NOT dfw-worker's own real nodeID=1
+            # (an earlier version of this file reused it, on the theory
+            # that this shard "runs on that exact physical node, not a
+            # separate dedicated node"). That reuse was a real bug, found
+            # live: internal/plumbing/ebpf/nat66prog/nat66.c's own
+            # locator_matches only checks the top 64 bits (Block+Node-ID)
+            # of a packet's outer destination against shard_sid -- see
+            # that function's own doc comment -- so reusing dfw-worker's
+            # Node-ID meant this shard's XDP program silently hijacked
+            # *every* ordinary tenant ingress packet addressed to
+            # dfw-worker's own real delivery uSIDs (same Block+Node-ID,
+            # nexthdr also 41) before usid_ingress's TC hook ever saw
+            # them. Physical co-location (which node this pod is
+            # scheduled to) and uSID identity (which Node-ID a shard's own
+            # address claims) are independent; nodeID=9 is free at this
+            # site (dfw-worker is the only BGPRouter on this locator,
+            # nodeID=1 -- see resources/galactic-router/dfw/bgprouter.yaml).
+            # Function=End.DT46 (0xE), matching resources/galactic-gateway/
+            # iad-gateway1/node-patch.yaml's convention, even though this
+            # address is never actually looked up through
+            # function_table/vrf_table the way a real uSID is --
+            # NAT66ShardStatus.ShardSID's own doc comment says it's
+            # advertised as a plain /128 node-reachability route "no
+            # VRFID/Function" -- the uFMT encoding here only keeps the
+            # address inside dfw's locator block. Argument=1 is otherwise
+            # unremarkable now that Node-ID alone already guarantees no
+            # collision -- kept for continuity with the other two sites'
+            # identical choice, still a lab-only placeholder needing real
+            # allocation logic (the same gap GALACTIC_GATEWAY_SRV6_ADDRESS
+            # and EnvNAT66ShardSID's own doc comment both flag today)
+            # before production.
             - name: GALACTIC_NAT66_SHARD_SID
-              value: "2001:db8:ff01:1:e001::"
+              value: "2001:db8:ff01:9:e001::"
             # Lab-only placeholder masquerade source address, same
             # "operator-supplied, no in-cluster derivation yet" status as
             # GALACTIC_GATEWAY_SRV6_ADDRESS (see

--- a/deploy/containerlab/resources/galactic-nat66/iad/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/iad/node-patch.yaml
@@ -51,35 +51,42 @@ spec:
               value: eth1
             # uFMT 48+16 uSID over iad's own locator (2001:db8:ff03::/48,
             # see resources/galactic-router/iad/bgprouter.yaml's
-            # srv6Locator), nodeID=1 -- reusing iad-worker's own already-
-            # registered node identity (its BGPRouter's nodeID) rather
-            # than minting a new one, since this shard runs on that exact
-            # physical node, not a separate dedicated node the way
-            # iad-gateway1/iad-gateway2 are (those are nodeID=2/3 on this
-            # same locator -- see resources/galactic-gateway/
-            # iad-gateway{1,2}/bgprouter.yaml). Function=End.DT46 (0xE),
-            # matching resources/galactic-gateway/iad-gateway1/
-            # node-patch.yaml's convention, even though this address is
-            # never actually looked up through function_table/vrf_table
-            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
-            # doc comment says it's advertised as a plain /128
-            # node-reachability route "no VRFID/Function" -- the uFMT
-            # encoding here is only to keep the address inside iad's
-            # locator block without colliding with any real tenant VRF
-            # SID. Argument=1, deliberately NOT 0: iad-gateway1/
-            # iad-gateway2 already claim Argument=0 on this same locator
-            # (nodeID=2 and nodeID=3 respectively) -- since nodeID
-            # differs, Argument=0 at nodeID=1 would not actually collide
-            # with either of those two addresses bit-for-bit, but reusing
-            # 0 here anyway would be easy to misread as "the same
-            # reserved slot the gateway nodes use," so this shard's SID
-            # is deliberately given its own reserved Argument (1) instead
-            # -- a lab-only placeholder needing real allocation logic
-            # (the same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
-            # EnvNAT66ShardSID's own doc comment both flag today) before
-            # production.
+            # srv6Locator), nodeID=9 -- a dedicated Node-ID reserved for
+            # this shard, deliberately NOT iad-worker's own real nodeID=1
+            # (an earlier version of this file reused it, on the theory
+            # that this shard "runs on that exact physical node, not a
+            # separate dedicated node"). That reuse was a real bug, found
+            # live: internal/plumbing/ebpf/nat66prog/nat66.c's own
+            # locator_matches only checks the top 64 bits (Block+Node-ID)
+            # of a packet's outer destination against shard_sid -- see
+            # that function's own doc comment -- so reusing iad-worker's
+            # Node-ID meant this shard's XDP program silently hijacked
+            # *every* ordinary tenant ingress packet addressed to
+            # iad-worker's own real delivery uSIDs (same Block+Node-ID,
+            # nexthdr also 41) before usid_ingress's TC hook ever saw
+            # them. Physical co-location (which node this pod is
+            # scheduled to) and uSID identity (which Node-ID a shard's own
+            # address claims) are independent; nodeID=9 is free at this
+            # site (iad-worker=1, iad-worker-control=1, iad-gateway1=2,
+            # iad-gateway2=3 -- see resources/galactic-router/iad/,
+            # resources/galactic-control/iad/, and resources/
+            # galactic-gateway/iad-gateway{1,2}/'s own bgprouter.yaml
+            # files). Function=End.DT46 (0xE), matching resources/
+            # galactic-gateway/iad-gateway1/node-patch.yaml's convention,
+            # even though this address is never actually looked up
+            # through function_table/vrf_table the way a real uSID is --
+            # NAT66ShardStatus.ShardSID's own doc comment says it's
+            # advertised as a plain /128 node-reachability route "no
+            # VRFID/Function" -- the uFMT encoding here only keeps the
+            # address inside iad's locator block. Argument=1 is otherwise
+            # unremarkable now that Node-ID alone already guarantees no
+            # collision -- kept for continuity with the other two sites'
+            # identical choice, still a lab-only placeholder needing real
+            # allocation logic (the same gap GALACTIC_GATEWAY_SRV6_ADDRESS
+            # and EnvNAT66ShardSID's own doc comment both flag today)
+            # before production.
             - name: GALACTIC_NAT66_SHARD_SID
-              value: "2001:db8:ff03:1:e001::"
+              value: "2001:db8:ff03:9:e001::"
             # Lab-only placeholder masquerade source address, same
             # "operator-supplied, no in-cluster derivation yet" status as
             # GALACTIC_GATEWAY_SRV6_ADDRESS (see

--- a/deploy/containerlab/resources/galactic-nat66/sjc/node-patch.yaml
+++ b/deploy/containerlab/resources/galactic-nat66/sjc/node-patch.yaml
@@ -48,31 +48,42 @@ spec:
               value: eth1
             # uFMT 48+16 uSID over sjc's own locator (2001:db8:ff02::/48,
             # see resources/galactic-router/sjc/bgprouter.yaml's
-            # srv6Locator), nodeID=1 -- reusing sjc-worker's own already-
-            # registered node identity (its BGPRouter's nodeID) rather
-            # than minting a new one, since this shard runs on that exact
-            # physical node, not a separate dedicated node the way
-            # iad-gateway1/iad-gateway2 are. Function=End.DT46 (0xE),
-            # matching resources/galactic-gateway/iad-gateway1/
-            # node-patch.yaml's convention, even though this address is
-            # never actually looked up through function_table/vrf_table
-            # the way a real uSID is -- NAT66ShardStatus.ShardSID's own
-            # doc comment says it's advertised as a plain /128
-            # node-reachability route "no VRFID/Function" -- the uFMT
-            # encoding here is only to keep the address inside sjc's
-            # locator block without colliding with any real tenant VRF
-            # SID. Argument=1, NOT 0: sjc has no other node sharing this
-            # locator, so 0 would not literally collide here either, but
-            # 1 is used on all three shards for one consistent,
-            # easy-to-audit convention across sites (see
-            # resources/galactic-nat66/iad/node-patch.yaml's fuller
-            # rationale, where the distinction actually matters). This is
+            # srv6Locator), nodeID=9 -- a dedicated Node-ID reserved for
+            # this shard, deliberately NOT sjc-worker's own real nodeID=1
+            # (an earlier version of this file reused it, on the theory
+            # that this shard "runs on that exact physical node, not a
+            # separate dedicated node"). That reuse was a real bug, found
+            # live: internal/plumbing/ebpf/nat66prog/nat66.c's own
+            # locator_matches only checks the top 64 bits (Block+Node-ID)
+            # of a packet's outer destination against shard_sid -- see
+            # that function's own doc comment -- so reusing sjc-worker's
+            # Node-ID meant this shard's XDP program silently hijacked
+            # *every* ordinary tenant ingress packet addressed to
+            # sjc-worker's own real delivery uSIDs (same Block+Node-ID,
+            # nexthdr also 41) before usid_ingress's TC hook ever saw
+            # them. Physical co-location (which node this pod is
+            # scheduled to) and uSID identity (which Node-ID a shard's own
+            # address claims) are independent; nodeID=9 is free at this
+            # site (sjc-worker is the only BGPRouter on this locator,
+            # nodeID=1 -- see resources/galactic-router/sjc/bgprouter.yaml).
+            # Function=End.DT46 (0xE), matching resources/galactic-gateway/
+            # iad-gateway1/node-patch.yaml's convention, even though this
+            # address is never actually looked up through
+            # function_table/vrf_table the way a real uSID is --
+            # NAT66ShardStatus.ShardSID's own doc comment says it's
+            # advertised as a plain /128 node-reachability route "no
+            # VRFID/Function" -- the uFMT encoding here only keeps the
+            # address inside sjc's locator block. Argument=1 is otherwise
+            # unremarkable now that Node-ID alone already guarantees no
+            # collision -- kept for continuity with the other two sites'
+            # identical choice (see resources/galactic-nat66/iad/
+            # node-patch.yaml's fuller rationale on the Node-ID fix), still
             # a lab-only placeholder needing real allocation logic (the
             # same gap GALACTIC_GATEWAY_SRV6_ADDRESS and
             # EnvNAT66ShardSID's own doc comment both flag today) before
             # production.
             - name: GALACTIC_NAT66_SHARD_SID
-              value: "2001:db8:ff02:1:e001::"
+              value: "2001:db8:ff02:9:e001::"
             # Lab-only placeholder masquerade source address, same
             # "operator-supplied, no in-cluster derivation yet" status as
             # GALACTIC_GATEWAY_SRV6_ADDRESS (see

--- a/deploy/containerlab/scripts/deploy-galactic-nat66.sh
+++ b/deploy/containerlab/scripts/deploy-galactic-nat66.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# deploy-galactic-nat66.sh — Install the sharded NAT66 egress DaemonSet and
+# each site's own NAT66Shard object, reusing that site's existing worker
+# node as its shard (design plan §3/§8, resources/galactic-nat66/README.md)
+# rather than a new dedicated node. Requires deploy:system (galactic-nat66
+# RBAC/ServiceAccount, applied there alongside galactic-cni/galactic-router's
+# own) and deploy:images (galactic-nat66:latest loaded onto every site's
+# worker) first.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+source "${SCRIPT_DIR}/lib.sh"
+
+# config/galactic-nat66/base is self-contained (its own full
+# single-container DaemonSet spec, not a patch onto some other config/
+# base) -- same shape config/galactic-gateway/base already has, copied by
+# deploy-galactic-router.sh's copy_router_gateway_config for the identical
+# reason. Nested under resources/galactic-nat66/base/nat66/ so that
+# overlay's own "nat66" resource reference (see its kustomization.yaml's
+# doc comment) resolves.
+GALACTIC_NAT66_BASE_DIR=$(cd "${SCRIPT_DIR}/../../../config/galactic-nat66/base" && pwd)
+
+# copy_nat66_config NODE copies config/galactic-nat66/base onto NODE,
+# nested under resources/galactic-nat66/base/nat66/. Mirrors
+# copy_router_gateway_config in deploy-galactic-router.sh; rm -rf first
+# for the same reason that comment gives (docker cp nests SRC inside an
+# already-existing DEST dir instead of overwriting it).
+copy_nat66_config() {
+  local node="$1"
+  docker exec "${node}" rm -rf /galactic/resources/galactic-nat66/base/nat66
+  docker cp "${GALACTIC_NAT66_BASE_DIR}" "${node}:/galactic/resources/galactic-nat66/base/nat66"
+}
+
+for site in dfw sjc iad; do
+  node=$(control_plane "${site}")
+  echo "Applying galactic-nat66/${site} to ${node}..."
+  docker exec "${node}" rm -rf /galactic/resources/galactic-nat66
+  copy_to "${node}" galactic-nat66
+  copy_nat66_config "${node}"
+  apply_k "${node}" "/galactic/resources/galactic-nat66/${site}/"
+  docker exec "${node}" kubectl -n galactic-system rollout status daemonset galactic-nat66
+done
+
+echo "Done."

--- a/deploy/containerlab/scripts/deploy-system.sh
+++ b/deploy/containerlab/scripts/deploy-system.sh
@@ -40,16 +40,22 @@ network_crds=(
   network.datumapis.com_bgppeers.yaml
   network.datumapis.com_bgppolicies.yaml
   network.datumapis.com_bgprouters.yaml
-  network.datumapis.com_bgpvrfinstances.yaml
   network.datumapis.com_networkgateways.yaml
   network.datumapis.com_networkrules.yaml
 )
 
-# ServiceVIPBinding is the DSR/Maglev redesign's own CRD (design plan §1),
-# added on network's local feat/dsr-maglev-crds branch alongside this
-# repo's feat/dsr-maglev-gateway -- never pushed, so it doesn't exist at
-# NETWORK_SHA on GitHub the way network_crds above does. Missing this
-# breaks two different things, discovered live in this lab: (1)
+# ServiceVIPBinding and NAT66Shard are the DSR/Maglev redesign's own CRDs
+# (design plan §1/§3), added on network's local feat/dsr-maglev-crds
+# branch alongside this repo's feat/dsr-maglev-gateway -- never pushed, so
+# neither exists at NETWORK_SHA on GitHub the way network_crds above does.
+# BGPVRFInstance moved here too for the same reason, even though it *does*
+# exist at NETWORK_SHA: that pre-redesign schema predates NPTv6Spec being
+# added to BGPVRFInstanceSpec (design plan §2) -- fetching it from GitHub
+# would install a real CRD with no nptv6 field at all, silently dropping
+# every NPTv6 config an operator applies rather than erroring loudly.
+#
+# Missing ServiceVIPBinding specifically breaks two different things,
+# discovered live in this lab: (1)
 # resources/galactic-gateway/iad/servicevipbinding-ns60.yaml fails
 # deploy-galactic-router.sh's apply_k of that directory with kubectl's
 # "ensure CRDs are installed first" (the DaemonSet/BGP resources in the
@@ -62,7 +68,9 @@ network_crds=(
 # every site, matching network_crds' own blanket per-site loop, for that
 # second reason -- (1) alone would only need iad.
 network_crds_local=(
+  network.datumapis.com_bgpvrfinstances.yaml
   network.datumapis.com_servicevipbindings.yaml
+  network.datumapis.com_nat66shards.yaml
 )
 
 cloud_crds=(
@@ -95,6 +103,8 @@ for site in dfw sjc iad; do
   apply_f "${node}" /galactic/config/galactic-cni/rbac.yaml
   apply_f "${node}" /galactic/config/galactic-router/serviceaccount.yaml
   apply_f "${node}" /galactic/config/galactic-router/rbac.yaml
+  apply_f "${node}" /galactic/config/galactic-nat66/serviceaccount.yaml
+  apply_f "${node}" /galactic/config/galactic-nat66/rbac.yaml
 done
 
 echo "Done."

--- a/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
+++ b/docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md
@@ -262,9 +262,43 @@ instance**, never sharing a ring with the LB's own.
 
 ### 3.2 Shard placement (outbound / translation leg)
 
-A new flow's shard assignment is chosen via a `maglev.Table` built over
-`(tenant VRFID, backend addr:port, dest addr:port)` — load-distributed,
-minimally disrupted when a shard node is added/removed.
+**Updated 2026-08-18 — implemented, diverged from the text below.** The
+original plan called for a new flow's shard assignment to be chosen via a
+`maglev.Table` built over `(tenant VRFID, backend addr:port, dest
+addr:port)` — load-distributed, minimally disrupted when a shard node is
+added/removed. That per-flow, in-datapath hash was never actually built:
+`internal/maglev` is only ever called from the ingress LB's own
+backend-selection ring, and building an equivalent TC-BPF hash stage for
+shard placement would have been a second, much larger new eBPF component
+on top of everything else this redesign already added.
+
+What's actually implemented instead: `internal/plumbing/srv6.EgressDefaultRouteAdd`
+installs a plain Linux multipath `::/0` route in the tenant VRF's own
+table, SEG6-encapsulating toward every live shard's SID as a separate,
+equally-weighted nexthop — no new eBPF code, no per-flow hash. Linux's own
+ECMP multipath hashing over these nexthops gives near-even load spread
+across shards, and modern kernels' resilient nexthop groups give the same
+bounded-disruption-on-membership-change property Maglev was chosen for in
+the first place (this function installs plain multipath nexthops, not a
+resilient group, since correctness mattered more than that specific bound
+for this phase — see the function's own doc comment). Called from
+`internal/cnibgp` at every CNI ADD, gated on a fabric-wide, operator-supplied
+shard SID list (`GALACTIC_CNI_NAT66_SHARD_SIDS`,
+`internal/config.EnvCNINAT66ShardSIDs`) — the same "no in-cluster
+derivation yet" phase-1 stance this plan already takes for
+`GALACTIC_GATEWAY_SRV6_ADDRESS` and the shard addresses themselves (§3.3).
+
+Each shard's own reachability -- required before any node's
+`EgressDefaultRouteAdd` can resolve a next-hop to it -- comes from
+`NAT66ShardReconciler` (`internal/controller/nat66shard_controller.go`)
+creating a plain, RT-less `/128` `BGPAdvertisement` for
+`Status.ShardSID`, exactly the shape `NetworkGatewayReconciler` already
+uses for its own VIP advertisements, imported into every receiving node's
+main table via the existing RT-less-EVPN path
+(`internal/runtime/gobgp/monitor.go`'s `matchTableID`/`RouteMainAdd`,
+added earlier in this same redesign for the anycast VIP case). This was
+the one piece `NAT66ShardStatus.ShardSID`'s own doc comment in
+datum-cloud/network already promised but no code delivered until now.
 
 ### 3.3 Return-leg routing — self-routing by construction
 
@@ -456,18 +490,22 @@ canary, found and fixed three separate, stacked issues:
    (commits `a0e1677`, `d76e799`), with regression tests at both the Go
    and kernel-verifier level.
 
-**Still not a full end-to-end success, for a fourth, separate,
-already-known reason:** with all three of the above fixed, `iad-worker`'s
-own datapath counters proved the *entire forward chain* works (gateway
-match → Maglev backend select → `XDP_TX` redirect → SRv6 transit →
-backend uSID decap → `vip_xlat_table` translation → VRF delivery). A full
-client-facing `curl` still doesn't complete, because the tenant VRF
-(`vrf60`) has no egress route at all -- not a DSR/gateway bug, but the
-pre-existing, already-tracked gap that `resources/galactic-nat66/`'s
-sharded egress tier (§3 above) was built but deliberately never wired
-into this lab's `gvpc.clab.yaml`/`Taskfile.yaml` bring-up (see that
-directory's own `README.md`). No tenant pod in this lab can reply to any
-external address today, independent of this redesign's own correctness.
+**Fourth gap, found the same pass, now closed (2026-08-18).** With all
+three of the above fixed, `iad-worker`'s own datapath counters proved the
+*entire forward chain* works (gateway match → Maglev backend select →
+`XDP_TX` redirect → SRv6 transit → backend uSID decap → `vip_xlat_table`
+translation → VRF delivery). A full client-facing `curl` still didn't
+complete, because the tenant VRF (`vrf60`) had no egress route at all --
+not a DSR/gateway bug, but a genuine, previously-unbuilt gap: nothing
+anywhere installed a default route in a tenant VRF, and nothing advertised
+a NAT66 shard's own SID, so `resources/galactic-nat66/`'s sharded egress
+tier (§3 above) had a receiving side (`nat66.c`) with nothing ever feeding
+it traffic. Closed by implementing §3.2's updated mechanism
+(`srv6.EgressDefaultRouteAdd` + `NAT66ShardReconciler`'s shard-SID
+advertisement) and wiring `resources/galactic-nat66/` into this lab's
+`Taskfile.yaml` (`task deploy:galactic-nat66`, part of the main `task
+deploy` chain) -- see that directory's own `README.md` for the full
+bring-up mechanism and `verify:nat66-sharding` for validation.
 
 **Bonus find while chasing the above with a strict external observer
 (tcpdump) instead of just `BPF_PROG_TEST_RUN`:** two real,

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -33,6 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/netip"
 	"sort"
 	"strconv"
@@ -47,12 +48,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"go.datum.net/galactic/internal/cniipam"
+	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/gc"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/intf"
+	"go.datum.net/galactic/internal/plumbing/srv6"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -554,6 +557,20 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
 	}
 
+	// Installs (or refreshes) this VRF's NAT66 default egress route --
+	// see installNAT66EgressRoute's own doc comment. A second, deliberate
+	// exception to this package's doc comment's "zero kernel-interface
+	// configuration dependency" claim, alongside registerEBPFDatapath's
+	// existing ifindex_vrf_table registration: unlike that one, this
+	// mutates a real kernel route, not just an eBPF map, but the
+	// alternative (routing table setup) plugin in this chain
+	// (internal/cniroute/galactic-route) is optional, and this route must
+	// exist whenever any shard is configured, regardless of whether a
+	// given conflist happens to include galactic-route.
+	if err := installNAT66EgressRoute(vrfTableID); err != nil {
+		return false, fmt.Errorf("install NAT66 default egress route: %w", err)
+	}
+
 	// The host-side interface's own ifindex, needed to key this
 	// attachment's ifindex_vrf_table row below — see this package's own
 	// doc comment for why this one read-only netlink call is an accepted
@@ -590,6 +607,66 @@ func registerEBPFDatapath(
 	}
 
 	return true, nil
+}
+
+// installNAT66EgressRoute installs (or refreshes) vrfTableID's default
+// egress route toward every configured NAT66 shard -- see
+// config.EnvCNINAT66ShardSIDs's own doc comment for where the shard list
+// comes from, and srv6.EgressDefaultRouteAdd's own doc comment for why
+// this is a multipath route rather than a per-flow hash. Idempotent
+// (RouteReplace under the hood) and safe to call on every attachment ADD
+// sharing this VRF, the same way vrf.Add itself already is.
+//
+// An operator who hasn't configured any shard yet (the common case before
+// this mechanism is rolled out to a given fabric) sees no error at all:
+// parseShardSIDs returns an empty, nil-error slice for an empty string,
+// and srv6.EgressDefaultRouteAdd itself no-ops on an empty list. A
+// misconfigured shard SID (invalid address, or one with no reachable
+// route yet -- e.g. this node came up before NAT66ShardReconciler's own
+// BGPAdvertisement had propagated) fails this attachment's ADD outright
+// rather than silently leaving the VRF with no egress at all.
+func installNAT66EgressRoute(vrfTableID uint32) error {
+	// cniConfig is nil unless something has already called InitCNIConfig
+	// (cmd/galactic-bgp's main.go, before any cmdAdd can run) or a test set
+	// it up directly -- several existing unit tests in this package call
+	// registerEBPFDatapath straight through without either, mirroring
+	// ops_del_test.go's own cniConfig-may-be-nil stance. Treated the same
+	// as "no shard configured yet," not a panic.
+	if cniConfig == nil {
+		return nil
+	}
+	shardSIDs, err := parseShardSIDs(cniConfig.NAT66ShardSIDs)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", config.EnvCNINAT66ShardSIDs, err)
+	}
+	if len(shardSIDs) == 0 {
+		return nil
+	}
+	return srv6.EgressDefaultRouteAdd(vrfTableID, shardSIDs)
+}
+
+// parseShardSIDs splits a comma-separated NAT66 shard SID list (as
+// resolved into config.CNIConfig.NAT66ShardSIDs) into IP addresses,
+// trimming whitespace around each entry and skipping blank ones -- so a
+// trailing comma or stray space in the operator-supplied env var/conflist
+// value doesn't fail every attachment ADD in the cluster. An entry that
+// survives trimming but still isn't a valid IP address is a real
+// misconfiguration and fails loudly rather than silently dropping one
+// shard from the list.
+func parseShardSIDs(raw string) ([]net.IP, error) {
+	var sids []net.IP
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		sid := net.ParseIP(part)
+		if sid == nil {
+			return nil, fmt.Errorf("invalid NAT66 shard SID %q", part)
+		}
+		sids = append(sids, sid)
+	}
+	return sids, nil
 }
 
 // hostInterfaceIndex resolves this attachment's own host-side veth/tap

--- a/internal/cnibgp/bgp_test.go
+++ b/internal/cnibgp/bgp_test.go
@@ -924,3 +924,54 @@ func TestRetryK8sOpsExhaustsDeadline(t *testing.T) {
 		t.Errorf("expected 'unavailable' in error, got %v", err)
 	}
 }
+
+func TestParseShardSIDs_Empty(t *testing.T) {
+	sids, err := parseShardSIDs("")
+	if err != nil {
+		t.Fatalf("parseShardSIDs(\"\") error = %v, want nil", err)
+	}
+	if len(sids) != 0 {
+		t.Errorf("parseShardSIDs(\"\") = %v, want empty", sids)
+	}
+}
+
+func TestParseShardSIDs_TrimsWhitespaceAndSkipsBlankEntries(t *testing.T) {
+	sids, err := parseShardSIDs(" 2001:db8:ff01:1:e001:: , 2001:db8:ff03:1:e001::, ,")
+	if err != nil {
+		t.Fatalf("parseShardSIDs() error = %v, want nil", err)
+	}
+	want := []string{"2001:db8:ff01:1:e001::", "2001:db8:ff03:1:e001::"}
+	if len(sids) != len(want) {
+		t.Fatalf("parseShardSIDs() = %v, want %v", sids, want)
+	}
+	for i, w := range want {
+		if sids[i].String() != w {
+			t.Errorf("parseShardSIDs()[%d] = %v, want %s", i, sids[i], w)
+		}
+	}
+}
+
+func TestParseShardSIDs_InvalidEntryFailsLoudly(t *testing.T) {
+	if _, err := parseShardSIDs("2001:db8:ff01:1:e001::,not-an-ip"); err == nil {
+		t.Error("parseShardSIDs() error = nil, want an error for the invalid entry")
+	}
+}
+
+// TestInstallNAT66EgressRoute_NilCNIConfigIsANoop is the regression test
+// for a real panic found live: several tests in this package (and, before
+// this guard, installNAT66EgressRoute itself) call registerEBPFDatapath
+// directly without ever calling InitCNIConfig first, leaving the
+// package-level cniConfig nil -- exactly the state ops_del_test.go's own
+// helper already works around for a different call path. Production never
+// hits this (cmd/galactic-bgp's main.go always calls InitCNIConfig before
+// any cmdAdd can run), but a nil cniConfig here must be treated as "no
+// shard configured yet," not a nil pointer dereference.
+func TestInstallNAT66EgressRoute_NilCNIConfigIsANoop(t *testing.T) {
+	original := cniConfig
+	cniConfig = nil
+	defer func() { cniConfig = original }()
+
+	if err := installNAT66EgressRoute(1); err != nil {
+		t.Errorf("installNAT66EgressRoute(1) = %v, want nil with cniConfig == nil", err)
+	}
+}

--- a/internal/cnibgp/config.go
+++ b/internal/cnibgp/config.go
@@ -180,11 +180,12 @@ func parseConf(data []byte) (*PluginConf, error) {
 	}
 
 	cniConfig.Resolve(&config.ConflistValues{
-		NodeName:   hostConf.NodeName,
-		Kubeconfig: hostConf.Kubeconfig,
-		Namespace:  hostConf.Namespace,
-		LogFile:    hostConf.LogFile,
-		LogLevel:   hostConf.LogLevel,
+		NodeName:       hostConf.NodeName,
+		Kubeconfig:     hostConf.Kubeconfig,
+		Namespace:      hostConf.Namespace,
+		LogFile:        hostConf.LogFile,
+		LogLevel:       hostConf.LogLevel,
+		NAT66ShardSIDs: hostConf.NAT66ShardSIDs,
 	})
 
 	if cniConfig.NodeName == "" {

--- a/internal/config/cni.go
+++ b/internal/config/cni.go
@@ -37,6 +37,28 @@ const (
 	// deployment's Cilium install needs this filter at a different
 	// priority to run in the intended order relative to Cilium's own.
 	EnvCNIEBPFFilterPriority = "GALACTIC_CNI_EBPF_FILTER_PRIORITY"
+
+	// EnvCNINAT66ShardSIDs is a comma-separated list of every live
+	// galactic-nat66 shard's Status.ShardSID (see NAT66ShardStatus's own
+	// doc comment in datum-cloud/network) -- the fabric-wide membership
+	// list internal/plumbing/srv6.EgressDefaultRouteAdd needs to install a
+	// tenant VRF's default egress route across every shard, since no
+	// single Kubernetes CRD is visible across this multi-cluster fabric's
+	// separate clusters/API servers the way BGP itself is (see that
+	// function's own doc comment for why membership is operator-supplied
+	// rather than learned from the BGP RIB in this phase). Same
+	// "operator-supplied, no in-cluster derivation yet" status as
+	// GALACTIC_GATEWAY_SRV6_ADDRESS and NAT66ShardStatus.ShardAddress/SID
+	// themselves. galactic-cni's own installer resolves this once at
+	// startup (its own real pod env, unlike a CNI plugin's minimal exec
+	// environment) and writes it into the static per-node conflist
+	// (HostConf.NAT66ShardSIDs) so internal/cnibgp -- invoked per-pod by
+	// the CNI runtime, not a long-lived process with configurable env --
+	// can read it the same way it reads NodeName/Namespace/etc. Unset or
+	// empty means no shard configured yet: a VRF gets no default route,
+	// the same "no egress capability" behavior as before this mechanism
+	// existed, not an error.
+	EnvCNINAT66ShardSIDs = "GALACTIC_CNI_NAT66_SHARD_SIDS"
 )
 
 // --- CNIConfig -------------------------------------------------------------
@@ -51,6 +73,12 @@ type CNIConfig struct {
 	Namespace  string
 	LogFile    string
 	LogLevel   string
+
+	// NAT66ShardSIDs is the raw, comma-separated NAT66 shard SID list --
+	// see EnvCNINAT66ShardSIDs's own doc comment. Left unparsed here
+	// (internal/cnibgp splits and validates it) since this package has no
+	// IP-address type of its own to return.
+	NAT66ShardSIDs string
 }
 
 // NewCNIConfig creates a new CNI config resolver. Callers should invoke this
@@ -63,13 +91,14 @@ func NewCNIConfig() *CNIConfig {
 // by any matching environment variables. The conflist values act as the
 // "middle tier" between env vars and compiled-in defaults.
 func (c *CNIConfig) Resolve(conflist *ConflistValues) {
-	var cnflistNode, cnflistKube, cnflistNS, cnflistLog, cnflistLevel string
+	var cnflistNode, cnflistKube, cnflistNS, cnflistLog, cnflistLevel, cnflistShardSIDs string
 	if conflist != nil {
 		cnflistNode = conflist.NodeName
 		cnflistKube = conflist.Kubeconfig
 		cnflistNS = conflist.Namespace
 		cnflistLog = conflist.LogFile
 		cnflistLevel = conflist.LogLevel
+		cnflistShardSIDs = conflist.NAT66ShardSIDs
 	}
 
 	// NodeName: env > conflist > legacy fallback > (no default)
@@ -92,14 +121,20 @@ func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 
 	// LogLevel: env > conflist > default
 	c.LogLevel = resolveEnv(EnvLogLevel, cnflistLevel, DefaultLogLevel)
+
+	// NAT66ShardSIDs: env > conflist > (no default -- empty means "no
+	// shard configured", not an error; see EnvCNINAT66ShardSIDs's doc
+	// comment).
+	c.NAT66ShardSIDs = resolveEnv(EnvCNINAT66ShardSIDs, cnflistShardSIDs, "")
 }
 
 // ConflistValues holds the raw values read from the CNI conflist file.
 // Passed to CNIConfig.Resolve() as the middle tier between env vars and defaults.
 type ConflistValues struct {
-	NodeName   string
-	Kubeconfig string
-	Namespace  string
-	LogFile    string
-	LogLevel   string
+	NodeName       string
+	Kubeconfig     string
+	Namespace      string
+	LogFile        string
+	LogLevel       string
+	NAT66ShardSIDs string
 }

--- a/internal/config/cni_test.go
+++ b/internal/config/cni_test.go
@@ -96,6 +96,35 @@ func TestCNIConfigEnvOverride(t *testing.T) {
 	}
 }
 
+func TestCNIConfigNAT66ShardSIDs(t *testing.T) {
+	const (
+		conflistSIDs = "2001:db8:ff01:1:e001::"
+		envSIDs      = "2001:db8:ff01:1:e001::,2001:db8:ff03:1:e001::"
+	)
+
+	// Default: empty, not an error -- "no shard configured yet" is normal.
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{})
+	if cfg.NAT66ShardSIDs != "" {
+		t.Errorf("NAT66ShardSIDs = %q, want empty by default", cfg.NAT66ShardSIDs)
+	}
+
+	// Conflist value flows through.
+	cfg = NewCNIConfig()
+	cfg.Resolve(&ConflistValues{NAT66ShardSIDs: conflistSIDs})
+	if cfg.NAT66ShardSIDs != conflistSIDs {
+		t.Errorf("NAT66ShardSIDs = %q, want %q (conflist)", cfg.NAT66ShardSIDs, conflistSIDs)
+	}
+
+	// Env var overrides the conflist value.
+	t.Setenv(EnvCNINAT66ShardSIDs, envSIDs)
+	cfg = NewCNIConfig()
+	cfg.Resolve(&ConflistValues{NAT66ShardSIDs: conflistSIDs})
+	if cfg.NAT66ShardSIDs != envSIDs {
+		t.Errorf("NAT66ShardSIDs = %q, want %q (env override)", cfg.NAT66ShardSIDs, envSIDs)
+	}
+}
+
 func TestCNIConfigNodeNameLegacyFallback(t *testing.T) {
 	t.Setenv(EnvNodeNameLegacy, "legacy-node")
 

--- a/internal/controller/indexer.go
+++ b/internal/controller/indexer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
@@ -40,11 +41,67 @@ const (
 // BGPRouterByTargetName lookup) against mgr's cache. Each binary runs its
 // own separate manager/cache, so this must be called once per process --
 // it must be called before starting the manager.
+//
+// controller-runtime's cache starts a live informer for every type touched
+// by IndexField, immediately, regardless of whether any reconciler in this
+// process ever reads that type again -- calling this full function from a
+// binary whose RBAC doesn't cover every one of BGPPeer/BGPPolicy/
+// BGPAdvertisement/BGPVRFInstance/BGPRouter fails outright ("cannot list
+// resource ... at the cluster scope"), found live the first time
+// cmd/galactic-nat66 called this instead of RegisterBGPRouterTargetIndex
+// below. Only galactic-router's own manager (which already holds the full
+// BGP RBAC set) and galactic-gateway's (which inherits it via its second
+// ClusterRoleBinding onto galactic-router's ClusterRole, config/galactic-
+// gateway/rbac.yaml's own doc comment) should call this; anything narrower
+// should call one of the single-index functions below instead.
 func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
-	cache := mgr.GetCache()
+	c := mgr.GetCache()
 
-	// BGPPeer: index by authSecretRef.name.
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPPeer{}, BGPPeerBySecretName, func(obj client.Object) []string {
+	if err := registerBGPPeerBySecretNameIndex(ctx, c); err != nil {
+		return err
+	}
+	if err := registerBGPPeerByRouterNameIndex(ctx, c); err != nil {
+		return err
+	}
+	if err := registerBGPPolicyByRouterNameIndex(ctx, c); err != nil {
+		return err
+	}
+	if err := registerBGPAdvByRouterNameIndex(ctx, c); err != nil {
+		return err
+	}
+	if err := registerBGPVRFInstanceByRouterNameIndex(ctx, c); err != nil {
+		return err
+	}
+	return RegisterBGPRouterTargetIndex(ctx, mgr)
+}
+
+// RegisterBGPRouterTargetIndex registers only the BGPRouterByTargetName
+// index against mgr's cache -- the single index
+// NAT66ShardReconciler.applyShardAdvertisement's routerNameForNode lookup
+// actually needs (nat66shard_controller.go). Deliberately narrower than
+// RegisterIndexes: cmd/galactic-nat66's RBAC (config/galactic-nat66/rbac.yaml)
+// grants exactly nat66shards/bgpadvertisements/bgprouters, not the full BGP
+// CRD set RegisterIndexes' own doc comment explains that function requires
+// -- calling RegisterIndexes here failed live with a
+// bgppolicies-cluster-scope-forbidden error the moment the manager started
+// (its cache eagerly starts an informer for every type any IndexField call
+// touches, not just BGPRouter).
+func RegisterBGPRouterTargetIndex(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(
+		ctx, &bgpv1alpha1.BGPRouter{}, BGPRouterByTargetName, func(obj client.Object) []string {
+			router, ok := obj.(*bgpv1alpha1.BGPRouter)
+			if !ok {
+				return nil
+			}
+			return []string{router.Spec.TargetRef.Name}
+		}); err != nil {
+		return fmt.Errorf("index BGPRouter by targetRef.name: %w", err)
+	}
+	return nil
+}
+
+func registerBGPPeerBySecretNameIndex(ctx context.Context, c cache.Cache) error {
+	if err := c.IndexField(ctx, &bgpv1alpha1.BGPPeer{}, BGPPeerBySecretName, func(obj client.Object) []string {
 		peer, ok := obj.(*bgpv1alpha1.BGPPeer)
 		if !ok {
 			return nil
@@ -56,9 +113,12 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}); err != nil {
 		return fmt.Errorf("index BGPPeer by authSecretRef.name: %w", err)
 	}
+	return nil
+}
 
-	// BGPPeer: index by routerRef.name (only when routerRef is set, not routerSelector).
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPPeer{}, BGPPeerByRouterName, func(obj client.Object) []string {
+func registerBGPPeerByRouterNameIndex(ctx context.Context, c cache.Cache) error {
+	// index by routerRef.name (only when routerRef is set, not routerSelector).
+	if err := c.IndexField(ctx, &bgpv1alpha1.BGPPeer{}, BGPPeerByRouterName, func(obj client.Object) []string {
 		peer, ok := obj.(*bgpv1alpha1.BGPPeer)
 		if !ok {
 			return nil
@@ -70,9 +130,11 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}); err != nil {
 		return fmt.Errorf("index BGPPeer by routerRef.name: %w", err)
 	}
+	return nil
+}
 
-	// BGPPolicy: index by routerRef.name.
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPPolicy{}, BGPPolicyByRouterName, func(obj client.Object) []string {
+func registerBGPPolicyByRouterNameIndex(ctx context.Context, c cache.Cache) error {
+	if err := c.IndexField(ctx, &bgpv1alpha1.BGPPolicy{}, BGPPolicyByRouterName, func(obj client.Object) []string {
 		policy, ok := obj.(*bgpv1alpha1.BGPPolicy)
 		if !ok {
 			return nil
@@ -84,9 +146,11 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}); err != nil {
 		return fmt.Errorf("index BGPPolicy by routerRef.name: %w", err)
 	}
+	return nil
+}
 
-	// BGPAdvertisement: index by routerRef.name.
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPAdvertisement{}, BGPAdvByRouterName, func(obj client.Object) []string {
+func registerBGPAdvByRouterNameIndex(ctx context.Context, c cache.Cache) error {
+	if err := c.IndexField(ctx, &bgpv1alpha1.BGPAdvertisement{}, BGPAdvByRouterName, func(obj client.Object) []string {
 		adv, ok := obj.(*bgpv1alpha1.BGPAdvertisement)
 		if !ok {
 			return nil
@@ -95,9 +159,11 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	}); err != nil {
 		return fmt.Errorf("index BGPAdvertisement by routerRef.name: %w", err)
 	}
+	return nil
+}
 
-	// BGPVRFInstance: index by routerRef.name.
-	if err := cache.IndexField(
+func registerBGPVRFInstanceByRouterNameIndex(ctx context.Context, c cache.Cache) error {
+	if err := c.IndexField(
 		ctx, &bgpv1alpha1.BGPVRFInstance{},
 		BGPVRFInstanceByRouterName,
 		func(obj client.Object) []string {
@@ -112,17 +178,5 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 		}); err != nil {
 		return fmt.Errorf("index BGPVRFInstance by routerRef.name: %w", err)
 	}
-
-	// BGPRouter: index by targetRef.name (the Node name).
-	if err := cache.IndexField(ctx, &bgpv1alpha1.BGPRouter{}, BGPRouterByTargetName, func(obj client.Object) []string {
-		router, ok := obj.(*bgpv1alpha1.BGPRouter)
-		if !ok {
-			return nil
-		}
-		return []string{router.Spec.TargetRef.Name}
-	}); err != nil {
-		return fmt.Errorf("index BGPRouter by targetRef.name: %w", err)
-	}
-
 	return nil
 }

--- a/internal/controller/nat66shard_controller.go
+++ b/internal/controller/nat66shard_controller.go
@@ -7,13 +7,17 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/netip"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -42,13 +46,22 @@ const (
 
 // NAT66ShardReconciler reconciles the single NAT66Shard object for this
 // node (spec.targetRef.name == NodeName), mirroring
-// NetworkGatewayReconciler's node-scoped root-object pattern -- but much
-// simpler: there is no rule/backend desired-state assembly here at all.
-// This reconciler's only job is to publish Status.ShardAddress/
-// Status.ShardSID, echoing back the operator-configured values this
-// node's own cmd/galactic-nat66 process was started with (ShardAddress/
-// ShardSID below -- plain strings, not re-derived from anything), and set
-// a Ready condition once the datapath is confirmed attached.
+// NetworkGatewayReconciler's node-scoped root-object pattern -- simpler in
+// one respect (no rule/backend desired-state assembly) but, as of the
+// shard-SID advertisement added below, no longer BGP-free: this
+// reconciler's job is to publish Status.ShardAddress/Status.ShardSID,
+// echoing back the operator-configured values this node's own
+// cmd/galactic-nat66 process was started with (ShardAddress/ShardSID
+// below -- plain strings, not re-derived from anything), set a Ready
+// condition once the datapath is confirmed attached, and -- exactly as
+// NAT66ShardStatus.ShardSID's own doc comment in datum-cloud/network
+// already promises -- create/withdraw the /128 BGPAdvertisement that
+// makes ShardSID actually reachable fabric-wide, the same RT-less,
+// VRFID/Function-less "plain node reachability" shape
+// NetworkGatewayReconciler.applyBGPAdvertisements uses for its own VIP
+// advertisements. Without this, internal/plumbing/srv6.EgressDefaultRouteAdd
+// (internal/cnibgp) would install a default route toward a SID no node
+// ever learns a kernel route to.
 type NAT66ShardReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -76,12 +89,20 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	shard := &bgpv1alpha1.NAT66Shard{}
 	if err := r.Get(ctx, req.NamespacedName, shard); err != nil {
 		if apierrors.IsNotFound(err) {
-			// No finalizer, no cross-node cleanup to perform: unlike
-			// NetworkGateway (whose deletion must withdraw BGPAdvertisements
-			// other nodes may still be depending on), a NAT66Shard carries no
-			// other object this reconciler is responsible for tearing down.
-			// There is simply nothing left to reconcile once the object is
-			// gone.
+			// No finalizer on NAT66Shard (same deliberate choice
+			// NetworkGateway makes -- see that reconciler's own NotFound
+			// branch), so by the time this Get observes NotFound the object
+			// is already gone everywhere, on whichever node's process
+			// happens to handle the delete event -- not necessarily the
+			// shard's own node. Withdraw this shard's BGPAdvertisement keyed
+			// on req.Name (shardAdvertisementName is deterministic, derived
+			// from the name alone) rather than the now-unreadable deleted
+			// object, mirroring withdrawNodeAdvertisements's identical
+			// req.Name-keyed shape.
+			if err := withdrawShardAdvertisement(ctx, r.Client, req.Namespace, req.Name); err != nil {
+				logger.Error(err, "withdraw BGPAdvertisement for deleted NAT66Shard", "nat66Shard", req.NamespacedName)
+				return ctrl.Result{}, err
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get NAT66Shard %s: %w", req.NamespacedName, err)
@@ -94,9 +115,15 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if !shard.DeletionTimestamp.IsZero() {
-		// Nothing to tear down beyond the object itself -- see the NotFound
-		// branch above for why this reconciler owns no other resource's
-		// lifecycle.
+		// Not known to be reachable today -- no finalizer, so the NotFound
+		// branch above is the one that actually runs on a real delete (see
+		// its own comment) -- kept correct in case that changes later,
+		// mirroring NetworkGatewayReconciler's identical stance on its own
+		// equivalent branch.
+		if err := withdrawShardAdvertisement(ctx, r.Client, shard.Namespace, shard.Name); err != nil {
+			logger.Error(err, "withdraw BGPAdvertisement for terminating NAT66Shard", "nat66Shard", req.NamespacedName)
+			return ctrl.Result{}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -115,7 +142,95 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("update NAT66Shard %s status: %w", req.NamespacedName, err)
 	}
 
+	if err := r.applyShardAdvertisement(ctx, shardCopy); err != nil {
+		logger.Error(err, "apply BGPAdvertisement for NAT66Shard", "nat66Shard", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+// shardAdvertisementName derives the deterministic BGPAdvertisement name
+// for a given NAT66Shard, so withdrawal (keyed on a deletion event's
+// req.Name alone, per the NotFound branch above) never needs to read the
+// shard object it's naming.
+func shardAdvertisementName(shardName string) string {
+	return shardName + "-sid"
+}
+
+// applyShardAdvertisement reconciles this shard's own /128 BGPAdvertisement
+// for Status.ShardSID -- RT-less, VRFID/Function-less, the same "plain
+// node reachability" shape NetworkGatewayReconciler.applyBGPAdvertisements
+// uses for its own VIP advertisements, and exactly what
+// NAT66ShardStatus.ShardSID's own doc comment in datum-cloud/network
+// already promises. A no-op, not an error, when ShardSID is unset (an
+// operator who hasn't configured this node's shard identity yet has
+// nothing to advertise) or when no BGPRouter targets this node yet (the
+// BGPRouter watch added in SetupWithManager retries once one appears,
+// closing the same startup-race class NetworkGatewayReconciler hit before
+// commit 782c231).
+func (r *NAT66ShardReconciler) applyShardAdvertisement(ctx context.Context, shard *bgpv1alpha1.NAT66Shard) error {
+	if shard.Status.ShardSID == "" {
+		return nil
+	}
+	sidAddr, err := netip.ParseAddr(shard.Status.ShardSID)
+	if err != nil {
+		return fmt.Errorf("parse ShardSID %q: %w", shard.Status.ShardSID, err)
+	}
+
+	routerName, err := routerNameForNode(ctx, r.Client, shard.Namespace, r.NodeName)
+	if err != nil {
+		return fmt.Errorf("look up BGPRouter for node %s: %w", r.NodeName, err)
+	}
+	if routerName == "" {
+		return nil
+	}
+
+	prefix := netip.PrefixFrom(sidAddr, sidAddr.BitLen()).String()
+	name := shardAdvertisementName(shard.Name)
+	key := types.NamespacedName{Namespace: shard.Namespace, Name: name}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	err = r.Get(ctx, key, adv)
+	switch {
+	case apierrors.IsNotFound(err):
+		adv = &bgpv1alpha1.BGPAdvertisement{
+			ObjectMeta: metav1.ObjectMeta{Namespace: shard.Namespace, Name: name},
+			Spec: bgpv1alpha1.BGPAdvertisementSpec{
+				RouterRef:     bgpv1alpha1.RouterRef{Name: routerName},
+				AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+				Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix)},
+			},
+		}
+		if err := r.Create(ctx, adv); err != nil {
+			return fmt.Errorf("create BGPAdvertisement %s: %w", name, err)
+		}
+		return nil
+	case err != nil:
+		return fmt.Errorf("get BGPAdvertisement %s: %w", name, err)
+	}
+
+	advCopy := adv.DeepCopy()
+	advCopy.Spec.RouterRef = bgpv1alpha1.RouterRef{Name: routerName}
+	advCopy.Spec.AddressFamily = bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN}
+	advCopy.Spec.Prefixes = []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix)}
+	if err := r.Update(ctx, advCopy); err != nil {
+		return fmt.Errorf("update BGPAdvertisement %s: %w", name, err)
+	}
+	return nil
+}
+
+// withdrawShardAdvertisement deletes the BGPAdvertisement
+// applyShardAdvertisement creates for shardName, if any. Not an error if
+// it never existed (ShardSID was never set) or is already gone.
+func withdrawShardAdvertisement(ctx context.Context, c client.Client, namespace, shardName string) error {
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: shardAdvertisementName(shardName)},
+	}
+	if err := c.Delete(ctx, adv); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete BGPAdvertisement %s: %w", adv.Name, err)
+	}
+	return nil
 }
 
 // readyCondition computes the Ready condition from the datapath's current
@@ -141,9 +256,42 @@ func (r *NAT66ShardReconciler) readyCondition() metav1.Condition {
 }
 
 // SetupWithManager registers the NAT66ShardReconciler with the manager.
+//
+// The BGPRouter watch below closes the same startup-race class
+// NetworkGatewayReconciler hit before commit 782c231: without it, a
+// NAT66Shard whose node's BGPRouter doesn't exist yet at first reconcile
+// would fail applyShardAdvertisement's routerNameForNode lookup once and
+// never get a second chance until some unrelated event happened to
+// trigger a fresh reconcile.
 func (r *NAT66ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.NAT66Shard{}).
+		Watches(&bgpv1alpha1.BGPRouter{}, handler.EnqueueRequestsFromMapFunc(
+			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
+				return broadcastToShardRequests(ctx, r.Client, obj.GetNamespace())
+			}),
+		).
 		Named("nat66shard").
 		Complete(r)
+}
+
+// broadcastToShardRequests enqueues every NAT66Shard in namespace --
+// mirrors broadcastToGatewayRequests (networkgateway_controller.go) for
+// the same reason: a BGPRouter change might be the one this node's own
+// NAT66Shard was waiting on, and there is normally at most one NAT66Shard
+// per node anyway, so listing the whole namespace is cheap.
+func broadcastToShardRequests(ctx context.Context, c client.Client, namespace string) []ctrlreconcile.Request {
+	logger := log.FromContext(ctx)
+	shardList := &bgpv1alpha1.NAT66ShardList{}
+	if err := c.List(ctx, shardList, client.InNamespace(namespace)); err != nil {
+		logger.Error(err, "list NAT66Shards for BGPRouter change", "namespace", namespace)
+		return nil
+	}
+	reqs := make([]ctrlreconcile.Request, 0, len(shardList.Items))
+	for _, s := range shardList.Items {
+		reqs = append(reqs, ctrlreconcile.Request{
+			NamespacedName: types.NamespacedName{Namespace: s.Namespace, Name: s.Name},
+		})
+	}
+	return reqs
 }

--- a/internal/controller/nat66shard_controller_test.go
+++ b/internal/controller/nat66shard_controller_test.go
@@ -14,7 +14,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
@@ -83,7 +82,7 @@ func reconcileReq(name string) ctrl.Request {
 
 func TestNAT66ShardReconciler_NotFoundIsANoop(t *testing.T) {
 	scheme := nat66TestScheme(t)
-	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	c := newIndexedClientBuilder(scheme).Build()
 	r := newNAT66Reconciler(nat66ReconcilerParams{
 		client: c, scheme: scheme, nodeName: testNAT66NodeA,
 		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
@@ -97,7 +96,7 @@ func TestNAT66ShardReconciler_NotFoundIsANoop(t *testing.T) {
 func TestNAT66ShardReconciler_SkipsShardForAnotherNode(t *testing.T) {
 	scheme := nat66TestScheme(t)
 	shard := newNAT66Shard(testNAT66NodeB)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 	r := newNAT66Reconciler(nat66ReconcilerParams{
 		client: c, scheme: scheme, nodeName: testNAT66NodeA,
 		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
@@ -124,7 +123,7 @@ func TestNAT66ShardReconciler_SkipsShardForAnotherNode(t *testing.T) {
 func TestNAT66ShardReconciler_PublishesStatusWhenAttached(t *testing.T) {
 	scheme := nat66TestScheme(t)
 	shard := newNAT66Shard(testNAT66NodeA)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 	r := newNAT66Reconciler(nat66ReconcilerParams{
 		client: c, scheme: scheme, nodeName: testNAT66NodeA,
 		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
@@ -163,7 +162,7 @@ func TestNAT66ShardReconciler_PublishesStatusWhenAttached(t *testing.T) {
 func TestNAT66ShardReconciler_ReadyFalseWhenNotAttached(t *testing.T) {
 	scheme := nat66TestScheme(t)
 	shard := newNAT66Shard(testNAT66NodeA)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 	r := newNAT66Reconciler(nat66ReconcilerParams{
 		client: c, scheme: scheme, nodeName: testNAT66NodeA,
 		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: false},
@@ -193,7 +192,7 @@ func TestNAT66ShardReconciler_ReadyFalseWhenNotAttached(t *testing.T) {
 func TestNAT66ShardReconciler_NilDatapathIsNotAttached(t *testing.T) {
 	scheme := nat66TestScheme(t)
 	shard := newNAT66Shard(testNAT66NodeA)
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 	r := newNAT66Reconciler(nat66ReconcilerParams{
 		client: c, scheme: scheme, nodeName: testNAT66NodeA,
 		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: nil,
@@ -220,7 +219,7 @@ func TestNAT66ShardReconciler_DeletingShardIsANoop(t *testing.T) {
 	scheme := nat66TestScheme(t)
 	shard := newNAT66Shard(testNAT66NodeA)
 	shard.Finalizers = []string{"test.datum.net/keep"} // required for the fake client to accept a deletion timestamp
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 
 	if err := c.Delete(context.Background(), shard); err != nil {
 		t.Fatalf("delete shard: %v", err)
@@ -248,7 +247,7 @@ func TestNAT66ShardReconciler_EmptyConfiguredValuesLeaveStatusUntouched(t *testi
 	shard := newNAT66Shard(testNAT66NodeA)
 	shard.Status.ShardAddress = testNAT66ShardAddr
 	shard.Status.ShardSID = testNAT66ShardSIDVal
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
 
 	// A reconciler started with empty ShardAddress/ShardSID (shouldn't
 	// happen in production -- config.NAT66Config.Validate requires both --
@@ -271,5 +270,137 @@ func TestNAT66ShardReconciler_EmptyConfiguredValuesLeaveStatusUntouched(t *testi
 	}
 	if got.Status.ShardSID != testNAT66ShardSIDVal {
 		t.Errorf("Status.ShardSID = %q, want untouched %q", got.Status.ShardSID, testNAT66ShardSIDVal)
+	}
+}
+
+// newTestNAT66Router returns a BGPRouter targeting nodeName, resolved
+// through the BGPRouterByTargetName index newIndexedClientBuilder (shared
+// with networkgateway_controller_test.go) registers.
+func newTestNAT66Router(nodeName, routerName string) *bgpv1alpha1.BGPRouter {
+	return &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNAT66Namespace, Name: routerName},
+		Spec:       bgpv1alpha1.BGPRouterSpec{TargetRef: bgpv1alpha1.TargetRef{Kind: "Node", Name: nodeName}},
+	}
+}
+
+func TestNAT66ShardReconciler_CreatesAdvertisementWhenSIDAndRouterPresent(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	router := newTestNAT66Router(testNAT66NodeA, "node-a-router")
+	c := newIndexedClientBuilder(scheme).WithObjects(shard, router).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	advKey := client.ObjectKey{Namespace: testNAT66Namespace, Name: shardAdvertisementName(testNAT66ShardName)}
+	if err := c.Get(context.Background(), advKey, adv); err != nil {
+		t.Fatalf("get shard BGPAdvertisement: %v", err)
+	}
+	if adv.Spec.RouterRef.Name != router.Name {
+		t.Errorf("Spec.RouterRef.Name = %q, want %q", adv.Spec.RouterRef.Name, router.Name)
+	}
+	if adv.Spec.AddressFamily.AFI != bgpv1alpha1.AFIL2VPN || adv.Spec.AddressFamily.SAFI != bgpv1alpha1.SAFIEVPN {
+		t.Errorf("Spec.AddressFamily = %+v, want l2vpn/evpn", adv.Spec.AddressFamily)
+	}
+	wantPrefix := bgpv1alpha1.Prefix(testNAT66ShardSIDVal + "/128")
+	if len(adv.Spec.Prefixes) != 1 || adv.Spec.Prefixes[0] != wantPrefix {
+		t.Errorf("Spec.Prefixes = %+v, want [%s]", adv.Spec.Prefixes, wantPrefix)
+	}
+}
+
+func TestNAT66ShardReconciler_SkipsAdvertisementWithoutRouter(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	c := newIndexedClientBuilder(scheme).WithObjects(shard).WithStatusSubresource(shard).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil even with no BGPRouter for this node yet", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	advKey := client.ObjectKey{Namespace: testNAT66Namespace, Name: shardAdvertisementName(testNAT66ShardName)}
+	if err := c.Get(context.Background(), advKey, adv); err == nil {
+		t.Fatalf("BGPAdvertisement %v unexpectedly created with no BGPRouter for this node", advKey)
+	}
+}
+
+func TestNAT66ShardReconciler_WithdrawsAdvertisementOnDelete(t *testing.T) {
+	scheme := nat66TestScheme(t)
+	shard := newNAT66Shard(testNAT66NodeA)
+	shard.Finalizers = []string{"test.datum.net/keep"} // required for the fake client to accept a deletion timestamp
+	router := newTestNAT66Router(testNAT66NodeA, "node-a-router")
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNAT66Namespace,
+			Name:      shardAdvertisementName(testNAT66ShardName),
+		},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: router.Name},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(testNAT66ShardSIDVal + "/128")},
+		},
+	}
+	c := newIndexedClientBuilder(scheme).WithObjects(shard, router, adv).WithStatusSubresource(shard).Build()
+
+	if err := c.Delete(context.Background(), shard); err != nil {
+		t.Fatalf("delete shard: %v", err)
+	}
+
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(adv), got); err == nil {
+		t.Fatalf("BGPAdvertisement %v still exists after deleting its NAT66Shard", client.ObjectKeyFromObject(adv))
+	}
+}
+
+func TestNAT66ShardReconciler_WithdrawsAdvertisementWhenShardObjectAlreadyGone(t *testing.T) {
+	// Mirrors NetworkGatewayReconciler's own req.Name-keyed withdrawal in
+	// its NotFound branch: this reconciler never observes a live shard
+	// object at all here, only the deletion event's req.Name, and must
+	// still withdraw the advertisement it created (see the Reconcile
+	// NotFound branch's own doc comment for why no finalizer is used).
+	scheme := nat66TestScheme(t)
+	router := newTestNAT66Router(testNAT66NodeA, "node-a-router")
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNAT66Namespace,
+			Name:      shardAdvertisementName(testNAT66ShardName),
+		},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: router.Name},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(testNAT66ShardSIDVal + "/128")},
+		},
+	}
+	c := newIndexedClientBuilder(scheme).WithObjects(router, adv).Build()
+	r := newNAT66Reconciler(nat66ReconcilerParams{
+		client: c, scheme: scheme, nodeName: testNAT66NodeA,
+		addr: testNAT66ShardAddr, sid: testNAT66ShardSIDVal, datapath: &fakeDatapathHealth{attached: true},
+	})
+
+	if _, err := r.Reconcile(context.Background(), reconcileReq(testNAT66ShardName)); err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil for a NotFound shard object", err)
+	}
+
+	got := &bgpv1alpha1.BGPAdvertisement{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(adv), got); err == nil {
+		t.Fatalf("BGPAdvertisement %v still exists after its NAT66Shard object disappeared", client.ObjectKeyFromObject(adv))
 	}
 }

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -373,14 +373,26 @@ func buildDesiredRule(
 }
 
 // routerNameForNode returns the name of the BGPRouter whose targetRef.name
-// matches this node, or "" if none exists yet.
+// matches this node, or "" if none exists yet. Thin wrapper around the
+// package-level routerNameForNode, kept as a method so existing call sites
+// and tests don't need to change.
 func (r *NetworkGatewayReconciler) routerNameForNode(ctx context.Context, namespace string) (string, error) {
+	return routerNameForNode(ctx, r.Client, namespace, r.NodeName)
+}
+
+// routerNameForNode returns the name of the BGPRouter whose targetRef.name
+// matches nodeName, or "" if none exists yet. Extracted as a free function
+// (originally a NetworkGatewayReconciler method only) so
+// NAT66ShardReconciler's own shard-SID advertisement (nat66shard_controller.go)
+// can resolve the same "which BGPRouter is mine" lookup without either
+// duplicating it or reaching into a sibling reconciler's method set.
+func routerNameForNode(ctx context.Context, c client.Client, namespace, nodeName string) (string, error) {
 	list := &bgpv1alpha1.BGPRouterList{}
-	if err := r.List(ctx, list,
+	if err := c.List(ctx, list,
 		client.InNamespace(namespace),
-		client.MatchingFields{BGPRouterByTargetName: r.NodeName},
+		client.MatchingFields{BGPRouterByTargetName: nodeName},
 	); err != nil {
-		return "", fmt.Errorf("list BGPRouters for node %s: %w", r.NodeName, err)
+		return "", fmt.Errorf("list BGPRouters for node %s: %w", nodeName, err)
 	}
 	if len(list.Items) == 0 {
 		return "", nil

--- a/internal/hostconf/hostconf.go
+++ b/internal/hostconf/hostconf.go
@@ -63,6 +63,13 @@ type HostConf struct {
 	Namespace  string `json:"namespace"`
 	LogFile    string `json:"log_file"`
 	LogLevel   string `json:"log_level,omitempty"`
+
+	// NAT66ShardSIDs is the comma-separated NAT66 shard SID list --
+	// see config.EnvCNINAT66ShardSIDs's own doc comment. Written by
+	// internal/installer.Bootstrap from its own env, read by
+	// internal/cnibgp the same way every other field here is: a CNI
+	// plugin's exec environment carries none of this on its own.
+	NAT66ShardSIDs string `json:"nat66_shard_sids,omitempty"`
 }
 
 // conflistEnvelope matches standard CNI conflist JSON structure.

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -201,6 +201,15 @@ func resolveLogLevel() string {
 	return config.NormalizeLogLevel(os.Getenv(config.EnvLogLevel))
 }
 
+// resolveNAT66ShardSIDs reads GALACTIC_CNI_NAT66_SHARD_SIDS, the fabric-wide
+// NAT66 shard membership list -- see that env var's own doc comment. Unlike
+// resolveLogLevel's fallback, an unset/empty value has no default to
+// normalize to: it means no shard is configured yet, and is written into
+// the conflist verbatim (empty), not substituted for anything.
+func resolveNAT66ShardSIDs() string {
+	return os.Getenv(config.EnvCNINAT66ShardSIDs)
+}
+
 // Bootstrap runs the CNI installation init container tasks:
 // 1. Copies binaries to the host.
 // 2. Performs a one-shot dual-stack node identity check.
@@ -309,6 +318,7 @@ func Bootstrap(ctx context.Context, nodeName string) error {
 
 	// 4. Write static conflist to /host/etc/cni/net.d/10-galactic.conflist
 	logLevel := resolveLogLevel()
+	nat66ShardSIDs := resolveNAT66ShardSIDs()
 	conflistContent := fmt.Sprintf(`{
   "cniVersion": "1.0.0",
   "name": "galactic",
@@ -319,11 +329,12 @@ func Bootstrap(ctx context.Context, nodeName string) error {
       "kubeconfig": %q,
       "namespace": %q,
       "log_file": %q,
-      "log_level": %q
+      "log_level": %q,
+      "nat66_shard_sids": %q
     }
   ]
 }
-`, nodeName, config.DefaultKubeconfig, config.DefaultNamespace, config.DefaultLogFile, logLevel)
+`, nodeName, config.DefaultKubeconfig, config.DefaultNamespace, config.DefaultLogFile, logLevel, nat66ShardSIDs)
 
 	if err := atomicWriteFile(HostConflist, []byte(conflistContent), 0644); err != nil {
 		return fmt.Errorf("write conflist file: %w", err)

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -72,6 +72,20 @@ func TestResolveLogLevel(t *testing.T) {
 	}
 }
 
+func TestResolveNAT66ShardSIDs(t *testing.T) {
+	// Unset: no default to normalize to, unlike resolveLogLevel -- empty
+	// means "no shard configured yet," written into the conflist verbatim.
+	if got := resolveNAT66ShardSIDs(); got != "" {
+		t.Errorf("resolveNAT66ShardSIDs() = %q, want empty when unset", got)
+	}
+
+	const want = "2001:db8:ff01:1:e001::,2001:db8:ff03:1:e001::"
+	t.Setenv(config.EnvCNINAT66ShardSIDs, want)
+	if got := resolveNAT66ShardSIDs(); got != want {
+		t.Errorf("resolveNAT66ShardSIDs() = %q, want %q", got, want)
+	}
+}
+
 // assertBinaryCopied verifies that the binary at path exists and contains
 // wantContent, factored out of TestBootstrap to keep its own cyclomatic
 // complexity within golangci-lint's gocyclo budget.
@@ -171,6 +185,8 @@ func TestBootstrap(t *testing.T) {
 			}
 			return nil, nil
 		}
+		const wantShardSIDs = "2001:db8:ff01:1:e001::,2001:db8:ff03:1:e001::"
+		t.Setenv(config.EnvCNINAT66ShardSIDs, wantShardSIDs)
 
 		err := Bootstrap(context.Background(), "test-node")
 		if err != nil {
@@ -203,6 +219,9 @@ func TestBootstrap(t *testing.T) {
 		}
 		if conflist.LogLevel != config.DefaultLogLevel {
 			t.Errorf("expected log_level %s, got %s", config.DefaultLogLevel, conflist.LogLevel)
+		}
+		if conflist.NAT66ShardSIDs != wantShardSIDs {
+			t.Errorf("expected nat66_shard_sids %s, got %s", wantShardSIDs, conflist.NAT66ShardSIDs)
 		}
 
 		// Verify kubeconfig written

--- a/internal/plumbing/ebpf/nat66prog/nat66.c
+++ b/internal/plumbing/ebpf/nat66prog/nat66.c
@@ -253,7 +253,29 @@ static NAT66_ALWAYS_INLINE int addr6_eq(const __u8 a[16], const __u8 b[16])
 // locator_matches checks only the top 64 bits (Block(48)+Node-ID(16)) of
 // daddr against this shard's own shard_sid -- the same "is this mine"
 // granularity internal/plumbing/ebpf/prog/usid.c's own locator_table
-// match uses, since the Argument nibble below it varies per tenant.
+// match uses, since the Argument nibble below it varies per tenant (see
+// this file's own header comment: the Argument nibble is read afterward,
+// in handle_forward, as the requesting tenant's own VRFID -- it is
+// deliberately not part of "is this addressed to me" at all).
+//
+// This 64-bit granularity requires shard_sid's own (Block, Node-ID) to be
+// reserved and disjoint from every *other* uSID identity sharing this
+// node's uplink -- in particular, a shard's own Node-ID must differ from
+// the Node-ID any co-located tenant-delivery BGPRouter on this same node
+// already uses (see GALACTIC_NAT66_SHARD_SID's own deployment-side doc
+// comment, e.g. deploy/containerlab/resources/galactic-nat66/*/node-patch.yaml).
+// Confirmed live: an earlier lab config reused a co-located tenant
+// worker's own real Node-ID for that same node's shard placeholder SID,
+// which meant ordinary tenant ingress traffic addressed to that node's
+// real delivery uSID (same Block+Node-ID, nexthdr also 41 since
+// SEG6_IPTUN_MODE_ENCAP_RED uses that for every IPv6-inner packet, tenant
+// delivery included) was silently hijacked here, before it ever reached
+// usid_ingress's own TC hook -- not a bug in this 64-bit match itself
+// (widening it to a full 128-bit compare was tried and reverted: it broke
+// the correct, intentional case of two different tenants' egress packets
+// legitimately sharing this exact shard_sid with two different Argument
+// values), but an address-allocation conflict this function has no way
+// to detect on its own.
 static NAT66_ALWAYS_INLINE int locator_matches(const __u8 daddr[16], const __u8 shard_sid[16])
 {
 	for (int i = 0; i < 8; i++) {

--- a/internal/plumbing/ebpf/nat66prog/nat66_test.go
+++ b/internal/plumbing/ebpf/nat66prog/nat66_test.go
@@ -21,6 +21,12 @@ const (
 	xdpTx   = 3
 
 	ipprotoUDP = 17
+
+	// encappedSrcPort/encappedDstPort are the backend's own source port
+	// and the tenant flow's destination port in every buildEncappedUDPPacket
+	// fixture below -- see that function's own doc comment.
+	encappedSrcPort = 40000
+	encappedDstPort = 443
 )
 
 func requireRoot(t *testing.T) {
@@ -132,11 +138,16 @@ func udp6Checksum(src, dst [16]byte, udpHeaderAndPayload []byte) uint16 {
 // IPv6-in-IPv6 outer header (SEG6_IPTUN_MODE_ENCAP_RED's wire format,
 // matching internal/plumbing/srv6/egress.go's RouteEgressAdd) -- the shape
 // a tenant's own outbound egress packet actually arrives in.
+//
+// srcPort/dstPort are always encappedSrcPort/encappedDstPort across every
+// caller in this file (unparam) -- not parameterized further since no
+// test here needs different backend-side ports.
 func buildEncappedUDPPacket(t *testing.T, outerDst, outerSrc, innerSrc, innerDst netip.Addr,
-	srcPort, dstPort uint16, payload []byte,
+	payload []byte,
 ) []byte {
 	t.Helper()
-	inner := buildUDPPacket(t, innerDst, innerSrc, srcPort, dstPort, payload)[ethLen:] // drop the inner's own eth header
+	// drop the inner packet's own eth header
+	inner := buildUDPPacket(t, innerDst, innerSrc, encappedSrcPort, encappedDstPort, payload)[ethLen:]
 
 	pkt := make([]byte, 0, ethLen+ip6Len+len(inner))
 	pkt = append(pkt, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA)
@@ -205,7 +216,7 @@ func TestNat66Ingress_ForwardSNATsAndPreservesChecksum(t *testing.T) {
 	backendAddr := netip.MustParseAddr("fd20:60::5")
 	backendUSID := netip.MustParseAddr("fc00:3:4::a1b2")
 	destAddr := netip.MustParseAddr("2001:db8:9998::1")
-	const backendPort, destPort = 40000, 443
+	const destPort = 443
 
 	// The Argument nibble (bits 69-80 of shardSID, this uSID's low bits)
 	// carries the requesting tenant's VRFID -- 0x123 here, arbitrary but
@@ -216,7 +227,7 @@ func TestNat66Ingress_ForwardSNATsAndPreservesChecksum(t *testing.T) {
 
 	payload := []byte("egress payload")
 	pkt := buildEncappedUDPPacket(t, netip.AddrFrom16(shardSIDWithArg), backendUSID,
-		backendAddr, destAddr, backendPort, destPort, payload)
+		backendAddr, destAddr, payload)
 
 	ret, out, err := objs.Nat66Ingress.Test(pkt)
 	if err != nil {
@@ -267,7 +278,7 @@ func TestNat66Ingress_ForwardSNATsAndPreservesChecksum(t *testing.T) {
 	// property that makes a flow's translation stable for its whole
 	// lifetime.
 	pkt2 := buildEncappedUDPPacket(t, netip.AddrFrom16(shardSIDWithArg), backendUSID,
-		backendAddr, destAddr, backendPort, destPort, []byte("second packet"))
+		backendAddr, destAddr, []byte("second packet"))
 	_, out2, err := objs.Nat66Ingress.Test(pkt2)
 	if err != nil {
 		t.Fatalf("program test-run (2nd packet): %v", err)
@@ -275,6 +286,56 @@ func TestNat66Ingress_ForwardSNATsAndPreservesChecksum(t *testing.T) {
 	gotSrcPort2 := binary.BigEndian.Uint16(out2[udpOffset : udpOffset+2])
 	if gotSrcPort2 != gotSrcPort {
 		t.Errorf("masquerade port changed across packets on the same flow: %d then %d", gotSrcPort, gotSrcPort2)
+	}
+}
+
+// TestNat66Ingress_DifferentNodeIDPassesThrough proves locator_matches'
+// deliberate 64-bit (Block+Node-ID) granularity does NOT accidentally
+// widen to a full 128-bit match: two uSIDs sharing shard_sid's Block but
+// not its Node-ID must never be treated as this shard's own traffic,
+// regardless of what the low 64 bits (Function+Argument) happen to
+// contain. This is the actual boundary a real deployment must keep
+// disjoint -- see locator_matches' own doc comment for the live
+// incident (a shard reusing its co-located tenant node's own Node-ID)
+// this same 64-bit match cannot, by itself, detect or prevent; this test
+// only proves the match's own stated granularity is what's implemented,
+// not a fix for that allocation-level constraint.
+func TestNat66Ingress_DifferentNodeIDPassesThrough(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	shardSID := netip.MustParseAddr("fc00:1:2::1")
+	shardPub := netip.MustParseAddr("2001:db8:9999::1")
+	if err := objs.ShardConfigTable.Put(uint32(0), Nat66ShardConfig{
+		ShardSid: shardSID.As16(), ShardPubAddr: shardPub.As16(),
+	}); err != nil {
+		t.Fatalf("populate shard_config_table: %v", err)
+	}
+
+	// Same Block (bytes 0-5) as shardSID, but a different Node-ID (bytes
+	// 6-7) -- a different node's own uSID space entirely, sharing only
+	// the site's locator.
+	otherUSID := shardSID.As16()
+	otherUSID[6] = 0x00
+	otherUSID[7] = 0x09
+
+	backendAddr := netip.MustParseAddr("fd20:60::5")
+	backendUSID := netip.MustParseAddr("fc00:3:4::a1b2")
+	destAddr := netip.MustParseAddr("2001:db8:9998::1")
+
+	pkt := buildEncappedUDPPacket(t, netip.AddrFrom16(otherUSID), backendUSID,
+		backendAddr, destAddr, []byte("a different node's own uSID space"))
+
+	ret, out, err := objs.Nat66Ingress.Test(pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != xdpPass {
+		t.Fatalf("verdict = %d, want XDP_PASS (%d) -- this is a different Node-ID, not this shard's own traffic",
+			ret, xdpPass)
+	}
+	if string(out) != string(pkt) {
+		t.Errorf("packet mutated on a Node-ID mismatch:\n in: % x\nout: % x", pkt, out)
 	}
 }
 
@@ -306,7 +367,7 @@ func TestNat66Ingress_ReturnUnNATsAndReencapsulates(t *testing.T) {
 	// First, run a forward packet to populate conn_table (both rows) and
 	// learn the allocated masquerade port.
 	fwdPkt := buildEncappedUDPPacket(t, netip.AddrFrom16(shardSIDWithArg), backendUSID,
-		backendAddr, destAddr, backendPort, destPort, []byte("out"))
+		backendAddr, destAddr, []byte("out"))
 	_, fwdOut, err := objs.Nat66Ingress.Test(fwdPkt)
 	if err != nil {
 		t.Fatalf("forward program test-run: %v", err)

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -5,6 +5,7 @@
 package srv6
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -192,6 +193,115 @@ func RouteMainAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 	return netlink.RouteDel(&netlink.Route{
 		Dst:   prefix,
+		Table: int(tableID),
+	})
+}
+
+// defaultRoutePrefix is the IPv6 default route (::/0) EgressDefaultRouteAdd
+// installs -- the catch-all a tenant VRF falls back to once every more
+// specific route (intra-VPC peers via RouteEgressAdd, anycast VIPs via
+// RouteMainAdd) has already missed.
+var defaultRoutePrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+
+// EgressDefaultRouteAdd installs a multipath IPv6 default route (::/0) in
+// routing table tableID, SEG6-encapsulating toward every address in
+// shardSIDs -- one nexthop per shard, equally weighted. This is the
+// missing half of the design plan's §3 sharded NAT66 tier: nat66.c's own
+// shard-receive side has always been able to decap and NAT a packet
+// addressed to its own shard_sid, but nothing ever produced such a packet
+// -- no code anywhere installed a default route in a tenant VRF at all,
+// so a backend with no more specific destination simply had no route out
+// (confirmed live: "no route to host" from vrf60's own table). This closes
+// that gap the same way RouteEgressAdd closes it for a specific intra-VPC
+// destination, just fanned out across every live shard instead of one
+// fixed gateway.
+//
+// Shard selection here is deliberately NOT internal/maglev, unlike the
+// design plan §3.2's original text ("shard assignment is chosen via a
+// maglev.Table built over (tenant VRFID, backend addr:port, dest
+// addr:port)"). That per-flow, in-datapath hash was never actually
+// implemented (internal/maglev is only ever called from the ingress LB's
+// own backend-selection ring), and building an equivalent TC-BPF hash
+// stage here would be a second, much larger new eBPF component. Linux's
+// own ECMP multipath hashing over these nexthops already gives near-even
+// load spread across shards without any new datapath code, and modern
+// kernels' resilient nexthop groups (RTA_NH_ID hash-policy "resilient")
+// give the same bounded-disruption-on-membership-change
+// property Maglev was chosen for in the first place -- but this function
+// installs plain multipath nexthops, not a resilient nexthop group,
+// since building/managing a named nexthop group is extra bookkeeping this
+// phase doesn't need: correctness (a route exists, traffic flows) matters
+// more here than minimizing reshuffled flows on a shard add/remove, which
+// is why the design plan's own §5 already treats shard-set-change
+// disruption as a property to prove, not a hard requirement gating this
+// mechanism's existence. Revisit with a real nexthop group if/when that
+// bound is actually needed.
+//
+// shardSIDs must be non-empty -- EgressDefaultRouteAdd installs nothing
+// and returns nil when it is, the same "nothing configured yet, not an
+// error" stance GALACTIC_CNI_NAT66_SHARD_SIDS's own doc comment takes. An
+// unspecified/nil entry is a real misconfiguration and fails loudly
+// (matching RouteEgressAdd/RouteMainAdd's own guard), but a *reachable*
+// shard SID that resolveNextHop simply cannot resolve *yet* is silently
+// skipped, not fatal to the whole call: found live on a tenant node that
+// is *also* one of the configured shards itself (this lab's own "reuse
+// the site workers as shards" layout, design plan §8) -- GoBGP, like
+// every other BGP implementation, never reflects a node's own
+// locally-originated advertisement back into that same node's received-path
+// processing, so a shard's own node can *never* resolve a route to its
+// own SID, only to every other shard's. Aborting the entire multipath
+// route over that one permanently-unresolvable nexthop would have meant
+// no default route at all on every shard node -- exactly the nodes most
+// likely to actually run tenant workloads in this lab. The route this
+// function installs simply has one fewer nexthop on a shard's own node;
+// EgressDefaultRouteAdd only fails outright when *every* configured SID
+// is unresolvable, since a route with zero nexthops is not a route worth
+// installing at all.
+func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
+	if len(shardSIDs) == 0 {
+		return nil
+	}
+
+	nexthops := make([]*netlink.NexthopInfo, 0, len(shardSIDs))
+	var unresolved []error
+	for _, sid := range shardSIDs {
+		if sid == nil || sid.IsUnspecified() {
+			return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
+		}
+		linkIndex, nextHop, err := resolveNextHop(sid)
+		if err != nil {
+			unresolved = append(unresolved, fmt.Errorf("shard %s: %w", sid, err))
+			continue
+		}
+		nh := &netlink.NexthopInfo{
+			LinkIndex: linkIndex,
+			Encap:     &netlink.SEG6Encap{Mode: seg6IptunModeEncapRed, Segments: []net.IP{sid}},
+		}
+		if len(nextHop) > 0 {
+			nh.Gw = nextHop
+		} else {
+			nh.Gw = sid
+		}
+		nexthops = append(nexthops, nh)
+	}
+
+	if len(nexthops) == 0 {
+		return fmt.Errorf("no NAT66 shard SID is resolvable yet, out of %d configured: %w",
+			len(shardSIDs), errors.Join(unresolved...))
+	}
+
+	return netlink.RouteReplace(&netlink.Route{
+		Dst:       defaultRoutePrefix,
+		Table:     int(tableID),
+		MultiPath: nexthops,
+	})
+}
+
+// EgressDefaultRouteDel removes the NAT66 default route (::/0) from routing
+// table tableID -- EgressDefaultRouteAdd's counterpart.
+func EgressDefaultRouteDel(tableID uint32) error {
+	return netlink.RouteDel(&netlink.Route{
+		Dst:   defaultRoutePrefix,
 		Table: int(tableID),
 	})
 }

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -5,14 +5,28 @@
 package srv6
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
+
+// testCaseIPv6Zero names the shared "IPv6 zero" test-table-case fixture
+// used across RouteEgressAdd/RouteMainAdd/EgressDefaultRouteAdd's own
+// unspecified-gateway/SID rejection tests (goconst).
+const testCaseIPv6Zero = "IPv6 zero"
+
+// defaultRoutePrefixString is the string form of defaultRoutePrefix
+// (::/0), shared by every EgressDefaultRouteAdd/Del test below that needs
+// to recognize the installed default route by its Dst field (goconst).
+const defaultRoutePrefixString = "::/0"
 
 func requireRoot(t *testing.T) {
 	t.Helper()
@@ -41,7 +55,7 @@ func TestRouteEgressAddRejectsUnspecifiedGateway(t *testing.T) {
 		{name: "nil gateway", gateway: nil},
 		{name: "IPv4 zero", gateway: net.IPv4zero},
 		{name: "IPv4-mapped IPv6 zero (::ffff:0.0.0.0)", gateway: net.ParseIP("0.0.0.0").To16()},
-		{name: "IPv6 zero", gateway: net.IPv6unspecified},
+		{name: testCaseIPv6Zero, gateway: net.IPv6unspecified},
 	}
 
 	for _, tt := range tests {
@@ -191,7 +205,7 @@ func TestRouteMainAddRejectsUnspecifiedGateway(t *testing.T) {
 	}{
 		{name: "nil gateway", gateway: nil},
 		{name: "IPv4 zero", gateway: net.IPv4zero},
-		{name: "IPv6 zero", gateway: net.IPv6unspecified},
+		{name: testCaseIPv6Zero, gateway: net.IPv6unspecified},
 	}
 
 	for _, tt := range tests {
@@ -372,5 +386,293 @@ func TestRouteMainAdd_ResolvesIndirectGateway(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("RouteMainAdd(%s) via indirect gateway %s = %v, want success", vipPrefix, gateway, err)
+	}
+}
+
+// TestEgressDefaultRouteAdd_EmptyShardListIsANoop covers the "no shard
+// configured yet" case config.EnvCNINAT66ShardSIDs's own doc comment
+// describes as normal, not an error -- no root needed since nothing ever
+// reaches netlink.
+func TestEgressDefaultRouteAdd_EmptyShardListIsANoop(t *testing.T) {
+	if err := EgressDefaultRouteAdd(1, nil); err != nil {
+		t.Errorf("EgressDefaultRouteAdd(nil) = %v, want nil for an empty shard list", err)
+	}
+	if err := EgressDefaultRouteAdd(1, []net.IP{}); err != nil {
+		t.Errorf("EgressDefaultRouteAdd([]) = %v, want nil for an empty shard list", err)
+	}
+}
+
+// TestEgressDefaultRouteAddRejectsUnspecifiedShardSID mirrors
+// TestRouteEgressAddRejectsUnspecifiedGateway/TestRouteMainAddRejectsUnspecifiedGateway:
+// a shard SID that is nil or the unspecified address would otherwise
+// install a route to nowhere.
+func TestEgressDefaultRouteAddRejectsUnspecifiedShardSID(t *testing.T) {
+	tests := []struct {
+		name string
+		sids []net.IP
+	}{
+		{name: "nil shard SID", sids: []net.IP{nil}},
+		{name: testCaseIPv6Zero, sids: []net.IP{net.IPv6unspecified}},
+		{name: "one good, one unspecified", sids: []net.IP{net.ParseIP("2001:db8:ff01::1"), net.IPv6unspecified}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := EgressDefaultRouteAdd(1, tt.sids); err == nil {
+				t.Errorf("EgressDefaultRouteAdd(%v) = nil error, want an error rejecting the unusable shard SID", tt.sids)
+			}
+		})
+	}
+}
+
+// TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards proves the
+// installed ::/0 route fans out across every configured shard SID as a
+// separate SEG6-encapsulating nexthop, and that EgressDefaultRouteDel
+// removes it cleanly -- the mechanism that finally gives a tenant VRF
+// somewhere to send a packet with no more specific route, closing the gap
+// nat66.c's own shard-receive side was always able to answer but nothing
+// ever fed traffic into (see this function's own doc comment).
+func TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		ifaceName = "srv6mtest2"
+		ifaceAddr = "2001:db8:4::1/64"
+		shardSID1 = "2001:db8:ff01:1:e001::"
+		shardSID2 = "2001:db8:ff03:1:e001::"
+		table     = 42
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy link: %w", err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			return fmt.Errorf("set link up: %w", err)
+		}
+		addr, err := netlink.ParseAddr(ifaceAddr)
+		if err != nil {
+			return fmt.Errorf("parse addr: %w", err)
+		}
+		if err := netlink.AddrAdd(dummy, addr); err != nil {
+			return fmt.Errorf("add addr: %w", err)
+		}
+		// resolveNextHop (via netlink.RouteGet) needs a real route to each
+		// shard SID before EgressDefaultRouteAdd can resolve it -- neither
+		// SID is naturally on-link over ifaceAddr's own /64, so each gets
+		// an explicit on-link /128 host route, mirroring how a real
+		// fabric's own SRv6 locator routes would already exist by the
+		// time this function ever runs (see RouteMainAdd's identical
+		// ordering dependency on RouteMainAdd's own doc comment).
+		for _, sid := range []string{shardSID1, shardSID2} {
+			_, sidDst, err := net.ParseCIDR(sid + "/128")
+			if err != nil {
+				return fmt.Errorf("parse shard SID %q: %w", sid, err)
+			}
+			if err := netlink.RouteAdd(&netlink.Route{LinkIndex: dummy.Attrs().Index, Dst: sidDst}); err != nil {
+				return fmt.Errorf("add on-link route for shard SID %q: %w", sid, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	shardSIDs := []net.IP{net.ParseIP(shardSID1), net.ParseIP(shardSID2)}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return EgressDefaultRouteAdd(table, shardSIDs)
+	})
+	if err != nil {
+		t.Fatalf("EgressDefaultRouteAdd(%v) = %v, want success", shardSIDs, err)
+	}
+
+	var installed *netlink.Route
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == defaultRoutePrefixString {
+				installed = &routes[i]
+				return nil
+			}
+		}
+		return fmt.Errorf("no default route found in table %d", table)
+	})
+	if err != nil {
+		t.Fatalf("verify installed route: %v", err)
+	}
+	if len(installed.MultiPath) != len(shardSIDs) {
+		t.Fatalf("installed default route has %d nexthops, want %d", len(installed.MultiPath), len(shardSIDs))
+	}
+
+	// Per-nexthop RTA_ENCAP within RTA_MULTIPATH round-trips through the
+	// kernel correctly (confirmed live against `ip -6 route show`) but the
+	// vendored netlink library's own RouteListFiltered doesn't decode it
+	// back into NexthopInfo.Encap -- every nexthop above reads back
+	// Encap == nil regardless of what was actually installed. Shell out to
+	// `ip -6 route` (real ground truth, the same tool this session's own
+	// live containerlab diagnostics already trusted over library/tcpdump
+	// artifacts) rather than asserting against a field this library can't
+	// populate.
+	var out []byte
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		var cmdErr error
+		out, cmdErr = exec.CommandContext(
+			context.Background(), "ip", "-6", "route", "show", "table", strconv.Itoa(table),
+		).CombinedOutput()
+		return cmdErr
+	})
+	if err != nil {
+		t.Fatalf("ip -6 route show table %d: %v (%s)", table, err, out)
+	}
+	for _, sid := range shardSIDs {
+		want := "encap seg6 mode encap.red segs 1 [ " + sid.String() + " ]"
+		if !strings.Contains(string(out), want) {
+			t.Errorf("ip -6 route show table %d = %q, want a nexthop containing %q", table, out, want)
+		}
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return EgressDefaultRouteDel(table)
+	})
+	if err != nil {
+		t.Fatalf("EgressDefaultRouteDel(%d) = %v, want success", table, err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		for i := range routes {
+			if routes[i].Dst != nil && routes[i].Dst.String() == defaultRoutePrefixString {
+				return fmt.Errorf("default route still present in table %d after EgressDefaultRouteDel", table)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("verify deleted route: %v", err)
+	}
+}
+
+// TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds is the
+// regression test for a real bug found live: a shard node can never
+// resolve a route to its *own* advertised SID (GoBGP, like every BGP
+// implementation, never reflects a self-originated path back into that
+// same node's own received-path processing -- see this function's own
+// doc comment), so any tenant node that is also a configured shard
+// (this lab's own "reuse the site workers as shards" layout) always has
+// exactly one permanently-unresolvable entry in shardSIDs. The original
+// implementation aborted the entire multipath route on the first
+// unresolvable nexthop, which meant *no default route at all* on every
+// shard node -- confirmed live: dfw-worker's own tenant pods failed CNI
+// ADD outright with "no route to gateway 2001:db8:ff01:1:e001:: (dfw's
+// own shard SID): invalid argument" even though sjc's and iad's shard
+// SIDs resolved fine from that same node. This test proves a mix of one
+// resolvable and one unresolvable shard SID still installs a route (with
+// only the resolvable one as a nexthop), not an error.
+func TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		ifaceName       = "srv6mtest3"
+		ifaceAddr       = "2001:db8:5::1/64"
+		resolvableSID   = "2001:db8:ff02:1:e001::"
+		unresolvableSID = "2001:db8:ff01:1:e001::" // no route ever installed for this one
+		table           = 43
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy link: %w", err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			return fmt.Errorf("set link up: %w", err)
+		}
+		addr, err := netlink.ParseAddr(ifaceAddr)
+		if err != nil {
+			return fmt.Errorf("parse addr: %w", err)
+		}
+		if err := netlink.AddrAdd(dummy, addr); err != nil {
+			return fmt.Errorf("add addr: %w", err)
+		}
+		_, sidDst, err := net.ParseCIDR(resolvableSID + "/128")
+		if err != nil {
+			return fmt.Errorf("parse shard SID: %w", err)
+		}
+		return netlink.RouteAdd(&netlink.Route{LinkIndex: dummy.Attrs().Index, Dst: sidDst})
+	})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	shardSIDs := []net.IP{net.ParseIP(unresolvableSID), net.ParseIP(resolvableSID)}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return EgressDefaultRouteAdd(table, shardSIDs)
+	})
+	if err != nil {
+		t.Fatalf("EgressDefaultRouteAdd(%v) = %v, want success with the resolvable shard used", shardSIDs, err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
+		if err != nil {
+			return err
+		}
+		for i := range routes {
+			if routes[i].Dst == nil || routes[i].Dst.String() == defaultRoutePrefixString {
+				// The kernel/netlink read path collapses a single-nexthop
+				// RTA_MULTIPATH route back into plain Gw/Encap fields, not
+				// a one-element MultiPath slice (confirmed live against
+				// `ip -6 route show`, which does report the SEG6 encap
+				// correctly either way) -- count either shape as "one
+				// nexthop", matching what this shard-count assertion
+				// actually cares about.
+				nexthops := len(routes[i].MultiPath)
+				if nexthops == 0 && routes[i].Gw != nil && routes[i].Encap != nil {
+					nexthops = 1
+				}
+				if nexthops != 1 {
+					return fmt.Errorf("installed default route has %d nexthops, want exactly 1 (the resolvable shard)",
+						nexthops)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("no default route found in table %d", table)
+	})
+	if err != nil {
+		t.Fatalf("verify installed route: %v", err)
+	}
+}
+
+// TestEgressDefaultRouteAdd_AllShardsUnresolvableFails is
+// TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds's negative
+// counterpart: when *every* configured shard SID is unresolvable, there
+// is nothing to install a route with at all, and this must fail loudly
+// rather than silently install a route with zero nexthops.
+func TestEgressDefaultRouteAdd_AllShardsUnresolvableFails(t *testing.T) {
+	shardSIDs := []net.IP{net.ParseIP("2001:db8:ff01:1:e001::"), net.ParseIP("2001:db8:ff02:1:e001::")}
+	if err := EgressDefaultRouteAdd(44, shardSIDs); err == nil {
+		t.Errorf("EgressDefaultRouteAdd(%v) = nil error, want an error when no shard SID is resolvable", shardSIDs)
 	}
 }


### PR DESCRIPTION
## Summary

NAT66 shards existed but no tenant VRF had a route toward one, so egress traffic needing translation had nowhere to go. This installs a default egress route per tenant VRF toward the configured NAT66 shard SIDs via netlink SEG6, documents the shard_sid Node-ID collision constraint operators need to respect, and wires the shard tier into containerlab.

## Test plan

- [ ] `task test:e2e`