### PR TITLE
fix(router): probe egress_route_table write access, not kernel routes

### DIFF
--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -17,12 +17,19 @@ import (
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
 	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	gobgpserver "github.com/osrg/gobgp/v4/pkg/server"
-	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
 )
+
+// pinDir is the bpffs directory probeEgressRouteWrite opens egress_route_table
+// from -- a package var defaulting to attach.PinDir, the same test seam
+// internal/plumbing/srv6's own pinDir var provides, so this package's tests
+// don't depend on a real bpffs mount or root privileges either.
+var pinDir = attach.PinDir
 
 // startRIBMonitor starts the shared EVPN best-path watcher goroutine once per
 // GoBGPRuntime lifetime, regardless of how many VRFs exist. It installs and
@@ -319,28 +326,44 @@ func addrToNetIP(addr netip.Addr) net.IP {
 	return ip
 }
 
-// probeRouteWrite verifies that the process holds the privileges needed to
-// install kernel routes into tableID. It installs a test host route from the
-// RFC 3849 documentation range (2001:db8::/32) — which can never conflict with
-// real VPC traffic — then immediately removes it. This catches a missing
-// runAsUser:0 or CAP_NET_ADMIN before the first real EVPN best-path event
-// arrives, rather than silently failing minutes later.
-func probeRouteWrite(tableID uint32) error {
-	lo, err := netlink.LinkByName("lo")
+// probeEgressRouteWrite verifies that this process can actually write
+// egress_route_table entries for tableID before applyVRFs trusts this VRF's
+// routing to work at all. It installs a pass-through test entry for a
+// prefix from the RFC 3849 documentation range (2001:db8::/32) — which can
+// never conflict with real VPC traffic — then immediately removes it. A
+// pass-through entry (RegisterPassThrough, not Register) is deliberate:
+// unlike a real route, it needs no SID/next-hop resolution, so this probe
+// only exercises the one thing it exists to check -- the pinned bpffs map's
+// open+write path -- not incidentally depending on some other prefix
+// already having a resolvable neighbor.
+//
+// This replaces an earlier version of this probe that wrote a real kernel
+// route via netlink instead (the same RFC 3849 prefix, same install/remove
+// shape) -- a leftover check from this codebase's pre-TC-BPF design, when
+// RouteEgressAdd really did write kernel SEG6 routes and so really did need
+// CAP_NET_ADMIN. Since the TC-BPF migration (see RouteEgressAdd's own doc
+// comment in internal/plumbing/srv6/egress.go), installing a VRF's routes
+// only ever writes into this pinned eBPF map — never the kernel FIB — so a
+// probe that tests kernel route-write capability instead tests a privilege
+// this path no longer needs, while never actually verifying the one this
+// path does need (a mounted bpffs at pinDir, readable/writable by this
+// process). galactic-router's DaemonSet happens to still grant NET_ADMIN
+// today (for the unrelated RouteMainAdd/anycast path), which is why the
+// old probe kept silently passing rather than ever catching this — but it
+// was verifying the wrong thing the whole time.
+func probeEgressRouteWrite(tableID uint32) error {
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {
-		return fmt.Errorf("lookup loopback for probe: %w", err)
+		return fmt.Errorf("open pinned egress_route_table (missing bpffs mount, BPF capability, or root?): %w", err)
 	}
-	_, dst, _ := net.ParseCIDR("2001:db8:ffff:ffff:ffff:ffff:ffff:fffe/128")
-	probe := &netlink.Route{
-		Dst:       dst,
-		Table:     int(tableID),
-		LinkIndex: lo.Attrs().Index,
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+
+	_, probe, _ := net.ParseCIDR("2001:db8:ffff:ffff:ffff:ffff:ffff:fffe/128")
+	if err := table.RegisterPassThrough(tableID, probe); err != nil {
+		return fmt.Errorf("egress_route_table write probe: %w", err)
 	}
-	if err := netlink.RouteReplace(probe); err != nil {
-		return fmt.Errorf("route write probe (missing root or CAP_NET_ADMIN?): %w", err)
-	}
-	if err := netlink.RouteDel(probe); err != nil {
-		slog.Warn("probeRouteWrite: failed to remove probe route", "dst", probe.Dst, "err", err)
+	if err := table.Unregister(tableID, probe); err != nil {
+		slog.Warn("probeEgressRouteWrite: failed to remove probe entry", "prefix", probe, "err", err)
 	}
 	return nil
 }

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -294,14 +294,15 @@ func (r *GoBGPRuntime) applyVRFs(
 			var err error
 			tableID, err = vrfTableID(v.Name)
 			if err != nil {
-				slog.Error("applyVRFs: failed to resolve kernel VRF table; SEG6 encap routes will not be installed",
+				slog.Error("applyVRFs: failed to resolve kernel VRF table; this VRF's routes will not be installed",
 					"vrf", v.Name, "err", err)
 				continue
 			}
-			if err := probeRouteWrite(tableID); err != nil {
-				slog.Error("applyVRFs: route write probe failed; SEG6 encap routes will not be installed",
+			if err := probeEgressRouteWrite(tableID); err != nil {
+				slog.Error("applyVRFs: egress_route_table write probe failed; this VRF's routes will not be installed",
 					"vrf", v.Name, "err", err,
-					"hint", "set runAsUser: 0 and capabilities.add: [NET_ADMIN] in the container securityContext")
+					"hint", "set runAsUser: 0 and capabilities.add: [BPF] in the container securityContext, "+
+						"and mount bpffs at "+pinDir)
 				continue
 			}
 			r.appliedVRFs[v.Name] = tableID


### PR DESCRIPTION
## What

`applyVRFs` gates whether a VRF's route target ever enters `rtIndex` (and therefore whether `processEVPNPath`'s `RouteEgressAdd` is ever attempted for it) behind a probe that wrote a real kernel route via netlink and required `CAP_NET_ADMIN`. That was correct for this codebase's pre-TC-BPF design, when `RouteEgressAdd` really did install kernel SEG6 routes — but since the TC-BPF migration, installing a VRF's routes only ever writes into the pinned `egress_route_table` eBPF map, never the kernel FIB. The old probe was testing a privilege this path no longer needs, while never verifying the one it does need: a mounted bpffs at `pinDir`, readable/writable by this process.

## Where this came from — a re-diagnosis, not the originally-suspected bug

This started as an investigation into a live cross-location EVPN ping failure originally attributed to "no kernel-level anchor route for tenant VRF traffic." That framing turned out to be a misdiagnosis: `ip -6 route show vrf` showing no entries is the *expected* steady state post-TC-BPF migration (routes live in the eBPF map, not the kernel FIB), not evidence of a gap — and the design intentionally never installs a default route for plain tenant traffic (only NAT66 egress gets one; tenant traffic is carried by specific per-prefix routes from the EVPN watcher, per the recovered TC-BPF migration design doc). The live symptom is much better explained by #454's backfill bug landing on an already-registered VRF at exactly the moment the RT set was widened.

That said, this probe genuinely was verifying the wrong privilege for what it gates — a real, independent correctness issue worth closing regardless. `galactic-router`'s DaemonSet happens to still grant `NET_ADMIN` today (for the unrelated `RouteMainAdd`/anycast path), which is why this kept silently passing rather than ever catching a real bpffs misconfiguration.

## Fix

Replace `probeRouteWrite` with `probeEgressRouteWrite`, which opens the real pinned `egress_route_table` map and round-trips a pass-through test entry (`RegisterPassThrough`, not `Register` — it needs no SID/next-hop resolution, so the probe only exercises the open+write path it exists to check). Also corrects two now-stale "SEG6 encap" log messages in the same function to describe what actually happens today, and updates the operator-facing hint to mention the `BPF` capability and bpffs mount instead of `NET_ADMIN`.

## Testing

- `go build ./...`, `go vet ./...`, `golangci-lint run` clean.
- `go test -race ./internal/runtime/gobgp/...` passes.
- No new unit test for `probeEgressRouteWrite` itself — like the `probeRouteWrite` it replaces, it requires a real bpffs mount and BPF capability to exercise meaningfully, matching this codebase's existing convention (see `docs/agents/CONVENTIONS.md`'s note on `internal/plumbing/vrf` preferring e2e over mock-heavy unit tests for privileged kernel-state code).

Stacked cleanly on `main` post-#453/#454 merge (rebased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)