### PR TITLE
fix(router): decode hex-encoded VPC segment in vrfTableID

### DIFF
--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -19,6 +19,7 @@ import (
 	gobgpserver "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
 )
@@ -217,20 +218,29 @@ func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeIn
 	return routeInstall{}, false
 }
 
-// vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{node}"
-// in base62 — see crdnames.BGPVRFInstanceName. The kernel VRF itself is
-// keyed by vpc alone (it's shared by every attachment on this VPC on this
-// node — vrfpkg.TableID needs no node component, since interface names only
-// need to be unique within one host's own namespace), so only the segment
-// before the first '-' matters here; node can itself contain '-' (e.g.
-// "dfw-worker-control"), which is why this splits into exactly 2 parts
-// instead of parsing node back out too.
+// vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{node}",
+// where vpc is hex-encoded per crdnames.BGPVRFInstanceName/VPCSegment. The
+// kernel VRF itself is keyed by the base62 vpc alone (it's shared by every
+// attachment on this VPC on this node — vrfpkg.TableID needs no node
+// component, since interface names only need to be unique within one host's
+// own namespace), so only the segment before the first '-' matters here;
+// node can itself contain '-' (e.g. "dfw-worker-control"), which is why this
+// splits into exactly 2 parts instead of parsing node back out too. The hex
+// segment has to be decoded back to base62 before it can be used to build
+// the kernel interface name — intf.HexToBase62 naturally errors out on the
+// SHA-256 hash fallback form (crdnames.nameSegment's "x..." prefix, for VPCs
+// that don't cleanly hex-encode), which is correct here too: that form was
+// never recoverable to a real interface name in the first place.
 func vrfTableID(vrfName string) (uint32, error) {
 	parts := strings.SplitN(vrfName, "-", 2)
 	if len(parts) != 2 {
 		return 0, fmt.Errorf("VRF name %q does not contain '-'", vrfName)
 	}
-	return vrfpkg.TableID(parts[0])
+	vpc, err := intf.HexToBase62(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("VRF name %q: could not decode VPC segment %q back to base62: %w", vrfName, parts[0], err)
+	}
+	return vrfpkg.TableID(vpc)
 }
 
 // evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path

--- a/internal/runtime/gobgp/monitor_test.go
+++ b/internal/runtime/gobgp/monitor_test.go
@@ -5,6 +5,7 @@
 package gobgp
 
 import (
+	"strings"
 	"testing"
 
 	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
@@ -94,5 +95,50 @@ func TestMatchTableID_NoExtendedCommunitiesAttributeAtAll(t *testing.T) {
 	}
 	if !got.plain || got.tableID != 0 {
 		t.Errorf("routeInstall = %+v, want {tableID:0 plain:true}", got)
+	}
+}
+
+// TestVRFTableID_DecodesHexSegmentBackToBase62 is a regression test for the
+// bug documented in the "vrfTableID hex/base62 mismatch" note: the CRD name
+// carries the VPC hex-encoded (crdnames.BGPVRFInstanceName/VPCSegment), but
+// the kernel VRF interface is named from the raw base62 VPC
+// (intf.GenerateInterfaceNameVRF). Feeding the hex segment straight into
+// vrfpkg.TableID built the wrong interface name entirely — "3e" (hex for
+// base62 "10") looked up "G00000003eV" instead of the real "G000000010V".
+// There's no VRF interface in the test sandbox for either name, so this
+// asserts on the interface name vrfpkg.TableID reports missing rather than
+// on a successful lookup.
+func TestVRFTableID_DecodesHexSegmentBackToBase62(t *testing.T) {
+	_, err := vrfTableID("3e-dfw-worker")
+	if err == nil {
+		t.Fatalf("vrfTableID() error = nil, want a 'VRF ID not found' error (no such kernel VRF in test env)")
+	}
+	if !strings.Contains(err.Error(), "G000000010V") {
+		t.Errorf("vrfTableID() error = %q, want it to reference the base62-decoded interface name G000000010V", err)
+	}
+	if strings.Contains(err.Error(), "G00000003eV") {
+		t.Errorf("vrfTableID() error = %q, looked up the raw hex segment as an interface name instead of decoding it", err)
+	}
+}
+
+// TestVRFTableID_HashFallbackSegmentErrors covers the SHA-256 hash fallback
+// form (crdnames.nameSegment's "x..." prefix, used for VPCs that don't
+// cleanly hex-encode) — intf.HexToBase62 can't decode it back to a real
+// interface name, so vrfTableID must fail fast on the decode rather than
+// attempt a kernel lookup with a garbage name.
+func TestVRFTableID_HashFallbackSegmentErrors(t *testing.T) {
+	_, err := vrfTableID("x0123456789ab-dfw-worker")
+	if err == nil {
+		t.Fatalf("vrfTableID() error = nil, want a base62-decode error for a hash-fallback segment")
+	}
+}
+
+// TestVRFTableID_NoDashErrors covers the pre-existing malformed-input guard:
+// a VRF name with no '-' at all can't be split into a VPC segment and a
+// node name.
+func TestVRFTableID_NoDashErrors(t *testing.T) {
+	_, err := vrfTableID("nodash")
+	if err == nil {
+		t.Fatalf("vrfTableID(\"nodash\") error = nil, want a \"does not contain '-'\" error")
 	}
 }


### PR DESCRIPTION
## Summary

A prior commit hex-encoded VPC identifiers in BGP CRD names to satisfy Kubernetes naming rules, but missed one spot that turned that hex segment back into a kernel VRF interface name expecting the original encoding. The mismatch built the wrong interface name entirely, so the kernel VRF table lookup always missed and SRv6 encap routes were never installed for cross-site VPC traffic — full packet loss between sites sharing a VRF. This restores the correct decode step so the lookup resolves the real interface again.

## Test plan

- [ ] Cross-site VPC traffic (same VRF, different nodes) round-trips instead of dropping 100%
- [ ] Unit tests, build, and lint pass
