### PR TITLE
refactor: Drop BGPRouter role dependency from reconcile

### DIFF
--- a/docs/agents/ARCHITECTURE-ROUTER.md
+++ b/docs/agents/ARCHITECTURE-ROUTER.md
@@ -72,7 +72,7 @@ galactic/
 │   │                        #   (NetworkGatewayReconciler/NetworkRuleReconciler also
 │   │                        #   live in this package but run in galactic-gateway, not
 │   │                        #   galactic-router — see ARCHITECTURE-GATEWAY.md.)
-│   ├── reconcile/           # CRD → DesiredRouter translation (node/role checks,
+│   ├── reconcile/           # CRD → DesiredRouter translation (node targeting,
 │   │                        #   secret resolution, IPv6 next-hop from Node)
 │   ├── runtime/             # RouterRuntime interface + RuntimeManager
 │   │   └── gobgp/           # GoBGP RouterRuntime (the only backend)
@@ -201,7 +201,7 @@ co-located `galactic-gateway` container's own health port on the same
 | Package                  | Binary                                   | Responsibility                                                                                                                                                   | Owns state        |
 | ------------------------ | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | `internal/controller`    | galactic-router                          | controller-runtime reconcilers (BGPRouter, BGPPeer, BGPAdvertisement, BGPVRFInstance, BGPPolicy, Node, Secret, GC); field index registration; CRD status helpers | No                |
-| `internal/reconcile`     | galactic-router                          | Translates BGPRouter + related CRDs into `model.DesiredRouter`; enforces node/role filtering, timer validation, AFI validation                                   | No                |
+| `internal/reconcile`     | galactic-router                          | Translates BGPRouter + related CRDs into `model.DesiredRouter`; enforces node targeting, timer validation, AFI validation                                        | No                |
 | `internal/runtime`       | galactic-router                          | `RouterRuntime` interface; `RuntimeManager` (keyed map of live runtimes, double-checked lock create)                                                             | Yes (runtime map) |
 | `internal/runtime/gobgp` | galactic-router                          | Embeds GoBGP v4; lazy-starts on first Apply; handles peer/VRF/EVPN-path/policy add/update/delete; tracks established timestamps                                  | Yes (per-router)  |
 | `internal/model`         | galactic-router                          | `DesiredRouter`, `DesiredPeer`, `DesiredAdvertisement`, `DesiredPolicy`, `DesiredVRFInstance`, `RuntimeStatus`; re-exports BGP API enums                         | No                |

--- a/internal/cnibgp/bgp_test.go
+++ b/internal/cnibgp/bgp_test.go
@@ -85,7 +85,6 @@ func routerForNode(name, nodeName, namespace string, asn int64) *bgpv1alpha1.BGP
 			},
 			LocalASN: asn,
 			RouterID: "10.0.0.1",
-			Roles:    []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			AddressFamilies: []bgpv1alpha1.AddressFamily{
 				{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
 			},

--- a/internal/controller/networkgateway_controller_test.go
+++ b/internal/controller/networkgateway_controller_test.go
@@ -125,7 +125,6 @@ func newTestRouter() *bgpv1alpha1.BGPRouter {
 			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testNodeGWA},
 			LocalASN:  65000,
 			RouterID:  "1.1.1.1",
-			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 		},
 	}
 }

--- a/internal/controller/networkrule_controller_test.go
+++ b/internal/controller/networkrule_controller_test.go
@@ -119,7 +119,6 @@ func newBackendFixtures(
 			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testComputeNodeName},
 			LocalASN:    65000,
 			RouterID:    testBackendRouterID,
-			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			SRv6Locator: testBackendLocator,
 			NodeID:      testBackendNodeID,
 		},

--- a/internal/controller/usidresolver_test.go
+++ b/internal/controller/usidresolver_test.go
@@ -108,7 +108,6 @@ func TestBackendSIDIndex_SkipsRouterWithoutSRv6Config(t *testing.T) {
 			TargetRef: bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: testComputeNodeName},
 			LocalASN:  65000,
 			RouterID:  testBackendRouterID,
-			Roles:     []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			// No SRv6Locator/NodeID.
 		},
 	}
@@ -159,7 +158,6 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: "node-a"},
 			LocalASN:    65000,
 			RouterID:    "1.1.1.1",
-			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			SRv6Locator: vpcALocator,
 			NodeID:      7,
 		},
@@ -170,7 +168,6 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 			TargetRef:   bgpv1alpha1.TargetRef{Kind: testTargetRefKind, Name: "node-b"},
 			LocalASN:    65000,
 			RouterID:    testBackendRouterID,
-			Roles:       []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			SRv6Locator: vpcBLocator,
 			NodeID:      8,
 		},

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"slices"
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,25 +52,13 @@ func New(c client.Client, nodeName, localAddress string) *Reconciler {
 
 // BuildDesiredRouter assembles the full DesiredRouter from BGP CRDs for
 // the given BGPRouter. It returns (nil, nil) if the router should be silently
-// skipped (wrong node or wrong role). It returns (nil, err) on error.
+// skipped (wrong node). It returns (nil, err) on error.
 func (r *Reconciler) BuildDesiredRouter(
 	ctx context.Context, router *bgpv1alpha1.BGPRouter,
 ) (*model.DesiredRouter, error) {
 	// Node check: skip routers that don't target this node.
 	if router.Spec.TargetRef.Name != r.nodeName {
 		return nil, nil
-	}
-
-	// Role check. galactic-router only ever runs the tenant role; a router
-	// carrying a different role (e.g. fabric, transit — both exist in the
-	// external RouterRole enum but have no implementation here) is safely
-	// skipped rather than reconciled against the GoBGP runtime.
-	if !slices.Contains(router.Spec.Roles, bgpv1alpha1.RouterRoleTenant) {
-		return nil, nil
-	}
-	if len(router.Spec.Roles) > 1 {
-		return nil, fmt.Errorf("multi-role routers not supported: router %s/%s has roles %v",
-			router.Namespace, router.Name, router.Spec.Roles)
 	}
 
 	namespace := router.Namespace

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -81,31 +81,22 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 // it, and the fake client has no cache to register it on implicitly.
 const routerRefIndexer = ".spec.routerRef.name"
 
-func TestBuildDesiredRouter_NodeAndRoleFilter(t *testing.T) {
+func TestBuildDesiredRouter_NodeFilter(t *testing.T) {
 	const thisNode = "node-a"
 
 	tests := []struct {
 		name       string
 		targetNode string
-		roles      []bgpv1alpha1.RouterRole
 		wantSkip   bool
 	}{
 		{
 			name:       "skips a router targeting a different node",
 			targetNode: "node-b",
-			roles:      []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			wantSkip:   true,
 		},
 		{
-			name:       "skips a router with a non-tenant role",
+			name:       "proceeds for a router targeting this node",
 			targetNode: thisNode,
-			roles:      []bgpv1alpha1.RouterRole{"fabric"},
-			wantSkip:   true,
-		},
-		{
-			name:       "proceeds for a tenant-role router on this node",
-			targetNode: thisNode,
-			roles:      []bgpv1alpha1.RouterRole{bgpv1alpha1.RouterRoleTenant},
 			wantSkip:   false,
 		},
 	}
@@ -116,7 +107,6 @@ func TestBuildDesiredRouter_NodeAndRoleFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
 				Spec: bgpv1alpha1.BGPRouterSpec{
 					TargetRef: bgpv1alpha1.TargetRef{Name: tc.targetNode},
-					Roles:     tc.roles,
 				},
 			}
 


### PR DESCRIPTION
## Summary

BGPRouter reconciliation used to skip any router unless it carried a "tenant" role, and error out on multi-role routers — a leftover from a router mode concept removed earlier, whose comparison got hardcoded rather than deleted. Nothing in the router reads that field otherwise, and every router in practice already carries the tenant role, so the check was dead weight rather than an active safeguard. Reconciliation now filters purely on node targeting, and the leftover role values in test fixtures and architecture docs are cleaned up to match.

## Test plan

- [ ] Build, vet, lint, and unit tests pass
- [ ] A BGPRouter with no role set (or a non-tenant role) still reconciles normally
