### PR TITLE
fix: Drop tenant role from lab BGP CRs, dedupe iad names

### DIFF
--- a/deploy/containerlab/resources/galactic-control/iad/bgppeer-dfw.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgppeer-dfw.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-control-tenant-to-dfw
+  name: galactic-router-dfw
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-control-tenant
+    name: galactic-control
   peerASN: 65000
   address: "fc00:0:2::1"
   addressFamilies:

--- a/deploy/containerlab/resources/galactic-control/iad/bgppeer-gateway1.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgppeer-gateway1.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-control-tenant-to-gateway1
+  name: galactic-gateway-iad-gateway1
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-control-tenant
+    name: galactic-control
   peerASN: 65000
   address: "fc00:0:9::1"
   addressFamilies:

--- a/deploy/containerlab/resources/galactic-control/iad/bgppeer-gateway2.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgppeer-gateway2.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-control-tenant-to-gateway2
+  name: galactic-gateway-iad-gateway2
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-control-tenant
+    name: galactic-control
   peerASN: 65000
   address: "fc00:0:a::1"
   addressFamilies:

--- a/deploy/containerlab/resources/galactic-control/iad/bgppeer-iad.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgppeer-iad.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-control-tenant-to-iad
+  name: galactic-router-iad
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-control-tenant
+    name: galactic-control
   peerASN: 65000
   address: "fc00:0:4::1"
   addressFamilies:

--- a/deploy/containerlab/resources/galactic-control/iad/bgppeer-sjc.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgppeer-sjc.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-control-tenant-to-sjc
+  name: galactic-router-sjc
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-control-tenant
+    name: galactic-control
   peerASN: 65000
   address: "fc00:0:3::1"
   addressFamilies:

--- a/deploy/containerlab/resources/galactic-control/iad/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-control/iad/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: iad-control-tenant
+  name: galactic-control
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: iad-worker-rr
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.255.255.4"
   srv6Locator: "2001:db8:ff03::/48"

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway1/bgppeer.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway1/bgppeer.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-gateway1-tenant-to-rr
+  name: galactic-control-gateway1
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-gateway1-tenant
+    name: galactic-router-gateway1
   peerASN: 65000
   address: "fc00:0:8::1"
   remotePort: 1790

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway1/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway1/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: iad-gateway1-tenant
+  name: galactic-router-gateway1
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: iad-gateway1
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.2.2"
   srv6Locator: "2001:db8:ff03::/48"

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway2/bgppeer.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway2/bgppeer.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-gateway2-tenant-to-rr
+  name: galactic-control-gateway2
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-gateway2-tenant
+    name: galactic-router-gateway2
   peerASN: 65000
   address: "fc00:0:8::1"
   remotePort: 1790

--- a/deploy/containerlab/resources/galactic-gateway/iad-gateway2/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-gateway/iad-gateway2/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: iad-gateway2-tenant
+  name: galactic-router-gateway2
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: iad-gateway2
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.2.3"
   srv6Locator: "2001:db8:ff03::/48"

--- a/deploy/containerlab/resources/galactic-router/dfw/bgppeer.yaml
+++ b/deploy/containerlab/resources/galactic-router/dfw/bgppeer.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: dfw-worker-tenant-to-rr
+  name: galactic-route-reflector-iad
   namespace: galactic-system
 spec:
   routerRef:
-    name: dfw-worker-tenant
+    name: galactic-router
   peerASN: 65000
   address: "fc00:0:8::1"
   remotePort: 1790

--- a/deploy/containerlab/resources/galactic-router/dfw/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-router/dfw/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: dfw-worker-tenant
+  name: galactic-router
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: dfw-worker
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.1.1"
   srv6Locator: "2001:db8:ff01::/48"

--- a/deploy/containerlab/resources/galactic-router/iad/bgppeer.yaml
+++ b/deploy/containerlab/resources/galactic-router/iad/bgppeer.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: iad-worker-tenant-to-rr
+  name: galactic-route-reflector-iad
   namespace: galactic-system
 spec:
   routerRef:
-    name: iad-worker-tenant
+    name: galactic-router
   peerASN: 65000
   address: "fc00:0:8::1"
   remotePort: 1790

--- a/deploy/containerlab/resources/galactic-router/iad/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-router/iad/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: iad-worker-tenant
+  name: galactic-router
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: iad-worker
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.2.1"
   srv6Locator: "2001:db8:ff03::/48"

--- a/deploy/containerlab/resources/galactic-router/sjc/bgppeer.yaml
+++ b/deploy/containerlab/resources/galactic-router/sjc/bgppeer.yaml
@@ -1,11 +1,11 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPPeer
 metadata:
-  name: sjc-worker-tenant-to-rr
+  name: galactic-route-reflector-iad
   namespace: galactic-system
 spec:
   routerRef:
-    name: sjc-worker-tenant
+    name: galactic-router
   peerASN: 65000
   address: "fc00:0:8::1"
   remotePort: 1790

--- a/deploy/containerlab/resources/galactic-router/sjc/bgprouter.yaml
+++ b/deploy/containerlab/resources/galactic-router/sjc/bgprouter.yaml
@@ -1,14 +1,12 @@
 apiVersion: network.datumapis.com/v1alpha1
 kind: BGPRouter
 metadata:
-  name: sjc-worker-tenant
+  name: galactic-router
   namespace: galactic-system
 spec:
   targetRef:
     kind: Node
     name: sjc-worker
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.3.1"
   srv6Locator: "2001:db8:ff02::/48"

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/vishvananda/netlink v1.3.2-0.20260803231012-156a440d85e5
-	go.datum.net/network v0.0.0-20260821012412-35ea8d019ad8
+	go.datum.net/network v0.0.0-20260825185725-392ac243999b
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	google.golang.org/grpc v1.83.1

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee h1:7tA+0C1pb/fu/wrgB3Vu+
 go.datum.net/network v0.0.0-20260819160013-45d0ff9deaee/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.datum.net/network v0.0.0-20260821012412-35ea8d019ad8 h1:F9AW79AfnWEpNuh0I2RAaEA438BqI17Z3FblSUeK6kA=
 go.datum.net/network v0.0.0-20260821012412-35ea8d019ad8/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
+go.datum.net/network v0.0.0-20260825185725-392ac243999b h1:g2l45aYl+OqDnIHaC0uiCYq+2PcLz08R6MaT80MYcbo=
+go.datum.net/network v0.0.0-20260825185725-392ac243999b/go.mod h1:dqzM8WZczbiZ9bCvsxjkoI10GJqQ24NVWnc9boXgOkE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -124,8 +124,6 @@ spec:
   targetRef:
     kind: Node
     name: ${E2E_NODE}
-  roles:
-    - tenant
   localASN: 65000
   routerID: "10.0.0.1"
   srv6Locator: "2001:db8:ff01::/48"


### PR DESCRIPTION
## Summary

The containerlab BGP fixtures were mid-rename, dropping a role field the router no longer reads and shortening resource names. That rename left two of the four gateway nodes sharing identical router and peer names on the same cluster, which broke `task deploy` with a kustomize id collision and would have silently overwritten one gateway's BGP state with the other's even without the build error.

Each gateway node's router and peer now get their own name, so all four routers coexist correctly. Also picks up the current CRD schema from the network module.

## Test plan

- [ ] `task deploy` completes without a kustomize id-collision error
- [ ] Both iad gateway nodes' BGPRouter/BGPPeer objects apply and coexist without clobbering each other
