### PR TITLE
fix: Derive route-reflector-client from an explicit signal

### DIFF
--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -76,7 +76,7 @@ func runCmd(cfg *config.RouterConfig) error {
 		return err
 	}
 
-	factory := gobgp.NewRuntimeFactory(int32(bgpListenPort), bgpLocalAddr)
+	factory := gobgp.NewRuntimeFactory(int32(bgpListenPort), cfg.Reflector, bgpLocalAddr)
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 

--- a/docs/agents/ARCHITECTURE-ROUTER.md
+++ b/docs/agents/ARCHITECTURE-ROUTER.md
@@ -172,16 +172,16 @@ sibling container instead.
 
 ### galactic-router environment variables
 
-| Variable                            | Required | Default           | Description                                                             |
-| ----------------------------------- | -------- | ----------------- | ----------------------------------------------------------------------- |
-| `GALACTIC_ROUTER_NODE_NAME`         | Yes      | —                 | Kubernetes node name; filters which BGPRouter CRDs this instance owns   |
-| `GALACTIC_ROUTER_REFLECTOR`         | No       | `false`           | Enable route reflector mode                                            |
-| `GALACTIC_ROUTER_BGP_LISTEN_PORT`   | No       | `179`             | BGP TCP listen port; `-1` disables inbound connections (outbound-only)  |
-| `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` | No       | —                 | Source address for outgoing BGP TCP connections (numbered underlay use) |
-| `GALACTIC_ROUTER_METRICS_PORT`      | No       | `9179`            | controller-runtime Prometheus metrics port                              |
-| `GALACTIC_ROUTER_GRPC_HEALTH_PORT`  | No       | `5179`            | gRPC health check port (liveness/readiness probes)                      |
-| `GALACTIC_ROUTER_GC_NAMESPACE`      | No       | `galactic-system` | Namespace the GC controller scans for orphaned CRDs                     |
-| `GALACTIC_ROUTER_GC_INTERVAL`       | No       | `5m`              | GC controller sweep interval                                            |
+| Variable                            | Required | Default           | Description                                                                                          |
+| ----------------------------------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------- |
+| `GALACTIC_ROUTER_NODE_NAME`         | Yes      | —                 | Kubernetes node name; filters which BGPRouter CRDs this instance owns                                |
+| `GALACTIC_ROUTER_REFLECTOR`         | No       | `false`           | Marks every peer as an iBGP route-reflector client; independent of `GALACTIC_ROUTER_BGP_LISTEN_PORT` |
+| `GALACTIC_ROUTER_BGP_LISTEN_PORT`   | No       | `179`             | BGP TCP listen port; `-1` disables inbound connections (outbound-only)                               |
+| `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS` | No       | —                 | Source address for outgoing BGP TCP connections (numbered underlay use)                              |
+| `GALACTIC_ROUTER_METRICS_PORT`      | No       | `9179`            | controller-runtime Prometheus metrics port                                                           |
+| `GALACTIC_ROUTER_GRPC_HEALTH_PORT`  | No       | `5179`            | gRPC health check port (liveness/readiness probes)                                                   |
+| `GALACTIC_ROUTER_GC_NAMESPACE`      | No       | `galactic-system` | Namespace the GC controller scans for orphaned CRDs                                                  |
+| `GALACTIC_ROUTER_GC_INTERVAL`       | No       | `5m`              | GC controller sweep interval                                                                         |
 
 See [docs/router/configuration.md](../router/configuration.md) for the full reference, including CLI flags and precedence.
 

--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -44,7 +44,12 @@ used to scope BGP configuration to the correct node.
 
 ### `--reflector` / `GALACTIC_ROUTER_REFLECTOR`
 
-Enable route reflector mode.
+Marks every BGP peer this instance adds as an iBGP route-reflector client
+(GoBGP's `RouteReflectorClient` flag), so this node reflects paths to those
+peers instead of requiring full-mesh iBGP. This is independent of
+`--bgp-listen-port`: accepting inbound BGP connections and acting as the
+fabric-facing route reflector are different properties, even though the
+`rr` overlay happens to set both.
 
 **Type:** boolean
 **Default:** `false`

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -67,7 +67,13 @@ type RouterConfig struct {
 	prefix string
 
 	// Resolved fields.
-	NodeName       string
+	NodeName string
+	// Reflector marks every BGP peer this router instance adds as an iBGP
+	// route-reflector client (GoBGP's RouteReflectorClient flag), so this
+	// node reflects paths to those peers instead of requiring full-mesh
+	// iBGP. This is a distinct signal from BGPListenPort: whether a node
+	// accepts inbound BGP connections is not the same property as whether
+	// it is the fabric-facing route reflector.
 	Reflector      bool
 	BGPListenPort  int
 	BGPLocalAddr   string

--- a/internal/runtime/gobgp/peers_test.go
+++ b/internal/runtime/gobgp/peers_test.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gobgp
+
+import (
+	"testing"
+
+	"go.datum.net/galactic/internal/model"
+)
+
+// TestPeerFromDesired_RouteReflectorClientFollowsExplicitFlag is the
+// regression test for a bug where the RouteReflectorClient flag was derived
+// from listenPort > 0 (whether this instance accepts inbound BGP) instead of
+// from an explicit reflector signal. The two properties are independent:
+// listenPort only controls the inbound listener, and must not by itself mark
+// every peer as a route-reflector client.
+func TestPeerFromDesired_RouteReflectorClientFollowsExplicitFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		reflector  bool
+		wantClient bool
+	}{
+		{name: "reflector disabled", reflector: false, wantClient: false},
+		{name: "reflector enabled", reflector: true, wantClient: true},
+	}
+
+	desired := model.DesiredPeer{Address: "2001:db8:ff01::1", PeerASN: 65000}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := peerFromDesired(desired, "", tc.reflector)
+
+			gotClient := peer.RouteReflector != nil && peer.RouteReflector.RouteReflectorClient
+			if gotClient != tc.wantClient {
+				t.Errorf("peerFromDesired() RouteReflectorClient = %v, want %v", gotClient, tc.wantClient)
+			}
+		})
+	}
+}

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -29,6 +29,7 @@ type GoBGPRuntime struct {
 	key          types.NamespacedName
 	server       *Server
 	listenPort   int32
+	reflector    bool
 	localAddress string
 	mu           sync.Mutex
 
@@ -73,14 +74,20 @@ type GoBGPRuntime struct {
 // NewRuntimeFactory returns a RuntimeFactory that creates a GoBGPRuntime per key.
 // listenPort controls the TCP port GoBGP binds for incoming BGP connections.
 // Pass -1 to disable inbound connections (outbound-only mode).
+// reflector, when true, marks every peer of this runtime instance as an iBGP
+// route-reflector client — this is a distinct, explicit signal from
+// listenPort: whether a node accepts inbound BGP is not the same property as
+// whether it is the fabric-facing route-reflector, even though the two
+// happen to coincide in every overlay that exists today.
 // localAddress, if non-empty, is bound as the source address for outgoing BGP
 // TCP connections (sets Transport.LocalAddress on every peer).
-func NewRuntimeFactory(listenPort int32, localAddress string) runtime.RuntimeFactory {
+func NewRuntimeFactory(listenPort int32, reflector bool, localAddress string) runtime.RuntimeFactory {
 	return func(key types.NamespacedName) (runtime.RouterRuntime, error) {
 		return &GoBGPRuntime{
 			key:                   key,
 			server:                newServer(Config{}),
 			listenPort:            listenPort,
+			reflector:             reflector,
 			localAddress:          localAddress,
 			establishedAt:         make(map[string]time.Time),
 			appliedPolicies:       make(map[string]model.BGPPolicyDirection),
@@ -198,7 +205,7 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 	}
 
 	for _, p := range peers {
-		peer := peerFromDesired(p, r.localAddress, r.listenPort > 0)
+		peer := peerFromDesired(p, r.localAddress, r.reflector)
 		addErr := b.AddPeer(ctx, &api.AddPeerRequest{Peer: peer})
 		if addErr != nil {
 			if strings.Contains(addErr.Error(), "can't overwrite") {


### PR DESCRIPTION
## Summary

Every BGP peer was marked as an iBGP route-reflector client based on whether this router instance accepted inbound BGP connections, not on the route-reflector config flag that has documented this behavior since it was added. That flag was parsed but never actually read anywhere. The two properties happen to coincide in every deployment overlay today, so this was latent rather than visibly broken, but a future role needing an inbound listener for an unrelated reason would silently get every peer wrongly marked, with no working way to opt out. The route-reflector-client flag is now driven by the documented config signal instead.

## Test plan

- [ ] Build, vet, lint, and unit tests pass
- [ ] A new unit test confirms the route-reflector-client flag follows the reflector signal independently of the listen port
