### PR TITLE
fix(router): require live peer presence for no-op reconcile skip

### DIFF
--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -124,11 +124,22 @@ func (r *BGPRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		logger.Error(statusErr, "get runtime status")
 	}
 
-	// Only skip Apply if the runtime is healthy AND the config is unchanged.
-	// If the runtime is unhealthy (e.g. after a controller restart where GoBGP
-	// was not yet running), we must re-apply to restart GoBGP even if the desired
-	// config hash matches the annotation.
-	if router.Annotations[annotationConfigHash] == newHash && runtimeStatus.Healthy {
+	// Only skip Apply if the runtime is healthy, the config is unchanged, AND
+	// every desired peer is actually present in the runtime's live peer list.
+	// runtimeStatus.Healthy only reflects "is the GoBGP process up" — it says
+	// nothing about whether GoBGP still holds every desired peer. A peer can
+	// be silently dropped from GoBGP's live state (e.g. a GC cycle deletes
+	// and recreates the BGPVRFInstance/BGPAdvertisement CRs backing it, and
+	// whatever happens during that churn drops the peer) without the desired
+	// config's hash ever changing, since the recreated CRs hash identically
+	// to before. Without this check, the no-op branch below wedges
+	// permanently — Apply() (and its ListPeer/AddPeer diff) never runs again
+	// until something manually busts the config-hash annotation. If the
+	// runtime is unhealthy (e.g. after a controller restart where GoBGP was
+	// not yet running), we must also re-apply to restart GoBGP even if the
+	// desired config hash matches the annotation.
+	if router.Annotations[annotationConfigHash] == newHash && runtimeStatus.Healthy &&
+		allDesiredPeersPresent(desired.Peers, runtimeStatus) {
 		// True no-op: runtime is healthy with the current config.
 		routerCopy := router.DeepCopy()
 		routerCopy.Status.ObservedGeneration = router.Generation
@@ -497,6 +508,25 @@ func (r *BGPRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Named("bgprouter").
 		Complete(r)
+}
+
+// allDesiredPeersPresent reports whether every desired peer appears in the
+// runtime's live peer list, matched by normalized address (see normalizeIP).
+// This is what distinguishes a true no-op reconcile — config unchanged,
+// runtime healthy, AND every peer GoBGP is supposed to hold is actually
+// present — from a runtime that is nominally healthy but has silently lost
+// a peer, which must fall through to Apply() instead of being skipped.
+func allDesiredPeersPresent(peers []model.DesiredPeer, rs model.RuntimeStatus) bool {
+	present := make(map[string]bool, len(rs.Peers))
+	for _, ps := range rs.Peers {
+		present[normalizeIP(ps.Address)] = true
+	}
+	for _, p := range peers {
+		if !present[normalizeIP(p.Address)] {
+			return false
+		}
+	}
+	return true
 }
 
 // normalizeIP returns the canonical text form of an IP address,

--- a/internal/controller/bgprouter_controller_test.go
+++ b/internal/controller/bgprouter_controller_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package controller
+
+import (
+	"testing"
+
+	"go.datum.net/galactic/internal/model"
+)
+
+const (
+	testPeerAddrV4 = "192.0.2.1"
+	testPeerAddrV6 = "2607:ed40:1fb::2"
+)
+
+// TestAllDesiredPeersPresent verifies the no-op reconcile guard used by
+// BGPRouterReconciler.Reconcile: a runtime that reports Healthy but has
+// silently lost a desired peer (e.g. a GC cycle dropped it from GoBGP's live
+// state without the desired config's hash ever changing) must not be
+// treated as a true no-op.
+func TestAllDesiredPeersPresent(t *testing.T) {
+	tests := []struct {
+		name  string
+		peers []model.DesiredPeer
+		rs    model.RuntimeStatus
+		want  bool
+	}{
+		{
+			name:  "no desired peers",
+			peers: nil,
+			rs:    model.RuntimeStatus{},
+			want:  true,
+		},
+		{
+			name:  "all desired peers present",
+			peers: []model.DesiredPeer{{Address: testPeerAddrV6}, {Address: testPeerAddrV4}},
+			rs: model.RuntimeStatus{Peers: []model.PeerStatus{
+				{Address: testPeerAddrV6}, {Address: testPeerAddrV4},
+			}},
+			want: true,
+		},
+		{
+			name:  "peer missing from runtime status (dropped without a hash change)",
+			peers: []model.DesiredPeer{{Address: testPeerAddrV6}, {Address: testPeerAddrV4}},
+			rs: model.RuntimeStatus{Peers: []model.PeerStatus{
+				{Address: testPeerAddrV4},
+			}},
+			want: false,
+		},
+		{
+			name:  "address normalization matches leading-zero IPv6 forms",
+			peers: []model.DesiredPeer{{Address: "2607:ed40:01fb::2"}},
+			rs: model.RuntimeStatus{Peers: []model.PeerStatus{
+				{Address: testPeerAddrV6},
+			}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allDesiredPeersPresent(tt.peers, tt.rs); got != tt.want {
+				t.Errorf("allDesiredPeersPresent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`BGPRouterReconciler.Reconcile`'s no-op branch skipped `Apply()` whenever the desired config hash matched the stored annotation and `runtimeStatus.Healthy` was true. `Healthy` only reflects "is the GoBGP process up" — it says nothing about whether GoBGP still holds every desired peer.

A GC cycle deleting and recreating a router's `BGPVRFInstance`/`BGPAdvertisement` CRs can drop a peer out of GoBGP's live state without the desired config's hash ever changing, since the recreated CRs hash identically to before. When that happens, the no-op branch wedges permanently: `Apply()` (and the `ListPeer`/`AddPeer` diff in `GoBGPRuntime.applyPeers`) never runs again until something manually busts the `config-hash` annotation.

## Where this came from

Found live-debugging a cross-location EVPN ping failure across two staging clusters. Router logs showed `peer not found in runtime status, skipping status update` every ~30s for hours after a GC churn cycle, confirming the peer had been silently dropped from GoBGP's live state while the config hash stayed unchanged. Live workaround at the time was clearing the `config-hash` annotation to force a reconcile; this PR is the real fix so it doesn't need a manual annotation bust the next time GC (or anything else) drops a peer without changing the desired config.

## Fix

Add `allDesiredPeersPresent`, which checks every desired peer's normalized address against the runtime's live peer list, and require it alongside the existing hash/`Healthy` checks before treating a reconcile as a true no-op. Any peer missing from the live list now falls through to `Apply()`, which re-adds it.

## Testing

- `TestAllDesiredPeersPresent` — new unit test covering all-present, one-missing, and IPv6 leading-zero address normalization cases.
- `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- `go test -race ./internal/controller/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)