### PR TITLE
fix(router): repair CI failures left behind by #449

### DIFF
--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -38,7 +38,11 @@ func (r *GoBGPRuntime) startRIBMonitor(b *gobgpserver.BgpServer) {
 	}
 	r.monitorOnce.Do(func() {
 		slog.Info("startRIBMonitor: launching shared watchEVPNRIB goroutine")
-		go r.watchEVPNRIB(r.srvCtx, b)
+		r.wg.Add(1)
+		go func() {
+			defer r.wg.Done()
+			r.watchEVPNRIB(r.srvCtx, b)
+		}()
 	})
 }
 

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -81,6 +81,15 @@ type GoBGPRuntime struct {
 	// started at most once per runtime lifetime; it dispatches to all VRFs via
 	// rtIndex rather than being scoped to one VRF.
 	monitorOnce sync.Once
+	// wg tracks the server.Start and watchEVPNRIB goroutines so Stop can block
+	// until both have actually exited instead of merely cancelling srvCtx and
+	// returning. GoBGP keeps some path-selection state (table.SelectionOptions,
+	// table.UseMultiplePaths) as package-level globals rather than per-server
+	// fields, so a BgpServer that outlives Stop() races the next runtime's
+	// StartBgp in any test (or other in-process caller) that creates more than
+	// one GoBGPRuntime -- this is what the CI race detector caught once this
+	// package's tests started creating more than one GoBGPRuntime per run.
+	wg sync.WaitGroup
 }
 
 // NewRuntimeFactory returns a RuntimeFactory that creates a GoBGPRuntime per key.
@@ -152,7 +161,9 @@ func (r *GoBGPRuntime) startGoBGP(ctx context.Context) (*gobgpserver.BgpServer, 
 		srvCtx, cancel := context.WithCancel(context.Background())
 		r.serverCtxCancel = cancel
 		r.srvCtx = srvCtx
+		r.wg.Add(1)
 		go func() {
+			defer r.wg.Done()
 			_ = r.server.Start(srvCtx)
 		}()
 
@@ -431,7 +442,11 @@ func (r *GoBGPRuntime) Status(ctx context.Context) (model.RuntimeStatus, error) 
 	return status, nil
 }
 
-// Stop shuts down the GoBGP server.
+// Stop shuts down the GoBGP server. It blocks until the embedded server and
+// the shared EVPN RIB watcher have both actually exited (not merely been
+// asked to), so a caller that creates another GoBGPRuntime immediately after
+// Stop returns -- as tests in this package do -- cannot race the outgoing
+// server's GoBGP package-level path-selection state (see the wg field doc).
 func (r *GoBGPRuntime) Stop(_ context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -440,6 +455,7 @@ func (r *GoBGPRuntime) Stop(_ context.Context) error {
 		r.serverCtxCancel()
 		r.serverCtxCancel = nil
 	}
+	r.wg.Wait()
 	return nil
 }
 

--- a/internal/runtime/gobgp/runtime_test.go
+++ b/internal/runtime/gobgp/runtime_test.go
@@ -27,7 +27,7 @@ func newTestBgpServer(t *testing.T) *gobgpserver.BgpServer {
 	if err := b.StartBgp(context.Background(), &api.StartBgpRequest{
 		Global: &api.Global{
 			Asn:        65000,
-			RouterId:   "1.2.3.4",
+			RouterId:   testRouterID1,
 			ListenPort: -1,
 		},
 	}); err != nil {
@@ -54,7 +54,7 @@ func TestApplyGlobal_ListenPortOverride(t *testing.T) {
 
 	desired := model.DesiredRouter{
 		LocalASN:   65000,
-		RouterID:   "1.2.3.4",
+		RouterID:   testRouterID1,
 		ListenPort: ptrInt32Test(1790),
 	}
 	if err := rt.Apply(ctx, desired); err != nil {
@@ -88,7 +88,7 @@ func TestApplyGlobal_ListenPortUnsetFallsBackToFactoryDefault(t *testing.T) {
 
 	desired := model.DesiredRouter{
 		LocalASN: 65000,
-		RouterID: "1.2.3.4",
+		RouterID: testRouterID1,
 	}
 	if err := rt.Apply(ctx, desired); err != nil {
 		t.Fatalf("Apply() error = %v", err)
@@ -118,7 +118,7 @@ func TestApplyVRFDerivesRouteDistinguisher(t *testing.T) {
 	}{
 		{
 			name:     "basic vrfID",
-			routerID: "1.2.3.4",
+			routerID: testRouterID1,
 			vrf: model.DesiredVRFInstance{
 				Name:               "vrf-a",
 				VRFID:              42,


### PR DESCRIPTION
#449 (\"fix(router): honor BGPRouter.spec.listenPort override\") was merged into `main` while its CI was still red. This PR fixes the two failures directly on `main`.

## Lint (`goconst`)
`internal/runtime/gobgp/runtime_test.go`, added by #449, repeated the literal `"1.2.3.4"` four times. `paths_test.go` in the same package already defines `testRouterID1 = "1.2.3.4"` — swapped the literals for the existing constant.

## Unit tests (`-race`)
`GoBGPRuntime.Stop()` only cancelled its internal context and returned immediately, without waiting for the `server.Start` goroutine or the shared `watchEVPNRIB` goroutine to actually exit. GoBGP v4.8.0 keeps some path-selection state (`table.SelectionOptions`, `table.UseMultiplePaths`) as **package-level globals**, not per-`BgpServer` fields, so a `BgpServer` instance that outlives `Stop()` races the next `GoBGPRuntime`'s `StartBgp` whenever more than one runtime exists in the same process — which is exactly what #449's new tests do (each test spins up its own runtime). Fixed by tracking both goroutines on a `sync.WaitGroup` and blocking on it in `Stop()`, so the embedded server is fully torn down before `Stop()` returns.

Verified locally: `task build`, `task lint` (0 issues), and `go test -race -count=5 ./internal/runtime/gobgp/...` all pass repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)