### PR TITLE
feat: Move egress routing from netlink SEG6 to TC-BPF

### DIFF
--- a/docs/plans/tc-bpf-egress-srv6-encap.md
+++ b/docs/plans/tc-bpf-egress-srv6-encap.md
@@ -1,0 +1,243 @@
+# Design Plan — Replace Kernel-Native SEG6 Lwtunnel Egress Encap with TC-BPF
+
+## 0. Problem statement
+
+Every tenant-VRF egress route this codebase installs today
+(`RouteEgressAdd`, `EgressDefaultRouteAdd`, both in
+`internal/plumbing/srv6/egress.go`) relies on the Linux kernel's own
+native SEG6 lwtunnel route encapsulation (`netlink.SEG6Encap`, mode
+`SEG6_IPTUN_MODE_ENCAP_RED`) to push the outer SRv6/tunnel header onto a
+packet leaving a tenant VRF. This is a real, currently-unpatched Linux
+kernel bug, confirmed live in the containerlab lab and documented in the
+kitt note `projects/galactic/seg6-vrf-recursion-kernel-bug.md`:
+
+- **CVE-2026-31668** — "seg6: separate dst_cache for input and output
+  paths in seg6 lwtunnel." The seg6 lwtunnel implementation shares a
+  single `dst_cache` per encap route between `seg6_input_core()` and
+  `seg6_output_core()`. When those two paths resolve the post-encap SID
+  lookup under **different routing contexts — the fix's own upstream
+  writeup names "VRF table separation" as a trigger case** — whichever
+  path runs first populates the cache, and the other reuses it blindly,
+  producing a routing loop that trips the kernel's own recursion guard
+  and silently drops the packet (`lwtunnel_input(): recursion limit
+  reached on datapath`).
+- Confirmed via direct testing on the lab's `dfw-worker`/`sjc-worker`
+  nodes: `verify:ns10` and `verify:ns20` (plain inter-site tenant
+  connectivity, no NAT66/DSR code involved) both fail with 100% packet
+  loss, the recursion message firing in lockstep with each ping attempt,
+  and `tcpdump` on the physical uplink showing the packet never leaves
+  the host at all — it's dropped inside the kernel's own encapsulation
+  logic before transmission.
+- The fix landed upstream at **7.1.7** on the 7.1.x stable branch (the
+  CVE's fixed-version list: 5.10.264, 5.15.215, 6.1.182, 6.6.150,
+  6.12.102, 6.18.43, 7.1.7, mainline 7.2-rc5). As of this writing, no
+  Fedora repo (stable or `updates-testing`) has shipped anything past
+  7.1.4 — the fix is not available to install, not just risky to apply.
+
+**This is not a lab-only problem.** Galactic is explicitly a *multi-cloud*
+dataplane — it cannot assume uniform control over every node's kernel
+version across every cloud it runs on, and even where the underlying
+infrastructure is controlled, tracking and enforcing a minimum kernel
+version fleet-wide is an open-ended operational burden that does nothing
+for any node already running an affected kernel. A production node on an
+affected kernel would silently black-hole ordinary inter-VPC tenant
+traffic with no application-level error at all — exactly what `verify:
+ns10`/`verify:ns20` demonstrate in the lab. Treating this as a
+lab-environment quirk to document and move past was the wrong call (see
+the kitt note's revision history); it needs a real fix.
+
+## 1. Goal
+
+Remove this codebase's dependency on kernel-native SEG6 lwtunnel route
+encapsulation entirely, for every egress path that currently uses it.
+Once done, no galactic-controlled datapath should touch
+`seg6_output_core()`/`seg6_input_core()` at all, on any kernel version —
+eliminating this entire bug class going forward rather than working
+around one instance of it.
+
+This mirrors a decision this codebase already made once, for a different
+but analogous reason: `usid_ingress` (the uSID decap path,
+`internal/plumbing/ebpf/prog/usid.c`) is a TC-BPF program, not a native
+`seg6local` route, specifically because kernel-native SRv6 endpoint
+processing was judged too fragile/under-tested a corner of the kernel
+networking stack to depend on for a multi-tenant dataplane. This plan
+applies the same judgment to the encapsulation (egress) side, which
+today is the one remaining place native kernel SRv6 machinery is still
+load-bearing.
+
+## 2. What's in scope
+
+Three call sites in `internal/plumbing/srv6/egress.go` currently install
+a `netlink.SEG6Encap`-bearing route:
+
+- `RouteEgressAdd` — per-destination-prefix intra-VPC peer routes (one
+  segment: the peer node's own uSID address).
+- `EgressDefaultRouteAdd` — the tenant VRF's `::/0` fallback, added for
+  NAT66 egress (one segment: a NAT66 shard's SID).
+
+`RouteMainAdd` is **out of scope** — it installs a plain, non-SEG6
+recursive route for RT-less anycast VIP paths (see its own doc comment:
+wrapping that traffic in another SRv6 header would make it
+undeliverable, nothing is listening for it). It never touches
+`netlink.SEG6Encap` and doesn't exercise the buggy kernel code path at
+all.
+
+## 3. Why this is smaller than "implement generic SRv6 encapsulation in
+BPF" sounds
+
+Every existing call site installs a route with **exactly one segment** —
+multi-segment SRH support has never actually been used. And
+`usid_ingress`'s own doc comment already establishes what today's wire
+format actually looks like: `SEG6_IPTUN_MODE_ENCAP_RED` with one segment
+omits the Segment Routing Header entirely (RFC 8754 Next Header 43) —
+"the one segment is already fully expressed by the outer destination
+address, so there is nothing left for an SRH to carry" — leaving the
+outer header's Next Header set **directly** to the inner packet's own
+protocol (4/IPIP or 41/IPv6-in-IPv6). `usid_ingress` already requires
+and depends on exactly this shape on decap (`DROP_REASON_UNEXPECTED_NEXTHDR`
+for anything else).
+
+So what needs replacing is not a general SRH pusher — it's a plain
+IPv6-in-IPv6 / IPIP-over-IPv6 tunnel header prepend, with the destination
+set to the resolved SID. That's a well-trodden `bpf_skb_adjust_room`
+pattern, structurally the mirror image of what `usid_ingress` already
+does on strip (step 7 of its own doc comment), not new territory.
+
+This plan explicitly does **not** add multi-segment SRH support in BPF —
+if a future requirement needs it, that's new scope on top of this, not
+part of closing out the kernel bug.
+
+## 4. Proposed mechanism
+
+### 4.1 Attachment point
+
+Attach a new TC-BPF program at **ingress on each tenant's host-side veth
+(or tap) interface** — i.e. the CNI's own per-attachment interface
+(`G0...H`), not the shared physical uplink `eth1`. This is the point
+where a pod's outbound packet first arrives on the host side, before any
+routing decision is made, and — critically — it is **already 1:1 with
+exactly one tenant VRF/routing table**, the same association
+`RouteEgressAdd`/`EgressDefaultRouteAdd` are keyed on today. That means
+the new program needs no VRF-table lookup of its own: which map to
+consult is implicit in which interface the program is attached to,
+exactly the same "attachment point carries tenant identity" property
+`usid_ingress`'s own `vrf_table`/`Argument` match already relies on for
+its side of the split.
+
+This also means CNI ADD/DEL, which already attaches/detaches per-veth TC
+filters today (`internal/plumbing/ebpf/attach`), is the natural place to
+attach/detach this program too — no new lifecycle hook needed.
+
+### 4.2 Map design
+
+One `BPF_MAP_TYPE_LPM_TRIE`, pinned per veth (or keyed by the veth's own
+ifindex in a single shared trie — pick whichever the implementation
+phase finds cleaner; both are viable, see the "open questions" list
+below), mapping destination prefix → `{segment SID, egress ifindex,
+resolved L2 next-hop}`. This is a direct port of what
+`RouteEgressAdd`/`EgressDefaultRouteAdd` already compute in Go today via
+`resolveNextHop` (which does exactly this resolution against the
+kernel's own routing table) — the *resolution* logic doesn't change, only
+where the result is installed: a BPF map entry via
+`ebpf.Map.Put`/`Update`, instead of a `netlink.RouteReplace` carrying
+`SEG6Encap`.
+
+A default (`::/0`) entry in the same trie replaces
+`EgressDefaultRouteAdd`'s route; LPM match naturally gives specific
+intra-VPC prefixes priority over it, matching today's FIB longest-prefix
+semantics with no special-casing needed.
+
+### 4.3 Datapath
+
+1. Parse the packet (inner IPv4 or IPv6 — dual-stack, matching
+   `usid_ingress`'s own DT46 handling).
+2. LPM-match the inner destination against this attachment's own trie.
+   No match — this shouldn't happen once the default entry exists (see
+   §5's rollout-ordering note); `TC_ACT_UNSPEC` if it ever does, so an
+   incompletely-configured attachment fails open to the normal stack
+   rather than black-holing traffic.
+3. `bpf_skb_adjust_room` to grow the packet, write the new outer IPv6
+   header (destination = matched SID, Next Header = 4 or 41 per inner
+   AF, matching `usid_ingress`'s own expectation on the receiving end).
+4. Redirect out the matched egress interface/next-hop
+   (`bpf_redirect`/`bpf_redirect_neigh`, resolved the same way
+   `usid_ingress`'s step 9 already picks between `bpf_redirect_peer` and
+   `bpf_redirect` depending on egress_kind — here egress is always the
+   shared physical uplink, not a netns-crossing veth, so this is closer
+   to `usid_ingress`'s tap-mode branch: same-netns, plain redirect).
+
+### 4.4 Go-side changes
+
+- `internal/plumbing/srv6/egress.go`: `RouteEgressAdd`/`RouteEgressDel`/
+  `EgressDefaultRouteAdd`/`EgressDefaultRouteDel` stop calling
+  `netlink.RouteReplace`/`netlink.RouteDel` with `SEG6Encap` and instead
+  write/delete entries in the new BPF map for the relevant attachment.
+  Keep `resolveNextHop` as-is — its job (flatten an indirect BGP
+  next-hop into a concrete link+L3 hop) is unchanged.
+- New file alongside `usid.c` (e.g. `usid_egress_route.c`, name TBD at
+  implementation time) plus its own `attach`/pin wiring in
+  `internal/plumbing/ebpf/attach`, following the exact pattern already
+  established for `usid_egress` (`AttachEgress`, `UsidEgressPinName`,
+  etc.) in this same package.
+- `internal/cnibgp/bgp.go`'s `registerEBPFDatapath` gets a new
+  attach/detach call alongside `attachUsidEgress`.
+
+## 5. Migration / rollout ordering
+
+Attach the new program and populate its default-route map entry
+*before* removing the old netlink SEG6 route it replaces, per attachment
+— never leave a window where a tenant VRF has neither. Given
+`RouteEgressAdd`/`EgressDefaultRouteAdd` are idempotent
+(`netlink.RouteReplace`) and the new program starts with an empty trie
+that fails open (`TC_ACT_UNSPEC`) rather than dropping, the safe
+sequence per existing attachment is: attach program → populate map →
+delete old netlink route. New attachments (fresh CNI ADD) only ever need
+the new path.
+
+## 6. Testing plan
+
+- Unit: `BPF_PROG_TEST_RUN`-based tests for the new program, matching
+  `usid_test.go`'s/`nat66_test.go`'s existing style — construct a raw
+  packet, run the program, assert the resulting header. Cover both inner
+  AFs (IPv4/IPIP, IPv6/IPv6-in-IPv6), the LPM default-vs-specific
+  priority case, and the fail-open (no map entries) case.
+- Local integration: real netns + real veth pair (no XDP/TC live-node
+  dependency), matching this session's existing `egress_test.go` style,
+  to prove map population write path end-to-end without touching the
+  live lab.
+- Containerlab: re-run `verify:ns10`, `verify:ns20`, and
+  `verify:nat66-sharding` against a lab rebuilt on this mechanism — these
+  are the exact three that motivated this plan and should all pass
+  without the kernel dependency once it lands.
+
+## 7. Explicitly out of scope
+
+- Multi-segment SRH support (§3) — no current call site needs it.
+- `RouteMainAdd`'s plain recursive route (§2) — untouched, doesn't use
+  SEG6 encap.
+- Any change to `usid_ingress`'s own decap side — it's already TC-BPF
+  and already unaffected by this bug.
+- A minimum-kernel-version enforcement mechanism — considered and
+  rejected as the primary fix (§0: doesn't hold up across genuinely
+  heterogeneous multi-cloud node kernels, and does nothing for
+  already-affected nodes), though nothing here prevents adding one later
+  as defense in depth once this lands.
+
+## 8. Open questions
+
+- Per-veth pinned map vs. one shared trie keyed by ifindex: the former
+  matches `usid_ingress`'s existing per-value (not per-interface) map
+  layout less closely but avoids any cross-tenant key collision by
+  construction; the latter is one map to manage instead of N. Decide at
+  implementation time once the attach/pin plumbing is actually being
+  written.
+- Exact redirect helper (`bpf_redirect` vs `bpf_redirect_neigh`) depends
+  on whether the physical uplink's L2 next-hop resolution needs to be
+  precomputed (as `resolveNextHop` does today) or can be left to the
+  kernel's neighbor table at redirect time — a real implementation-time
+  tradeoff, not a design blocker.
+- Whether this new program and `usid_egress` (the existing DSR
+  reply-path VIP-translation program) should be merged into one program
+  attached at the same point, or stay separate — they run at different
+  conceptual stages (VIP translation vs. VRF-egress routing) but may end
+  up on the same interface. Decide once both are concretely in hand.

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -54,6 +54,7 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/gc"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
@@ -619,7 +620,55 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("attach eBPF usid_egress to host interface %q: %w", hostName, err)
 	}
 
+	// Registers this node's own SRv6 source address into
+	// node_src_addr_table -- see registerNodeSourceAddress's own doc
+	// comment. A per-node constant, not per-attachment, but idempotent
+	// and cheap enough (one netlink route/address query, one map write)
+	// to simply redo on every attachment ADD, the same way every other
+	// registration in this function already is, rather than adding a
+	// separate once-per-node lifecycle hook.
+	//
+	// Deliberately non-fatal to this ADD, unlike every other registration
+	// step above: ResolveNodeSourceAddress needs a converged main-table
+	// IPv6 default route, which a node can genuinely, transiently lack
+	// early in its own boot sequence (before the underlay eBGP session
+	// comes up) -- failing every pod attach on the whole node until that
+	// converges would be a real availability regression from today's
+	// behavior, where a missing egress route only ever failed traffic to
+	// the *specific* destination that needed it, never CNI ADD itself.
+	// usid_egress's own "not yet configured" check already fails open
+	// (TC_ACT_UNSPEC) for exactly this gap; a later attachment's ADD (or
+	// this same one's next retry) succeeds here once the route exists.
+	if err := registerNodeSourceAddress(pinDir); err != nil {
+		slog.Warn("ADD: could not register this node's own SRv6 source address; "+
+			"egress routing will fail open until this succeeds", "err", err)
+	}
+
 	return true, nil
+}
+
+// registerNodeSourceAddress resolves this node's own SRv6/underlay-facing
+// source address (srv6.ResolveNodeSourceAddress) and writes it into
+// node_src_addr_table (egressroutemap.NodeSourceAddress) -- the value
+// usid_egress's egress-routing extension stamps into every outer header
+// it pushes (docs/plans/tc-bpf-egress-srv6-encap.md). Without this, every
+// egress_route_table hit fails open (TC_ACT_UNSPEC) rather than
+// encapsulating at all -- see usid.c's own "not yet configured" check on
+// this map -- so this must succeed before EgressDefaultRouteAdd/
+// RouteEgressAdd's own installed entries can ever actually carry traffic.
+// See this function's own call site for why a failure here doesn't fail
+// the whole CNI ADD.
+func registerNodeSourceAddress(pinDir string) error {
+	addr, err := srv6.ResolveNodeSourceAddress()
+	if err != nil {
+		return fmt.Errorf("resolve node source address: %w", err)
+	}
+	nodeSrc, closer, err := egressroutemap.OpenPinnedNodeSourceAddress(pinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned node_src_addr_table: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+	return nodeSrc.Set(addr)
 }
 
 // attachUsidEgress loads usid_egress from its own pin (attach.Load pins it

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -35,11 +35,13 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/vishvananda/netlink"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +53,7 @@ import (
 	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/gc"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
@@ -606,7 +609,50 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
 	}
 
+	// Attach usid_egress to this attachment's own host-side interface --
+	// see attachUsidEgress's own doc comment for why this was, until now,
+	// entirely missing: it's a real, previously-undiscovered gap, not
+	// specific to NAT66 at all, in every veth/tap ServiceVIPBinding's own
+	// reply path.
+	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
+	if err := attachUsidEgress(pinDir, hostName); err != nil {
+		return false, fmt.Errorf("attach eBPF usid_egress to host interface %q: %w", hostName, err)
+	}
+
 	return true, nil
+}
+
+// attachUsidEgress loads usid_egress from its own pin (attach.Load pins it
+// there, alongside every usid_ingress map, specifically so a short-lived
+// process like this one can reach it -- see that function's own doc
+// comment) and attaches it to ifaceName's TC ingress hook.
+//
+// This was a real, previously-undiscovered gap: usid_egress has existed
+// since the DSR/Maglev redesign's component 0.1/2 work (NPTv6 and tap-VIP
+// substitution's outbound-direction translation), but nothing anywhere in
+// this codebase ever called attach.AttachEgress (or any equivalent) to
+// actually put it on an interface -- confirmed live via `tc filter show`
+// on a real backend's own host-side veth: no filter at all, on either
+// direction. Every fix this redesign made to the *forward* path (client
+// -> VIP -> backend) worked and was validated without ever exercising
+// this gap, because none of them depended on the *reply* leaving with its
+// source address translated back -- only once the forward path, the
+// NAT66 egress route, and everything else were all working at once did a
+// real end-to-end curl's TCP handshake finally depend on it, and stall
+// with the reply silently discarded by the client (its source address
+// never got translated from the backend's real address back to the VIP).
+//
+// Idempotent (attach.AttachEgress's own FilterReplace semantics) and safe
+// to call on every attachment ADD, the same way every other registration
+// in this function already is.
+func attachUsidEgress(pinDir, ifaceName string) error {
+	program, err := ebpf.LoadPinnedProgram(filepath.Join(pinDir, attach.UsidEgressPinName), nil)
+	if err != nil {
+		return fmt.Errorf("load pinned usid_egress program: %w", err)
+	}
+	defer func() { _ = program.Close() }()
+
+	return attach.AttachEgress(program, ifaceName)
 }
 
 // installNAT66EgressRoute installs (or refreshes) vrfTableID's default

--- a/internal/cnibgp/bgp_ebpf_test.go
+++ b/internal/cnibgp/bgp_ebpf_test.go
@@ -187,6 +187,31 @@ func TestRegisterEBPFDatapath_RegistersAllThreeTables(t *testing.T) {
 	if len(fnEntries) != 1 {
 		t.Errorf("function_table entries = %+v, want exactly 1", fnEntries)
 	}
+
+	// Regression guard for a real bug found live: usid_egress was compiled
+	// and loaded (attach.Load pins it, alongside every map) but nothing
+	// ever attached it anywhere -- confirmed live via `tc filter show`
+	// against a real backend's own host-side veth showing no filter at
+	// all, on either direction. This is why every reply a DSR/veth
+	// backend ever sent silently kept its own real address instead of the
+	// VIP a client actually connected to, and no forward-path validation
+	// this redesign ran ever caught it. Asserts registerEBPFDatapath's
+	// own attachUsidEgress call actually put a filter on this attachment's
+	// host interface's ingress hook, not just that it returned no error.
+	filters, err := netlink.FilterList(hostLinkObj, netlink.HANDLE_MIN_INGRESS)
+	if err != nil {
+		t.Fatalf("FilterList(ingress) on host interface: %v", err)
+	}
+	var foundEgressFilter bool
+	for _, f := range filters {
+		if bpfFilter, ok := f.(*netlink.BpfFilter); ok && bpfFilter.Name == "galactic_usid_egress" {
+			foundEgressFilter = true
+		}
+	}
+	if !foundEgressFilter {
+		t.Errorf("no galactic_usid_egress tc filter found on host interface %q ingress hook -- "+
+			"registerEBPFDatapath must attach usid_egress there", intf.GenerateInterfaceNameHost(vpc, testAttachment))
+	}
 }
 
 // TestRegisterEBPFDatapath_SecondAttachmentSharesEntry covers the whole

--- a/internal/plumbing/ebpf/attach/attach.go
+++ b/internal/plumbing/ebpf/attach/attach.go
@@ -180,8 +180,34 @@ func Load(pinDir string) (objs *prog.UsidObjects, err error) {
 		return nil, err
 	}
 
+	// Pin usid_egress too, alongside the maps above -- unlike usid_ingress
+	// (attached once per node, by this same long-running process, to a
+	// known interface name from a static env var), usid_egress attaches
+	// per-attachment, at CNI ADD time, to an interface that doesn't exist
+	// until that ADD creates it -- internal/cnibgp, a short-lived process
+	// with no other handle on this collection, needs to load this exact
+	// program by its pin to attach it. A stale pin from a previous
+	// process's Load is removed and replaced unconditionally: unlike a
+	// map, a program has no persistent state to preserve across the
+	// swap, so there's no reuse-vs-recreate decision to make the way
+	// unpinIncompatibleMaps has to make for maps.
+	egressPinPath := filepath.Join(pinDir, UsidEgressPinName)
+	if rmErr := os.Remove(egressPinPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		err = fmt.Errorf("attach: remove stale usid_egress pin: %w", rmErr)
+		return nil, err
+	}
+	if pinErr := loaded.UsidEgress.Pin(egressPinPath); pinErr != nil {
+		err = fmt.Errorf("attach: pin usid_egress program: %w", pinErr)
+		return nil, err
+	}
+
 	return &loaded, nil
 }
+
+// UsidEgressPinName is the bpffs filename usid_egress is pinned under,
+// alongside (but distinct from, so it can never collide with) every map
+// name under the same pinDir.
+const UsidEgressPinName = "usid_egress_prog"
 
 // unpinIncompatibleMaps removes the on-disk pin for every map spec.Maps
 // names, if one exists under pinDir -- called after LoadAndAssign fails
@@ -231,19 +257,44 @@ func Attach(program *ebpf.Program, ifaceNames []string) error {
 
 	var errs []error
 	for _, name := range ifaceNames {
-		if err := attachOne(program, name); err != nil {
+		if err := attachOne(program, name, filterName); err != nil {
 			errs = append(errs, fmt.Errorf("interface %q: %w", name, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// attachOne attaches program to one interface's ingress hook. It is the
-// single internal choke point every attach path in this package goes
-// through (Attach's loop below, and Watch's netlink-driven reconcile in
-// watch.go), so instrumenting it here with attachHook (hooks.go, Milestone
-// 4) observes every attach attempt regardless of caller.
-func attachOne(program *ebpf.Program, name string) (err error) {
+// egressFilterName identifies usid_egress's own TC-BPF ingress filter,
+// mirroring filterName's identical "so a re-attach replaces the same
+// filter instead of stacking a duplicate" role for usid_ingress -- kept
+// as its own distinct constant even though the two programs never
+// target the same interface in practice (usid_ingress: the shared
+// uplink; usid_egress: each tenant's own host-side veth/tap).
+const egressFilterName = "galactic_usid_egress"
+
+// AttachEgress attaches program (usid_egress, loaded via its own pin --
+// see Load's own doc comment for why) to ifaceName's ingress hook: the
+// tenant's own host-side veth/tap interface, per usid_egress's own doc
+// comment in usid.c for why that -- not the shared uplink usid_ingress
+// uses -- is the correct attach point. Thin wrapper around the same
+// attachOne/FilterReplace idempotency Attach already provides, just
+// under egressFilterName and for exactly one interface at a time (each
+// internal/cnibgp CNI ADD attaches its own single attachment's interface,
+// never a batch).
+func AttachEgress(program *ebpf.Program, ifaceName string) error {
+	if program == nil {
+		return errors.New("attach: program is nil")
+	}
+	return attachOne(program, ifaceName, egressFilterName)
+}
+
+// attachOne attaches program to one interface's ingress hook under the
+// given tc filter name. It is the single internal choke point every
+// attach path in this package goes through (Attach's loop above,
+// AttachEgress above, and Watch's netlink-driven reconcile in watch.go),
+// so instrumenting it here with attachHook (hooks.go, Milestone 4)
+// observes every attach attempt regardless of caller.
+func attachOne(program *ebpf.Program, name, tcFilterName string) (err error) {
 	defer func() { attachHook(name, err) }()
 
 	link, err := netlink.LinkByName(name)
@@ -266,7 +317,7 @@ func attachOne(program *ebpf.Program, name string) (err error) {
 			Priority:  filterPriorityFn(),
 		},
 		Fd:           program.FD(),
-		Name:         filterName,
+		Name:         tcFilterName,
 		DirectAction: true,
 	}
 	if err = netlink.FilterReplace(filter); err != nil {

--- a/internal/plumbing/ebpf/attach/watch.go
+++ b/internal/plumbing/ebpf/attach/watch.go
@@ -382,7 +382,7 @@ func reconcile(program *ebpf.Program, current, next map[string]struct{}) map[str
 	}
 
 	for name := range next {
-		if err := attachOne(program, name); err != nil {
+		if err := attachOne(program, name, filterName); err != nil {
 			slog.Warn("attach: failed to (re)attach resolved interface, will retry on next re-evaluation",
 				"interface", name, "err", err)
 			delete(result, name)

--- a/internal/plumbing/ebpf/egressroutemap/doc.go
+++ b/internal/plumbing/ebpf/egressroutemap/doc.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package egressroutemap implements the read/write API for the eBPF uSID
+// datapath's egress_route_table and node_src_addr_table maps
+// (internal/plumbing/ebpf/prog/usid.c's struct egress_route_key/value and
+// usid_egress's egress-routing extension) -- see
+// docs/plans/tc-bpf-egress-srv6-encap.md for the mechanism this replaces
+// (internal/plumbing/srv6's kernel-native SEG6 lwtunnel route
+// encapsulation, confirmed broken by CVE-2026-31668 under this
+// codebase's own per-tenant-VRF architecture) and why.
+//
+// Two callers, two processes, mirroring vipxlatmap's own precedent for
+// exactly this shape: internal/runtime/gobgp/monitor.go
+// (galactic-router, a long-lived daemon that never loads/attaches an
+// eBPF program of its own) writes Register/Unregister entries as EVPN
+// paths arrive and are withdrawn -- the same events that used to drive
+// srv6.RouteEgressAdd/RouteEgressDel/RouteMainAdd/RouteMainDel -- and
+// internal/cnibgp (galactic-cni, the process that actually loads and
+// attaches usid_egress) writes this node's own SetNodeSourceAddress
+// entry once, at datapath registration time, alongside its existing
+// attachUsidEgress call.
+package egressroutemap

--- a/internal/plumbing/ebpf/egressroutemap/egressroute.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package egressroutemap
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// egressRouteFamilyINET6/egressRouteFamilyINET4 mirror usid.c's
+// USID_EGRESS_ROUTE_FAMILY_INET6/USID_EGRESS_ROUTE_FAMILY_INET4 --
+// bpf2go generates no symbol for a #define, so this package names the raw
+// values once here, the same way usid_test.go's own identically-named
+// constants do for the datapath's own tests.
+const (
+	egressRouteFamilyINET6 = uint8(0)
+	egressRouteFamilyINET4 = uint8(1)
+)
+
+// egressRouteKeyFixedBits is the number of bits egress_route_key's fixed
+// (always fully matched) portion occupies ahead of the variable-length
+// address bits -- table_id (32) + family (8) -- matching usid.c's own
+// `8 * (sizeof(rkey.table_id) + sizeof(rkey.family))` computation exactly.
+const egressRouteKeyFixedBits = 8 * (4 + 1)
+
+// DefaultPrefix is the IPv6 default route (::/0) Register installs when
+// called with it -- srv6.EgressDefaultRouteAdd's own defaultRoutePrefix,
+// reproduced here rather than imported (internal/plumbing/srv6 has no
+// eBPF/cilium dependency today and this package does not want to be the
+// reason it acquires one just for a shared constant).
+var DefaultPrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+
+// EgressRouteTable is the read/write API for egress_route_table -- the
+// TC-BPF replacement for srv6.RouteEgressAdd/RouteEgressDel (a specific
+// destination prefix) and srv6.EgressDefaultRouteAdd/EgressDefaultRouteDel
+// (prefix == DefaultPrefix); both are the same primitive here, unlike
+// their netlink-route counterparts, since a longest-prefix-match trie
+// naturally gives a more specific entry priority over a ::/0 one with no
+// special-casing needed.
+type EgressRouteTable struct {
+	table usidmap.Table
+}
+
+// NewEgressRouteTable wraps table as an EgressRouteTable. Production
+// callers pass a usidmap.KernelTable wrapping a loaded egress_route_table
+// map (see OpenPinnedEgressRouteTable); tests pass a fake usidmap.Table.
+func NewEgressRouteTable(table usidmap.Table) *EgressRouteTable {
+	return &EgressRouteTable{table: table}
+}
+
+// buildKey composes egress_route_table's LPM key for (tableID, prefix) --
+// see usid.c's struct egress_route_key doc comment for the exact bit
+// layout this must match byte-for-byte.
+func buildKey(tableID uint32, prefix *net.IPNet) (prog.UsidEgressRouteKey, error) {
+	if prefix == nil {
+		return prog.UsidEgressRouteKey{}, errors.New("egressroutemap: egress_route_table: prefix is nil")
+	}
+	ones, bits := prefix.Mask.Size()
+	if bits == 0 {
+		return prog.UsidEgressRouteKey{}, fmt.Errorf("egressroutemap: egress_route_table: prefix %s has a bad mask", prefix)
+	}
+
+	key := prog.UsidEgressRouteKey{
+		TableId:   tableID,
+		Prefixlen: uint32(egressRouteKeyFixedBits + ones),
+	}
+	if v4 := prefix.IP.To4(); v4 != nil {
+		key.Family = egressRouteFamilyINET4
+		copy(key.Addr[:4], v4)
+		return key, nil
+	}
+	v6 := prefix.IP.To16()
+	if v6 == nil {
+		return prog.UsidEgressRouteKey{}, fmt.Errorf("egressroutemap: egress_route_table: %s is not a valid prefix", prefix)
+	}
+	key.Family = egressRouteFamilyINET6
+	copy(key.Addr[:], v6)
+	return key, nil
+}
+
+// sidTo16 returns sid's raw 16 bytes in wire order, or an error if sid is
+// not a genuine IPv6 address -- SRv6 SIDs are IPv6-only in this
+// architecture (matching srv6.RouteEgressAdd's own "gateway must be a
+// real SRv6 SID" guard).
+func sidTo16(sid net.IP) ([16]byte, error) {
+	if sid == nil {
+		return [16]byte{}, errors.New("egressroutemap: egress_route_table: sid is nil")
+	}
+	a, ok := netip.AddrFromSlice(sid)
+	if !ok {
+		return [16]byte{}, fmt.Errorf("egressroutemap: egress_route_table: %v is not a valid IP address", sid)
+	}
+	a = a.Unmap()
+	if !a.Is6() || a.IsUnspecified() {
+		return [16]byte{}, fmt.Errorf(
+			"egressroutemap: egress_route_table: %s is not a usable SRv6 SID (must be a specified IPv6 address)", a)
+	}
+	return a.As16(), nil
+}
+
+// Register installs (or replaces) egress_route_table's entry for prefix
+// in Linux VRF table tableID, encapsulating toward sid -- the TC-BPF
+// replacement for srv6.RouteEgressAdd (a specific prefix) and
+// srv6.EgressDefaultRouteAdd (prefix == DefaultPrefix).
+//
+// Unlike RouteEgressAdd/EgressDefaultRouteAdd, this never needs to
+// resolve sid's own link/next-hop (no srv6.resolveNextHop equivalent):
+// usid_egress's own bpf_fib_lookup() resolves that fresh, per packet --
+// see struct egress_route_value's doc comment in usid.c for why.
+func (t *EgressRouteTable) Register(tableID uint32, prefix *net.IPNet, sid net.IP) error {
+	key, err := buildKey(tableID, prefix)
+	if err != nil {
+		return fmt.Errorf("egressroutemap: egress_route_table: register: %w", err)
+	}
+	rawSID, err := sidTo16(sid)
+	if err != nil {
+		return fmt.Errorf("egressroutemap: egress_route_table: register: %w", err)
+	}
+	value := prog.UsidEgressRouteValue{Sid: rawSID}
+	if err := t.table.Put(key, value); err != nil {
+		return fmt.Errorf("egressroutemap: egress_route_table: register table=%d prefix=%s: %w", tableID, prefix, err)
+	}
+	return nil
+}
+
+// Lookup reads egress_route_table's entry for (tableID, prefix) -- the
+// exact entry Register would have installed for that pair -- reporting
+// whether it exists. Note this is an exact-match lookup on the same key
+// Register/Unregister use, not the longest-prefix-match usid_egress
+// itself performs against an arbitrary packet destination; it exists for
+// tests and observability, not to answer "what would this destination
+// resolve to."
+func (t *EgressRouteTable) Lookup(tableID uint32, prefix *net.IPNet) (sid net.IP, ok bool, err error) {
+	key, err := buildKey(tableID, prefix)
+	if err != nil {
+		return nil, false, fmt.Errorf("egressroutemap: egress_route_table: lookup: %w", err)
+	}
+	var value prog.UsidEgressRouteValue
+	if err := t.table.Lookup(key, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("egressroutemap: egress_route_table: lookup table=%d prefix=%s: %w",
+			tableID, prefix, err)
+	}
+	sid = make(net.IP, 16)
+	copy(sid, value.Sid[:])
+	return sid, true, nil
+}
+
+// Unregister removes egress_route_table's entry for (tableID, prefix), if
+// present. Not an error if already absent, mirroring this codebase's
+// other map-writer packages' identical idempotency contract (e.g.
+// usidmap.VRFTable.Unregister, vipxlatmap's unregister).
+func (t *EgressRouteTable) Unregister(tableID uint32, prefix *net.IPNet) error {
+	key, err := buildKey(tableID, prefix)
+	if err != nil {
+		return fmt.Errorf("egressroutemap: egress_route_table: unregister: %w", err)
+	}
+	if err := t.table.Delete(key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
+		return fmt.Errorf("egressroutemap: egress_route_table: unregister table=%d prefix=%s: %w", tableID, prefix, err)
+	}
+	return nil
+}
+
+// NodeSourceAddress is the read/write API for node_src_addr_table -- this
+// node's own SRv6/underlay-facing source address, the single value
+// usid_egress's egress-routing extension writes into every outer header
+// it pushes.
+type NodeSourceAddress struct {
+	table usidmap.Table
+}
+
+// nodeSourceAddressKey is node_src_addr_table's only valid key --
+// BPF_MAP_TYPE_ARRAY, one entry, matching usid.c's own `src_key = 0`.
+const nodeSourceAddressKey = uint32(0)
+
+// Set writes this node's own source address. Called once, at CNI
+// datapath registration time (mirroring attachUsidEgress's own
+// once-per-node lifecycle), not per CNI ADD/DEL -- see usid.c's own
+// node_src_addr_table comment for why a single-entry array, not a field
+// on every egress_route_table entry.
+//
+// addr must be a specified (non-nil, non-unspecified) IPv6 address --
+// usid_egress treats an all-zero entry as "not configured yet" and fails
+// open rather than encapsulate with a garbage source (BPF_MAP_TYPE_ARRAY
+// has no genuine "missing key" state to detect that some other way; see
+// that check's own comment in usid.c).
+func (n *NodeSourceAddress) Set(addr net.IP) error {
+	raw, err := sidTo16(addr) // identical validation: a specified, non-unspecified IPv6 address
+	if err != nil {
+		return fmt.Errorf("egressroutemap: node_src_addr_table: set: %w", err)
+	}
+	if err := n.table.Put(nodeSourceAddressKey, raw); err != nil {
+		return fmt.Errorf("egressroutemap: node_src_addr_table: set %s: %w", addr, err)
+	}
+	return nil
+}
+
+// Get reads this node's own currently-registered source address,
+// reporting whether one has ever been Set (an unset/all-zero entry --
+// see Set's own comment for why that's the map's "not configured" state
+// -- reports ok=false, not an all-zero net.IP).
+func (n *NodeSourceAddress) Get() (addr net.IP, ok bool, err error) {
+	var raw [16]byte
+	if err := n.table.Lookup(nodeSourceAddressKey, &raw); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("egressroutemap: node_src_addr_table: get: %w", err)
+	}
+	a, _ := netip.AddrFromSlice(raw[:])
+	if !a.IsValid() || a.IsUnspecified() {
+		return nil, false, nil
+	}
+	return net.IP(raw[:]), true, nil
+}

--- a/internal/plumbing/ebpf/egressroutemap/egressroute.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 
 	"github.com/cilium/ebpf"
+	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
@@ -107,15 +108,75 @@ func sidTo16(sid net.IP) ([16]byte, error) {
 	return a.As16(), nil
 }
 
+// resolveLinkAndL2Fn is a package-level override point so tests can
+// substitute a fake resolver instead of touching the real host network
+// stack -- the same pattern internal/plumbing/ebpf/attach's own
+// routeListFn/linkByIndexFn vars establish, needed here because Register
+// otherwise always calls the real netlink functions below regardless of
+// whether the usidmap.Table it was given is itself a fake.
+var resolveLinkAndL2Fn = resolveLinkAndL2
+
+// resolveLinkAndL2 resolves sid's real, immediate next-hop -- the exact
+// link plus the concrete L2 (destination and source MAC) address a
+// packet must carry to actually reach it -- via netlink.RouteGet and the
+// kernel's own already-populated neighbor cache.
+//
+// This mirrors srv6.resolveNextHop's own job (and, for the exact same
+// reason: IPv6 route installation/resolution does not recurse through an
+// indirect gateway on its own), but cannot simply call it: this package
+// is already imported by internal/plumbing/srv6 (for pinDir/
+// attach.ResolveInterfaces), so the reverse import would be a cycle.
+// Resolving the L2 addresses too, not just the link/next-hop, is new
+// here relative to that function -- see struct egress_route_value's own
+// doc comment in usid.c for why usid_egress needs them precomputed
+// rather than resolving them itself at packet-processing time.
+func resolveLinkAndL2(sid net.IP) (linkIndex int, dmac, smac net.HardwareAddr, err error) {
+	routes, err := netlink.RouteGet(sid)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("no route to %s: %w", sid, err)
+	}
+	if len(routes) == 0 {
+		return 0, nil, nil, fmt.Errorf("no route to %s", sid)
+	}
+	linkIndex = routes[0].LinkIndex
+	nextHop := routes[0].Gw
+	if nextHop == nil {
+		nextHop = sid // gateway itself is on-link
+	}
+
+	link, err := netlink.LinkByIndex(linkIndex)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("look up link %d: %w", linkIndex, err)
+	}
+	smac = link.Attrs().HardwareAddr
+
+	neighs, err := netlink.NeighList(linkIndex, netlink.FAMILY_V6)
+	if err != nil {
+		return 0, nil, nil, fmt.Errorf("list neighbors on link %d: %w", linkIndex, err)
+	}
+	for _, n := range neighs {
+		if n.IP.Equal(nextHop) && len(n.HardwareAddr) == 6 {
+			return linkIndex, n.HardwareAddr, smac, nil
+		}
+	}
+	return 0, nil, nil, fmt.Errorf("no resolved neighbor entry for %s on link %d (next-hop for sid %s)",
+		nextHop, linkIndex, sid)
+}
+
 // Register installs (or replaces) egress_route_table's entry for prefix
 // in Linux VRF table tableID, encapsulating toward sid -- the TC-BPF
 // replacement for srv6.RouteEgressAdd (a specific prefix) and
 // srv6.EgressDefaultRouteAdd (prefix == DefaultPrefix).
 //
-// Unlike RouteEgressAdd/EgressDefaultRouteAdd, this never needs to
-// resolve sid's own link/next-hop (no srv6.resolveNextHop equivalent):
-// usid_egress's own bpf_fib_lookup() resolves that fresh, per packet --
-// see struct egress_route_value's doc comment in usid.c for why.
+// Resolves sid's own link and L2 (dmac/smac) information at registration
+// time via resolveLinkAndL2, storing all of it in the installed entry --
+// see struct egress_route_value's own doc comment in usid.c for why
+// usid_egress cannot resolve this itself, at packet-processing time, the
+// way it originally did. This means Register can fail the same way
+// srv6.RouteEgressAdd's own pre-TC-BPF implementation could (no route yet,
+// no resolved neighbor yet) -- callers that iterate multiple candidate
+// SIDs (e.g. EgressDefaultRouteAdd's own shard-SID list) must expect and
+// tolerate that.
 func (t *EgressRouteTable) Register(tableID uint32, prefix *net.IPNet, sid net.IP) error {
 	key, err := buildKey(tableID, prefix)
 	if err != nil {
@@ -125,7 +186,15 @@ func (t *EgressRouteTable) Register(tableID uint32, prefix *net.IPNet, sid net.I
 	if err != nil {
 		return fmt.Errorf("egressroutemap: egress_route_table: register: %w", err)
 	}
-	value := prog.UsidEgressRouteValue{Sid: rawSID}
+	linkIndex, dmac, smac, err := resolveLinkAndL2Fn(sid)
+	if err != nil {
+		return fmt.Errorf("egressroutemap: egress_route_table: register: resolve link/L2 for sid %s: %w", sid, err)
+	}
+
+	value := prog.UsidEgressRouteValue{Sid: rawSID, LinkIfindex: uint32(linkIndex)}
+	copy(value.Dmac[:], dmac)
+	copy(value.Smac[:], smac)
+
 	if err := t.table.Put(key, value); err != nil {
 		return fmt.Errorf("egressroutemap: egress_route_table: register table=%d prefix=%s: %w", tableID, prefix, err)
 	}

--- a/internal/plumbing/ebpf/egressroutemap/egressroute_test.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package egressroutemap
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+)
+
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return n
+}
+
+func TestEgressRouteTable_RegisterThenLookupRoundTrips(t *testing.T) {
+	tbl := NewEgressRouteTable(newFakeTable())
+	prefix := mustCIDR(t, "2001:db8:ffff::/96")
+	sid := net.ParseIP("2001:db8:ff01:1:e001::")
+
+	if err := tbl.Register(7, prefix, sid); err != nil {
+		t.Fatalf("Register(%v) = %v, want success", prefix, err)
+	}
+
+	key, err := buildKey(7, prefix)
+	if err != nil {
+		t.Fatalf("buildKey: %v", err)
+	}
+	var got prog.UsidEgressRouteValue
+	if err := tbl.table.Lookup(key, &got); err != nil {
+		t.Fatalf("lookup installed entry: %v", err)
+	}
+	want := sid.To16()
+	for i := range want {
+		if got.Sid[i] != want[i] {
+			t.Fatalf("stored sid = % x, want % x", got.Sid, want)
+		}
+	}
+}
+
+func TestEgressRouteTable_RegisterDefaultPrefixUsesZeroPrefixBits(t *testing.T) {
+	tbl := NewEgressRouteTable(newFakeTable())
+	sid := net.ParseIP("2001:db8:ff01:9:e001::")
+
+	if err := tbl.Register(1, DefaultPrefix, sid); err != nil {
+		t.Fatalf("Register(default) = %v, want success", err)
+	}
+
+	key, err := buildKey(1, DefaultPrefix)
+	if err != nil {
+		t.Fatalf("buildKey: %v", err)
+	}
+	if key.Prefixlen != egressRouteKeyFixedBits {
+		t.Errorf("default route prefixlen = %d, want %d (fixed portion only, no address bits)",
+			key.Prefixlen, egressRouteKeyFixedBits)
+	}
+	if key.Family != egressRouteFamilyINET6 {
+		t.Errorf("default route family = %d, want %d (INET6)", key.Family, egressRouteFamilyINET6)
+	}
+}
+
+func TestEgressRouteTable_IPv4PrefixStoresAddressLeftJustified(t *testing.T) {
+	// usid.c's egress-routing extension memsets rkey.addr to zero, then
+	// memcpy's only the raw 4-byte IPv4 destination into its first 4
+	// bytes -- never the IPv4-mapped-IPv6 (::ffff:a.b.c.d) convention,
+	// which would place those bytes at offset 12. buildKey must match
+	// that exactly or a real CNI-configured IPv4 VPC's egress route would
+	// silently never match any packet (found and fixed once already,
+	// as an analogous bug in this program's own test helper -- see
+	// usid_test.go's egressRouteKey comment).
+	prefix := mustCIDR(t, "172.40.10.0/24")
+	key, err := buildKey(9, prefix)
+	if err != nil {
+		t.Fatalf("buildKey: %v", err)
+	}
+	if key.Family != egressRouteFamilyINET4 {
+		t.Errorf("family = %d, want %d (INET4)", key.Family, egressRouteFamilyINET4)
+	}
+	want := [4]byte{172, 40, 10, 0}
+	for i, b := range want {
+		if key.Addr[i] != b {
+			t.Errorf("Addr[%d] = %#x, want %#x", i, key.Addr[i], b)
+		}
+	}
+	for i := 4; i < 16; i++ {
+		if key.Addr[i] != 0 {
+			t.Errorf("Addr[%d] = %#x, want 0 (IPv4 prefix must be zero-padded beyond its own 4 bytes)", i, key.Addr[i])
+		}
+	}
+	if key.Prefixlen != egressRouteKeyFixedBits+24 {
+		t.Errorf("prefixlen = %d, want %d (fixed + /24)", key.Prefixlen, egressRouteKeyFixedBits+24)
+	}
+}
+
+func TestEgressRouteTable_RegisterRejectsUnusableSID(t *testing.T) {
+	tbl := NewEgressRouteTable(newFakeTable())
+	prefix := mustCIDR(t, "2001:db8:ffff::/96")
+
+	tests := []struct {
+		name string
+		sid  net.IP
+	}{
+		{"nil sid", nil},
+		{"unspecified sid", net.IPv6unspecified},
+		{"IPv4 sid", net.ParseIP("10.0.0.1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tbl.Register(1, prefix, tt.sid); err == nil {
+				t.Errorf("Register(sid=%v) = nil error, want an error rejecting the unusable SID", tt.sid)
+			}
+		})
+	}
+}
+
+func TestEgressRouteTable_UnregisterAbsentEntryIsANoop(t *testing.T) {
+	tbl := NewEgressRouteTable(newFakeTable())
+	if err := tbl.Unregister(1, mustCIDR(t, "2001:db8:ffff::/96")); err != nil {
+		t.Errorf("Unregister(never registered) = %v, want nil (idempotent)", err)
+	}
+}
+
+func TestEgressRouteTable_RegisterThenUnregisterRemovesEntry(t *testing.T) {
+	tbl := NewEgressRouteTable(newFakeTable())
+	prefix := mustCIDR(t, "2001:db8:ffff::/96")
+	sid := net.ParseIP("2001:db8:ff01:1:e001::")
+
+	if err := tbl.Register(1, prefix, sid); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := tbl.Unregister(1, prefix); err != nil {
+		t.Fatalf("Unregister: %v", err)
+	}
+
+	key, err := buildKey(1, prefix)
+	if err != nil {
+		t.Fatalf("buildKey: %v", err)
+	}
+	var got prog.UsidEgressRouteValue
+	if err := tbl.table.Lookup(key, &got); err == nil {
+		t.Error("entry still present after Unregister")
+	}
+}
+
+func TestEgressRouteTable_SameTableIDDifferentFamilyDoNotCollide(t *testing.T) {
+	// family sits inside the LPM-matched fixed portion specifically so
+	// two entries can never compare equal on address bits alone once
+	// table_id+family already differ -- see struct egress_route_key's
+	// own doc comment in usid.c.
+	tbl := NewEgressRouteTable(newFakeTable())
+	v6 := mustCIDR(t, "::/0")
+	v4 := &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+
+	if err := tbl.Register(5, v6, net.ParseIP("2001:db8:ff01:9:e001::")); err != nil {
+		t.Fatalf("register v6 default: %v", err)
+	}
+	if err := tbl.Register(5, v4, net.ParseIP("2001:db8:ff02:9:e001::")); err != nil {
+		t.Fatalf("register v4 default: %v", err)
+	}
+
+	v6Key, _ := buildKey(5, v6)
+	v4Key, _ := buildKey(5, v4)
+	var v6Val, v4Val prog.UsidEgressRouteValue
+	if err := tbl.table.Lookup(v6Key, &v6Val); err != nil {
+		t.Fatalf("lookup v6 entry: %v", err)
+	}
+	if err := tbl.table.Lookup(v4Key, &v4Val); err != nil {
+		t.Fatalf("lookup v4 entry: %v", err)
+	}
+	if v6Val == v4Val {
+		t.Error("v6 and v4 default-route entries share the same value -- family must not have collided them")
+	}
+}
+
+func TestNodeSourceAddress_SetThenGetRoundTrips(t *testing.T) {
+	n := &NodeSourceAddress{table: newFakeTable()}
+	addr := net.ParseIP("2001:db8:1:10::2")
+
+	if err := n.Set(addr); err != nil {
+		t.Fatalf("Set(%v) = %v, want success", addr, err)
+	}
+	got, ok, err := n.Get()
+	if err != nil {
+		t.Fatalf("Get() = %v, want success", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true after Set")
+	}
+	gotAddr, _ := netip.AddrFromSlice(got)
+	wantAddr, _ := netip.AddrFromSlice(addr.To16())
+	if gotAddr != wantAddr {
+		t.Errorf("Get() = %s, want %s", gotAddr, wantAddr)
+	}
+}
+
+func TestNodeSourceAddress_GetBeforeSetReportsNotOK(t *testing.T) {
+	n := &NodeSourceAddress{table: newFakeTable()}
+	_, ok, err := n.Get()
+	if err != nil {
+		t.Fatalf("Get() = %v, want success", err)
+	}
+	if ok {
+		t.Error("Get() ok = true before any Set, want false")
+	}
+}
+
+func TestNodeSourceAddress_SetRejectsUnspecifiedAddress(t *testing.T) {
+	n := &NodeSourceAddress{table: newFakeTable()}
+	if err := n.Set(net.IPv6unspecified); err == nil {
+		t.Error("Set(::) = nil error, want an error -- usid_egress treats an all-zero entry as \"not configured\"")
+	}
+}

--- a/internal/plumbing/ebpf/egressroutemap/egressroute_test.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute_test.go
@@ -21,7 +21,33 @@ func mustCIDR(t *testing.T, s string) *net.IPNet {
 	return n
 }
 
+// fakeLinkIndex/fakeDmac/fakeSmac are the fixed values
+// stubResolveLinkAndL2 always returns, for tests that don't care about
+// the specific resolved link/L2 content -- only that Register reaches
+// the point of storing *something* for them.
+const fakeLinkIndex = 42
+
+var (
+	fakeDmac = net.HardwareAddr{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	fakeSmac = net.HardwareAddr{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+)
+
+// stubResolveLinkAndL2 replaces resolveLinkAndL2Fn for the duration of
+// the calling test, so Register's tests exercise the map read/write
+// logic this package owns without depending on real kernel routing
+// state -- see resolveLinkAndL2Fn's own doc comment for why Register
+// can't simply be tested against a fake usidmap.Table alone.
+func stubResolveLinkAndL2(t *testing.T) {
+	t.Helper()
+	prev := resolveLinkAndL2Fn
+	resolveLinkAndL2Fn = func(net.IP) (int, net.HardwareAddr, net.HardwareAddr, error) {
+		return fakeLinkIndex, fakeDmac, fakeSmac, nil
+	}
+	t.Cleanup(func() { resolveLinkAndL2Fn = prev })
+}
+
 func TestEgressRouteTable_RegisterThenLookupRoundTrips(t *testing.T) {
+	stubResolveLinkAndL2(t)
 	tbl := NewEgressRouteTable(newFakeTable())
 	prefix := mustCIDR(t, "2001:db8:ffff::/96")
 	sid := net.ParseIP("2001:db8:ff01:1:e001::")
@@ -44,9 +70,19 @@ func TestEgressRouteTable_RegisterThenLookupRoundTrips(t *testing.T) {
 			t.Fatalf("stored sid = % x, want % x", got.Sid, want)
 		}
 	}
+	if got.LinkIfindex != fakeLinkIndex {
+		t.Errorf("stored link_ifindex = %d, want %d", got.LinkIfindex, fakeLinkIndex)
+	}
+	if string(got.Dmac[:]) != string(fakeDmac) {
+		t.Errorf("stored dmac = % x, want % x", got.Dmac, fakeDmac)
+	}
+	if string(got.Smac[:]) != string(fakeSmac) {
+		t.Errorf("stored smac = % x, want % x", got.Smac, fakeSmac)
+	}
 }
 
 func TestEgressRouteTable_RegisterDefaultPrefixUsesZeroPrefixBits(t *testing.T) {
+	stubResolveLinkAndL2(t)
 	tbl := NewEgressRouteTable(newFakeTable())
 	sid := net.ParseIP("2001:db8:ff01:9:e001::")
 
@@ -129,6 +165,7 @@ func TestEgressRouteTable_UnregisterAbsentEntryIsANoop(t *testing.T) {
 }
 
 func TestEgressRouteTable_RegisterThenUnregisterRemovesEntry(t *testing.T) {
+	stubResolveLinkAndL2(t)
 	tbl := NewEgressRouteTable(newFakeTable())
 	prefix := mustCIDR(t, "2001:db8:ffff::/96")
 	sid := net.ParseIP("2001:db8:ff01:1:e001::")
@@ -155,6 +192,7 @@ func TestEgressRouteTable_SameTableIDDifferentFamilyDoNotCollide(t *testing.T) {
 	// two entries can never compare equal on address bits alone once
 	// table_id+family already differ -- see struct egress_route_key's
 	// own doc comment in usid.c.
+	stubResolveLinkAndL2(t)
 	tbl := NewEgressRouteTable(newFakeTable())
 	v6 := mustCIDR(t, "::/0")
 	v4 := &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}

--- a/internal/plumbing/ebpf/egressroutemap/faketable_test.go
+++ b/internal/plumbing/ebpf/egressroutemap/faketable_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package egressroutemap
+
+import (
+	"reflect"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// fakeTable is an in-memory usidmap.Table implementation for this
+// package's tests -- copied from vipxlatmap's own identical fakeTable
+// (see that package's doc comment for why a comparable `any` key, not a
+// hardcoded uint64: this package's own key, prog.UsidEgressRouteKey, is a
+// struct too).
+type fakeTable struct {
+	entries map[any]any
+	order   []any
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[any]any)}
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	if _, exists := f.entries[key]; !exists {
+		f.order = append(f.order, key)
+	}
+	f.entries[key] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	v, ok := f.entries[key]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	if _, ok := f.entries[key]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, key)
+	for i, k := range f.order {
+		if k == key {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() usidmap.Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }

--- a/internal/plumbing/ebpf/egressroutemap/pin.go
+++ b/internal/plumbing/ebpf/egressroutemap/pin.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package egressroutemap
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// OpenPinnedEgressRouteTable opens egress_route_table from its pinned path
+// under pinDir (internal/plumbing/ebpf/attach.Load pins every usid_ingress
+// map at <pinDir>/<map name> -- see usidmap.OpenPinnedRegistry's identical
+// convention) and returns an *EgressRouteTable wrapping it.
+//
+// The returned io.Closer should be closed once at process shutdown for a
+// long-lived caller (galactic-router), or immediately after use for a
+// short-lived one (galactic-cni's own per-CNI-ADD/DEL process) --
+// mirroring vipxlatmap.OpenPinnedVipXlatTable's identical note; closing
+// only releases this process's own file descriptor onto the kernel-side
+// map object, never the map's pinned lifetime itself.
+func OpenPinnedEgressRouteTable(pinDir string) (*EgressRouteTable, io.Closer, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapEgressRouteTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("egressroutemap: open pinned map %q under %q: %w",
+			prog.UsidMapEgressRouteTable, pinDir, err)
+	}
+	return NewEgressRouteTable(usidmap.KernelTable{Map: m}), m, nil
+}
+
+// OpenPinnedNodeSourceAddress opens node_src_addr_table from its pinned
+// path under pinDir and returns a *NodeSourceAddress wrapping it. See
+// OpenPinnedEgressRouteTable's own comment for the pinning convention and
+// close-lifetime contract.
+func OpenPinnedNodeSourceAddress(pinDir string) (*NodeSourceAddress, io.Closer, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapNodeSrcAddrTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("egressroutemap: open pinned map %q under %q: %w",
+			prog.UsidMapNodeSrcAddrTable, pinDir, err)
+	}
+	return &NodeSourceAddress{table: usidmap.KernelTable{Map: m}}, m, nil
+}

--- a/internal/plumbing/ebpf/prog/doc.go
+++ b/internal/plumbing/ebpf/prog/doc.go
@@ -67,4 +67,4 @@ package prog
 // directive needing to change, while everyone else keeps getting plain
 // "clang" off their PATH.
 //
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value -type ifindex_vrf_value -type nptv6_value -type vip_xlat_key -type vip_xlat_value Usid usid.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value -type ifindex_vrf_value -type nptv6_value -type vip_xlat_key -type vip_xlat_value -type egress_route_key -type egress_route_value Usid usid.c

--- a/internal/plumbing/ebpf/prog/dropreason.go
+++ b/internal/plumbing/ebpf/prog/dropreason.go
@@ -17,19 +17,22 @@ package prog
 // constants directly rather than keeping its own copy -- if usid.c's enum
 // drop_reason ever changes, update both this file and usid_test.go.
 const (
-	DropReasonUnknownFunction     uint32 = 0
-	DropReasonUnknownArgument     uint32 = 1
-	DropReasonMalformedInner      uint32 = 2
-	DropReasonUnknownInnerVer     uint32 = 3
-	DropReasonStripFailed         uint32 = 4
-	DropReasonFibLookupFailed     uint32 = 5
-	DropReasonRedirectFailed      uint32 = 6
-	DropReasonFibNoNeigh          uint32 = 7
-	DropReasonFibUnreachable      uint32 = 8
-	DropReasonFibFragNeeded       uint32 = 9
-	DropReasonUnexpectedNextHdr   uint32 = 10
-	DropReasonUnsupportedBehavior uint32 = 11
-	DropReasonCount               uint32 = 12
+	DropReasonUnknownFunction            uint32 = 0
+	DropReasonUnknownArgument            uint32 = 1
+	DropReasonMalformedInner             uint32 = 2
+	DropReasonUnknownInnerVer            uint32 = 3
+	DropReasonStripFailed                uint32 = 4
+	DropReasonFibLookupFailed            uint32 = 5
+	DropReasonRedirectFailed             uint32 = 6
+	DropReasonFibNoNeigh                 uint32 = 7
+	DropReasonFibUnreachable             uint32 = 8
+	DropReasonFibFragNeeded              uint32 = 9
+	DropReasonUnexpectedNextHdr          uint32 = 10
+	DropReasonUnsupportedBehavior        uint32 = 11
+	DropReasonEgressRouteEncapFailed     uint32 = 12
+	DropReasonEgressRouteFibLookupFailed uint32 = 13
+	DropReasonEgressRouteRedirectFailed  uint32 = 14
+	DropReasonCount                      uint32 = 15
 )
 
 // DropReasonNames maps each DropReason* index to a short, stable,
@@ -37,16 +40,19 @@ const (
 // 4) and any other external representation from usid.c's C identifier
 // spelling.
 var DropReasonNames = map[uint32]string{
-	DropReasonUnknownFunction:     "unknown_function",
-	DropReasonUnknownArgument:     "unknown_argument",
-	DropReasonMalformedInner:      "malformed_inner",
-	DropReasonUnknownInnerVer:     "unknown_inner_version",
-	DropReasonStripFailed:         "strip_failed",
-	DropReasonFibLookupFailed:     "fib_lookup_failed",
-	DropReasonRedirectFailed:      "redirect_failed",
-	DropReasonFibNoNeigh:          "fib_no_neigh",
-	DropReasonFibUnreachable:      "fib_unreachable",
-	DropReasonFibFragNeeded:       "fib_frag_needed",
-	DropReasonUnexpectedNextHdr:   "unexpected_nexthdr",
-	DropReasonUnsupportedBehavior: "unsupported_behavior",
+	DropReasonUnknownFunction:            "unknown_function",
+	DropReasonUnknownArgument:            "unknown_argument",
+	DropReasonMalformedInner:             "malformed_inner",
+	DropReasonUnknownInnerVer:            "unknown_inner_version",
+	DropReasonStripFailed:                "strip_failed",
+	DropReasonFibLookupFailed:            "fib_lookup_failed",
+	DropReasonRedirectFailed:             "redirect_failed",
+	DropReasonFibNoNeigh:                 "fib_no_neigh",
+	DropReasonFibUnreachable:             "fib_unreachable",
+	DropReasonFibFragNeeded:              "fib_frag_needed",
+	DropReasonUnexpectedNextHdr:          "unexpected_nexthdr",
+	DropReasonUnsupportedBehavior:        "unsupported_behavior",
+	DropReasonEgressRouteEncapFailed:     "egress_route_encap_failed",
+	DropReasonEgressRouteFibLookupFailed: "egress_route_fib_lookup_failed",
+	DropReasonEgressRouteRedirectFailed:  "egress_route_redirect_failed",
 }

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -225,6 +225,28 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 #define USID_TCP_CSUM_OFFSET 16
 #define USID_UDP_CSUM_OFFSET 6
 
+// USID_RT_TABLE_MAIN is RT_TABLE_MAIN (uapi/linux/rtnetlink.h), reproduced
+// as a plain constant for the same reason every other ABI value in this
+// file is: it never changes, and pulling in rtnetlink.h for one integer
+// would add a real header dependency. usid_egress's own egress-routing
+// extension uses this to force its bpf_fib_lookup() for a resolved SID's
+// L2 next-hop to run against the main table specifically (via
+// BPF_FIB_LOOKUP_TBID) regardless of which VRF-enslaved interface this
+// program happens to be attached to -- the SID itself is always reachable
+// via the underlay/main table, the same table
+// internal/plumbing/srv6.resolveNextHop's netlink.RouteGet call already
+// resolves it against today, never the tenant VRF's own table.
+#define USID_RT_TABLE_MAIN 254
+
+// USID_EGRESS_HOP_LIMIT is the hop limit usid_egress writes into the outer
+// IPv6 header it pushes for a resolved egress route -- a fixed, reasonable
+// default (matching this lab's/most Linux hosts' own default unicast hop
+// limit), not read from the inner packet's own hop limit: the outer
+// header's hop count only needs to survive the underlay's own hop count
+// (a handful of hops in every topology this program runs on), not mirror
+// whatever budget the inner packet's original sender picked.
+#define USID_EGRESS_HOP_LIMIT 64
+
 // USID_L3_OFFSET is the fixed byte offset of the L3 (IPv6) header from
 // skb->data -- always sizeof(struct usid_ethhdr), a compile-time constant.
 // apply_vip_xlat's csum_off/addr_off/port_off arguments must be this kind
@@ -482,6 +504,91 @@ struct vip_xlat_value {
 	__be16 port;
 };
 
+// ---------------------------------------------------------------------
+// TC-BPF egress-routing extension (docs/plans/tc-bpf-egress-srv6-encap.md):
+// replaces internal/plumbing/srv6's kernel-native SEG6 lwtunnel route
+// encapsulation (RouteEgressAdd/EgressDefaultRouteAdd) with an in-program
+// header push, closing CVE-2026-31668 (seg6 lwtunnel shares one dst_cache
+// per route between its input and output resolution paths, and reuses a
+// stale cached result across different routing contexts -- the upstream
+// fix's own writeup names VRF table separation, this codebase's own
+// per-tenant-VRF architecture, as a trigger). See that plan document for
+// the full mechanism and its own §3's explanation of why this is a plain
+// tunnel-header prepend, not a general SRH pusher: every existing call
+// site installs exactly one segment, and SEG6_IPTUN_MODE_ENCAP_RED
+// already omits the SRH entirely for that case (usid_ingress's own
+// decap side already requires and depends on exactly this shape).
+// ---------------------------------------------------------------------
+
+// struct egress_route_key is egress_route_table's LPM_TRIE key. Keyed on
+// the Linux VRF table id (table_id), not (block, argument): every one of
+// RouteEgressAdd/EgressDefaultRouteAdd/RouteMainAdd's own Go-side callers
+// (internal/runtime/gobgp/monitor.go, internal/cnibgp/bgp.go) already has
+// the Linux table id in hand -- that is the identity BGP path processing
+// and NAT66 shard-SID resolution are already scoped by -- and none of them
+// otherwise need to resolve a uSID (block, argument) identity at all. This
+// program itself has no direct route from its own per-attachment identity
+// (ifindex_vrf_table's block/argument) to a Linux table id either, so it
+// takes one extra vrf_table lookup (already keyed by the vrf_key this
+// program computes for the NPTv6/vip_xlat lookups above) to read
+// vrf->vrf_table_id, rather than teaching ifindex_vrf_table or
+// egress_route_table a second, redundant identity scheme.
+//
+// family disambiguates an IPv4 VPC prefix from an IPv6 one sharing the
+// same leading bytes when addr's low bytes happen to coincide (e.g. an
+// IPv4 /24 stored zero-extended into addr's first 4 bytes could otherwise
+// collide with an IPv6 prefix whose own first 4 bytes are identical by
+// coincidence) -- placed inside the LPM-matched region (never past
+// table_id, always matched in full) specifically so this can never happen:
+// two entries can only ever compare equal on their address bits once
+// table_id and family already match exactly.
+//
+// prefixlen is bits, not bytes, per LPM_TRIE's own convention -- always at
+// least 40 (the fixed table_id(32)+family(8) portion, matching
+// EgressDefaultRouteAdd's own ::/0 entries) and up to 40+128=168 for a
+// full IPv6 host route or 40+32=72 for a full IPv4 host route.
+//
+// __attribute__((packed)), unlike vrf_value/nptv6_value/vip_xlat_value
+// above: an LPM_TRIE's matching semantics only ever compare the first
+// prefixlen *bits*, so (unlike vip_xlat_key's HASH-map full-key-equality
+// requirement, which forced that struct's own explicit pad2 field)
+// trailing compiler-inserted padding here would never affect a lookup's
+// correctness either way -- packed is used anyway to make the exact byte
+// layout this comment's own bit-offset reasoning depends on unambiguous,
+// rather than relying on it holding incidentally.
+struct egress_route_key {
+	__u32 prefixlen;
+	__u32 table_id;
+	__u8 family;
+	__u8 addr[16];
+} __attribute__((packed));
+
+// USID_EGRESS_ROUTE_FAMILY_INET6/INET4 are egress_route_key.family's two
+// values -- deliberately not reusing USID_AF_INET/USID_AF_INET6 (which are
+// the kernel's real AF_INET/AF_INET6 values, sized and spaced for a
+// different purpose, struct bpf_fib_lookup.family) for a field whose only
+// job is disambiguating two prefixes within this one map, not naming a
+// real address family to any kernel API.
+#define USID_EGRESS_ROUTE_FAMILY_INET6 0
+#define USID_EGRESS_ROUTE_FAMILY_INET4 1
+
+// struct egress_route_value is egress_route_table's value: the resolved
+// SRv6 SID (or NAT66 shard SID, for a default-route entry) to
+// encapsulate toward. Deliberately just the address -- no precomputed
+// link/next-hop/L2 fields, unlike the netlink-route mechanism this
+// replaces (RouteEgressAdd's own resolveNextHop, run once at route-install
+// time): usid_egress instead runs a fresh bpf_fib_lookup() per packet
+// against sid (see that call site's own comment), which is both simpler
+// (Go's writer needs no next-hop resolution logic of its own at all, only
+// the SID) and self-healing (a next-hop/neighbor change on the underlay
+// takes effect on the very next packet, not only the next time Go
+// re-resolves and rewrites this entry).
+struct egress_route_value {
+	__u8 sid[16];
+} __attribute__((packed));
+
+// ---------------------------------------------------------------------
+
 // enum drop_reason indexes drop_reasons (design plan §4.4's fourth map,
 // observability only).
 enum drop_reason {
@@ -507,6 +614,24 @@ enum drop_reason {
 	// future L2 path this program doesn't implement) -- step 4, see its
 	// comment above.
 	DROP_REASON_UNSUPPORTED_BEHAVIOR = 11,
+	// usid_egress's own egress-routing extension (docs/plans/
+	// tc-bpf-egress-srv6-encap.md): egress_route_table matched (a route
+	// was configured for this destination) but bpf_skb_adjust_room
+	// failed to grow room for the new outer header -- essentially never
+	// expected to fire (the same helper's shrink direction is
+	// unconditionally trusted by usid_ingress above), kept as its own
+	// reason rather than folded into an unrelated one so it's visible if
+	// it ever does.
+	DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED = 12,
+	// The outer header was pushed, but resolving the egress link/L2
+	// next-hop for the matched SID failed (no route, no neighbor entry,
+	// MTU exceeded, etc.) -- the in-kernel equivalent of what
+	// srv6.resolveNextHop's "no route to gateway" error meant for the
+	// netlink-route mechanism this replaces.
+	DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED = 13,
+	// FIB lookup for the SID succeeded but the redirect out the
+	// resolved physical interface itself failed.
+	DROP_REASON_EGRESS_ROUTE_REDIRECT_FAILED = 14,
 	__DROP_REASON_MAX,
 };
 
@@ -595,6 +720,46 @@ struct {
 	__type(key, struct vip_xlat_key);
 	__type(value, struct vip_xlat_value);
 } vip_xlat_table SEC(".maps");
+
+// egress_route_table: see struct egress_route_key's comment above. The
+// first (and, as of this writing, only) BPF_MAP_TYPE_LPM_TRIE in this
+// file -- everything above is deliberately BPF_MAP_TYPE_HASH (uSID
+// decode is always a fixed-width exact match, per R1/R2), but egress
+// routing is inherently a longest-prefix-match problem (an intra-VPC
+// peer's specific prefix must win over a tenant VRF's own ::/0 default),
+// exactly what locator_table/function_table/vrf_table's own doc comment
+// says this format never needs -- that reasoning is scoped to uSID
+// decode, not to this unrelated map. BPF_F_NO_PREALLOC is required by the
+// kernel for this map type (lpm_trie_alloc rejects any other map_flags
+// value outright), not an optional tuning choice.
+//
+// Sized well above vrf_table's own 8192: this map holds routes, not VRFs
+// -- one VRF can have several intra-VPC-peer entries (RouteEgressAdd) plus
+// one default (EgressDefaultRouteAdd), so entries-per-VRF is not 1:1 the
+// way locator_table/vrf_table's own sizing reasoning assumes.
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__uint(max_entries, 32768);
+	__type(key, struct egress_route_key);
+	__type(value, struct egress_route_value);
+} egress_route_table SEC(".maps");
+
+// node_src_addr_table: this node's own SRv6/underlay-facing source
+// address, the single value usid_egress's egress-routing extension writes
+// into the outer IPv6 header it pushes -- a per-node constant, not
+// per-VRF/per-route, hence the single-entry BPF_MAP_TYPE_ARRAY rather than
+// folding it into egress_route_value (which would mean every route entry
+// redundantly carrying the same 16 bytes, and Go's writer needing to know
+// this node's own address just to register an unrelated destination
+// route). Populated once, at CNI datapath registration time (mirroring
+// attachUsidEgress's own once-per-node lifecycle), not per CNI ADD/DEL.
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u8[16]);
+} node_src_addr_table SEC(".maps");
 
 // ---------------------------------------------------------------------
 // Helpers
@@ -1180,19 +1345,21 @@ int usid_ingress(struct __sk_buff *skb)
 // usid_egress (design plan §0.1, §2) is usid_ingress's outbound companion:
 // a tenant's own reply/outbound traffic needs the reverse NPTv6 rewrite
 // (ULA -> public, on the packet's *source*) and/or the reverse tap-VIP
-// substitution (real addr:port -> VIP addr:port, also on *source*) before
-// it reaches the kernel's SEG6 encap route.
+// substitution (real addr:port -> VIP addr:port, also on *source*), and
+// (docs/plans/tc-bpf-egress-srv6-encap.md) the tenant VRF's own egress
+// SRv6 encapsulation, before the packet leaves this node at all.
 //
 // Attach point, and why it is NOT the shared physical/fabric-facing
-// interface usid_ingress attaches to: by the time a tenant's outbound
-// packet reaches that interface, internal/plumbing/srv6.RouteEgressAdd's
-// own per-VRF-table SEG6 encap route has already pushed the outer SRv6
-// header -- and that outer header's *destination* names the *remote*
-// peer's own (Block, Argument), not the local sending VRF's. There is
-// nothing at that shared attach point to key a per-sender-VRF lookup on
-// without decoding the inner packet's own (potentially colliding across
-// tenants, per the same reasoning usidresolver.go's tenant-ownership fix
-// already closed for a different lookup) ULA source address.
+// interface usid_ingress attaches to: this program's whole job (both its
+// original NPTv6/VIP-xlat responsibilities and its egress-routing
+// extension below) is to run *before* anything has yet decided how to
+// route this packet onward -- once a packet reaches the physical uplink,
+// that decision has already been made and the SID this program itself now
+// resolves would have to be un-done and re-done. There is also nothing at
+// that shared attach point to key a per-sender-VRF lookup on without
+// decoding the inner packet's own (potentially colliding across tenants,
+// per the same reasoning usidresolver.go's tenant-ownership fix already
+// closed for a different lookup) ULA source address.
 //
 // Correct attach point: TC *ingress* of the tenant's own host-side veth (or
 // tap, for a VM), the exact interface usid_ingress's own step 9 already
@@ -1203,12 +1370,17 @@ int usid_ingress(struct __sk_buff *skb)
 // ifindex_vrf_table (keyed on skb->ifindex, this interface's own identity),
 // not decoded from packet content at all.
 //
-// This program never "claims" a packet the way usid_ingress does: an
-// attachment with no NPTv6 mapping and no active ServiceVIPBinding is
-// common and expected (most VRFs/backends need neither), so a miss on
-// either lookup below is not an error -- just pass the packet through
-// unmodified (TC_ACT_UNSPEC) to the kernel's normal routing/SEG6-encap
-// path.
+// This program never "claims" a packet the way usid_ingress does for its
+// NPTv6/VIP-xlat responsibilities: an attachment with no NPTv6 mapping and
+// no active ServiceVIPBinding is common and expected (most VRFs/backends
+// need neither), so a miss on either lookup is not an error. The
+// egress-routing extension below is different: once egress_route_table
+// has a matching entry, this program *is* that packet's only path off
+// this node (the kernel-native SEG6 route this extension replaces is
+// being removed, not left as a fallback -- see the design plan's own §5
+// migration-ordering note for why it's still safe to leave both mechanisms
+// briefly installed together during rollout), so a failure past that
+// point is a drop, not a pass-through.
 SEC("tc")
 int usid_egress(struct __sk_buff *skb)
 {
@@ -1223,16 +1395,17 @@ int usid_egress(struct __sk_buff *skb)
 	if ((void *) (eth + 1) > data_end)
 		return TC_ACT_UNSPEC;
 
-	// IPv6 only (component 2/0.1 are both IPv6-only by design) -- an IPv4
-	// VPC's own outbound traffic has nothing to translate here and passes
-	// through unmodified, same as any packet this program has no mapping
-	// for.
-	if (eth->h_proto != __builtin_bswap16(USID_ETH_P_IPV6))
-		return TC_ACT_UNSPEC;
+	// NPTv6/VIP-xlat remain IPv6-only by design (component 2/0.1); the
+	// egress-routing extension below does not share that restriction --
+	// RouteEgressAdd/EgressDefaultRouteAdd have always supported IPv4 VPC
+	// prefixes egressing over this IPv6-only underlay (egress.go's own
+	// Via-attribute handling) -- so an IPv4 packet still needs to reach
+	// that logic even though it skips the two IPv6-only rewrites above.
+	// Anything that's neither passes through unmodified, same as any
+	// packet this program has no mapping for.
+	__be16 h_proto = eth->h_proto;
 
-	struct usid_ip6hdr *ip6 = (void *) (eth + 1);
-
-	if ((void *) (ip6 + 1) > data_end)
+	if (h_proto != __builtin_bswap16(USID_ETH_P_IPV6) && h_proto != __builtin_bswap16(USID_ETH_P_IP))
 		return TC_ACT_UNSPEC;
 
 	__u32 ifindex = skb->ifindex;
@@ -1243,43 +1416,207 @@ int usid_egress(struct __sk_buff *skb)
 
 	__u64 vrf_key = (iv->block << 12) | iv->argument;
 
-	struct nptv6_value *npt = bpf_map_lookup_elem(&nptv6_table, &vrf_key);
+	__u8 route_family;
+	__u8 dst_addr[16];
 
-	if (npt)
-		apply_nptv6(ip6->saddr, npt, 1 /* outbound: ULA -> public */);
+	__builtin_memset(dst_addr, 0, sizeof(dst_addr));
 
-	if (ip6->nexthdr == USID_IPPROTO_TCP || ip6->nexthdr == USID_IPPROTO_UDP) {
-		struct usid_l4ports *ports = (void *) (ip6 + 1);
+	if (h_proto == __builtin_bswap16(USID_ETH_P_IPV6)) {
+		struct usid_ip6hdr *ip6 = (void *) (eth + 1);
 
-		if ((void *) (ports + 1) <= data_end) {
-			struct vip_xlat_key vkey = {
-				.block = iv->block, .argument = iv->argument,
-				.proto = ip6->nexthdr, .port = ports->source,
-				.direction = USID_VIP_XLAT_DIR_EGRESS,
-			};
-			struct vip_xlat_value *vv = bpf_map_lookup_elem(&vip_xlat_table, &vkey);
+		if ((void *) (ip6 + 1) > data_end)
+			return TC_ACT_UNSPEC;
 
-			if (vv) {
-				__u32 csum_off = USID_L3_OFFSET + (ip6->nexthdr == USID_IPPROTO_TCP
-								     ? sizeof(struct usid_ip6hdr) + USID_TCP_CSUM_OFFSET
-								     : sizeof(struct usid_ip6hdr) + USID_UDP_CSUM_OFFSET);
-				__u32 addr_off = USID_L3_OFFSET + USID_OFFSETOF(struct usid_ip6hdr, saddr);
-				__u32 port_off = USID_L3_OFFSET + (__u32) sizeof(struct usid_ip6hdr) +
-						  USID_OFFSETOF(struct usid_l4ports, source);
+		struct nptv6_value *npt = bpf_map_lookup_elem(&nptv6_table, &vrf_key);
 
-				// A checksum/store failure here is not this
-				// program's packet to drop -- unlike
-				// usid_ingress, egress traffic that fails a
-				// rewrite still has a normal, valid path
-				// through the kernel stack if simply left
-				// alone; only the rewrite itself is abandoned.
-				apply_vip_xlat(skb, addr_off, port_off, csum_off, ip6->nexthdr, ip6->saddr,
-						ports->source, vv);
+		if (npt)
+			apply_nptv6(ip6->saddr, npt, 1 /* outbound: ULA -> public */);
+
+		if (ip6->nexthdr == USID_IPPROTO_TCP || ip6->nexthdr == USID_IPPROTO_UDP) {
+			struct usid_l4ports *ports = (void *) (ip6 + 1);
+
+			if ((void *) (ports + 1) <= data_end) {
+				struct vip_xlat_key vkey = {
+					.block = iv->block, .argument = iv->argument,
+					.proto = ip6->nexthdr, .port = ports->source,
+					.direction = USID_VIP_XLAT_DIR_EGRESS,
+				};
+				struct vip_xlat_value *vv = bpf_map_lookup_elem(&vip_xlat_table, &vkey);
+
+				if (vv) {
+					__u32 csum_off = USID_L3_OFFSET + (ip6->nexthdr == USID_IPPROTO_TCP
+									     ? sizeof(struct usid_ip6hdr) + USID_TCP_CSUM_OFFSET
+									     : sizeof(struct usid_ip6hdr) + USID_UDP_CSUM_OFFSET);
+					__u32 addr_off = USID_L3_OFFSET + USID_OFFSETOF(struct usid_ip6hdr, saddr);
+					__u32 port_off = USID_L3_OFFSET + (__u32) sizeof(struct usid_ip6hdr) +
+							  USID_OFFSETOF(struct usid_l4ports, source);
+
+					// A checksum/store failure here is not
+					// this program's packet to drop --
+					// only the rewrite itself is
+					// abandoned; the egress-routing
+					// extension below still runs.
+					apply_vip_xlat(skb, addr_off, port_off, csum_off, ip6->nexthdr, ip6->saddr,
+							ports->source, vv);
+
+					// apply_vip_xlat's bpf_skb_store_bytes
+					// calls invalidate every
+					// previously-derived packet pointer --
+					// re-derive before reading ip6->daddr
+					// below.
+					data = (void *) (long) skb->data;
+					data_end = (void *) (long) skb->data_end;
+					eth = data;
+					if ((void *) (eth + 1) > data_end)
+						return TC_ACT_SHOT;
+					ip6 = (void *) (eth + 1);
+					if ((void *) (ip6 + 1) > data_end)
+						return TC_ACT_SHOT;
+				}
 			}
 		}
+
+		route_family = USID_EGRESS_ROUTE_FAMILY_INET6;
+		__builtin_memcpy(dst_addr, ip6->daddr, 16);
+	} else {
+		struct usid_iphdr *ip4 = (void *) (eth + 1);
+
+		if ((void *) (ip4 + 1) > data_end)
+			return TC_ACT_UNSPEC;
+
+		route_family = USID_EGRESS_ROUTE_FAMILY_INET4;
+		__builtin_memcpy(dst_addr, ip4->daddr, sizeof(ip4->daddr));
 	}
 
-	return TC_ACT_UNSPEC;
+	// Resolve this attachment's Linux VRF table id via vrf_table --
+	// already populated identically to ifindex_vrf_table at CNI ADD
+	// time -- see struct egress_route_key's own comment for why this,
+	// not (block, argument), is egress_route_table's key.
+	struct vrf_value *vrf = bpf_map_lookup_elem(&vrf_table, &vrf_key);
+
+	if (!vrf)
+		return TC_ACT_UNSPEC; // attachment registered but its vrf_table entry isn't -- shouldn't happen; fail open
+
+	struct egress_route_key rkey;
+
+	__builtin_memset(&rkey, 0, sizeof(rkey));
+	rkey.table_id = vrf->vrf_table_id;
+	rkey.family = route_family;
+	__builtin_memcpy(rkey.addr, dst_addr, sizeof(rkey.addr));
+	rkey.prefixlen = 8 * (sizeof(rkey.table_id) + sizeof(rkey.family)) +
+			 (route_family == USID_EGRESS_ROUTE_FAMILY_INET6 ? 128 : 32);
+
+	struct egress_route_value *rv = bpf_map_lookup_elem(&egress_route_table, &rkey);
+
+	if (!rv)
+		return TC_ACT_UNSPEC; // no configured route for this destination -- defer to the kernel (still-installed netlink route during migration, or genuinely none)
+
+	// node_src_addr_table is BPF_MAP_TYPE_ARRAY, not BPF_MAP_TYPE_HASH:
+	// every one of its (here, exactly one) slots always exists from map
+	// creation onward, pre-zeroed -- bpf_map_lookup_elem on an in-range
+	// array index can never itself signal "not configured yet" the way a
+	// HASH map miss (a null return) can. An all-zero address is
+	// otherwise never a legitimate value here (the unspecified address
+	// convention internal/plumbing/srv6's own RouteEgressAdd/RouteMainAdd
+	// already use for "not a usable address"), so it's checked
+	// explicitly below as this map's own "not yet configured" signal.
+	__u32 src_key = 0;
+	__u8 *src = bpf_map_lookup_elem(&node_src_addr_table, &src_key);
+
+	if (!src)
+		return TC_ACT_UNSPEC; // array map, so this is unreachable in practice -- kept as a defensive null check anyway
+
+	__u8 src_or = 0;
+
+#pragma unroll
+	for (int i = 0; i < 16; i++)
+		src_or |= src[i];
+
+	if (src_or == 0)
+		return TC_ACT_UNSPEC; // this node's own source address isn't registered yet -- fail open rather than encapsulate with an all-zero source
+
+	// Push room for a new outer IPv6 header. Positive len_diff grows
+	// room (usid_ingress's own strip, above, is this same call with a
+	// negative len_diff) -- BPF_ADJ_ROOM_MAC keeps the Ethernet header
+	// at the very front and opens the new space directly after it,
+	// exactly where the outer header being pushed here belongs.
+	if (bpf_skb_adjust_room(skb, (__s32) sizeof(struct usid_ip6hdr), BPF_ADJ_ROOM_MAC, 0)) {
+		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	data = (void *) (long) skb->data;
+	data_end = (void *) (long) skb->data_end;
+
+	struct usid_ethhdr *new_eth = data;
+
+	if ((void *) (new_eth + 1) > data_end) {
+		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	struct usid_ip6hdr *outer = (void *) (new_eth + 1);
+
+	if ((void *) (outer + 1) > data_end) {
+		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
+	outer->vtc_flow[0] = 0x60; // version 6, traffic class/flow label left zero
+	// skb->len is now the full grown frame (Ethernet + new outer header +
+	// original inner packet); the inner payload length this header's own
+	// payload_len must carry is that minus the Ethernet and outer-header
+	// bytes just added.
+	__u16 inner_len = (__u16) (skb->len - (__u32) sizeof(struct usid_ethhdr) - (__u32) sizeof(struct usid_ip6hdr));
+
+	outer->payload_len = __builtin_bswap16(inner_len);
+	outer->nexthdr = (route_family == USID_EGRESS_ROUTE_FAMILY_INET6) ? USID_IPPROTO_IPV6 : USID_IPPROTO_IPIP;
+	outer->hop_limit = USID_EGRESS_HOP_LIMIT;
+	__builtin_memcpy(outer->saddr, src, 16);
+	__builtin_memcpy(outer->daddr, rv->sid, 16);
+	new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IPV6);
+
+	// Resolve the resolved SID's own L2 next-hop and real egress
+	// interface fresh, per packet -- see struct egress_route_value's own
+	// comment for why this program does this instead of the Go control
+	// plane precomputing and storing it. BPF_FIB_LOOKUP_TBID +
+	// USID_RT_TABLE_MAIN pins this to the main table regardless of which
+	// VRF-enslaved interface this program is attached to (see
+	// USID_RT_TABLE_MAIN's own comment).
+	struct bpf_fib_lookup fib_params;
+
+	__builtin_memset(&fib_params, 0, sizeof(fib_params));
+	fib_params.family = USID_AF_INET6;
+	__builtin_memcpy(fib_params.ipv6_src, src, sizeof(fib_params.ipv6_src));
+	__builtin_memcpy(fib_params.ipv6_dst, rv->sid, sizeof(fib_params.ipv6_dst));
+	fib_params.tot_len = (__u16) sizeof(struct usid_ip6hdr) + inner_len;
+	fib_params.tbid = USID_RT_TABLE_MAIN;
+
+	long fib_rc = bpf_fib_lookup(skb, &fib_params, sizeof(fib_params),
+				      BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
+
+	if (fib_rc != BPF_FIB_LKUP_RET_SUCCESS) {
+		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	__builtin_memcpy(new_eth->h_dest, fib_params.dmac, sizeof(new_eth->h_dest));
+	__builtin_memcpy(new_eth->h_source, fib_params.smac, sizeof(new_eth->h_source));
+
+	// Same-netns redirect: this program's attach point (the tenant's own
+	// host-side veth) and the resolved physical uplink both live in the
+	// root/host netns, unlike usid_ingress's step 9 veth-mode branch
+	// (which crosses into a *different* netns and needs
+	// bpf_redirect_peer for exactly that reason).
+	long redirect_rc = bpf_redirect(fib_params.ifindex, 0);
+
+	if (redirect_rc != TC_ACT_REDIRECT) {
+		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_REDIRECT_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	return redirect_rc;
 }
 
 char __license[] SEC("license") = "GPL";

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -225,19 +225,6 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 #define USID_TCP_CSUM_OFFSET 16
 #define USID_UDP_CSUM_OFFSET 6
 
-// USID_RT_TABLE_MAIN is RT_TABLE_MAIN (uapi/linux/rtnetlink.h), reproduced
-// as a plain constant for the same reason every other ABI value in this
-// file is: it never changes, and pulling in rtnetlink.h for one integer
-// would add a real header dependency. usid_egress's own egress-routing
-// extension uses this to force its bpf_fib_lookup() for a resolved SID's
-// L2 next-hop to run against the main table specifically (via
-// BPF_FIB_LOOKUP_TBID) regardless of which VRF-enslaved interface this
-// program happens to be attached to -- the SID itself is always reachable
-// via the underlay/main table, the same table
-// internal/plumbing/srv6.resolveNextHop's netlink.RouteGet call already
-// resolves it against today, never the tenant VRF's own table.
-#define USID_RT_TABLE_MAIN 254
-
 // USID_EGRESS_HOP_LIMIT is the hop limit usid_egress writes into the outer
 // IPv6 header it pushes for a resolved egress route -- a fixed, reasonable
 // default (matching this lab's/most Linux hosts' own default unicast hop
@@ -574,17 +561,33 @@ struct egress_route_key {
 
 // struct egress_route_value is egress_route_table's value: the resolved
 // SRv6 SID (or NAT66 shard SID, for a default-route entry) to
-// encapsulate toward. Deliberately just the address -- no precomputed
-// link/next-hop/L2 fields, unlike the netlink-route mechanism this
-// replaces (RouteEgressAdd's own resolveNextHop, run once at route-install
-// time): usid_egress instead runs a fresh bpf_fib_lookup() per packet
-// against sid (see that call site's own comment), which is both simpler
-// (Go's writer needs no next-hop resolution logic of its own at all, only
-// the SID) and self-healing (a next-hop/neighbor change on the underlay
-// takes effect on the very next packet, not only the next time Go
-// re-resolves and rewrites this entry).
+// encapsulate toward, plus the fully precomputed link/L2 information
+// needed to actually deliver that encapsulated packet.
+//
+// An earlier version of this struct carried only sid, on the theory that
+// usid_egress could resolve link_ifindex/dmac/smac itself, fresh, via a
+// per-packet bpf_fib_lookup() -- both simpler for the Go side (no
+// next-hop resolution logic of its own) and self-healing (a next-hop
+// change on the underlay takes effect on the very next packet). That
+// theory doesn't hold: confirmed live, bpf_fib_lookup() called from
+// usid_egress's own attach point (the tenant's own VRF-enslaved veth)
+// unconditionally returns BPF_FIB_LKUP_RET_BLACKHOLE for a main-table
+// destination that resolves just fine via `ip -6 route get` outside BPF --
+// tried with/without BPF_FIB_LOOKUP_TBID, with/without BPF_FIB_LOOKUP_DIRECT,
+// and with fib_params.ifindex set to both skb->ifindex and a neutral
+// non-VRF-enslaved ifindex; all four combinations blackholed identically.
+// This is the kernel's own VRF/l3mdev isolation boundary asserting itself
+// against the *attaching* skb's real device, independent of any
+// bpf_fib_lookup parameter -- not something tunable from inside this
+// program at all. The Go control plane must resolve link/L2 information
+// the same way the netlink-route mechanism this replaces always did
+// (RouteEgressAdd's own resolveNextHop, run once at route-install time),
+// and store it here -- see egressroutemap.EgressRouteTable.Register.
 struct egress_route_value {
 	__u8 sid[16];
+	__u32 link_ifindex;
+	__u8 dmac[6];
+	__u8 smac[6];
 } __attribute__((packed));
 
 // ---------------------------------------------------------------------
@@ -623,14 +626,18 @@ enum drop_reason {
 	// reason rather than folded into an unrelated one so it's visible if
 	// it ever does.
 	DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED = 12,
-	// The outer header was pushed, but resolving the egress link/L2
-	// next-hop for the matched SID failed (no route, no neighbor entry,
-	// MTU exceeded, etc.) -- the in-kernel equivalent of what
-	// srv6.resolveNextHop's "no route to gateway" error meant for the
-	// netlink-route mechanism this replaces.
+	// Unused: an earlier version of usid_egress's egress-routing
+	// extension ran its own per-packet bpf_fib_lookup() to resolve the
+	// matched SID's link/L2 next-hop, and this counted that call
+	// failing. That approach doesn't work at all from this program's own
+	// attach point (see struct egress_route_value's own comment for why
+	// -- a real kernel VRF/l3mdev isolation boundary, not a parameter
+	// bug) and was replaced with Go-side precomputation
+	// (egressroutemap.EgressRouteTable.Register), which has nothing left
+	// to fail in the same way at packet-processing time. Kept
+	// undeleted rather than renumbering every index after it.
 	DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED = 13,
-	// FIB lookup for the SID succeeded but the redirect out the
-	// resolved physical interface itself failed.
+	// The redirect out the resolved physical interface failed.
 	DROP_REASON_EGRESS_ROUTE_REDIRECT_FAILED = 14,
 	__DROP_REASON_MAX,
 };
@@ -1476,6 +1483,29 @@ int usid_egress(struct __sk_buff *skb)
 			}
 		}
 
+		// Multicast (ff00::/8) and link-local (fe80::/10) destinations
+		// must never be matched against egress_route_table, no matter
+		// how broad a registered entry is (in particular
+		// EgressDefaultRouteAdd's own ::/0 default, which -- being a
+		// literal catch-all -- otherwise matches these exactly like any
+		// other destination). Found live: a tenant pod's own Neighbor
+		// Discovery traffic for resolving its *own default gateway's*
+		// link-layer address (an NS targeting a solicited-node
+		// multicast address) was being caught by the ::/0 default entry
+		// and redirected toward a NAT66 shard SID instead of ever
+		// reaching the normal kernel/host-side NDP handling that must
+		// answer it -- the container's own gateway neighbor entry went
+		// to FAILED and every packet through it silently died with a
+		// locally-synthesized "Destination unreachable", never sending
+		// anything at all, let alone anything usid_egress's own drop
+		// counters could see. The kernel's own routing has an equivalent
+		// carve-out by construction (link-local/multicast destinations
+		// are always handled by dedicated local-scope routing, never an
+		// application's own default route); this replicates it here,
+		// since nothing else in this program's own routing model does.
+		if (ip6->daddr[0] == 0xFF || (ip6->daddr[0] == 0xFE && (ip6->daddr[1] & 0xC0) == 0x80))
+			return TC_ACT_UNSPEC;
+
 		route_family = USID_EGRESS_ROUTE_FAMILY_INET6;
 		__builtin_memcpy(dst_addr, ip6->daddr, 16);
 	} else {
@@ -1577,39 +1607,32 @@ int usid_egress(struct __sk_buff *skb)
 	__builtin_memcpy(outer->daddr, rv->sid, 16);
 	new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IPV6);
 
-	// Resolve the resolved SID's own L2 next-hop and real egress
-	// interface fresh, per packet -- see struct egress_route_value's own
-	// comment for why this program does this instead of the Go control
-	// plane precomputing and storing it. BPF_FIB_LOOKUP_TBID +
-	// USID_RT_TABLE_MAIN pins this to the main table regardless of which
-	// VRF-enslaved interface this program is attached to (see
-	// USID_RT_TABLE_MAIN's own comment).
-	struct bpf_fib_lookup fib_params;
-
-	__builtin_memset(&fib_params, 0, sizeof(fib_params));
-	fib_params.family = USID_AF_INET6;
-	__builtin_memcpy(fib_params.ipv6_src, src, sizeof(fib_params.ipv6_src));
-	__builtin_memcpy(fib_params.ipv6_dst, rv->sid, sizeof(fib_params.ipv6_dst));
-	fib_params.tot_len = (__u16) sizeof(struct usid_ip6hdr) + inner_len;
-	fib_params.tbid = USID_RT_TABLE_MAIN;
-
-	long fib_rc = bpf_fib_lookup(skb, &fib_params, sizeof(fib_params),
-				      BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
-
-	if (fib_rc != BPF_FIB_LKUP_RET_SUCCESS) {
-		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED, vrf);
-		return TC_ACT_SHOT;
-	}
-
-	__builtin_memcpy(new_eth->h_dest, fib_params.dmac, sizeof(new_eth->h_dest));
-	__builtin_memcpy(new_eth->h_source, fib_params.smac, sizeof(new_eth->h_source));
+	// L2 (dmac/smac) and the real egress interface all come straight from
+	// rv -- resolved once by the Go control plane at Register time, not
+	// via a runtime bpf_fib_lookup() here. This is a deliberate departure
+	// from usid_ingress's own step 8 (which *does* call bpf_fib_lookup()
+	// per packet): confirmed live, bpf_fib_lookup() called from this
+	// program's own attach point (the tenant's own VRF-enslaved veth)
+	// unconditionally returns BPF_FIB_LKUP_RET_BLACKHOLE for a
+	// main-table destination -- tried with BPF_FIB_LOOKUP_TBID, without
+	// it, with BPF_FIB_LOOKUP_DIRECT, without it, and with fib_params.ifindex
+	// set to both skb->ifindex and a neutral non-VRF-enslaved ifindex,
+	// all four combinations identically blackholed a destination `ip -6
+	// route get` resolves just fine outside BPF. This is the kernel's own
+	// VRF/l3mdev isolation boundary asserting itself against the
+	// *attaching* skb's real device (skb->dev), independent of anything
+	// bpf_fib_lookup's own params can override -- not a parameter bug.
+	// usid_ingress never hits this because its own attach point (the
+	// physical uplink) was never VRF-enslaved to begin with.
+	__builtin_memcpy(new_eth->h_dest, rv->dmac, sizeof(new_eth->h_dest));
+	__builtin_memcpy(new_eth->h_source, rv->smac, sizeof(new_eth->h_source));
 
 	// Same-netns redirect: this program's attach point (the tenant's own
 	// host-side veth) and the resolved physical uplink both live in the
 	// root/host netns, unlike usid_ingress's step 9 veth-mode branch
 	// (which crosses into a *different* netns and needs
 	// bpf_redirect_peer for exactly that reason).
-	long redirect_rc = bpf_redirect(fib_params.ifindex, 0);
+	long redirect_rc = bpf_redirect(rv->link_ifindex, 0);
 
 	if (redirect_rc != TC_ACT_REDIRECT) {
 		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_REDIRECT_FAILED, vrf);

--- a/internal/plumbing/ebpf/prog/usid_test.go
+++ b/internal/plumbing/ebpf/prog/usid_test.go
@@ -1344,7 +1344,12 @@ func TestUsidEgress_RouteHitPushesIPv6InIPv6OuterHeader(t *testing.T) {
 	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
 	dst := netip.MustParseAddr("2001:db8:ffff::1")
 	key := egressRouteKey(tableID, egressRouteFamilyINET6, dst, 128)
-	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{Sid: sid.As16()}); err != nil {
+	dmac := [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}
+	smac := [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}
+	const linkIfindex = 1 // loopback always exists; redirect delivery itself is a live-cluster concern, see below
+	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{
+		Sid: sid.As16(), LinkIfindex: linkIfindex, Dmac: dmac, Smac: smac,
+	}); err != nil {
 		t.Fatalf("populate egress_route_table: %v", err)
 	}
 
@@ -1353,28 +1358,40 @@ func TestUsidEgress_RouteHitPushesIPv6InIPv6OuterHeader(t *testing.T) {
 	if err := objs.NodeSrcAddrTable.Put(uint32(0), nodeSrcBytes); err != nil {
 		t.Fatalf("populate node_src_addr_table: %v", err)
 	}
-
 	src := netip.MustParseAddr("fd20:70::1")
 	pkt := buildPacketWithV6Addrs(t, dst, src, src, dst)
 
+	// Unlike usid_ingress's own FIB-lookup-dependent step 8/9 (which
+	// BPF_PROG_TEST_RUN cannot fully exercise without a real route/
+	// interface), usid_egress's egress-routing extension no longer does
+	// any per-packet FIB lookup at all -- dmac/smac/link_ifindex all come
+	// straight from the matched egress_route_table entry (see that
+	// struct's own doc comment in usid.c for why) -- so this test can
+	// assert a full, real TC_ACT_REDIRECT success end to end.
 	ret, out, err := objs.UsidEgress.Test(pkt)
 	if err != nil {
 		t.Fatalf("program test-run: %v", err)
 	}
-	if ret != tcActShot {
-		t.Fatalf("verdict = %d, want TC_ACT_SHOT (%d) (main-table fib_lookup against a fabricated SID must fail)",
-			ret, tcActShot)
-	}
-	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteFibLookupFailed); got != 1 {
-		t.Errorf("drop_reasons[egress_route_fib_lookup_failed] = %d, want 1 (route must match, reach fib_lookup)", got)
+	if ret != tcActRedirect {
+		t.Fatalf("verdict = %d, want TC_ACT_REDIRECT (%d)", ret, tcActRedirect)
 	}
 	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteEncapFailed); got != 0 {
 		t.Errorf("drop_reasons[egress_route_encap_failed] = %d, want 0 -- the header push itself must have succeeded", got)
+	}
+	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteRedirectFailed); got != 0 {
+		t.Errorf("drop_reasons[egress_route_redirect_failed] = %d, want 0", got)
 	}
 
 	if len(out) != len(pkt)+ip6HeaderLen {
 		t.Fatalf("output packet length = %d, want %d (original %d + one pushed IPv6 header)",
 			len(out), len(pkt)+ip6HeaderLen, len(pkt))
+	}
+
+	if string(out[0:6]) != string(dmac[:]) {
+		t.Errorf("pushed outer h_dest = % x, want %x (egress_route_table's own dmac)", out[0:6], dmac)
+	}
+	if string(out[6:12]) != string(smac[:]) {
+		t.Errorf("pushed outer h_source = % x, want %x (egress_route_table's own smac)", out[6:12], smac)
 	}
 
 	outer := out[ethHeaderLen : ethHeaderLen+ip6HeaderLen]
@@ -1417,7 +1434,12 @@ func TestUsidEgress_RouteHitIPv4InnerUsesIPIPNextHeader(t *testing.T) {
 	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
 	dst := netip.MustParseAddr("172.40.10.2")
 	key := egressRouteKey(tableID, egressRouteFamilyINET4, dst, 32)
-	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{Sid: sid.As16()}); err != nil {
+	dmac := [6]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}
+	smac := [6]byte{0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD}
+	const linkIfindex = 1
+	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{
+		Sid: sid.As16(), LinkIfindex: linkIfindex, Dmac: dmac, Smac: smac,
+	}); err != nil {
 		t.Fatalf("populate egress_route_table: %v", err)
 	}
 
@@ -1436,17 +1458,16 @@ func TestUsidEgress_RouteHitIPv4InnerUsesIPIPNextHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("program test-run: %v", err)
 	}
-	if ret != tcActShot {
-		t.Fatalf("verdict = %d, want TC_ACT_SHOT (%d) (main-table fib_lookup against a fabricated SID must fail)",
-			ret, tcActShot)
-	}
-	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteFibLookupFailed); got != 1 {
-		t.Errorf("drop_reasons[egress_route_fib_lookup_failed] = %d, want 1 (route must match, reach fib_lookup)", got)
+	if ret != tcActRedirect {
+		t.Fatalf("verdict = %d, want TC_ACT_REDIRECT (%d)", ret, tcActRedirect)
 	}
 
 	if len(out) != len(v4pkt)+ip6HeaderLen {
 		t.Fatalf("output packet length = %d, want %d (original %d + one pushed IPv6 header)",
 			len(out), len(v4pkt)+ip6HeaderLen, len(v4pkt))
+	}
+	if string(out[0:6]) != string(dmac[:]) {
+		t.Errorf("pushed outer h_dest = % x, want %x (egress_route_table's own dmac)", out[0:6], dmac)
 	}
 	outer := out[ethHeaderLen : ethHeaderLen+ip6HeaderLen]
 	if gotNextHdr := outer[6]; gotNextHdr != 4 {
@@ -1491,5 +1512,67 @@ func TestUsidEgress_NoNodeSourceAddressFailsOpen(t *testing.T) {
 	}
 	if string(out) != string(pkt) {
 		t.Errorf("packet mutated with no node_src_addr_table entry:\n in: % x\nout: % x", pkt, out)
+	}
+}
+
+// TestUsidEgress_LinkLocalAndMulticastDestinationsNeverMatchEgressRoute is
+// the regression test for a real bug found live: a registered ::/0
+// default entry (EgressDefaultRouteAdd's own NAT66 default route) is a
+// literal catch-all, and without this exclusion it also matches
+// link-local and multicast destinations -- including a tenant pod's own
+// Neighbor Discovery traffic for resolving its *own default gateway's*
+// link-layer address. That NS packet got redirected toward a NAT66 shard
+// SID instead of ever reaching the normal host-side NDP handling that
+// must answer it, so the container's own gateway neighbor entry went to
+// FAILED and every packet through it died silently with a
+// locally-synthesized "Destination unreachable" -- confirmed live in
+// containerlab, and invisible to every one of this program's own drop
+// counters, since the packet was never dropped by this program at all,
+// just misrouted.
+func TestUsidEgress_LinkLocalAndMulticastDestinationsNeverMatchEgressRoute(t *testing.T) {
+	requireRoot(t)
+
+	const tableID = 12
+	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
+	src := netip.MustParseAddr("fd20:70::1")
+
+	tests := []struct {
+		name string
+		dst  netip.Addr
+	}{
+		{name: "link-local unicast", dst: netip.MustParseAddr("fe80::1")},
+		{name: "solicited-node multicast (a real NS target)", dst: netip.MustParseAddr("ff02::1:ff00:1")},
+		{name: "all-nodes multicast", dst: netip.MustParseAddr("ff02::1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := loadObjects(t)
+			setUpEgressRouteAttachment(t, objs, 0xaabbcc, 0x600, tableID)
+
+			// A ::/0 default entry -- the exact shape
+			// EgressDefaultRouteAdd installs -- so this test proves the
+			// exclusion, not just "no route happened to match."
+			if err := objs.EgressRouteTable.Put(
+				egressRouteKey(tableID, egressRouteFamilyINET6, netip.IPv6Unspecified(), 0),
+				UsidEgressRouteValue{Sid: sid.As16()},
+			); err != nil {
+				t.Fatalf("populate egress_route_table default entry: %v", err)
+			}
+			if err := objs.NodeSrcAddrTable.Put(uint32(0), netip.MustParseAddr("2001:db8:1:10::2").As16()); err != nil {
+				t.Fatalf("populate node_src_addr_table: %v", err)
+			}
+
+			pkt := buildPacketWithV6Addrs(t, tt.dst, src, src, tt.dst)
+			ret, out, err := objs.UsidEgress.Test(pkt)
+			if err != nil {
+				t.Fatalf("program test-run: %v", err)
+			}
+			if ret != tcActUnspec {
+				t.Errorf("verdict = %d, want TC_ACT_UNSPEC (%d) -- must never be claimed by the default route", ret, tcActUnspec)
+			}
+			if string(out) != string(pkt) {
+				t.Errorf("packet mutated for excluded destination %s:\n in: % x\nout: % x", tt.dst, pkt, out)
+			}
+		})
 	}
 }

--- a/internal/plumbing/ebpf/prog/usid_test.go
+++ b/internal/plumbing/ebpf/prog/usid_test.go
@@ -1174,3 +1174,322 @@ func TestUsidEgress_NoMappingPassesThroughUnmodified(t *testing.T) {
 		t.Errorf("packet mutated with no ifindex_vrf_table entry:\n in: % x\nout: % x", pkt, out)
 	}
 }
+
+// ipv4HeaderLen is struct usid_iphdr's fixed size (usid.c) -- this file's
+// test packets never carry IPv4 options, so the header is always exactly
+// this long, mirroring ip6HeaderLen's identical role for usid_ip6hdr.
+const ipv4HeaderLen = 20
+
+// buildPlainIPv4Packet builds a minimal Ethernet+IPv4 frame (header only,
+// no payload) with h_proto = ETH_P_IP -- the shape usid_egress's
+// egress-routing extension parses directly for an IPv4 VPC's own outbound
+// traffic (dst.Egress -- unlike buildPacket/buildPacketWithV6Addrs, no
+// outer/inner nesting: this program is not decapsulating anything).
+func buildPlainIPv4Packet(t *testing.T, src, dst netip.Addr) []byte {
+	t.Helper()
+	if !src.Is4() || !dst.Is4() {
+		t.Fatalf("buildPlainIPv4Packet: src=%s dst=%s must both be IPv4", src, dst)
+	}
+
+	pkt := make([]byte, 0, ethHeaderLen+ipv4HeaderLen)
+	pkt = append(pkt, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA)
+	pkt = append(pkt, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB)
+	pkt = append(pkt, 0x08, 0x00) // h_proto = ETH_P_IP
+
+	pkt = append(pkt, 0x45, 0x00) // ver_ihl=4/5, tos=0
+	totLen := uint16(ipv4HeaderLen)
+	pkt = append(pkt, byte(totLen>>8), byte(totLen))
+	pkt = append(pkt, 0x00, 0x00) // id
+	pkt = append(pkt, 0x00, 0x00) // frag_off
+	pkt = append(pkt, 64)         // ttl
+	pkt = append(pkt, 59)         // protocol = no next header (plain address test, no L4)
+	pkt = append(pkt, 0x00, 0x00) // checksum (unvalidated by usid_egress)
+	srcBytes := src.As4()
+	pkt = append(pkt, srcBytes[:]...)
+	dstBytes := dst.As4()
+	pkt = append(pkt, dstBytes[:]...)
+
+	return pkt
+}
+
+// egressRouteFamilyINET6/egressRouteFamilyINET4 mirror usid.c's
+// USID_EGRESS_ROUTE_FAMILY_INET6/USID_EGRESS_ROUTE_FAMILY_INET4 -- see
+// usidVIPXlatDirIngress/usidVIPXlatDirEgress's identical comment above for
+// why bpf2go generates no symbol for a #define.
+const (
+	egressRouteFamilyINET6 = 0
+	egressRouteFamilyINET4 = 1
+)
+
+// egressRouteKey builds the LPM key usid_egress's egress-routing extension
+// computes for a full (prefixlen == address width) host route -- the only
+// shape these tests need, matching how egress.go's own
+// RouteEgressAdd/EgressDefaultRouteAdd style callers register either a
+// specific host/prefix route or, for the default, prefixlen 0 (the "no
+// address bits, always matches" case a table_id+family-only key already
+// models -- see hostPrefixBits' own doc comment).
+// addr's own byte layout depends on family: usid.c's egress-routing
+// extension memsets rkey.addr to zero, then memcpy's *only* the raw
+// 4-byte IPv4 destination (ip4->daddr) into its first 4 bytes for an
+// INET4 route, or the full 16-byte IPv6 destination for an INET6 one --
+// never the IPv4-mapped-IPv6 (::ffff:a.b.c.d) convention netip.Addr.As16
+// produces for a v4 address, which would place those same 4 bytes at
+// offset 12, not 0. Found by a real test failure (an early draft of this
+// helper called addr.As16() unconditionally): the IPv4 test below matched
+// nothing at all -- registered under one 16-byte pattern, looked up
+// against a different one -- until traced back here.
+func egressRouteKey(tableID uint32, family uint8, addr netip.Addr, prefixBits int) UsidEgressRouteKey {
+	var a [16]byte
+	if family == egressRouteFamilyINET4 {
+		v4 := addr.As4()
+		copy(a[:4], v4[:])
+	} else {
+		a = addr.As16()
+	}
+	return UsidEgressRouteKey{
+		Prefixlen: uint32(8*(4+1) + prefixBits),
+		TableId:   tableID,
+		Family:    family,
+		Addr:      a,
+	}
+}
+
+// setUpEgressRouteAttachment registers the two per-attachment lookups
+// usid_egress's egress-routing extension needs before it can ever reach
+// egress_route_table at all: ifindex_vrf_table (this ifindex belongs to
+// block/argument) and vrf_table (that (block, argument) resolves to
+// tableID) -- mirroring what internal/cnibgp's registerEBPFDatapath and
+// the CNI's own vrf_table.Register call already do together at CNI ADD
+// time (usid.c's own struct egress_route_key comment explains why both
+// are needed to get from an ifindex to a Linux table id).
+//
+// Always registers under ifindex 1 -- the default skb->ifindex value
+// Program.Test leaves in place when no explicit context is supplied
+// (confirmed empirically: it matches lo, not 0), the same value every
+// call site below is testing against, so it's hardcoded here rather than
+// taken as a parameter every caller would pass identically anyway.
+func setUpEgressRouteAttachment(t *testing.T, objs *UsidObjects, block uint64, argument uint16, tableID uint32) {
+	t.Helper()
+	const ifindex uint32 = 1
+	if err := objs.IfindexVrfTable.Put(ifindex, UsidIfindexVrfValue{Block: block, Argument: argument}); err != nil {
+		t.Fatalf("populate ifindex_vrf_table: %v", err)
+	}
+	vrfKey, err := uformat.NewVRFKey(block, argument)
+	if err != nil {
+		t.Fatalf("NewVRFKey: %v", err)
+	}
+	if err := objs.VrfTable.Put(uint64(vrfKey), UsidVrfValue{VrfTableId: tableID}); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+}
+
+// TestUsidEgress_RouteMissPassesThroughUnmodified covers the common case
+// once egress_route_table exists as a concept at all: an attachment fully
+// registered (ifindex_vrf_table + vrf_table both present, exactly as a
+// real CNI ADD leaves them) but with no egress_route_table entry covering
+// this packet's destination -- e.g. a VRF with no NAT66 default route
+// configured and no intra-VPC peer route for this particular prefix
+// (yet), or (design plan §5's migration-ordering note) an attachment
+// still relying on the kernel-native SEG6 route this extension replaces
+// during rollout. Must defer to the kernel (TC_ACT_UNSPEC, byte-for-byte
+// unmodified), not drop -- there may still be a valid path via the
+// still-installed netlink route, or genuinely none, either of which is
+// the kernel's call to make, not this program's.
+func TestUsidEgress_RouteMissPassesThroughUnmodified(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	setUpEgressRouteAttachment(t, objs, 0xABCDEF, 0x100, 7)
+
+	pkt := buildPacketWithV6Addrs(t,
+		netip.MustParseAddr("2001:db8:ffff::1"), netip.MustParseAddr("fd20:70::1"),
+		netip.MustParseAddr("fd20:70::1"), netip.MustParseAddr("2001:db8:ffff::1"))
+
+	ret, out, err := objs.UsidEgress.Test(pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != tcActUnspec {
+		t.Errorf("verdict = %d, want TC_ACT_UNSPEC (%d)", ret, tcActUnspec)
+	}
+	if string(out) != string(pkt) {
+		t.Errorf("packet mutated on an egress_route_table miss:\n in: % x\nout: % x", pkt, out)
+	}
+}
+
+// TestUsidEgress_RouteHitPushesIPv6InIPv6OuterHeader covers the core new
+// mechanism (docs/plans/tc-bpf-egress-srv6-encap.md): an egress_route_table
+// hit must push a new 40-byte outer IPv6 header (nexthdr=41,
+// IPv6-in-IPv6, matching usid_ingress's own decap-side expectation) in
+// front of the original packet, addressed to the matched SID, before
+// attempting delivery.
+//
+// The FIB lookup for that SID's own L2 next-hop still fails here, the
+// same limitation TestUsidIngress_VRFTableMatchReachesFIBLookup already
+// documents for the decap side: BPF_PROG_TEST_RUN has no real routing
+// table to succeed against, only whatever the test host's own main table
+// happens to contain, which never has a route to a fabricated SID address
+// -- confirming this far (header pushed with the right bytes, main-table
+// FIB lookup genuinely attempted and genuinely failing, not short-circuited
+// by an earlier drop) is what a BPF_PROG_TEST_RUN-based test can prove;
+// real delivery is a live-cluster (ContainerLab) concern, same as
+// usid_ingress's own redirect path.
+func TestUsidEgress_RouteHitPushesIPv6InIPv6OuterHeader(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	const tableID = 8
+	setUpEgressRouteAttachment(t, objs, 0x123456, 0x200, tableID)
+
+	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
+	dst := netip.MustParseAddr("2001:db8:ffff::1")
+	key := egressRouteKey(tableID, egressRouteFamilyINET6, dst, 128)
+	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{Sid: sid.As16()}); err != nil {
+		t.Fatalf("populate egress_route_table: %v", err)
+	}
+
+	nodeSrc := netip.MustParseAddr("2001:db8:1:10::2")
+	nodeSrcBytes := nodeSrc.As16()
+	if err := objs.NodeSrcAddrTable.Put(uint32(0), nodeSrcBytes); err != nil {
+		t.Fatalf("populate node_src_addr_table: %v", err)
+	}
+
+	src := netip.MustParseAddr("fd20:70::1")
+	pkt := buildPacketWithV6Addrs(t, dst, src, src, dst)
+
+	ret, out, err := objs.UsidEgress.Test(pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != tcActShot {
+		t.Fatalf("verdict = %d, want TC_ACT_SHOT (%d) (main-table fib_lookup against a fabricated SID must fail)",
+			ret, tcActShot)
+	}
+	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteFibLookupFailed); got != 1 {
+		t.Errorf("drop_reasons[egress_route_fib_lookup_failed] = %d, want 1 (route must match, reach fib_lookup)", got)
+	}
+	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteEncapFailed); got != 0 {
+		t.Errorf("drop_reasons[egress_route_encap_failed] = %d, want 0 -- the header push itself must have succeeded", got)
+	}
+
+	if len(out) != len(pkt)+ip6HeaderLen {
+		t.Fatalf("output packet length = %d, want %d (original %d + one pushed IPv6 header)",
+			len(out), len(pkt)+ip6HeaderLen, len(pkt))
+	}
+
+	outer := out[ethHeaderLen : ethHeaderLen+ip6HeaderLen]
+	if outer[0]>>4 != 6 {
+		t.Errorf("pushed outer header version nibble = %d, want 6", outer[0]>>4)
+	}
+	if gotNextHdr := outer[6]; gotNextHdr != 41 {
+		t.Errorf("pushed outer header nexthdr = %d, want 41 (IPv6-in-IPv6, matching usid_ingress's decap side)", gotNextHdr)
+	}
+	gotSrc, _ := netip.AddrFromSlice(outer[8:24])
+	if gotSrc != nodeSrc {
+		t.Errorf("pushed outer header src = %s, want %s (node_src_addr_table's own entry)", gotSrc, nodeSrc)
+	}
+	gotDst, _ := netip.AddrFromSlice(outer[24:40])
+	if gotDst != sid {
+		t.Errorf("pushed outer header dst = %s, want %s (the matched egress_route_table SID)", gotDst, sid)
+	}
+
+	// The original packet must survive completely unmodified, immediately
+	// after the new outer header.
+	if string(out[ethHeaderLen+ip6HeaderLen:]) != string(pkt[ethHeaderLen:]) {
+		t.Errorf("original packet content not preserved after the pushed outer header:\n want: % x\n  got: % x",
+			pkt[ethHeaderLen:], out[ethHeaderLen+ip6HeaderLen:])
+	}
+}
+
+// TestUsidEgress_RouteHitIPv4InnerUsesIPIPNextHeader covers the dual-stack
+// half of the same mechanism: RouteEgressAdd/EgressDefaultRouteAdd have
+// always supported IPv4 VPC prefixes egressing over this IPv6-only
+// underlay, unlike this program's own NPTv6/vip_xlat rewrites (IPv6-only
+// by design) -- so an IPv4 packet must still reach the egress-routing
+// extension and get encapsulated, with nexthdr=4 (IPIP) rather than 41.
+func TestUsidEgress_RouteHitIPv4InnerUsesIPIPNextHeader(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	const tableID = 9
+	setUpEgressRouteAttachment(t, objs, 0x654321, 0x300, tableID)
+
+	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
+	dst := netip.MustParseAddr("172.40.10.2")
+	key := egressRouteKey(tableID, egressRouteFamilyINET4, dst, 32)
+	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{Sid: sid.As16()}); err != nil {
+		t.Fatalf("populate egress_route_table: %v", err)
+	}
+
+	nodeSrc := netip.MustParseAddr("2001:db8:1:10::2")
+	if err := objs.NodeSrcAddrTable.Put(uint32(0), nodeSrc.As16()); err != nil {
+		t.Fatalf("populate node_src_addr_table: %v", err)
+	}
+
+	// usid_egress parses the packet's own single IPv6/IPv4 header
+	// directly (it is not itself decapsulating anything, unlike
+	// usid_ingress) -- build a plain Ethernet+IPv4 frame the same way
+	// buildPacketWithV6Addrs builds a plain Ethernet+IPv6 one.
+	v4pkt := buildPlainIPv4Packet(t, netip.MustParseAddr("10.0.0.1"), dst)
+
+	ret, out, err := objs.UsidEgress.Test(v4pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != tcActShot {
+		t.Fatalf("verdict = %d, want TC_ACT_SHOT (%d) (main-table fib_lookup against a fabricated SID must fail)",
+			ret, tcActShot)
+	}
+	if got := sumPerCPU(t, objs.DropReasons, DropReasonEgressRouteFibLookupFailed); got != 1 {
+		t.Errorf("drop_reasons[egress_route_fib_lookup_failed] = %d, want 1 (route must match, reach fib_lookup)", got)
+	}
+
+	if len(out) != len(v4pkt)+ip6HeaderLen {
+		t.Fatalf("output packet length = %d, want %d (original %d + one pushed IPv6 header)",
+			len(out), len(v4pkt)+ip6HeaderLen, len(v4pkt))
+	}
+	outer := out[ethHeaderLen : ethHeaderLen+ip6HeaderLen]
+	if gotNextHdr := outer[6]; gotNextHdr != 4 {
+		t.Errorf("pushed outer header nexthdr = %d, want 4 (IPIP, inner packet is IPv4)", gotNextHdr)
+	}
+	gotDst, _ := netip.AddrFromSlice(outer[24:40])
+	if gotDst != sid {
+		t.Errorf("pushed outer header dst = %s, want %s (the matched egress_route_table SID)", gotDst, sid)
+	}
+}
+
+// TestUsidEgress_NoNodeSourceAddressFailsOpen covers node_src_addr_table
+// not yet being populated (a real, expected transient state: this
+// program can be attached and egress_route_table populated slightly
+// before internal/cnibgp's registerEBPFDatapath gets around to writing
+// this node's own source address) -- must fail open (TC_ACT_UNSPEC,
+// unmodified) rather than encapsulate with a garbage all-zero source.
+func TestUsidEgress_NoNodeSourceAddressFailsOpen(t *testing.T) {
+	requireRoot(t)
+	objs := loadObjects(t)
+
+	const tableID = 10
+	setUpEgressRouteAttachment(t, objs, 0x789abc, 0x400, tableID)
+
+	dst := netip.MustParseAddr("2001:db8:ffff::2")
+	key := egressRouteKey(tableID, egressRouteFamilyINET6, dst, 128)
+	sid := netip.MustParseAddr("2001:db8:ff09:9:e001::")
+	if err := objs.EgressRouteTable.Put(key, UsidEgressRouteValue{Sid: sid.As16()}); err != nil {
+		t.Fatalf("populate egress_route_table: %v", err)
+	}
+	// node_src_addr_table deliberately left empty.
+
+	src := netip.MustParseAddr("fd20:70::1")
+	pkt := buildPacketWithV6Addrs(t, dst, src, src, dst)
+
+	ret, out, err := objs.UsidEgress.Test(pkt)
+	if err != nil {
+		t.Fatalf("program test-run: %v", err)
+	}
+	if ret != tcActUnspec {
+		t.Errorf("verdict = %d, want TC_ACT_UNSPEC (%d)", ret, tcActUnspec)
+	}
+	if string(out) != string(pkt) {
+		t.Errorf("packet mutated with no node_src_addr_table entry:\n in: % x\nout: % x", pkt, out)
+	}
+}

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -10,98 +10,60 @@ import (
 	"net"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 )
 
-// seg6IptunModeEncapRed is SEG6_IPTUN_MODE_ENCAP_RED from the kernel UAPI
-// (include/uapi/linux/seg6_iptunnel.h's mode enum: INLINE=0, ENCAP=1,
-// L2ENCAP=2, ENCAP_RED=3, L2ENCAP_RED=4). The vendored
-// github.com/vishvananda/netlink/nl package only exports INLINE(0)/ENCAP(1)
-// -- it has never picked up the kernel's later reduced-mode values -- but
-// netlink.SEG6Encap.Mode is a plain int forwarded verbatim to the kernel via
-// nl.EncodeSEG6Encap with no validation, so the numeric value can be used
-// directly without patching or forking that dependency.
-//
-// "Reduced" encap matters here because it changes the wire format for the
-// single-segment case this function always installs (Segments always has
-// exactly one entry, the resolved SID). Confirmed empirically against this
-// SID/lab's kernel and iproute2 (ip -6 route add ... encap seg6 mode
-// encap.red segs <sid> ..., captured on the wire both for an IPv6 inner
-// packet and, matching this codebase's actual IPv4-VPC-over-IPv6-underlay
-// case, an IPv4 inner packet): SEG6_IPTUN_MODE_ENCAP (the previous value
-// here) always prepends a full Segment Routing Header (RFC 8754, outer
-// Next Header = 43/Routing), even for one segment. SEG6_IPTUN_MODE_ENCAP_RED
-// omits the SRH entirely for a single segment -- the one segment is already
-// fully expressed by the outer destination address, so there is nothing
-// left for an SRH to carry -- leaving the outer Next Header set directly to
-// the inner packet's own protocol (4/IPIP or 41/IPv6-in-IPv6).
-//
-// That distinction is why cross-node pod traffic was silently black-holed:
-// internal/plumbing/ebpf/prog/usid.c's galactic_usid_ingress TC-BPF program
-// (the sole ingress/decap path since the legacy seg6local route model was
-// removed) requires the outer Next Header to name the inner packet's AF
-// directly (IPIP=4 or IPv6-in-IPv6=41) and unconditionally drops anything
-// else -- including a Routing Header -- as DROP_REASON_UNEXPECTED_NEXTHDR.
-// Every packet this function's previous SEG6_IPTUN_MODE_ENCAP route
-// produced hit exactly that drop on arrival at the destination node.
-const seg6IptunModeEncapRed = 3
+// pinDir is the bpffs directory RouteEgressAdd/RouteEgressDel/
+// EgressDefaultRouteAdd/EgressDefaultRouteDel open egress_route_table
+// from -- a package var defaulting to attach.PinDir (the same seam
+// internal/cnibgp/cnibgp.go's own ebpfPinDir var provides), overridable in
+// this package's own tests so they don't depend on a real bpffs mount or
+// root privileges the way a live pinned-map integration test would.
+var pinDir = attach.PinDir
 
-// RouteEgressAdd installs a SEG6 encap route for prefix into routing table
-// tableID, encapsulating to the given SRv6 SID (gateway). The outgoing
-// interface and L3 next-hop are resolved from the kernel's routing table for
-// gateway so the encapsulated outer packet can be L2-resolved on egress.
+// RouteEgressAdd installs an egress_route_table entry for prefix in Linux
+// VRF table tableID, encapsulating toward the given SRv6 SID (gateway) --
+// the TC-BPF replacement for what used to be a kernel-native SEG6 encap
+// route (netlink.SEG6Encap). See docs/plans/tc-bpf-egress-srv6-encap.md
+// for why: that kernel mechanism is confirmed broken by CVE-2026-31668
+// under this codebase's own per-tenant-VRF architecture (seg6 lwtunnel's
+// dst_cache reused blindly across the input/output resolution paths'
+// differing routing contexts), not fixable by any change to how this
+// package calls it.
 //
 // gateway must be a real SRv6 SID: an unspecified address (0.0.0.0 or ::,
 // including its IPv4-mapped ::ffff:0.0.0.0 form) means the caller never
 // resolved a real destination SID — installing it anyway would silently
 // blackhole traffic to prefix behind a route to nowhere, which is exactly
 // what happened before this check existed (an EVPN path with no usable SID
-// attribute was fed straight through). Fail loudly instead.
+// attribute was fed straight through). Fail loudly instead --
+// egressroutemap.EgressRouteTable.Register itself already enforces this.
 //
-// The resolved next-hop is attached via RTA_VIA (netlink.Route.Via) only
-// when prefix's family differs from the next-hop's — SRv6 SIDs are
-// IPv6-only in this architecture, so that's exactly the IPv4 VPC prefix
-// case (egressing over an IPv6 SRv6 underlay), where the plain Gw field
-// can't be used: Gw requires its address to share Dst's family and the
-// kernel rejects the mismatch outright, while Via carries a next-hop of a
-// different family than Dst by design.
-//
-// For an IPv6 VPC prefix, though, the next-hop already shares Dst's family,
-// and Via must NOT be used: unlike iproute2's `via` keyword, which silently
-// downgrades to a plain RTA_GATEWAY whenever the given address turns out to
-// share Dst's family, this netlink library sends whatever attribute the
-// caller set verbatim — RTA_VIA with a same-family address is rejected by
-// the kernel with EINVAL. Confirmed empirically: this function unconditionally
-// using Via previously blackholed every IPv6 VPC prefix's egress route
-// (RouteEgressAdd failing with "invalid argument"), while the IPv4 case,
-// which does need Via, worked fine.
+// Unlike the netlink-route mechanism this replaces, this function no
+// longer resolves gateway's own link/next-hop at install time
+// (resolveNextHop, below, is no longer called from here): usid_egress's
+// own bpf_fib_lookup() resolves that fresh, per packet -- see
+// egress_route_value's doc comment in usid.c for why that's both simpler
+// and self-healing.
 func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
+	// Checked here, before ever touching bpffs, not left solely to
+	// egressroutemap.EgressRouteTable.Register's own identical guard: a
+	// caller passing a bad gateway shouldn't need a real pinned map (or
+	// root) on hand just to get the right error back -- matching this
+	// function's own pre-TC-BPF behavior, which failed this same check
+	// before its first netlink call.
 	if gateway == nil || gateway.IsUnspecified() {
-		return fmt.Errorf("refusing to install seg6 encap route for %s: gateway %s is not a usable SRv6 SID", prefix, gateway)
+		return fmt.Errorf("refusing to install egress route for %s: gateway %s is not a usable SRv6 SID", prefix, gateway)
 	}
-	linkIndex, nextHop, err := resolveNextHop(gateway)
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("srv6: RouteEgressAdd: %w", err)
 	}
-	encap := &netlink.SEG6Encap{
-		Mode:     seg6IptunModeEncapRed,
-		Segments: []net.IP{gateway},
-	}
-	route := &netlink.Route{
-		Dst:       prefix,
-		Table:     int(tableID),
-		Encap:     encap,
-		LinkIndex: linkIndex,
-	}
-	if len(nextHop) > 0 {
-		if prefix.IP.To4() != nil {
-			// IPv4 VPC prefix, IPv6 next-hop: cross-family, must use Via.
-			route.Via = &netlink.Via{AddrFamily: netlink.FAMILY_V6, Addr: nextHop}
-		} else {
-			// IPv6 VPC prefix: next-hop shares Dst's family, use Gw.
-			route.Gw = nextHop
-		}
-	}
-	return netlink.RouteReplace(route)
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+	return table.Register(tableID, prefix, gateway)
 }
 
 // resolveNextHop resolves gateway's real, immediate next-hop -- the exact
@@ -115,8 +77,12 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 // through a link-local next-hop) rather than being on-link itself --
 // confirmed empirically live in containerlab, where every BGP next-hop
 // used as a plain gateway (RouteMainAdd, below) is exactly this indirect
-// shape. Both RouteEgressAdd and RouteMainAdd need gateway flattened into
-// one concrete hop before installing anything, for the same reason.
+// shape.
+//
+// Only RouteMainAdd calls this today: RouteEgressAdd/EgressDefaultRouteAdd
+// used to (their own SEG6 encap routes needed the identical flattening),
+// but no longer do -- usid_egress's own per-packet bpf_fib_lookup replaces
+// that resolution entirely for both (see RouteEgressAdd's own doc comment).
 func resolveNextHop(gateway net.IP) (linkIndex int, nextHop net.IP, err error) {
 	routes, err := netlink.RouteGet(gateway)
 	if err != nil {
@@ -128,18 +94,24 @@ func resolveNextHop(gateway net.IP) (linkIndex int, nextHop net.IP, err error) {
 	return routes[0].LinkIndex, routes[0].Gw, nil
 }
 
-// RouteEgressDel removes the SEG6 encap route for prefix from routing table tableID.
+// RouteEgressDel removes the egress_route_table entry for prefix from
+// Linux VRF table tableID -- RouteEgressAdd's counterpart.
 func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
-	return netlink.RouteDel(&netlink.Route{
-		Dst:   prefix,
-		Table: int(tableID),
-		Encap: &netlink.SEG6Encap{},
-	})
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
+	if err != nil {
+		return fmt.Errorf("srv6: RouteEgressDel: %w", err)
+	}
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+	return table.Unregister(tableID, prefix)
 }
 
 // RouteMainAdd installs a plain route for prefix in routing table tableID,
 // forwarding to gateway via ordinary recursive next-hop resolution -- no
-// SEG6 encapsulation, unlike RouteEgressAdd.
+// SEG6 encapsulation, unlike RouteEgressAdd, and untouched by the
+// TC-BPF migration RouteEgressAdd/EgressDefaultRouteAdd underwent above:
+// this function never called netlink.SEG6Encap in the first place, so it
+// was never exposed to CVE-2026-31668 at all (see its own doc comment
+// below for why an anycast route specifically must not be SEG6-wrapped).
 //
 // This exists for EVPN Type 5 paths that carry no Route Target extended
 // community at all (see matchTableID in internal/runtime/gobgp/monitor.go):
@@ -197,15 +169,11 @@ func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 	})
 }
 
-// defaultRoutePrefix is the IPv6 default route (::/0) EgressDefaultRouteAdd
-// installs -- the catch-all a tenant VRF falls back to once every more
-// specific route (intra-VPC peers via RouteEgressAdd, anycast VIPs via
-// RouteMainAdd) has already missed.
-var defaultRoutePrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
-
-// EgressDefaultRouteAdd installs a single-path IPv6 default route (::/0)
-// in routing table tableID, SEG6-encapsulating toward the first resolvable
-// address in shardSIDs. This is the missing half of the design plan's §3
+// EgressDefaultRouteAdd installs egress_route_table's default (::/0)
+// entry for Linux VRF table tableID, encapsulating toward the first
+// usable address in shardSIDs -- the TC-BPF replacement for what used to
+// be a kernel-native SEG6 encap default route (see RouteEgressAdd's own
+// doc comment for why). This is the missing half of the design plan's §3
 // sharded NAT66 tier: nat66.c's own shard-receive side has always been
 // able to decap and NAT a packet addressed to its own shard_sid, but
 // nothing ever produced such a packet -- no code anywhere installed a
@@ -214,101 +182,106 @@ var defaultRoutePrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)
 // route to host" from vrf60's own table). This closes that gap the same
 // way RouteEgressAdd closes it for a specific intra-VPC destination.
 //
-// Deliberately single-path, not a kernel ECMP multipath route across
-// every shard (an earlier version of this function installed one) --
-// though see the correction below, multipath turned out NOT to be the
-// actual trigger of the bug that motivated this change. `dmesg` showed
-// "lwtunnel_input(): recursion limit reached on datapath" repeating
-// continuously the moment a multipath version of this route was
-// installed, and ordinary inter-VPC SRv6 traffic (verify:ns10/ns20,
-// previously unrelated to NAT66 at all) silently stopped being delivered
-// at the same time. That correlation is real, but it was NOT causation:
-// removing this route (and even force-refreshing the pre-existing
-// RouteEgressAdd routes' own lwtunnel state) on a live node did not stop
-// the recursion -- verify:ns20, which never installs this route at all,
-// fails with the identical signature. The actual root cause is
-// CVE-2026-31668, an upstream Linux kernel bug (fixed at 7.1.7 on the
-// 7.1.x branch; unpatched on this lab's host kernel as of this writing):
-// seg6 lwtunnel shares one dst_cache per route between its input and
-// output resolution paths, and reuses a stale cached result across
-// different routing contexts -- the CVE's own writeup names "VRF table
-// separation" as a trigger, which is exactly this codebase's per-tenant-VRF
-// architecture. This is not something EgressDefaultRouteAdd, RouteEgressAdd,
-// or any other purely userspace/netlink code in this package can fix --
-// see docs/plans/tc-bpf-egress-srv6-encap.md for the actual fix (moving
-// SRv6 encapsulation out of the kernel's native seg6 lwtunnel entirely,
-// into a TC-BPF program, mirroring how usid_ingress already avoids native
-// seg6local decap for unrelated but analogous fragility reasons). Kept
-// single-path here anyway since it's no worse than multipath and it's
-// what RouteEgressAdd already does, but this comment no longer claims it
-// fixes anything kernel-recursion-related.
-//
-// Picking only the first resolvable shard, rather than spreading load
-// across all of them, is a real, deliberate simplification this
-// regression forced: design plan §3.2's own per-flow hash (internal/
-// maglev, or Linux ECMP as this function's own multipath predecessor
-// approximated it) was never a hard requirement -- §3.5 treats
-// shard-set-change disruption as a property to prove, not one gating
-// this mechanism's existence at all -- and correctness (a route exists,
-// traffic flows, no recursive drop) matters more here than shard load
-// distribution. Revisit with a real nexthop group or a userspace
-// selection mechanism if per-shard load spreading is ever needed;
-// nexthop groups were not evaluated here for whether they share this
-// same recursion behavior.
+// Picking only the first usable shard, rather than spreading load across
+// all of them, is a deliberate simplification: design plan §3.2's own
+// per-flow hash (internal/maglev, or an earlier version of this
+// function's own kernel-ECMP-multipath approximation of it) was never a
+// hard requirement -- §3.5 treats shard-set-change disruption as a
+// property to prove, not one gating this mechanism's existence at all --
+// and correctness (a route exists, traffic flows) matters more here than
+// shard load distribution. Revisit with a real selection mechanism (a
+// second, larger LPM/hash map in usid.c, or per-flow hashing inside
+// usid_egress itself) if per-shard load spreading is ever needed.
 //
 // shardSIDs must be non-empty -- EgressDefaultRouteAdd installs nothing
 // and returns nil when it is, the same "nothing configured yet, not an
 // error" stance GALACTIC_CNI_NAT66_SHARD_SIDS's own doc comment takes. An
 // unspecified/nil entry is a real misconfiguration and fails loudly
-// (matching RouteEgressAdd/RouteMainAdd's own guard), but a *reachable*
-// shard SID that resolveNextHop simply cannot resolve *yet* is silently
-// skipped, not fatal to the whole call: found live on a tenant node that
-// is *also* one of the configured shards itself (this lab's own "reuse
-// the site workers as shards" layout, design plan §8) -- GoBGP, like
-// every other BGP implementation, never reflects a node's own
-// locally-originated advertisement back into that same node's received-path
-// processing, so a shard's own node can *never* resolve a route to its
-// own SID, only to every other shard's. EgressDefaultRouteAdd only fails
-// outright when *every* configured SID is unresolvable.
+// (matching RouteEgressAdd's own guard, enforced by
+// egressroutemap.EgressRouteTable.Register).
+//
+// Unlike the netlink-route mechanism this replaces, EgressDefaultRouteAdd
+// no longer needs to skip a shard SID it cannot yet resolve a route to
+// (a real, previously-necessary case: a tenant node that is *also* one of
+// the configured shards itself, this lab's own "reuse the site workers as
+// shards" layout, can never resolve a route to its *own* advertised SID --
+// GoBGP, like every BGP implementation, never reflects a self-originated
+// path back into that same node's received-path processing). That
+// resolvability check existed only because the old mechanism needed a
+// concrete link/next-hop *at install time* (resolveNextHop); this one
+// doesn't -- usid_egress's own bpf_fib_lookup resolves the chosen SID
+// fresh, per packet, so an unreachable shard now simply fails that
+// per-packet lookup (DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED) instead
+// of ever needing to be detected here.
 func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 	if len(shardSIDs) == 0 {
 		return nil
 	}
-
-	var unresolved []error
-	for _, sid := range shardSIDs {
-		if sid == nil || sid.IsUnspecified() {
-			return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
-		}
-		linkIndex, nextHop, err := resolveNextHop(sid)
-		if err != nil {
-			unresolved = append(unresolved, fmt.Errorf("shard %s: %w", sid, err))
-			continue
-		}
-
-		route := &netlink.Route{
-			Dst:       defaultRoutePrefix,
-			Table:     int(tableID),
-			Encap:     &netlink.SEG6Encap{Mode: seg6IptunModeEncapRed, Segments: []net.IP{sid}},
-			LinkIndex: linkIndex,
-		}
-		if len(nextHop) > 0 {
-			route.Gw = nextHop
-		} else {
-			route.Gw = sid
-		}
-		return netlink.RouteReplace(route)
+	// Checked here, before ever touching bpffs -- see RouteEgressAdd's
+	// identical guard for why.
+	if sid := shardSIDs[0]; sid == nil || sid.IsUnspecified() {
+		return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
 	}
-
-	return fmt.Errorf("no NAT66 shard SID is resolvable yet, out of %d configured: %w",
-		len(shardSIDs), errors.Join(unresolved...))
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
+	if err != nil {
+		return fmt.Errorf("srv6: EgressDefaultRouteAdd: %w", err)
+	}
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+	return table.Register(tableID, egressroutemap.DefaultPrefix, shardSIDs[0])
 }
 
-// EgressDefaultRouteDel removes the NAT66 default route (::/0) from routing
-// table tableID -- EgressDefaultRouteAdd's counterpart.
+// EgressDefaultRouteDel removes egress_route_table's default (::/0) entry
+// for Linux VRF table tableID -- EgressDefaultRouteAdd's counterpart.
 func EgressDefaultRouteDel(tableID uint32) error {
-	return netlink.RouteDel(&netlink.Route{
-		Dst:   defaultRoutePrefix,
-		Table: int(tableID),
-	})
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
+	if err != nil {
+		return fmt.Errorf("srv6: EgressDefaultRouteDel: %w", err)
+	}
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+	return table.Unregister(tableID, egressroutemap.DefaultPrefix)
+}
+
+// ResolveNodeSourceAddress resolves this node's own SRv6/underlay-facing
+// source address: the primary global IPv6 address on whichever interface
+// currently carries the kernel's own main-table IPv6 default route.
+//
+// This is the address usid_egress's egress-routing extension writes into
+// every outer header it pushes (via egressroutemap.NodeSourceAddress) --
+// the TC-BPF replacement's own analog of a property the kernel-native
+// SEG6 lwtunnel mechanism gave for free, via ordinary IPv6
+// source-address-selection: confirmed live, `ip -6 route get <SID>`
+// reported `src 2001:db8:1:10::2` (this node's own fabric-facing
+// address) for every SEG6-encapsulated route this package ever installed,
+// with no explicit `src` ever configured anywhere in this codebase.
+// Deriving it the same way here -- from the node's own live routing
+// state, not a new piece of required operator configuration -- keeps
+// that same "just works, no new config" property for the TC-BPF
+// mechanism, at the one-time cost of running this resolution once at
+// datapath registration rather than getting it for free per-route.
+func ResolveNodeSourceAddress() (net.IP, error) {
+	defaultDst := &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
+		&netlink.Route{Dst: defaultDst, Table: unix.RT_TABLE_MAIN},
+		netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return nil, fmt.Errorf("list main-table IPv6 default route: %w", err)
+	}
+	if len(routes) == 0 {
+		return nil, errors.New("no main-table IPv6 default route found -- can't determine this node's own source address")
+	}
+
+	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
+	if err != nil {
+		return nil, fmt.Errorf("resolve default route's own link (ifindex %d): %w", routes[0].LinkIndex, err)
+	}
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+	if err != nil {
+		return nil, fmt.Errorf("list addresses on %s: %w", link.Attrs().Name, err)
+	}
+	for _, a := range addrs {
+		if a.Scope == unix.RT_SCOPE_UNIVERSE && !a.IP.IsUnspecified() {
+			return a.IP, nil
+		}
+	}
+	return nil, fmt.Errorf("no global-scope IPv6 address found on %s (default-route interface)", link.Attrs().Name)
 }

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -242,46 +242,54 @@ func EgressDefaultRouteDel(tableID uint32) error {
 }
 
 // ResolveNodeSourceAddress resolves this node's own SRv6/underlay-facing
-// source address: the primary global IPv6 address on whichever interface
-// currently carries the kernel's own main-table IPv6 default route.
+// source address: the primary global IPv6 address on the same
+// interface(s) usid_ingress/usid_egress themselves are attached to
+// (attach.ResolveInterfaces).
 //
 // This is the address usid_egress's egress-routing extension writes into
 // every outer header it pushes (via egressroutemap.NodeSourceAddress) --
 // the TC-BPF replacement's own analog of a property the kernel-native
 // SEG6 lwtunnel mechanism gave for free, via ordinary IPv6
-// source-address-selection: confirmed live, `ip -6 route get <SID>`
-// reported `src 2001:db8:1:10::2` (this node's own fabric-facing
-// address) for every SEG6-encapsulated route this package ever installed,
-// with no explicit `src` ever configured anywhere in this codebase.
-// Deriving it the same way here -- from the node's own live routing
-// state, not a new piece of required operator configuration -- keeps
-// that same "just works, no new config" property for the TC-BPF
-// mechanism, at the one-time cost of running this resolution once at
-// datapath registration rather than getting it for free per-route.
+// source-address-selection (RTA_PREFSRC): confirmed live, `ip -6 route get
+// <SID>` reported `src 2001:db8:1:10::2` (this node's own fabric-facing
+// eth1 address) for every SEG6-encapsulated route this package ever
+// installed, with no explicit `src` ever configured anywhere in this
+// codebase.
+//
+// Deliberately reuses attach.ResolveInterfaces rather than re-deriving
+// "the fabric interface" via its own separate heuristic (an earlier
+// version of this function guessed from the main-table IPv6 default
+// route's own interface): found live, that guess is simply wrong on this
+// lab's own topology (and, in general, on any node where the default
+// route belongs to the cluster/pod network, not the SRv6 underlay) --
+// eth0 (the container network) carries the default route, while eth1
+// (the real fabric interface, attached to `GALACTIC_CNI_EBPF_INTERFACES`
+// or, in its absence, this same package's own auto-detected default-route
+// interface) does not. attach.ResolveInterfaces is the datapath's own,
+// already-correct answer to "which interface is the fabric one" -- reusing
+// it here guarantees this function can never disagree with wherever
+// usid_egress itself is actually attached.
 func ResolveNodeSourceAddress() (net.IP, error) {
-	defaultDst := &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
-	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
-		&netlink.Route{Dst: defaultDst, Table: unix.RT_TABLE_MAIN},
-		netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE)
+	names, err := attach.ResolveInterfaces()
 	if err != nil {
-		return nil, fmt.Errorf("list main-table IPv6 default route: %w", err)
+		return nil, fmt.Errorf("resolve SRv6/underlay-facing interface: %w", err)
 	}
-	if len(routes) == 0 {
-		return nil, errors.New("no main-table IPv6 default route found -- can't determine this node's own source address")
+	if len(names) == 0 {
+		return nil, errors.New("attach.ResolveInterfaces returned no interfaces")
 	}
 
-	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
+	link, err := netlink.LinkByName(names[0])
 	if err != nil {
-		return nil, fmt.Errorf("resolve default route's own link (ifindex %d): %w", routes[0].LinkIndex, err)
+		return nil, fmt.Errorf("look up interface %q: %w", names[0], err)
 	}
 	addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
 	if err != nil {
-		return nil, fmt.Errorf("list addresses on %s: %w", link.Attrs().Name, err)
+		return nil, fmt.Errorf("list addresses on %s: %w", names[0], err)
 	}
 	for _, a := range addrs {
 		if a.Scope == unix.RT_SCOPE_UNIVERSE && !a.IP.IsUnspecified() {
 			return a.IP, nil
 		}
 	}
-	return nil, fmt.Errorf("no global-scope IPv6 address found on %s (default-route interface)", link.Attrs().Name)
+	return nil, fmt.Errorf("no global-scope IPv6 address found on %s (the SRv6/underlay-facing interface)", names[0])
 }

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -203,39 +203,58 @@ func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 // RouteMainAdd) has already missed.
 var defaultRoutePrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
 
-// EgressDefaultRouteAdd installs a multipath IPv6 default route (::/0) in
-// routing table tableID, SEG6-encapsulating toward every address in
-// shardSIDs -- one nexthop per shard, equally weighted. This is the
-// missing half of the design plan's §3 sharded NAT66 tier: nat66.c's own
-// shard-receive side has always been able to decap and NAT a packet
-// addressed to its own shard_sid, but nothing ever produced such a packet
-// -- no code anywhere installed a default route in a tenant VRF at all,
-// so a backend with no more specific destination simply had no route out
-// (confirmed live: "no route to host" from vrf60's own table). This closes
-// that gap the same way RouteEgressAdd closes it for a specific intra-VPC
-// destination, just fanned out across every live shard instead of one
-// fixed gateway.
+// EgressDefaultRouteAdd installs a single-path IPv6 default route (::/0)
+// in routing table tableID, SEG6-encapsulating toward the first resolvable
+// address in shardSIDs. This is the missing half of the design plan's §3
+// sharded NAT66 tier: nat66.c's own shard-receive side has always been
+// able to decap and NAT a packet addressed to its own shard_sid, but
+// nothing ever produced such a packet -- no code anywhere installed a
+// default route in a tenant VRF at all, so a backend with no more
+// specific destination simply had no route out (confirmed live: "no
+// route to host" from vrf60's own table). This closes that gap the same
+// way RouteEgressAdd closes it for a specific intra-VPC destination.
 //
-// Shard selection here is deliberately NOT internal/maglev, unlike the
-// design plan §3.2's original text ("shard assignment is chosen via a
-// maglev.Table built over (tenant VRFID, backend addr:port, dest
-// addr:port)"). That per-flow, in-datapath hash was never actually
-// implemented (internal/maglev is only ever called from the ingress LB's
-// own backend-selection ring), and building an equivalent TC-BPF hash
-// stage here would be a second, much larger new eBPF component. Linux's
-// own ECMP multipath hashing over these nexthops already gives near-even
-// load spread across shards without any new datapath code, and modern
-// kernels' resilient nexthop groups (RTA_NH_ID hash-policy "resilient")
-// give the same bounded-disruption-on-membership-change
-// property Maglev was chosen for in the first place -- but this function
-// installs plain multipath nexthops, not a resilient nexthop group,
-// since building/managing a named nexthop group is extra bookkeeping this
-// phase doesn't need: correctness (a route exists, traffic flows) matters
-// more here than minimizing reshuffled flows on a shard add/remove, which
-// is why the design plan's own §5 already treats shard-set-change
-// disruption as a property to prove, not a hard requirement gating this
-// mechanism's existence. Revisit with a real nexthop group if/when that
-// bound is actually needed.
+// Deliberately single-path, not a kernel ECMP multipath route across
+// every shard (an earlier version of this function installed one) --
+// though see the correction below, multipath turned out NOT to be the
+// actual trigger of the bug that motivated this change. `dmesg` showed
+// "lwtunnel_input(): recursion limit reached on datapath" repeating
+// continuously the moment a multipath version of this route was
+// installed, and ordinary inter-VPC SRv6 traffic (verify:ns10/ns20,
+// previously unrelated to NAT66 at all) silently stopped being delivered
+// at the same time. That correlation is real, but it was NOT causation:
+// removing this route (and even force-refreshing the pre-existing
+// RouteEgressAdd routes' own lwtunnel state) on a live node did not stop
+// the recursion -- verify:ns20, which never installs this route at all,
+// fails with the identical signature. The actual root cause is
+// CVE-2026-31668, an upstream Linux kernel bug (fixed at 7.1.7 on the
+// 7.1.x branch; unpatched on this lab's host kernel as of this writing):
+// seg6 lwtunnel shares one dst_cache per route between its input and
+// output resolution paths, and reuses a stale cached result across
+// different routing contexts -- the CVE's own writeup names "VRF table
+// separation" as a trigger, which is exactly this codebase's per-tenant-VRF
+// architecture. This is not something EgressDefaultRouteAdd, RouteEgressAdd,
+// or any other purely userspace/netlink code in this package can fix --
+// see docs/plans/tc-bpf-egress-srv6-encap.md for the actual fix (moving
+// SRv6 encapsulation out of the kernel's native seg6 lwtunnel entirely,
+// into a TC-BPF program, mirroring how usid_ingress already avoids native
+// seg6local decap for unrelated but analogous fragility reasons). Kept
+// single-path here anyway since it's no worse than multipath and it's
+// what RouteEgressAdd already does, but this comment no longer claims it
+// fixes anything kernel-recursion-related.
+//
+// Picking only the first resolvable shard, rather than spreading load
+// across all of them, is a real, deliberate simplification this
+// regression forced: design plan §3.2's own per-flow hash (internal/
+// maglev, or Linux ECMP as this function's own multipath predecessor
+// approximated it) was never a hard requirement -- §3.5 treats
+// shard-set-change disruption as a property to prove, not one gating
+// this mechanism's existence at all -- and correctness (a route exists,
+// traffic flows, no recursive drop) matters more here than shard load
+// distribution. Revisit with a real nexthop group or a userspace
+// selection mechanism if per-shard load spreading is ever needed;
+// nexthop groups were not evaluated here for whether they share this
+// same recursion behavior.
 //
 // shardSIDs must be non-empty -- EgressDefaultRouteAdd installs nothing
 // and returns nil when it is, the same "nothing configured yet, not an
@@ -249,20 +268,13 @@ var defaultRoutePrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)
 // every other BGP implementation, never reflects a node's own
 // locally-originated advertisement back into that same node's received-path
 // processing, so a shard's own node can *never* resolve a route to its
-// own SID, only to every other shard's. Aborting the entire multipath
-// route over that one permanently-unresolvable nexthop would have meant
-// no default route at all on every shard node -- exactly the nodes most
-// likely to actually run tenant workloads in this lab. The route this
-// function installs simply has one fewer nexthop on a shard's own node;
-// EgressDefaultRouteAdd only fails outright when *every* configured SID
-// is unresolvable, since a route with zero nexthops is not a route worth
-// installing at all.
+// own SID, only to every other shard's. EgressDefaultRouteAdd only fails
+// outright when *every* configured SID is unresolvable.
 func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 	if len(shardSIDs) == 0 {
 		return nil
 	}
 
-	nexthops := make([]*netlink.NexthopInfo, 0, len(shardSIDs))
 	var unresolved []error
 	for _, sid := range shardSIDs {
 		if sid == nil || sid.IsUnspecified() {
@@ -273,28 +285,23 @@ func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 			unresolved = append(unresolved, fmt.Errorf("shard %s: %w", sid, err))
 			continue
 		}
-		nh := &netlink.NexthopInfo{
-			LinkIndex: linkIndex,
+
+		route := &netlink.Route{
+			Dst:       defaultRoutePrefix,
+			Table:     int(tableID),
 			Encap:     &netlink.SEG6Encap{Mode: seg6IptunModeEncapRed, Segments: []net.IP{sid}},
+			LinkIndex: linkIndex,
 		}
 		if len(nextHop) > 0 {
-			nh.Gw = nextHop
+			route.Gw = nextHop
 		} else {
-			nh.Gw = sid
+			route.Gw = sid
 		}
-		nexthops = append(nexthops, nh)
+		return netlink.RouteReplace(route)
 	}
 
-	if len(nexthops) == 0 {
-		return fmt.Errorf("no NAT66 shard SID is resolvable yet, out of %d configured: %w",
-			len(shardSIDs), errors.Join(unresolved...))
-	}
-
-	return netlink.RouteReplace(&netlink.Route{
-		Dst:       defaultRoutePrefix,
-		Table:     int(tableID),
-		MultiPath: nexthops,
-	})
+	return fmt.Errorf("no NAT66 shard SID is resolvable yet, out of %d configured: %w",
+		len(shardSIDs), errors.Join(unresolved...))
 }
 
 // EgressDefaultRouteDel removes the NAT66 default route (::/0) from routing

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -200,34 +200,44 @@ func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 // (matching RouteEgressAdd's own guard, enforced by
 // egressroutemap.EgressRouteTable.Register).
 //
-// Unlike the netlink-route mechanism this replaces, EgressDefaultRouteAdd
-// no longer needs to skip a shard SID it cannot yet resolve a route to
-// (a real, previously-necessary case: a tenant node that is *also* one of
-// the configured shards itself, this lab's own "reuse the site workers as
-// shards" layout, can never resolve a route to its *own* advertised SID --
-// GoBGP, like every BGP implementation, never reflects a self-originated
-// path back into that same node's received-path processing). That
-// resolvability check existed only because the old mechanism needed a
-// concrete link/next-hop *at install time* (resolveNextHop); this one
-// doesn't -- usid_egress's own bpf_fib_lookup resolves the chosen SID
-// fresh, per packet, so an unreachable shard now simply fails that
-// per-packet lookup (DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED) instead
-// of ever needing to be detected here.
+// EgressDefaultRouteAdd still needs to skip a shard SID it cannot yet
+// resolve a route+neighbor for, and only fail if every one does: a real,
+// necessary case found live -- a tenant node that is *also* one of the
+// configured shards itself (this lab's own "reuse the site workers as
+// shards" layout) can never resolve a route to its *own* advertised SID,
+// since GoBGP, like every BGP implementation, never reflects a
+// self-originated path back into that same node's received-path
+// processing. egressroutemap.EgressRouteTable.Register resolves
+// link/L2 information at registration time (see its own doc comment for
+// why), so this same resolvability constraint that applied to the
+// netlink-route mechanism's own resolveNextHop applies again here,
+// unlike an intermediate version of this function that (incorrectly)
+// assumed it no longer would.
 func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 	if len(shardSIDs) == 0 {
 		return nil
-	}
-	// Checked here, before ever touching bpffs -- see RouteEgressAdd's
-	// identical guard for why.
-	if sid := shardSIDs[0]; sid == nil || sid.IsUnspecified() {
-		return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
 	}
 	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {
 		return fmt.Errorf("srv6: EgressDefaultRouteAdd: %w", err)
 	}
 	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
-	return table.Register(tableID, egressroutemap.DefaultPrefix, shardSIDs[0])
+
+	var unresolved []error
+	for _, sid := range shardSIDs {
+		// Checked here, before ever touching bpffs -- see RouteEgressAdd's
+		// identical guard for why.
+		if sid == nil || sid.IsUnspecified() {
+			return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
+		}
+		if err := table.Register(tableID, egressroutemap.DefaultPrefix, sid); err != nil {
+			unresolved = append(unresolved, fmt.Errorf("shard %s: %w", sid, err))
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("no NAT66 shard SID is resolvable yet, out of %d configured: %w",
+		len(shardSIDs), errors.Join(unresolved...))
 }
 
 // EgressDefaultRouteDel removes egress_route_table's default (::/0) entry

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -62,6 +62,65 @@ func setUpTestPinDir(t *testing.T) string {
 	return testPinDir
 }
 
+// setUpResolvableSID creates a fresh test netns with a dummy interface
+// (ifaceName/ifaceAddr) that has an on-link route to sid and a static,
+// already-resolved neighbor entry for it -- everything
+// egressroutemap.EgressRouteTable.Register's own resolveLinkAndL2 needs
+// to succeed (a route via netlink.RouteGet, then a matching neighbor
+// cache entry with a real hardware address), the same two-part
+// requirement srv6.RouteEgressAdd's own pre-TC-BPF resolveNextHop had
+// for exactly the same reason (see that function's own doc comment).
+// Returns the netns so callers can run RouteEgressAdd/EgressDefaultRouteAdd
+// inside it via nsObj.Do.
+func setUpResolvableSID(t *testing.T, ifaceName, ifaceAddr, sid string) ns.NetNS {
+	t.Helper()
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	t.Cleanup(func() { _ = nsObj.Close() })
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
+		if err := netlink.LinkAdd(dummy); err != nil {
+			return fmt.Errorf("add dummy link: %w", err)
+		}
+		if err := netlink.LinkSetUp(dummy); err != nil {
+			return fmt.Errorf("set link up: %w", err)
+		}
+		addr, err := netlink.ParseAddr(ifaceAddr)
+		if err != nil {
+			return fmt.Errorf("parse addr: %w", err)
+		}
+		if err := netlink.AddrAdd(dummy, addr); err != nil {
+			return fmt.Errorf("add addr: %w", err)
+		}
+		_, sidDst, err := net.ParseCIDR(sid + "/128")
+		if err != nil {
+			return fmt.Errorf("parse sid %q: %w", sid, err)
+		}
+		if err := netlink.RouteAdd(&netlink.Route{LinkIndex: dummy.Attrs().Index, Dst: sidDst}); err != nil {
+			return fmt.Errorf("add on-link route for sid %q: %w", sid, err)
+		}
+		neigh := &netlink.Neigh{
+			LinkIndex:    dummy.Attrs().Index,
+			Family:       netlink.FAMILY_V6,
+			State:        netlink.NUD_PERMANENT,
+			IP:           net.ParseIP(sid),
+			HardwareAddr: net.HardwareAddr{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA},
+		}
+		if err := netlink.NeighAdd(neigh); err != nil {
+			return fmt.Errorf("add static neighbor entry for sid %q: %w", sid, err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setUpResolvableSID: %v", err)
+	}
+	return nsObj
+}
+
 // TestRouteEgressAddRejectsUnspecifiedGateway verifies that RouteEgressAdd
 // refuses to install an egress_route_table entry when it isn't handed a
 // real SRv6 SID. This is the defense-in-depth backstop for the bug where a
@@ -114,8 +173,14 @@ func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 	requireRoot(t)
 	testPinDir := setUpTestPinDir(t)
 
-	const table = 100
-	sid := net.ParseIP("2001:db8:9::9")
+	const (
+		ifaceName = "srv6egtest0"
+		ifaceAddr = "2001:db8:1::1/64"
+		sid       = "2001:db8:9::9"
+		table     = 100
+	)
+
+	nsObj := setUpResolvableSID(t, ifaceName, ifaceAddr, sid)
 
 	// Family/address-byte-layout correctness within the key itself is
 	// covered by egressroutemap's own
@@ -138,7 +203,10 @@ func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 				t.Fatalf("ParseCIDR(%q): %v", tt.prefix, err)
 			}
 
-			if err := RouteEgressAdd(prefix, sid, table); err != nil {
+			err = nsObj.Do(func(_ ns.NetNS) error {
+				return RouteEgressAdd(prefix, net.ParseIP(sid), table)
+			})
+			if err != nil {
 				t.Fatalf("RouteEgressAdd(%s) = %v, want success", tt.prefix, err)
 			}
 
@@ -155,7 +223,7 @@ func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 			if !ok {
 				t.Fatalf("installed entry not found for %s", tt.prefix)
 			}
-			if !gotSID.Equal(sid) {
+			if !gotSID.Equal(net.ParseIP(sid)) {
 				t.Errorf("installed sid = %s, want %s", gotSID, sid)
 			}
 		})
@@ -170,14 +238,23 @@ func TestRouteEgressDel_RemovesInstalledEntry(t *testing.T) {
 	requireRoot(t)
 	testPinDir := setUpTestPinDir(t)
 
-	const table = 101
+	const (
+		ifaceName = "srv6egtest1"
+		ifaceAddr = "2001:db8:2::1/64"
+		sid       = "2001:db8:9::9"
+		table     = 101
+	)
 	_, prefix, err := net.ParseCIDR("fd20:10:ff03::/96")
 	if err != nil {
 		t.Fatalf("ParseCIDR: %v", err)
 	}
-	sid := net.ParseIP("2001:db8:9::9")
 
-	if err := RouteEgressAdd(prefix, sid, table); err != nil {
+	nsObj := setUpResolvableSID(t, ifaceName, ifaceAddr, sid)
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		return RouteEgressAdd(prefix, net.ParseIP(sid), table)
+	})
+	if err != nil {
 		t.Fatalf("RouteEgressAdd: %v", err)
 	}
 	if err := RouteEgressDel(prefix, table); err != nil {
@@ -450,12 +527,23 @@ func TestEgressDefaultRouteAdd_InstallsDefaultEntryForFirstShard(t *testing.T) {
 	requireRoot(t)
 	testPinDir := setUpTestPinDir(t)
 
-	const table = 42
-	shardSID1 := net.ParseIP("2001:db8:ff01:1:e001::")
-	shardSID2 := net.ParseIP("2001:db8:ff03:1:e001::")
-	shardSIDs := []net.IP{shardSID1, shardSID2}
+	const (
+		ifaceName = "srv6egtest2"
+		ifaceAddr = "2001:db8:4::1/64"
+		shardSID1 = "2001:db8:ff01:1:e001::"
+		shardSID2 = "2001:db8:ff03:1:e001::"
+		table     = 42
+	)
+	nsObj := setUpResolvableSID(t, ifaceName, ifaceAddr, shardSID1)
+	// shardSID2 is deliberately left unresolvable (no route/neighbor for
+	// it at all): this test's own job is proving the first *resolvable*
+	// shard wins, not that every configured shard must resolve.
+	shardSIDs := []net.IP{net.ParseIP(shardSID1), net.ParseIP(shardSID2)}
 
-	if err := EgressDefaultRouteAdd(table, shardSIDs); err != nil {
+	err := nsObj.Do(func(_ ns.NetNS) error {
+		return EgressDefaultRouteAdd(table, shardSIDs)
+	})
+	if err != nil {
 		t.Fatalf("EgressDefaultRouteAdd(%v) = %v, want success", shardSIDs, err)
 	}
 
@@ -472,7 +560,7 @@ func TestEgressDefaultRouteAdd_InstallsDefaultEntryForFirstShard(t *testing.T) {
 	if !ok {
 		t.Fatal("no default entry installed")
 	}
-	if !gotSID.Equal(shardSID1) {
+	if !gotSID.Equal(net.ParseIP(shardSID1)) {
 		t.Errorf("installed default entry sid = %s, want %s (the first configured shard)", gotSID, shardSID1)
 	}
 

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -5,28 +5,22 @@
 package srv6
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 )
 
 // testCaseIPv6Zero names the shared "IPv6 zero" test-table-case fixture
 // used across RouteEgressAdd/RouteMainAdd/EgressDefaultRouteAdd's own
 // unspecified-gateway/SID rejection tests (goconst).
 const testCaseIPv6Zero = "IPv6 zero"
-
-// defaultRoutePrefixString is the string form of defaultRoutePrefix
-// (::/0), shared by every EgressDefaultRouteAdd/Del test below that needs
-// to recognize the installed default route by its Dst field (goconst).
-const defaultRoutePrefixString = "::/0"
 
 func requireRoot(t *testing.T) {
 	t.Helper()
@@ -35,13 +29,46 @@ func requireRoot(t *testing.T) {
 	}
 }
 
+// setUpTestPinDir loads the real usid.c program (attach.Load, the same
+// production loader every other integration test in this codebase that
+// needs a real pinned map uses -- e.g. usidmap's own
+// TestOpenPinnedRegistry_RoundTrip) into a fresh, throwaway bpffs
+// directory, points this package's own pinDir seam at it for the
+// duration of the calling test, and registers cleanup for both. Returns
+// the directory so the calling test can also open its own independent
+// second handle (egressroutemap.OpenPinnedEgressRouteTable) to verify
+// what RouteEgressAdd/EgressDefaultRouteAdd actually installed.
+func setUpTestPinDir(t *testing.T) string {
+	t.Helper()
+
+	testPinDir := fmt.Sprintf("/sys/fs/bpf/galactic-srv6-egress-test-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.RemoveAll(testPinDir) })
+
+	objs, err := attach.Load(testPinDir)
+	if err != nil {
+		t.Fatalf("attach.Load: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := objs.Close(); err != nil {
+			t.Errorf("close loader-side objects: %v", err)
+		}
+	})
+
+	prevPinDir := pinDir
+	pinDir = testPinDir
+	t.Cleanup(func() { pinDir = prevPinDir })
+
+	return testPinDir
+}
+
 // TestRouteEgressAddRejectsUnspecifiedGateway verifies that RouteEgressAdd
-// refuses to install a seg6 encap route when it isn't handed a real SRv6 SID.
-// This is the defense-in-depth backstop for the bug where a missing/zero SID
-// upstream (e.g. an EVPN path with no Prefix-SID attribute) got fed straight
-// through and silently installed a route encapsulating to
-// "::ffff:0.0.0.0" — a route to nowhere — instead of failing loudly. The
-// check must run before any netlink call so this test needs no privileges.
+// refuses to install an egress_route_table entry when it isn't handed a
+// real SRv6 SID. This is the defense-in-depth backstop for the bug where a
+// missing/zero SID upstream (e.g. an EVPN path with no Prefix-SID
+// attribute) got fed straight through and silently installed a route
+// encapsulating to "::ffff:0.0.0.0" — a route to nowhere — instead of
+// failing loudly. The check runs before this function ever opens a pinned
+// map, so this test needs no privileges and no real bpffs mount.
 func TestRouteEgressAddRejectsUnspecifiedGateway(t *testing.T) {
 	_, prefix, err := net.ParseCIDR("172.20.20.2/32")
 	if err != nil {
@@ -67,81 +94,40 @@ func TestRouteEgressAddRejectsUnspecifiedGateway(t *testing.T) {
 	}
 }
 
-// TestRouteEgressAdd_InstallsForBothPrefixFamilies covers the regression
-// where every IPv6 VPC prefix's egress route failed to install with
-// "invalid argument": RouteEgressAdd unconditionally attached the resolved
-// next-hop via netlink.Route.Via, which the kernel only accepts when Via's
-// address family differs from Dst's. An IPv4 VPC prefix egressing over the
-// IPv6 SRv6 underlay needs exactly that cross-family Via -- and did already
-// work -- but an IPv6 VPC prefix's next-hop shares Dst's family and must go
-// through the plain Gw field instead, or the kernel rejects the route
-// outright. This test installs one route of each prefix family against a
-// real kernel routing table and asserts both succeed, with the outcome
-// (Gw vs Via) matching each family's requirement.
+// TestRouteEgressAdd_InstallsForBothPrefixFamilies covers the TC-BPF
+// replacement's own analog of what used to be a netlink Via-vs-Gw
+// distinction: an IPv4 VPC prefix and an IPv6 VPC prefix must both
+// install correctly into egress_route_table, landing in the right LPM
+// slot (egress_route_key's own family field, not a route attribute
+// choice) so usid_egress's dual-stack match (usid.c) finds each one for
+// its own inner packet's address family and not the other's.
+//
+// Loads the real usid.c program (attach.Load, the real production
+// loader) into a throwaway pin directory -- the same integration pattern
+// usidmap's own TestOpenPinnedRegistry_RoundTrip already establishes --
+// points this package's own pinDir seam at it, calls RouteEgressAdd, and
+// reads the installed entry back through a second, independent handle
+// (egressroutemap.OpenPinnedEgressRouteTable) to prove cross-process
+// visibility, the whole point of pinning.
 func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 	requireRoot(t)
+	testPinDir := setUpTestPinDir(t)
 
-	const (
-		ifaceName  = "srv6test0"
-		ifaceAddr  = "2001:db8:1::1/64"
-		sidRoute   = "2001:db8:9::9/128" // reachable via ifaceAddr's subnet
-		sidGateway = "2001:db8:1::2"     // on-link next-hop for sidRoute
-		sid        = "2001:db8:9::9"     // the resolved SRv6 SID (gateway arg)
-		table      = 100
-	)
+	const table = 100
+	sid := net.ParseIP("2001:db8:9::9")
 
-	nsObj, err := ns.TempNetNS()
-	if err != nil {
-		t.Fatalf("create test netns: %v", err)
-	}
-	defer func() { _ = nsObj.Close() }()
-
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
-		if err := netlink.LinkAdd(dummy); err != nil {
-			return fmt.Errorf("add dummy link: %w", err)
-		}
-		if err := netlink.LinkSetUp(dummy); err != nil {
-			return fmt.Errorf("set link up: %w", err)
-		}
-		addr, err := netlink.ParseAddr(ifaceAddr)
-		if err != nil {
-			return fmt.Errorf("parse addr: %w", err)
-		}
-		if err := netlink.AddrAdd(dummy, addr); err != nil {
-			return fmt.Errorf("add addr: %w", err)
-		}
-		// A multi-hop route to the SID via an on-link next-hop, so
-		// RouteGet(sid) resolves with Gw set -- exactly the shape
-		// RouteEgressAdd expects from a real BGP-learned SRv6 SID.
-		_, sidDst, err := net.ParseCIDR(sidRoute)
-		if err != nil {
-			return fmt.Errorf("parse SID route: %w", err)
-		}
-		route := &netlink.Route{
-			LinkIndex: dummy.Attrs().Index,
-			Dst:       sidDst,
-			Gw:        net.ParseIP(sidGateway),
-		}
-		if err := netlink.RouteAdd(route); err != nil {
-			return fmt.Errorf("add route to SID: %w", err)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	gateway := net.ParseIP(sid)
-
+	// Family/address-byte-layout correctness within the key itself is
+	// covered by egressroutemap's own
+	// TestEgressRouteTable_IPv4PrefixStoresAddressLeftJustified and
+	// TestEgressRouteTable_SameTableIDDifferentFamilyDoNotCollide; this
+	// test's own job is proving RouteEgressAdd actually reaches a real,
+	// cross-process-visible pinned map entry at all, for both families.
 	tests := []struct {
-		name    string
-		prefix  string
-		wantVia bool // Via must be set (cross-family: IPv4 prefix, IPv6 next-hop)
-		wantGw  bool // Gw must be set (same-family: IPv6 prefix, IPv6 next-hop)
+		name   string
+		prefix string
 	}{
-		{name: "IPv4 VPC prefix uses Via (cross-family)", prefix: "172.20.20.2/32", wantVia: true},
-		{name: "IPv6 VPC prefix uses Gw (same-family)", prefix: "fd20:10:ff02::/96", wantGw: true},
+		{name: "IPv4 VPC prefix", prefix: "172.20.20.2/32"},
+		{name: "IPv6 VPC prefix", prefix: "fd20:10:ff02::/96"},
 	}
 
 	for _, tt := range tests {
@@ -151,42 +137,62 @@ func TestRouteEgressAdd_InstallsForBothPrefixFamilies(t *testing.T) {
 				t.Fatalf("ParseCIDR(%q): %v", tt.prefix, err)
 			}
 
-			err = nsObj.Do(func(_ ns.NetNS) error {
-				return RouteEgressAdd(prefix, gateway, table)
-			})
-			if err != nil {
+			if err := RouteEgressAdd(prefix, sid, table); err != nil {
 				t.Fatalf("RouteEgressAdd(%s) = %v, want success", tt.prefix, err)
 			}
 
-			var installed *netlink.Route
-			err = nsObj.Do(func(_ ns.NetNS) error {
-				family := netlink.FAMILY_V6
-				if prefix.IP.To4() != nil {
-					family = netlink.FAMILY_V4
-				}
-				routes, err := netlink.RouteListFiltered(family, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
-				if err != nil {
-					return err
-				}
-				for i := range routes {
-					if routes[i].Dst != nil && routes[i].Dst.String() == prefix.String() {
-						installed = &routes[i]
-						return nil
-					}
-				}
-				return fmt.Errorf("no route to %s found in table %d", prefix, table)
-			})
+			entryTable, closer, err := egressroutemap.OpenPinnedEgressRouteTable(testPinDir)
 			if err != nil {
-				t.Fatalf("verify installed route: %v", err)
+				t.Fatalf("open pinned egress_route_table: %v", err)
 			}
+			defer func() { _ = closer.Close() }()
 
-			if tt.wantVia && installed.Via == nil {
-				t.Errorf("installed route for %s has no Via, want cross-family Via set", tt.prefix)
+			gotSID, ok, err := entryTable.Lookup(table, prefix)
+			if err != nil {
+				t.Fatalf("lookup installed entry: %v", err)
 			}
-			if tt.wantGw && installed.Gw == nil {
-				t.Errorf("installed route for %s has no Gw, want same-family Gw set", tt.prefix)
+			if !ok {
+				t.Fatalf("installed entry not found for %s", tt.prefix)
+			}
+			if !gotSID.Equal(sid) {
+				t.Errorf("installed sid = %s, want %s", gotSID, sid)
 			}
 		})
+	}
+}
+
+// TestRouteEgressDel_RemovesInstalledEntry covers RouteEgressAdd's
+// counterpart: an installed entry must actually disappear from
+// egress_route_table, not merely stop being returned by some
+// higher-level cache.
+func TestRouteEgressDel_RemovesInstalledEntry(t *testing.T) {
+	requireRoot(t)
+	testPinDir := setUpTestPinDir(t)
+
+	const table = 101
+	_, prefix, err := net.ParseCIDR("fd20:10:ff03::/96")
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	sid := net.ParseIP("2001:db8:9::9")
+
+	if err := RouteEgressAdd(prefix, sid, table); err != nil {
+		t.Fatalf("RouteEgressAdd: %v", err)
+	}
+	if err := RouteEgressDel(prefix, table); err != nil {
+		t.Fatalf("RouteEgressDel: %v", err)
+	}
+
+	entryTable, closer, err := egressroutemap.OpenPinnedEgressRouteTable(testPinDir)
+	if err != nil {
+		t.Fatalf("open pinned egress_route_table: %v", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if _, ok, err := entryTable.Lookup(table, prefix); err != nil {
+		t.Fatalf("lookup after delete: %v", err)
+	} else if ok {
+		t.Error("entry still present after RouteEgressDel")
 	}
 }
 
@@ -424,178 +430,73 @@ func TestEgressDefaultRouteAddRejectsUnspecifiedShardSID(t *testing.T) {
 	}
 }
 
-// TestEgressDefaultRouteAdd_InstallsSinglePathToFirstResolvableShard
-// proves the installed ::/0 route is a single SEG6-encapsulating nexthop
-// toward the first resolvable configured shard SID (not a kernel
-// multipath route fanned out across all of them -- an earlier version of
-// this function did exactly that, and it triggered a real, confirmed
-// kernel routing loop: see EgressDefaultRouteAdd's own doc comment), and
-// that EgressDefaultRouteDel removes it cleanly -- the mechanism that
-// finally gives a tenant VRF somewhere to send a packet with no more
-// specific route, closing the gap nat66.c's own shard-receive side was
-// always able to answer but nothing ever fed traffic into.
-func TestEgressDefaultRouteAdd_InstallsSinglePathToFirstResolvableShard(t *testing.T) {
+// TestEgressDefaultRouteAdd_InstallsDefaultEntryForFirstShard proves
+// EgressDefaultRouteAdd installs egress_route_table's ::/0 entry
+// encapsulating toward the first configured shard SID, and that
+// EgressDefaultRouteDel removes it cleanly -- the mechanism that finally
+// gives a tenant VRF somewhere to send a packet with no more specific
+// route, closing the gap nat66.c's own shard-receive side was always
+// able to answer but nothing ever fed traffic into.
+//
+// Unlike this function's pre-TC-BPF implementation, no live route to
+// each shard SID needs to exist first: usid_egress's own bpf_fib_lookup
+// resolves the chosen SID fresh, per packet, so EgressDefaultRouteAdd
+// itself no longer needs to (and no longer can, having no netlink
+// dependency left at all) verify reachability at install time -- see
+// this function's own doc comment for the "skip unresolvable shards"
+// behavior this replaces and why it's no longer needed.
+func TestEgressDefaultRouteAdd_InstallsDefaultEntryForFirstShard(t *testing.T) {
 	requireRoot(t)
+	testPinDir := setUpTestPinDir(t)
 
-	const (
-		ifaceName = "srv6mtest2"
-		ifaceAddr = "2001:db8:4::1/64"
-		shardSID1 = "2001:db8:ff01:1:e001::"
-		shardSID2 = "2001:db8:ff03:1:e001::"
-		table     = 42
-	)
+	const table = 42
+	shardSID1 := net.ParseIP("2001:db8:ff01:1:e001::")
+	shardSID2 := net.ParseIP("2001:db8:ff03:1:e001::")
+	shardSIDs := []net.IP{shardSID1, shardSID2}
 
-	nsObj, err := ns.TempNetNS()
-	if err != nil {
-		t.Fatalf("create test netns: %v", err)
-	}
-	defer func() { _ = nsObj.Close() }()
-
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifaceName}}
-		if err := netlink.LinkAdd(dummy); err != nil {
-			return fmt.Errorf("add dummy link: %w", err)
-		}
-		if err := netlink.LinkSetUp(dummy); err != nil {
-			return fmt.Errorf("set link up: %w", err)
-		}
-		addr, err := netlink.ParseAddr(ifaceAddr)
-		if err != nil {
-			return fmt.Errorf("parse addr: %w", err)
-		}
-		if err := netlink.AddrAdd(dummy, addr); err != nil {
-			return fmt.Errorf("add addr: %w", err)
-		}
-		// resolveNextHop (via netlink.RouteGet) needs a real route to each
-		// shard SID before EgressDefaultRouteAdd can resolve it -- neither
-		// SID is naturally on-link over ifaceAddr's own /64, so each gets
-		// an explicit on-link /128 host route, mirroring how a real
-		// fabric's own SRv6 locator routes would already exist by the
-		// time this function ever runs (see RouteMainAdd's identical
-		// ordering dependency on RouteMainAdd's own doc comment).
-		for _, sid := range []string{shardSID1, shardSID2} {
-			_, sidDst, err := net.ParseCIDR(sid + "/128")
-			if err != nil {
-				return fmt.Errorf("parse shard SID %q: %w", sid, err)
-			}
-			if err := netlink.RouteAdd(&netlink.Route{LinkIndex: dummy.Attrs().Index, Dst: sidDst}); err != nil {
-				return fmt.Errorf("add on-link route for shard SID %q: %w", sid, err)
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	shardSIDs := []net.IP{net.ParseIP(shardSID1), net.ParseIP(shardSID2)}
-
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		return EgressDefaultRouteAdd(table, shardSIDs)
-	})
-	if err != nil {
+	if err := EgressDefaultRouteAdd(table, shardSIDs); err != nil {
 		t.Fatalf("EgressDefaultRouteAdd(%v) = %v, want success", shardSIDs, err)
 	}
 
-	var installed *netlink.Route
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
-		if err != nil {
-			return err
-		}
-		for i := range routes {
-			if routes[i].Dst != nil && routes[i].Dst.String() == defaultRoutePrefixString {
-				installed = &routes[i]
-				return nil
-			}
-		}
-		return fmt.Errorf("no default route found in table %d", table)
-	})
+	entryTable, closer, err := egressroutemap.OpenPinnedEgressRouteTable(testPinDir)
 	if err != nil {
-		t.Fatalf("verify installed route: %v", err)
+		t.Fatalf("open pinned egress_route_table: %v", err)
 	}
-	if len(installed.MultiPath) != 0 {
-		t.Fatalf("installed default route has %d MultiPath nexthops, want 0 (single-path route)", len(installed.MultiPath))
+	defer func() { _ = closer.Close() }()
+
+	gotSID, ok, err := entryTable.Lookup(table, egressroutemap.DefaultPrefix)
+	if err != nil {
+		t.Fatalf("lookup default entry: %v", err)
 	}
-	if installed.Encap == nil {
-		t.Fatalf("installed default route has no Encap, want a SEG6 encap toward %s", shardSID1)
+	if !ok {
+		t.Fatal("no default entry installed")
+	}
+	if !gotSID.Equal(shardSID1) {
+		t.Errorf("installed default entry sid = %s, want %s (the first configured shard)", gotSID, shardSID1)
 	}
 
-	// Shell out to `ip -6 route` (real ground truth, the same tool this
-	// session's own live containerlab diagnostics already trusted over
-	// library/tcpdump artifacts) to confirm which shard SID the single
-	// nexthop actually encapsulates toward: the first resolvable one in
-	// shardSIDs order (shardSID1), never shardSID2.
-	var out []byte
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		var cmdErr error
-		out, cmdErr = exec.CommandContext(
-			context.Background(), "ip", "-6", "route", "show", "table", strconv.Itoa(table),
-		).CombinedOutput()
-		return cmdErr
-	})
-	if err != nil {
-		t.Fatalf("ip -6 route show table %d: %v (%s)", table, err, out)
-	}
-	want := "encap seg6 mode encap.red segs 1 [ " + shardSID1 + " ]"
-	if !strings.Contains(string(out), want) {
-		t.Errorf("ip -6 route show table %d = %q, want a nexthop containing %q", table, out, want)
-	}
-	if strings.Contains(string(out), shardSID2) {
-		t.Errorf("ip -6 route show table %d = %q, want no nexthop toward the second shard %q (single-path only)",
-			table, out, shardSID2)
-	}
-
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		return EgressDefaultRouteDel(table)
-	})
-	if err != nil {
+	if err := EgressDefaultRouteDel(table); err != nil {
 		t.Fatalf("EgressDefaultRouteDel(%d) = %v, want success", table, err)
 	}
-
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
-		if err != nil {
-			return err
-		}
-		for i := range routes {
-			if routes[i].Dst != nil && routes[i].Dst.String() == defaultRoutePrefixString {
-				return fmt.Errorf("default route still present in table %d after EgressDefaultRouteDel", table)
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("verify deleted route: %v", err)
+	if _, ok, err := entryTable.Lookup(table, egressroutemap.DefaultPrefix); err != nil {
+		t.Fatalf("lookup after delete: %v", err)
+	} else if ok {
+		t.Error("default entry still present after EgressDefaultRouteDel")
 	}
 }
 
-// TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds is the
-// regression test for a real bug found live: a shard node can never
-// resolve a route to its *own* advertised SID (GoBGP, like every BGP
-// implementation, never reflects a self-originated path back into that
-// same node's own received-path processing -- see this function's own
-// doc comment), so any tenant node that is also a configured shard
-// (this lab's own "reuse the site workers as shards" layout) always has
-// exactly one permanently-unresolvable entry in shardSIDs. An earlier
-// implementation aborted outright on the first unresolvable nexthop,
-// which meant *no default route at all* on every shard node -- confirmed
-// live: dfw-worker's own tenant pods failed CNI ADD outright with "no
-// route to gateway 2001:db8:ff01:1:e001:: (dfw's own shard SID): invalid
-// argument" even though sjc's and iad's shard SIDs resolved fine from
-// that same node. This test proves a mix of one resolvable and one
-// unresolvable shard SID still installs a route (skipping the
-// unresolvable one and using the resolvable one as the single nexthop),
-// not an error.
-func TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds(t *testing.T) {
+// TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress proves
+// ResolveNodeSourceAddress finds the primary global IPv6 address on
+// whichever interface carries the main-table IPv6 default route --
+// exactly the address the kernel's own source-address-selection rules
+// picked automatically for the SEG6 lwtunnel mechanism this replaces (see
+// this function's own doc comment).
+func TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress(t *testing.T) {
 	requireRoot(t)
 
 	const (
-		ifaceName       = "srv6mtest3"
-		ifaceAddr       = "2001:db8:5::1/64"
-		resolvableSID   = "2001:db8:ff02:1:e001::"
-		unresolvableSID = "2001:db8:ff01:1:e001::" // no route ever installed for this one
-		table           = 43
+		ifaceName = "srv6srctest0"
+		ifaceAddr = "2001:db8:7::2/64"
 	)
 
 	nsObj, err := ns.TempNetNS()
@@ -619,65 +520,51 @@ func TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds(t *testing.T) {
 		if err := netlink.AddrAdd(dummy, addr); err != nil {
 			return fmt.Errorf("add addr: %w", err)
 		}
-		_, sidDst, err := net.ParseCIDR(resolvableSID + "/128")
-		if err != nil {
-			return fmt.Errorf("parse shard SID: %w", err)
-		}
-		return netlink.RouteAdd(&netlink.Route{LinkIndex: dummy.Attrs().Index, Dst: sidDst})
+		return netlink.RouteReplace(&netlink.Route{
+			LinkIndex: dummy.Attrs().Index,
+			Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+		})
 	})
 	if err != nil {
 		t.Fatalf("setup: %v", err)
 	}
 
-	shardSIDs := []net.IP{net.ParseIP(unresolvableSID), net.ParseIP(resolvableSID)}
-
+	var got net.IP
 	err = nsObj.Do(func(_ ns.NetNS) error {
-		return EgressDefaultRouteAdd(table, shardSIDs)
+		var doErr error
+		got, doErr = ResolveNodeSourceAddress()
+		return doErr
 	})
 	if err != nil {
-		t.Fatalf("EgressDefaultRouteAdd(%v) = %v, want success with the resolvable shard used", shardSIDs, err)
+		t.Fatalf("ResolveNodeSourceAddress: %v", err)
 	}
 
-	err = nsObj.Do(func(_ ns.NetNS) error {
-		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{Table: table}, netlink.RT_FILTER_TABLE)
-		if err != nil {
-			return err
-		}
-		for i := range routes {
-			if routes[i].Dst == nil || routes[i].Dst.String() == defaultRoutePrefixString {
-				// The kernel/netlink read path collapses a single-nexthop
-				// RTA_MULTIPATH route back into plain Gw/Encap fields, not
-				// a one-element MultiPath slice (confirmed live against
-				// `ip -6 route show`, which does report the SEG6 encap
-				// correctly either way) -- count either shape as "one
-				// nexthop", matching what this shard-count assertion
-				// actually cares about.
-				nexthops := len(routes[i].MultiPath)
-				if nexthops == 0 && routes[i].Gw != nil && routes[i].Encap != nil {
-					nexthops = 1
-				}
-				if nexthops != 1 {
-					return fmt.Errorf("installed default route has %d nexthops, want exactly 1 (the resolvable shard)",
-						nexthops)
-				}
-				return nil
-			}
-		}
-		return fmt.Errorf("no default route found in table %d", table)
-	})
-	if err != nil {
-		t.Fatalf("verify installed route: %v", err)
+	want := net.ParseIP("2001:db8:7::2")
+	if !got.Equal(want) {
+		t.Errorf("ResolveNodeSourceAddress() = %s, want %s", got, want)
 	}
 }
 
-// TestEgressDefaultRouteAdd_AllShardsUnresolvableFails is
-// TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds's negative
-// counterpart: when *every* configured shard SID is unresolvable, there
-// is nothing to install a route with at all, and this must fail loudly
-// rather than silently install a route with zero nexthops.
-func TestEgressDefaultRouteAdd_AllShardsUnresolvableFails(t *testing.T) {
-	shardSIDs := []net.IP{net.ParseIP("2001:db8:ff01:1:e001::"), net.ParseIP("2001:db8:ff02:1:e001::")}
-	if err := EgressDefaultRouteAdd(44, shardSIDs); err == nil {
-		t.Errorf("EgressDefaultRouteAdd(%v) = nil error, want an error when no shard SID is resolvable", shardSIDs)
+// TestResolveNodeSourceAddress_NoDefaultRouteFailsLoudly covers the
+// no-main-table-default-route case (e.g. this function called before the
+// underlay eBGP session has converged) -- must fail with an actionable
+// error, not silently return an unspecified/nil address that
+// node_src_addr_table's own "all-zero means not configured" convention
+// would otherwise treat as a legitimate value.
+func TestResolveNodeSourceAddress_NoDefaultRouteFailsLoudly(t *testing.T) {
+	requireRoot(t)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		_, doErr := ResolveNodeSourceAddress()
+		return doErr
+	})
+	if err == nil {
+		t.Error("ResolveNodeSourceAddress() = nil error in a netns with no default route, want an error")
 	}
 }

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 )
@@ -485,19 +486,31 @@ func TestEgressDefaultRouteAdd_InstallsDefaultEntryForFirstShard(t *testing.T) {
 	}
 }
 
-// TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress proves
+// TestResolveNodeSourceAddress_ReturnsInterfaceAddress proves
 // ResolveNodeSourceAddress finds the primary global IPv6 address on
-// whichever interface carries the main-table IPv6 default route --
-// exactly the address the kernel's own source-address-selection rules
+// whichever interface attach.ResolveInterfaces names -- exactly the
+// address the kernel's own source-address-selection rules (RTA_PREFSRC)
 // picked automatically for the SEG6 lwtunnel mechanism this replaces (see
 // this function's own doc comment).
-func TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress(t *testing.T) {
+//
+// Uses config.EnvCNIEBPFInterfaces to pin attach.ResolveInterfaces at a
+// specific interface, rather than relying on a real default route --
+// found live in containerlab that guessing from the main-table default
+// route (an earlier version of this function's own approach) picks the
+// wrong interface entirely whenever the default route belongs to the
+// container/pod network rather than the SRv6 underlay (eth0 vs eth1 in
+// that lab's own topology), which is exactly the scenario this test's
+// own setup reproduces: ifaceName here deliberately has no default route
+// through it at all.
+func TestResolveNodeSourceAddress_ReturnsInterfaceAddress(t *testing.T) {
 	requireRoot(t)
 
 	const (
 		ifaceName = "srv6srctest0"
 		ifaceAddr = "2001:db8:7::2/64"
 	)
+
+	t.Setenv(config.EnvCNIEBPFInterfaces, ifaceName)
 
 	nsObj, err := ns.TempNetNS()
 	if err != nil {
@@ -517,13 +530,9 @@ func TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress(t *testing
 		if err != nil {
 			return fmt.Errorf("parse addr: %w", err)
 		}
-		if err := netlink.AddrAdd(dummy, addr); err != nil {
-			return fmt.Errorf("add addr: %w", err)
-		}
-		return netlink.RouteReplace(&netlink.Route{
-			LinkIndex: dummy.Attrs().Index,
-			Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
-		})
+		return netlink.AddrAdd(dummy, addr)
+		// Deliberately no default route added through this interface --
+		// see this test's own doc comment.
 	})
 	if err != nil {
 		t.Fatalf("setup: %v", err)
@@ -545,14 +554,18 @@ func TestResolveNodeSourceAddress_ReturnsDefaultRouteInterfaceAddress(t *testing
 	}
 }
 
-// TestResolveNodeSourceAddress_NoDefaultRouteFailsLoudly covers the
-// no-main-table-default-route case (e.g. this function called before the
-// underlay eBGP session has converged) -- must fail with an actionable
-// error, not silently return an unspecified/nil address that
-// node_src_addr_table's own "all-zero means not configured" convention
-// would otherwise treat as a legitimate value.
-func TestResolveNodeSourceAddress_NoDefaultRouteFailsLoudly(t *testing.T) {
+// TestResolveNodeSourceAddress_UnresolvableInterfaceFailsLoudly covers
+// attach.ResolveInterfaces itself failing (e.g. the configured interface
+// doesn't exist, or -- with no override set -- no default IPv6 route
+// exists yet to auto-detect from, such as before the underlay eBGP
+// session has converged) -- must fail with an actionable error, not
+// silently return an unspecified/nil address that node_src_addr_table's
+// own "all-zero means not configured" convention would otherwise treat
+// as a legitimate value.
+func TestResolveNodeSourceAddress_UnresolvableInterfaceFailsLoudly(t *testing.T) {
 	requireRoot(t)
+
+	t.Setenv(config.EnvCNIEBPFInterfaces, "srv6srctest-does-not-exist")
 
 	nsObj, err := ns.TempNetNS()
 	if err != nil {
@@ -565,6 +578,6 @@ func TestResolveNodeSourceAddress_NoDefaultRouteFailsLoudly(t *testing.T) {
 		return doErr
 	})
 	if err == nil {
-		t.Error("ResolveNodeSourceAddress() = nil error in a netns with no default route, want an error")
+		t.Error("ResolveNodeSourceAddress() = nil error for a nonexistent interface, want an error")
 	}
 }

--- a/internal/plumbing/srv6/egress_test.go
+++ b/internal/plumbing/srv6/egress_test.go
@@ -424,14 +424,17 @@ func TestEgressDefaultRouteAddRejectsUnspecifiedShardSID(t *testing.T) {
 	}
 }
 
-// TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards proves the
-// installed ::/0 route fans out across every configured shard SID as a
-// separate SEG6-encapsulating nexthop, and that EgressDefaultRouteDel
-// removes it cleanly -- the mechanism that finally gives a tenant VRF
-// somewhere to send a packet with no more specific route, closing the gap
-// nat66.c's own shard-receive side was always able to answer but nothing
-// ever fed traffic into (see this function's own doc comment).
-func TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards(t *testing.T) {
+// TestEgressDefaultRouteAdd_InstallsSinglePathToFirstResolvableShard
+// proves the installed ::/0 route is a single SEG6-encapsulating nexthop
+// toward the first resolvable configured shard SID (not a kernel
+// multipath route fanned out across all of them -- an earlier version of
+// this function did exactly that, and it triggered a real, confirmed
+// kernel routing loop: see EgressDefaultRouteAdd's own doc comment), and
+// that EgressDefaultRouteDel removes it cleanly -- the mechanism that
+// finally gives a tenant VRF somewhere to send a packet with no more
+// specific route, closing the gap nat66.c's own shard-receive side was
+// always able to answer but nothing ever fed traffic into.
+func TestEgressDefaultRouteAdd_InstallsSinglePathToFirstResolvableShard(t *testing.T) {
 	requireRoot(t)
 
 	const (
@@ -511,19 +514,18 @@ func TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify installed route: %v", err)
 	}
-	if len(installed.MultiPath) != len(shardSIDs) {
-		t.Fatalf("installed default route has %d nexthops, want %d", len(installed.MultiPath), len(shardSIDs))
+	if len(installed.MultiPath) != 0 {
+		t.Fatalf("installed default route has %d MultiPath nexthops, want 0 (single-path route)", len(installed.MultiPath))
+	}
+	if installed.Encap == nil {
+		t.Fatalf("installed default route has no Encap, want a SEG6 encap toward %s", shardSID1)
 	}
 
-	// Per-nexthop RTA_ENCAP within RTA_MULTIPATH round-trips through the
-	// kernel correctly (confirmed live against `ip -6 route show`) but the
-	// vendored netlink library's own RouteListFiltered doesn't decode it
-	// back into NexthopInfo.Encap -- every nexthop above reads back
-	// Encap == nil regardless of what was actually installed. Shell out to
-	// `ip -6 route` (real ground truth, the same tool this session's own
-	// live containerlab diagnostics already trusted over library/tcpdump
-	// artifacts) rather than asserting against a field this library can't
-	// populate.
+	// Shell out to `ip -6 route` (real ground truth, the same tool this
+	// session's own live containerlab diagnostics already trusted over
+	// library/tcpdump artifacts) to confirm which shard SID the single
+	// nexthop actually encapsulates toward: the first resolvable one in
+	// shardSIDs order (shardSID1), never shardSID2.
 	var out []byte
 	err = nsObj.Do(func(_ ns.NetNS) error {
 		var cmdErr error
@@ -535,11 +537,13 @@ func TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ip -6 route show table %d: %v (%s)", table, err, out)
 	}
-	for _, sid := range shardSIDs {
-		want := "encap seg6 mode encap.red segs 1 [ " + sid.String() + " ]"
-		if !strings.Contains(string(out), want) {
-			t.Errorf("ip -6 route show table %d = %q, want a nexthop containing %q", table, out, want)
-		}
+	want := "encap seg6 mode encap.red segs 1 [ " + shardSID1 + " ]"
+	if !strings.Contains(string(out), want) {
+		t.Errorf("ip -6 route show table %d = %q, want a nexthop containing %q", table, out, want)
+	}
+	if strings.Contains(string(out), shardSID2) {
+		t.Errorf("ip -6 route show table %d = %q, want no nexthop toward the second shard %q (single-path only)",
+			table, out, shardSID2)
 	}
 
 	err = nsObj.Do(func(_ ns.NetNS) error {
@@ -573,15 +577,16 @@ func TestEgressDefaultRouteAdd_InstallsMultipathAcrossShards(t *testing.T) {
 // same node's own received-path processing -- see this function's own
 // doc comment), so any tenant node that is also a configured shard
 // (this lab's own "reuse the site workers as shards" layout) always has
-// exactly one permanently-unresolvable entry in shardSIDs. The original
-// implementation aborted the entire multipath route on the first
-// unresolvable nexthop, which meant *no default route at all* on every
-// shard node -- confirmed live: dfw-worker's own tenant pods failed CNI
-// ADD outright with "no route to gateway 2001:db8:ff01:1:e001:: (dfw's
-// own shard SID): invalid argument" even though sjc's and iad's shard
-// SIDs resolved fine from that same node. This test proves a mix of one
-// resolvable and one unresolvable shard SID still installs a route (with
-// only the resolvable one as a nexthop), not an error.
+// exactly one permanently-unresolvable entry in shardSIDs. An earlier
+// implementation aborted outright on the first unresolvable nexthop,
+// which meant *no default route at all* on every shard node -- confirmed
+// live: dfw-worker's own tenant pods failed CNI ADD outright with "no
+// route to gateway 2001:db8:ff01:1:e001:: (dfw's own shard SID): invalid
+// argument" even though sjc's and iad's shard SIDs resolved fine from
+// that same node. This test proves a mix of one resolvable and one
+// unresolvable shard SID still installs a route (skipping the
+// unresolvable one and using the resolvable one as the single nexthop),
+// not an error.
 func TestEgressDefaultRouteAdd_SkipsUnresolvableShardButSucceeds(t *testing.T) {
 	requireRoot(t)
 


### PR DESCRIPTION
## Summary

The netlink SEG6 routes from the previous PR don't scale past a handful of shards and can't resolve their own L2 next hop reliably. This replaces them with a TC-BPF extension on `usid_egress`: routes are now programmed directly into an eBPF map, with the L2 next hop precomputed in Go at registration time instead of resolved per packet. Also fixes `usid_egress` never being attached anywhere, a gap the netlink path had been masking.

## Test plan

- [ ] `task test`
- [ ] `task test:e2e`