### PR TITLE
fix(router): backfill EVPN routes when a VRF's import RTs change

### DIFF
--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -57,6 +57,11 @@ type GoBGPRuntime struct {
 	// they disappear from desired state and so the route-write privilege probe
 	// runs only once per VRF rather than on every reconcile.
 	appliedVRFs map[string]uint32
+	// appliedVRFImportRTs tracks the last-applied import route-target set for
+	// each already-registered VRF, keyed by VRF name, so applyVRFs can detect
+	// when an existing VRF's import RTs change (not just when a VRF is first
+	// registered) and trigger a RIB backfill for it — see applyVRFs.
+	appliedVRFImportRTs map[string][]string
 	// rtIndexMu guards rtIndex, which is read concurrently by the shared EVPN
 	// RIB watcher goroutine.
 	rtIndexMu sync.RWMutex
@@ -113,6 +118,7 @@ func NewRuntimeFactory(listenPort int32, reflector bool, localAddress string) ru
 			establishedAt:         make(map[string]time.Time),
 			appliedPolicies:       make(map[string]model.BGPPolicyDirection),
 			appliedVRFs:           make(map[string]uint32),
+			appliedVRFImportRTs:   make(map[string][]string),
 			rtIndex:               make(map[string]uint32),
 			appliedAdvertisements: make(map[string]model.DesiredAdvertisement),
 		}, nil
@@ -272,11 +278,12 @@ func (r *GoBGPRuntime) applyVRFs(
 		if _, ok := desired[name]; !ok {
 			deleteVRF(ctx, b, name)
 			delete(r.appliedVRFs, name)
+			delete(r.appliedVRFImportRTs, name)
 		}
 	}
 
 	rtIndex := make(map[string]uint32, len(vrfs))
-	newlyRegistered := false
+	needsBackfill := false
 	for _, v := range vrfs {
 		if err := applyVRF(ctx, b, &v, routerID); err != nil {
 			return fmt.Errorf("apply VRF %s: %w", v.Name, err)
@@ -298,8 +305,19 @@ func (r *GoBGPRuntime) applyVRFs(
 				continue
 			}
 			r.appliedVRFs[v.Name] = tableID
-			newlyRegistered = true
+			needsBackfill = true
+		} else if !equalRTSets(r.appliedVRFImportRTs[v.Name], v.ImportRouteTargets) {
+			// This VRF was already registered, but its import route-target
+			// set has changed (e.g. an import policy widened to pick up
+			// another VPC/location's RT). A remote path matching a
+			// newly-added RT may already be best-path in GoBGP's RIB —
+			// added before this VRF's rtIndex entry existed for that RT —
+			// and watchEVPNRIB only notifies on *future* best-path events,
+			// so it would never be redelivered without a backfill.
+			needsBackfill = true
 		}
+		r.appliedVRFImportRTs[v.Name] = append([]string(nil), v.ImportRouteTargets...)
+
 		for _, rt := range v.ImportRouteTargets {
 			rtIndex[rt] = tableID
 		}
@@ -309,16 +327,38 @@ func (r *GoBGPRuntime) applyVRFs(
 	r.rtIndex = rtIndex
 	r.rtIndexMu.Unlock()
 
-	// A newly registered VRF's route targets may match paths that were
-	// already best-path in GoBGP's RIB before this VRF existed in rtIndex —
+	// A newly registered VRF's route targets, or a route-target set that
+	// changed on an already-registered VRF, may match paths that were
+	// already best-path in GoBGP's RIB before that RT existed in rtIndex —
 	// the shared watcher's WatchBestPath(true) only replays the RIB once, at
 	// its own startup, so it would never redeliver those. Backfill from the
-	// current RIB now that rtIndex includes the new VRF.
-	if newlyRegistered {
+	// current RIB now that rtIndex reflects the change.
+	if needsBackfill {
 		r.backfillEVPNRoutes(b)
 	}
 
 	return nil
+}
+
+// equalRTSets reports whether a and b contain the same route targets,
+// ignoring order — the desired route-target list's order isn't guaranteed
+// stable across reconciles, since it round-trips through a Kubernetes CR
+// spec (BGPVRFInstance.Spec.ImportRouteTargets).
+func equalRTSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, rt := range a {
+		counts[rt]++
+	}
+	for _, rt := range b {
+		counts[rt]--
+		if counts[rt] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // applyEVPN advertises EVPN paths for all relevant advertisements, withdrawing

--- a/internal/runtime/gobgp/runtime_test.go
+++ b/internal/runtime/gobgp/runtime_test.go
@@ -170,3 +170,61 @@ func TestApplyVRFDerivesRouteDistinguisher(t *testing.T) {
 		})
 	}
 }
+
+// TestEqualRTSets verifies the order-independent route-target set comparison
+// applyVRFs uses to detect when an already-registered VRF's import RTs
+// change (e.g. an import policy widens to pick up another VPC/location's
+// RT) — the signal that must trigger a RIB backfill so an already-best-path
+// remote route isn't left undelivered until the next router restart.
+func TestEqualRTSets(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{name: "both empty", a: nil, b: nil, want: true},
+		{name: "identical single", a: []string{testRT100}, b: []string{testRT100}, want: true},
+		{
+			name: "same elements, different order",
+			a:    []string{testRT100, testRT200},
+			b:    []string{testRT200, testRT100},
+			want: true,
+		},
+		{
+			name: "widened set (RT added)",
+			a:    []string{testRT100},
+			b:    []string{testRT100, testRT200},
+			want: false,
+		},
+		{
+			name: "narrowed set (RT removed)",
+			a:    []string{testRT100, testRT200},
+			b:    []string{testRT100},
+			want: false,
+		},
+		{
+			name: "same length, disjoint",
+			a:    []string{testRT100},
+			b:    []string{testRT200},
+			want: false,
+		},
+		{
+			name: "duplicate handling",
+			a:    []string{testRT100, testRT100},
+			b:    []string{testRT100},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := equalRTSets(tt.a, tt.b); got != tt.want {
+				t.Errorf("equalRTSets(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+			// Symmetric.
+			if got := equalRTSets(tt.b, tt.a); got != tt.want {
+				t.Errorf("equalRTSets(%v, %v) = %v, want %v (symmetry)", tt.b, tt.a, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`GoBGPRuntime.applyVRFs` only called `backfillEVPNRoutes` when a VRF was newly registered (its first appearance in `appliedVRFs`), never when an already-registered VRF's import route-target set later changed — e.g. an import policy widening to pick up another VPC/location's RT for cross-location routing.

`rtIndex` (the RT-string → kernel-table-ID map `watchEVPNRIB`/`processEVPNPath` use to decide where to install a route) was already rebuilt correctly on every call, so *future* best-path events resolve correctly. But a remote EVPN path that was already best-path in GoBGP's RIB before the RT widened would never be redelivered: `WatchBestPath(true)` only replays the RIB once, at the watcher's own startup, and only notifies on new best-path transitions afterward.

## Where this came from

Found live-debugging a cross-location EVPN ping failure across two staging clusters. The only way to pick up an already-resident path after widening a VRF's import RTs was to restart the router pod, which resets `appliedVRFs` to empty in-memory state and forces `newlyRegistered` (and therefore a backfill) on the next reconcile. Confirmed via startup logs after the restart: `watchEVPNRIB: installing route ... table=<correct VRF table>` on both sides. This PR makes that recovery automatic on an RT change instead of requiring a pod restart.

## Fix

Add `appliedVRFImportRTs`, tracking each registered VRF's last-applied import RT set, and `equalRTSets`, an order-independent comparison (the desired RT list's order isn't guaranteed stable across reconciles, since it round-trips through the `BGPVRFInstance` CR spec). `applyVRFs` now triggers a backfill whenever a VRF is newly registered *or* its import RT set no longer matches what was last applied, and cleans up `appliedVRFImportRTs` alongside `appliedVRFs` when a VRF is removed.

## Testing

- `TestEqualRTSets` — new unit test covering identical/reordered/widened/narrowed/disjoint/duplicate RT sets.
- `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- `go test -race ./internal/runtime/gobgp/...` passes, including the existing `TestApplyVRFDerivesRouteDistinguisher` and listen-port tests.

Note: a full integration test exercising `applyVRFs`'s backfill trigger end-to-end would need real kernel VRF interfaces and `CAP_NET_ADMIN` (same constraint noted in `docs/agents/CONVENTIONS.md` for `internal/plumbing/vrf`), so coverage here is scoped to the new comparison logic that gates the fix, consistent with this package's existing test style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)