### PR TITLE
fix(ci): harden apt-get against mirror hangs in eBPF/vrf-module steps

### DIFF
--- a/.github/actions/install-ebpf-deps/action.yaml
+++ b/.github/actions/install-ebpf-deps/action.yaml
@@ -25,5 +25,12 @@ runs:
     - name: Install clang/llvm/linux-libc-dev
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-18 llvm-18 linux-libc-dev
+        # -o Acquire::Retries/::*::Timeout: bare `apt-get update` has no
+        # per-request timeout, so a stalled connection to GitHub's default
+        # regional mirror (azure.archive.ubuntu.com has been observed
+        # hanging outright) blocks until the job's own timeout-minutes
+        # finally kills it -- burning the whole budget on jobs #424/#425
+        # both hit. These bound each attempt and retry instead, so a bad
+        # mirror fails in seconds rather than minutes.
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y clang-18 llvm-18 linux-libc-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,9 +134,13 @@ jobs:
         # same fix and same reasoning as scripts/ci.sh's e2etest case,
         # which needs this for the same underlying reason (SEG6Local
         # END.DT46's VRFTABLE flag) and already does this exact install.
+        #
+        # -o Acquire::Retries/::*::Timeout: see install-ebpf-deps' own
+        # identical flags -- without them this step hung the whole job
+        # against a stalled mirror until timeout-minutes killed it (#425).
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update -qq
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
           sudo modprobe vrf
 
       - name: Install eBPF build dependencies

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,11 +44,15 @@ case "$COMMAND" in
 
     if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
       echo "--- Loading kernel modules required by galactic"
-      sudo apt-get update -qq
+      # -o Acquire::Retries/::*::Timeout: bare `apt-get update` has no
+      # per-request timeout, so a stalled mirror connection hangs until the
+      # job's own timeout-minutes kills it -- see ci.yaml's identical flags
+      # on this same install for the incident that motivated them (#425).
+      sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update -qq
       # Pin to the running kernel so modprobe finds the modules. The unversioned
       # meta-package may pull a newer kernel's modules than the one the runner is
       # actually executing, which causes modprobe to fail.
-      sudo apt-get install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
+      sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install -y --no-install-recommends "linux-modules-extra-$(uname -r)"
     fi
     sudo modprobe vrf
 


### PR DESCRIPTION
## Summary

Both #424 and #425 hit the same CI failure in the same run window, on two otherwise-unrelated branches: an `apt-get update`/`apt-get install` step hung until the job's `timeout-minutes` killed it, rather than failing fast or retrying.

- #424: the E2E Tests job's `install-ebpf-deps` composite action (clang/llvm/linux-libc-dev) hung ~25 minutes against `azure.archive.ubuntu.com` before falling back to `archive.ubuntu.com`, then got cancelled at the job's 25-minute timeout with `apt-get install` never completing.
- #425: the `Unit Tests (root)` job's "Load vrf kernel module" step (`linux-modules-extra-$(uname -r)`) hung on `apt-get update -qq` for the full 15-minute timeout with no output at all (suppressed by `-qq`).

Root cause: none of this repo's three `apt-get` call sites set any retry/timeout options, so a single unreachable/slow mirror blocks indefinitely instead of failing over quickly.

## Fix

Add `-o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10` to every CI `apt-get update`/`apt-get install` invocation:

- `.github/actions/install-ebpf-deps/action.yaml` (clang/llvm/linux-libc-dev — used by every job)
- `.github/workflows/ci.yaml`'s `test-unit-root` job (vrf kernel module)
- `scripts/ci.sh`'s `e2etest` case (same vrf kernel module install, for local/CI parity)

This bounds each mirror attempt to ~10s and retries up to 3 times, so a bad mirror fails in well under a minute instead of consuming the entire job timeout.

## Test plan

- [x] YAML/shell syntax validated (`python3 -c "import yaml; ..."`, `bash -n scripts/ci.sh`)
- [x] `yamlfmt -lint` clean
- [ ] Confirm CI passes on this PR itself, then re-run the affected jobs on #424/#425

🤖 Generated with [Claude Code](https://claude.com/claude-code)