### PR TITLE
feat: prefix-preserving dual-stack IPAM for pre-decided addresses

### DIFF
--- a/docs/cni/configuration.md
+++ b/docs/cni/configuration.md
@@ -223,27 +223,61 @@ is decided entirely by which of the fields below are present.
 | Field              | Required | Type        | Description                                                                                                                                                                                                                                                                        |
 | ------------------ | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`             | **Yes**  | `string`    | Names the delegated CNI IPAM binary. Always `"galactic-ipam"` today.                                                                                                                                                                                                               |
-| `static_ip`        | No       | `string`    | A single IPv6 address to assign. Presence selects the static allocation path (below); mutually exclusive in practice with the subnet fields.                                                                                                                                       |
+| `addresses`        | No       | `[]Address` | Addresses decided outside `galactic-ipam` (`address`, `gateway`). Presence selects the [addresses path](#ipam-addresses) below, which assigns exactly these — both families, prefix length preserved — and allocates, stores and releases nothing. Rejected if combined with `static_ip`/`ipv6_subnet`/`ipv4_subnet`. |
+| `static_ip`        | No       | `string`    | A single IPv6 address to assign, with a `/64` mask and no IPv4. The legacy single-address path, superseded by `addresses`; mutually exclusive in practice with the subnet fields.                                                                                                  |
 | `ipv6_subnet`      | No       | `string`    | Region IPv6 pool CIDR; endpoints allocate a `/96` from it by default.                                                                                                                                                                                                              |
 | `ipv4_subnet`      | No       | `string`    | Site IPv4 pool CIDR; endpoints allocate a `/32` host address from it.                                                                                                                                                                                                              |
 | `address_families` | No       | `[]string`  | Restricts allocation to the listed families, narrowing whichever of `ipv6_subnet`/`ipv4_subnet` are configured on this attachment (never widens beyond them). Omit for no restriction — allocate from every pool configured. Rejects a config that excludes every configured pool. |
-| `routes`           | No       | `[]Route`   | Declared on the `IPAM` struct (`dst`, `gw`) but not read by any current allocation path — vestigial.                                                                                                                                                                               |
-| `addresses`        | No       | `[]Address` | Declared on the `IPAM` struct (`address`) but not read by any current allocation path — vestigial.                                                                                                                                                                                 |
+| `routes`           | No       | `[]Route`   | Declared on the `IPAM` struct (`dst`, `gw`) but not read by any current allocation path — vestigial. Every path publishes a default route per configured family instead.                                                                                                           |
 
 Whether IPAM runs at all is decided **solely** by `"ipam"` block presence in
 the master plugin's own stanza — no environment variable can trigger or
 suppress that (see [`GALACTIC_IPAM_ENABLE_LOCAL_IPAM`](#galactic_ipam_enable_local_ipam)
 above, which only fills a default when the block is present but
-under-specified). Once delegated to, `static_ip` presence selects the static
-path; otherwise `ipv6_subnet`/`ipv4_subnet` (either alone, or both) select the
-pool path. See `internal/cniipam`'s package doc comment for the full explicit
-contract.
+under-specified). Once delegated to, `addresses` presence selects the
+addresses path; otherwise `static_ip` presence selects the static path;
+otherwise `ipv6_subnet`/`ipv4_subnet` (either alone, or both) select the pool
+path. Mixing `addresses` with any of the others is a config error, not a
+precedence question. See `internal/cniipam`'s package doc comment for the full
+explicit contract.
+
+### IPAM `addresses`
+
+The path for addresses this attachment did not choose. Datum's networking
+layer decides an interface's addresses before the workload is scheduled — an
+IPv6 endpoint block (typically a `/96`), optionally an IPv4 `/32`, each with a
+gateway — and this path configures exactly those:
+
+- **Prefix length is preserved as given.** A `/96` stays a `/96`; nothing is
+  re-masked. This is the difference from `static_ip`, which forces `/64`.
+- **Both families.** At most one address per family, either alone or both.
+- **Gateways are honoured** per address, and must be the same family as the
+  address they accompany.
+- **Nothing is allocated and nothing is persisted**, so no pool CIDR is
+  involved and `address_families` has no effect (as with `static_ip`).
+
+Each entry takes:
+
+| Field     | Required | Type     | Description                                                                                             |
+| --------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `address` | **Yes**  | `string` | The address in CIDR form. An explicit prefix length is required. An IPv4 entry must be a `/32` — the data plane models an IPv4 endpoint as a host route. |
+| `gateway` | No       | `string` | Next-hop for this address's family. Need not be inside the address's own prefix.                        |
+
+`galactic-ipam` keeps no record of these addresses — the system that decided
+them is their source of truth. As with `static_ip`, they are validated once at
+ADD and never stored, so DEL has nothing to release and CHECK always passes
+(there is nothing on-node for a delegated IPAM plugin to verify: the master
+plugin owns interface configuration, and on the tap path the guest configures
+itself). A retried ADD is idempotent because nothing is written. Only the pool
+path writes allocation state to `internal/cni/ipam.DefaultLockDir`.
 
 ### IPAM `static_ip`
 
 Validates and assigns a single IPv6 address with a `/64` mask. No IPv4 address
 is ever allocated alongside it — static IPAM is a single fixed address, not a
-dual-stack pool.
+dual-stack pool. Use [`addresses`](#ipam-addresses) instead for an address
+decided upstream: it preserves the prefix length it was given and supports
+both families.
 
 ### Pool IPAM via `ipv6_subnet`/`ipv4_subnet`
 
@@ -402,6 +436,39 @@ the IPv6 `/96` and IPv4 `/32` prefixes.
 
 `ipv4_subnet` alone opts the config into pool IPAM with no IPv6 allocation at
 all; the resulting `BGPAdvertisement` carries only the IPv4 `/32` prefix.
+
+### Pre-decided dual-stack addresses (`addresses`)
+
+The shape a `NetworkAttachmentDefinition` takes when the platform has already
+allocated this interface's addresses:
+
+```json
+{
+  "cniVersion": "1.0.0",
+  "name": "vpc60",
+  "plugins": [
+    {
+      "type": "galactic-tap",
+      "vpc": "60",
+      "vpcattachment": "60",
+      "namespace": "galactic-system",
+      "ipam": {
+        "type": "galactic-ipam",
+        "addresses": [
+          { "address": "fd20:60:ff03:0:1::/96", "gateway": "fd20:60:ff03::1" },
+          { "address": "203.0.113.17/32", "gateway": "203.0.113.1" }
+        ]
+      }
+    },
+    { "type": "galactic-bgp", "vpc": "60", "vpcattachment": "60", "namespace": "galactic-system" }
+  ]
+}
+```
+
+The guest is configured with `fd20:60:ff03:0:1::/96` and `203.0.113.17/32` —
+the exact prefixes given, not a re-derived `/64` and not a pool allocation —
+and the resulting `BGPAdvertisement` carries both. Drop either entry for a
+single-family attachment.
 
 ### Static IP configuration
 

--- a/internal/cniipam/allocate.go
+++ b/internal/cniipam/allocate.go
@@ -25,14 +25,55 @@ const localIPAMDefaultPool = "fd00:10:ff01::/64"
 // touch the real production path.
 var lockDir = ipam.DefaultLockDir
 
-// allocate allocates addresses for the given container according to conf's
-// mode: presence of StaticIP selects the static path; otherwise the pool
-// path (either family alone, or both).
+// allocate assigns addresses for the given container according to conf's
+// mode: presence of Addresses selects the pre-decided addresses path,
+// presence of StaticIP the legacy static path; otherwise the pool path
+// (either family alone, or both).
 func allocate(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
-	if conf.StaticIP != "" {
+	switch {
+	case len(conf.Addresses) > 0:
+		return allocateAddresses(args, conf)
+	case conf.StaticIP != "":
 		return allocateStatic(args, conf)
+	default:
+		return allocatePool(args, conf)
 	}
-	return allocatePool(args, conf)
+}
+
+// allocateAddresses assigns the addresses the config already carries, exactly
+// as given — prefix length included, both families, gateways honored. Nothing
+// is allocated and nothing is persisted: the addresses belong to whoever
+// decided them.
+func allocateAddresses(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
+	parsed, err := parseAddresses(conf.Addresses)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("IPAM: assigned pre-decided addresses", "containerID", args.ContainerID,
+		"ipv6Subnet", parsed.ipv6, "ipv6Gateway", parsed.ipv6Gateway,
+		"ipv4Address", parsed.ipv4, "ipv4Gateway", parsed.ipv4Gateway)
+
+	return &IPAMResult{
+		IPv6Subnet:  parsed.ipv6,
+		IPv6Gateway: parsed.ipv6Gateway,
+		IPv4Address: parsed.ipv4,
+		IPv4Gateway: parsed.ipv4Gateway,
+		Routes:      defaultRoutes(parsed.ipv6 != nil, parsed.ipv4 != nil),
+	}, nil
+}
+
+// defaultRoutes returns the per-family default route each configured family
+// gets, the same set the pool path publishes.
+func defaultRoutes(ipv6, ipv4 bool) []*net.IPNet {
+	var routes []*net.IPNet
+	if ipv6 {
+		routes = append(routes, &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)})
+	}
+	if ipv4 {
+		routes = append(routes, &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)})
+	}
+	return routes
 }
 
 // allocateStatic validates and returns the pre-assigned static IPv6 address
@@ -73,13 +114,7 @@ func allocatePool(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 		return nil, fmt.Errorf("allocate dual-stack addresses: %w", err)
 	}
 
-	var routes []*net.IPNet
-	if res.IPv6Subnet != nil {
-		routes = append(routes, &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)})
-	}
-	if res.IPv4Address != nil {
-		routes = append(routes, &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)})
-	}
+	routes := defaultRoutes(res.IPv6Subnet != nil, res.IPv4Address != nil)
 
 	slog.Debug("IPAM: allocated", "containerID", args.ContainerID,
 		"ipv6Subnet", res.IPv6Subnet, "ipv6Gateway", res.IPv6Gateway,
@@ -119,6 +154,11 @@ func effectiveIPv6Subnet(conf *IPAM) string {
 // other — each call is independent and silently no-ops if nothing is
 // found.
 func deallocate(containerID string, conf *IPAM) {
+	if len(conf.Addresses) > 0 {
+		// Externally decided addresses were never allocated here, so there is nothing to release.
+		return
+	}
+
 	if conf.StaticIP != "" {
 		// Static allocations don't need deallocation.
 		return
@@ -146,13 +186,13 @@ func deallocate(containerID string, conf *IPAM) {
 }
 
 // checkAllocation verifies that containerID still holds an allocation
-// against every family conf configures — used by CHECK. A static
-// allocation has nothing persisted to check (it's validated once, at ADD,
-// and never stored), so it always passes. Returns one error per
-// missing/unreachable family; nil means every configured family checked
-// out.
+// against every family conf configures — used by CHECK. An externally
+// decided address (addresses, static_ip) has nothing persisted to check
+// (it's validated once, at ADD, and never stored), so it always passes.
+// Returns one error per missing/unreachable family; nil means every
+// configured family checked out.
 func checkAllocation(containerID string, conf *IPAM) []error {
-	if conf.StaticIP != "" {
+	if len(conf.Addresses) > 0 || conf.StaticIP != "" {
 		return nil
 	}
 

--- a/internal/cniipam/allocate_test.go
+++ b/internal/cniipam/allocate_test.go
@@ -7,6 +7,7 @@ package cniipam
 import (
 	"fmt"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -159,5 +160,148 @@ func TestCheckAllocationUnknownContainer(t *testing.T) {
 	errs := checkAllocation("no-such-container", conf)
 	if len(errs) != 2 {
 		t.Fatalf("checkAllocation for unknown container = %v, want 2 errors (one per family)", errs)
+	}
+}
+
+const (
+	testEndpointIPv6 = "fd20:60:ff03:0:1::/96"
+	testGatewayIPv6  = "fd20:60:ff03::1"
+	testEndpointIPv4 = "203.0.113.17/32"
+	testGatewayIPv4  = "203.0.113.1"
+)
+
+func dualStackAddresses() *IPAM {
+	return &IPAM{
+		Type: testIPAMType,
+		Addresses: []Address{
+			{Address: testEndpointIPv6, Gateway: testGatewayIPv6},
+			{Address: testEndpointIPv4, Gateway: testGatewayIPv4},
+		},
+	}
+}
+
+// TestAllocateAddressesPreservesPrefixLength is the whole point of this path:
+// an endpoint block decided upstream as a /96 must stay a /96, where the
+// legacy static_ip path forced a /64.
+func TestAllocateAddressesPreservesPrefixLength(t *testing.T) {
+	withTempLockDir(t)
+	res, err := allocate(&skel.CmdArgs{ContainerID: testContainerID}, &IPAM{
+		Type:      testIPAMType,
+		Addresses: []Address{{Address: testEndpointIPv6, Gateway: testGatewayIPv6}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.IPv6Subnet.String(); got != testEndpointIPv6 {
+		t.Errorf("IPv6Subnet = %q, want %q", got, testEndpointIPv6)
+	}
+	if !res.IPv6Gateway.Equal(net.ParseIP(testGatewayIPv6)) {
+		t.Errorf("IPv6Gateway = %v, want %s", res.IPv6Gateway, testGatewayIPv6)
+	}
+	if res.IPv4Address != nil {
+		t.Errorf("IPv4Address = %v, want nil for an IPv6-only addresses config", res.IPv4Address)
+	}
+	if len(res.Routes) != 1 {
+		t.Errorf("Routes = %v, want only the IPv6 default route", res.Routes)
+	}
+}
+
+func TestAllocateAddressesDualStack(t *testing.T) {
+	withTempLockDir(t)
+	res, err := allocate(&skel.CmdArgs{ContainerID: testContainerID}, dualStackAddresses())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := res.IPv6Subnet.String(); got != testEndpointIPv6 {
+		t.Errorf("IPv6Subnet = %q, want %q", got, testEndpointIPv6)
+	}
+	if !res.IPv4Address.Equal(net.ParseIP("203.0.113.17")) {
+		t.Errorf("IPv4Address = %v, want 203.0.113.17", res.IPv4Address)
+	}
+	if !res.IPv4Gateway.Equal(net.ParseIP(testGatewayIPv4)) {
+		t.Errorf("IPv4Gateway = %v, want %s", res.IPv4Gateway, testGatewayIPv4)
+	}
+	if len(res.Routes) != 2 {
+		t.Errorf("Routes = %v, want one default route per family", res.Routes)
+	}
+}
+
+func TestAllocateAddressesIPv4Only(t *testing.T) {
+	withTempLockDir(t)
+	res, err := allocate(&skel.CmdArgs{ContainerID: testContainerID}, &IPAM{
+		Type:      testIPAMType,
+		Addresses: []Address{{Address: testEndpointIPv4, Gateway: testGatewayIPv4}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IPv6Subnet != nil {
+		t.Errorf("IPv6Subnet = %v, want nil for an IPv4-only addresses config", res.IPv6Subnet)
+	}
+	if res.IPv4Address == nil || !res.IPv4Address.Equal(net.ParseIP("203.0.113.17")) {
+		t.Errorf("IPv4Address = %v, want 203.0.113.17", res.IPv4Address)
+	}
+}
+
+// TestAllocateAddressesRetriedADDIsIdempotent covers a runtime retrying ADD
+// for the same container: nothing is persisted, so every attempt returns the
+// same assignment.
+func TestAllocateAddressesRetriedADDIsIdempotent(t *testing.T) {
+	withTempLockDir(t)
+	args := &skel.CmdArgs{ContainerID: testContainerID}
+	first, err := allocate(args, dualStackAddresses())
+	if err != nil {
+		t.Fatalf("first ADD: %v", err)
+	}
+	second, err := allocate(args, dualStackAddresses())
+	if err != nil {
+		t.Fatalf("retried ADD: %v", err)
+	}
+	if first.IPv6Subnet.String() != second.IPv6Subnet.String() || !first.IPv4Address.Equal(second.IPv4Address) {
+		t.Errorf("retried ADD returned %v/%v, want the first attempt's %v/%v",
+			second.IPv6Subnet, second.IPv4Address, first.IPv6Subnet, first.IPv4Address)
+	}
+	if entries, err := os.ReadDir(lockDir); err != nil || len(entries) != 0 {
+		t.Errorf("lock dir holds %v (err %v), want nothing persisted for pre-decided addresses", entries, err)
+	}
+}
+
+// TestAddressesDeallocateAndCheckAreNoops matches the static_ip path: nothing
+// was allocated, so DEL has nothing to release and CHECK has nothing to
+// verify.
+func TestAddressesDeallocateAndCheckAreNoops(t *testing.T) {
+	withTempLockDir(t)
+	conf := dualStackAddresses()
+	if _, err := allocate(&skel.CmdArgs{ContainerID: testContainerID}, conf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	deallocate(testContainerID, conf)
+
+	if errs := checkAllocation(testContainerID, conf); len(errs) > 0 {
+		t.Errorf("checkAllocation = %v, want nil (nothing is stored to check)", errs)
+	}
+}
+
+func TestParseAddressesRejectsBadConfigs(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []Address
+	}{
+		{"no prefix length", []Address{{Address: "fd20:60:ff03::5"}}},
+		{"unparseable address", []Address{{Address: "not-an-address/96"}}},
+		{"IPv4 that is not a /32", []Address{{Address: "203.0.113.0/24"}}},
+		{"two IPv6 addresses", []Address{{Address: testEndpointIPv6}, {Address: "fd20:60:ff03:0:2::/96"}}},
+		{"two IPv4 addresses", []Address{{Address: testEndpointIPv4}, {Address: "203.0.113.18/32"}}},
+		{"gateway of the wrong family", []Address{{Address: testEndpointIPv6, Gateway: testGatewayIPv4}}},
+		{"unparseable gateway", []Address{{Address: testEndpointIPv6, Gateway: "nope"}}},
+		{"empty", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseAddresses(tt.addresses); err == nil {
+				t.Errorf("parseAddresses(%v) = nil error, want a config error", tt.addresses)
+			}
+		})
 	}
 }

--- a/internal/cniipam/config.go
+++ b/internal/cniipam/config.go
@@ -47,6 +47,12 @@ func parseConf(data []byte) (*pluginConf, error) {
 		return nil, &types.Error{Code: 7, Msg: "ipam block is required"}
 	}
 
+	if len(conf.IPAM.Addresses) > 0 {
+		if err := validateAddressesMode(conf.IPAM); err != nil {
+			return nil, err
+		}
+	}
+
 	if conf.IPAM.IPv6Subnet != "" {
 		if err := validateIPv6Subnet(conf.IPAM.IPv6Subnet); err != nil {
 			return nil, err
@@ -62,7 +68,8 @@ func parseConf(data []byte) (*pluginConf, error) {
 	// neither a static address nor a pool CIDR for either family. Cannot
 	// manufacture an ipam block out of thin air — that decision already
 	// happened in the master plugin, before this process was even execed.
-	if conf.IPAM.StaticIP == "" && conf.IPAM.IPv6Subnet == "" && conf.IPAM.IPv4Subnet == "" {
+	if len(conf.IPAM.Addresses) == 0 && conf.IPAM.StaticIP == "" &&
+		conf.IPAM.IPv6Subnet == "" && conf.IPAM.IPv4Subnet == "" {
 		if config.IPAMGetEnableLocalIPAM() {
 			conf.IPAM.IPv6Subnet = localIPAMDefaultPool
 		}
@@ -89,10 +96,10 @@ func parseConf(data []byte) (*pluginConf, error) {
 			}
 		}
 
-		// Meaningless for the single-address static path — allocate picks
-		// that path on static_ip presence alone, unconditionally, regardless
-		// of what else is configured.
-		if conf.IPAM.StaticIP == "" {
+		// Meaningless for the paths that carry addresses they were given
+		// rather than allocating: both are selected on their own field's
+		// presence, regardless of what else is configured.
+		if conf.IPAM.StaticIP == "" && len(conf.IPAM.Addresses) == 0 {
 			if !wantIPv6 {
 				conf.IPAM.IPv6Subnet = ""
 			}
@@ -109,6 +116,106 @@ func parseConf(data []byte) (*pluginConf, error) {
 	}
 
 	return conf, nil
+}
+
+// parsedAddresses is the addresses path's config, validated and parsed:
+// at most one address per family, each keeping the exact prefix length it
+// was given.
+type parsedAddresses struct {
+	ipv6        *net.IPNet
+	ipv6Gateway net.IP
+	ipv4        net.IP
+	ipv4Gateway net.IP
+}
+
+// validateAddressesMode rejects a config that pairs addresses with another
+// mode's fields, so mode selection never has to guess.
+func validateAddressesMode(conf *IPAM) error {
+	for field, set := range map[string]bool{
+		"static_ip":   conf.StaticIP != "",
+		"ipv6_subnet": conf.IPv6Subnet != "",
+		"ipv4_subnet": conf.IPv4Subnet != "",
+	} {
+		if set {
+			return &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"ipam.addresses cannot be combined with ipam.%s: addresses assigns "+
+					"pre-decided addresses, the other fields allocate", field),
+			}
+		}
+	}
+	_, err := parseAddresses(conf.Addresses)
+	return err
+}
+
+// parseAddresses validates and parses the addresses block. Every address
+// must carry an explicit prefix length, which is preserved exactly: an
+// endpoint block decided upstream as a /96 stays a /96.
+func parseAddresses(addresses []Address) (*parsedAddresses, error) {
+	parsed := &parsedAddresses{}
+	for _, addr := range addresses {
+		ip, cidr, err := net.ParseCIDR(addr.Address)
+		if err != nil {
+			return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+				"invalid CIDR value for field 'ipam.addresses[].address': %q "+
+					"(an explicit prefix length is required)", sanitizeForError(addr.Address)),
+			}
+		}
+		gateway, err := parseAddressGateway(addr, ip)
+		if err != nil {
+			return nil, err
+		}
+
+		prefixLen, _ := cidr.Mask.Size()
+		if ip.To4() != nil {
+			if parsed.ipv4 != nil {
+				return nil, &types.Error{Code: 7, Msg: "ipam.addresses carries more than one IPv4 address"}
+			}
+			if prefixLen != maxIPv4SubnetPrefixLen {
+				return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+					"ipam.addresses IPv4 entry %q must be a /%d: the data plane models an IPv4 "+
+						"endpoint as a host route", sanitizeForError(addr.Address), maxIPv4SubnetPrefixLen),
+				}
+			}
+			parsed.ipv4 = ip
+			parsed.ipv4Gateway = gateway
+			continue
+		}
+
+		if parsed.ipv6 != nil {
+			return nil, &types.Error{Code: 7, Msg: "ipam.addresses carries more than one IPv6 address"}
+		}
+		parsed.ipv6 = &net.IPNet{IP: ip.To16(), Mask: cidr.Mask}
+		parsed.ipv6Gateway = gateway
+	}
+
+	if parsed.ipv6 == nil && parsed.ipv4 == nil {
+		return nil, &types.Error{Code: 7, Msg: "ipam.addresses is present but empty"}
+	}
+	return parsed, nil
+}
+
+// parseAddressGateway validates an entry's gateway against its own address:
+// a gateway of the other family is a config error, not a silent drop.
+func parseAddressGateway(addr Address, ip net.IP) (net.IP, error) {
+	if addr.Gateway == "" {
+		return nil, nil
+	}
+	gateway := net.ParseIP(addr.Gateway)
+	if gateway == nil {
+		return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+			"invalid IP for field 'ipam.addresses[].gateway': %q", sanitizeForError(addr.Gateway)),
+		}
+	}
+	if (gateway.To4() != nil) != (ip.To4() != nil) {
+		return nil, &types.Error{Code: 7, Msg: fmt.Sprintf(
+			"ipam.addresses gateway %q is not the same address family as %q",
+			sanitizeForError(addr.Gateway), sanitizeForError(addr.Address)),
+		}
+	}
+	if gateway.To4() != nil {
+		return gateway.To4(), nil
+	}
+	return gateway.To16(), nil
 }
 
 func validateIPv6Subnet(subnet string) error {

--- a/internal/cniipam/config_test.go
+++ b/internal/cniipam/config_test.go
@@ -227,3 +227,67 @@ func TestParseStatusConf(t *testing.T) {
 		t.Error("expected error for missing cniVersion, got nil")
 	}
 }
+
+// addressesJSON is the dual-stack addresses block used by the cases below.
+const addressesJSON = `"addresses":[` +
+	`{"address":"fd20:60:ff03:0:1::/96","gateway":"fd20:60:ff03::1"},` +
+	`{"address":"203.0.113.17/32","gateway":"203.0.113.1"}]`
+
+func TestParseConfAddresses(t *testing.T) {
+	conf, err := parseConf([]byte(confJSON(fmt.Sprintf(`"type":%q,%s`, testIPAMType, addressesJSON))))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conf.IPAM.Addresses) != 2 {
+		t.Fatalf("Addresses = %v, want both families", conf.IPAM.Addresses)
+	}
+	if conf.IPAM.IPv6Subnet != "" || conf.IPAM.IPv4Subnet != "" {
+		t.Errorf("IPv6Subnet/IPv4Subnet = %q/%q, want both empty (the addresses path allocates nothing)",
+			conf.IPAM.IPv6Subnet, conf.IPAM.IPv4Subnet)
+	}
+}
+
+// TestParseConfAddressesDefaultFillerDoesNotApply guards against the local
+// IPAM default pool being filled in behind a config that already carries its
+// own addresses.
+func TestParseConfAddressesDefaultFillerDoesNotApply(t *testing.T) {
+	t.Setenv("GALACTIC_IPAM_ENABLE_LOCAL_IPAM", "true")
+
+	conf, err := parseConf([]byte(confJSON(fmt.Sprintf(`"type":%q,%s`, testIPAMType, addressesJSON))))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conf.IPAM.IPv6Subnet != "" {
+		t.Errorf("IPv6Subnet = %q, want empty", conf.IPAM.IPv6Subnet)
+	}
+}
+
+// TestParseConfAddressesWithAddressFamilies covers address_families being
+// meaningless here rather than rejecting the config: these addresses were
+// decided upstream and are carried as given.
+func TestParseConfAddressesWithAddressFamilies(t *testing.T) {
+	body := fmt.Sprintf(`"type":%q,%s,"address_families":["ipv6"]`, testIPAMType, addressesJSON)
+	if _, err := parseConf([]byte(confJSON(body))); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseConfAddressesRejectsMixedModes(t *testing.T) {
+	tests := []struct{ name, extra string }{
+		{"WithStaticIP", `"static_ip":"fd00:1::1"`},
+		{"WithIPv6Subnet", fmt.Sprintf(`"ipv6_subnet":%q`, testIPv6SubnetCIDR)},
+		{"WithIPv4Subnet", fmt.Sprintf(`"ipv4_subnet":%q`, testIPv4SubnetCIDR)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`"type":%q,%s,%s`, testIPAMType, addressesJSON, tt.extra)
+			_, err := parseConf([]byte(confJSON(body)))
+			if err == nil {
+				t.Fatal("expected a config error combining ipam.addresses with another mode, got nil")
+			}
+			if !strings.Contains(err.Error(), "ipam.addresses cannot be combined") {
+				t.Errorf("error = %v, want the mixed-mode rejection", err)
+			}
+		})
+	}
+}

--- a/internal/cniipam/ops_test.go
+++ b/internal/cniipam/ops_test.go
@@ -79,3 +79,27 @@ func TestCmdCheckStaticAlwaysPasses(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// TestCmdAddCmdDelCmdCheckRoundTripAddresses exercises the delegation
+// protocol end to end for pre-decided addresses. Unlike the pool path, CHECK
+// still passes after DEL: nothing was allocated, so there is no record whose
+// absence could fail.
+func TestCmdAddCmdDelCmdCheckRoundTripAddresses(t *testing.T) {
+	withTempLockDir(t)
+
+	conf := confJSON(fmt.Sprintf(`"type":%q,%s`, testIPAMType, addressesJSON))
+	args := &skel.CmdArgs{ContainerID: testContainerID, StdinData: []byte(conf)}
+
+	if err := cmdAdd(args); err != nil {
+		t.Fatalf("cmdAdd: unexpected error: %v", err)
+	}
+	if err := cmdCheck(args); err != nil {
+		t.Fatalf("cmdCheck after cmdAdd: unexpected error: %v", err)
+	}
+	if err := cmdDel(args); err != nil {
+		t.Fatalf("cmdDel: unexpected error: %v", err)
+	}
+	if err := cmdCheck(args); err != nil {
+		t.Fatalf("cmdCheck after cmdDel: unexpected error: %v", err)
+	}
+}

--- a/internal/cniipam/types.go
+++ b/internal/cniipam/types.go
@@ -11,18 +11,32 @@
 // "ipam" block is present at all — no environment variable or sibling
 // config field can trigger or suppress that decision (that's the master's
 // own call, made before this package is ever invoked). Once delegated to,
-// mode selection is entirely this package's own: presence of
-// ipam.static_ip selects the static single-address path; otherwise
-// ipam.ipv6_subnet/ipv4_subnet (either family alone, or both) select the
-// pool path. GALACTIC_IPAM_ENABLE_LOCAL_IPAM only fills in a default IPv6
-// pool CIDR when the ipam block is present but specifies neither
-// static_ip nor a subnet — it can no longer manufacture an ipam block out
+// mode selection is entirely this package's own, decided by which fields
+// are present and rejected as a config error if they disagree:
+//
+//   - ipam.addresses — the addresses were decided upstream (Datum's
+//     networking layer allocates an IPv6 endpoint block, typically a /96,
+//     optionally an IPv4 /32, each with a gateway). Nothing is allocated:
+//     every address is assigned exactly as given, prefix length included,
+//     for both families, and nothing is persisted. Cannot be combined with
+//     the fields below.
+//   - ipam.static_ip — the legacy single-address path: one IPv6 address,
+//     assigned with a /64, no IPv4. Superseded by ipam.addresses.
+//   - ipam.ipv6_subnet/ipv4_subnet (either family alone, or both) — the
+//     pool path: this package chooses the address.
+//
+// GALACTIC_IPAM_ENABLE_LOCAL_IPAM only fills in a default IPv6
+// pool CIDR when the ipam block is present but specifies no addresses, no
+// static_ip and no subnet — it can no longer manufacture an ipam block out
 // of thin air the way its GALACTIC_CNI_ENABLE_LOCAL_IPAM predecessor did.
 //
 // Allocation state persists in on-disk marker files (internal/cni/ipam),
 // keyed by containerID, so this package never needs a Kubernetes client
 // at all: DEL looks its own allocation up locally instead of reading it
-// back from a BGPAdvertisement CRD annotation galactic-bgp wrote.
+// back from a BGPAdvertisement CRD annotation galactic-bgp wrote. Only the
+// pool path persists anything: an address decided elsewhere (addresses,
+// static_ip) is validated at ADD and never stored, so DEL has nothing to
+// release and CHECK nothing to verify.
 package cniipam
 
 import (
@@ -41,7 +55,9 @@ type IPAM struct {
 	// pkg/ipam.ExecAdd/ExecDel read this to know which binary to exec), not
 	// a mode selector. Mode is decided from which of the fields below are
 	// present instead — see the package doc comment.
-	Type       string `json:"type"`
+	Type string `json:"type"`
+	// StaticIP is the legacy single-address path: one IPv6 address, no
+	// prefix length of its own, no IPv4. Addresses supersedes it.
 	StaticIP   string `json:"static_ip,omitempty"`
 	IPv6Subnet string `json:"ipv6_subnet,omitempty"`
 	IPv4Subnet string `json:"ipv4_subnet,omitempty"`
@@ -52,11 +68,15 @@ type IPAM struct {
 	// pools are already configured — it can't widen allocation to a family
 	// with no pool CIDR set. Empty means no restriction (allocate from every
 	// configured pool, same as if this field didn't exist). Meaningless for
-	// the static_ip path, which allocates a single fixed IPv6 address
-	// regardless of this field.
-	AddressFamilies []string  `json:"address_families,omitempty"`
-	Routes          []Route   `json:"routes,omitempty"`
-	Addresses       []Address `json:"addresses,omitempty"`
+	// the static_ip and addresses paths, which carry exactly what they were
+	// given regardless of this field.
+	AddressFamilies []string `json:"address_families,omitempty"`
+	// Routes is declared but not read by any allocation path.
+	Routes []Route `json:"routes,omitempty"`
+	// Addresses carries addresses decided outside galactic-ipam. Presence
+	// selects the addresses path, which assigns exactly these -- both
+	// families, prefix lengths preserved -- rather than allocating anything.
+	Addresses []Address `json:"addresses,omitempty"`
 }
 
 // Route describes a static route to install.
@@ -65,9 +85,11 @@ type Route struct {
 	GW  string `json:"gw,omitempty"`
 }
 
-// Address describes a static IP address assignment.
+// Address is one pre-decided address in CIDR form (an explicit prefix length
+// is required) with the gateway reachability through it depends on.
 type Address struct {
 	Address string `json:"address"`
+	Gateway string `json:"gateway,omitempty"`
 }
 
 // IPAMResult holds the allocation details a master plugin uses to build


### PR DESCRIPTION
Datum's networking layer decides an interface's addresses before the workload is scheduled — an IPv6 endpoint block, optionally an IPv4 address, each with a prefix length that means something. Galactic's CNI cannot currently be told to use them.

`static_ip` takes a single IPv6 address, forces a `/64` mask and allocates no IPv4, so an externally decided `/96` comes out as a `/64`. The only alternative is the pool path, where galactic re-decides the address and the platform's allocation becomes fiction.

This adds an `addresses` path that carries pre-decided addresses exactly: any number, both families, prefix length preserved, gateway honoured.

```json
{
  "type": "galactic-ipam",
  "addresses": [
    {"address": "fd00:10:ff01:0:1::1/96", "gateway": "fd00:10:ff01::1"},
    {"address": "172.20.1.7/32", "gateway": "172.20.1.1"}
  ]
}
```

It reuses `ipam.addresses`, which was already declared and documented as vestigial, rather than inventing a key. `static_ip` is unchanged as the legacy single-address path. Combining `addresses` with `static_ip` or a subnet is a config error rather than a precedence question.

## Galactic stores nothing on this path

The marker files under the pool allocators exist because galactic has had to be its own IPAM authority: the file *is* the allocation, and losing it means double-allocating. That authority is what produces #156, #328 and #329.

Nothing is allocated here, so there is nothing to persist. ADD parses and returns, DEL has nothing to release, and CHECK passes — exactly what `static_ip` already does two lines away, for the same reason. `galactic-ipam` is a delegated plugin and on the tap path galactic never configures a guest address at all, so there is nothing on-node for it to verify either.

An earlier revision of this PR added a reservation store. Removing it keeps the new path out of #328's scope rather than extending it.

## Related

This is the CNI-side mechanism datum-cloud/galactic#197 needs. That issue's problem is two systems each believing they know what is allocated; a plugin that can be handed a decided address, and honour it exactly, is what lets an external authority own the pool. Consumed by the VPC controller in datum-cloud/cloud#6, which renders these addresses into the NAD from what NSO allocated (datum-cloud/network-services-operator#164).

Two existing issues, and how the new path stands against them:

- datum-cloud/galactic#328 (nothing reclaims when DEL never runs) does not apply: this path writes no on-disk state, so there is nothing for a missed DEL to leak. The earlier revision of this PR did add such state; removing it keeps the new path out of that issue's scope entirely.
- datum-cloud/galactic#329 (in-place upgrade hands a live pod's subnet to a new one) does not apply either: this path allocates nothing, so there is no prior state to import and no pool view to start empty.

datum-cloud/galactic#156 is unchanged — this PR adds a path alongside the pool allocators rather than altering them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

