### PR TITLE
fix: Mount real CNI state dir and skip wireguard links in autodetect

### DIFF
--- a/config/galactic-gateway/base/daemonset.yaml
+++ b/config/galactic-gateway/base/daemonset.yaml
@@ -141,6 +141,16 @@ spec:
             - name: netns
               mountPath: /var/run/netns
               readOnly: true
+            # See config/galactic-router/base/daemonset.yaml's own cni-state
+            # mount comment: this container runs the same GC reconciler
+            # (GALACTIC_ROUTER_GC_NAMESPACE above), so it hits the same
+            # internal/plumbing/vrf/lock.go flock against the real, unmounted
+            # /var/lib/cni/galactic-vrf path -- readOnlyRootFilesystem below
+            # otherwise sends that MkdirAll against this container's own
+            # throwaway overlay fs and the lock (and any VRF orphan GC it
+            # guards) never succeeds.
+            - name: cni-state
+              mountPath: /var/lib/cni
         - name: galactic-gateway
           # See the galactic-router container above: same placeholder-tag
           # caveat.
@@ -236,6 +246,10 @@ spec:
         - name: netns
           hostPath:
             path: /var/run/netns
+            type: DirectoryOrCreate
+        - name: cni-state
+          hostPath:
+            path: /var/lib/cni
             type: DirectoryOrCreate
         - name: bpf-fs
           hostPath:

--- a/config/galactic-router/base/daemonset.yaml
+++ b/config/galactic-router/base/daemonset.yaml
@@ -152,10 +152,29 @@ spec:
               readOnly: true
             - name: bpf-fs
               mountPath: /sys/fs/bpf
+            # internal/plumbing/vrf/lock.go's flock serializes VRF table ID
+            # allocation between this container's GC pass (RemoveOrphanedVRFs
+            # -> vrf.Delete) and the galactic-cni plugin's ADD/DEL, which runs
+            # as a bare process directly on the host and locks the real
+            # /var/lib/cni/galactic-vrf path unconditionally -- the lockDir
+            # constant is not configurable. Without this mount,
+            # readOnlyRootFilesystem above sends the container's MkdirAll
+            # against its own throwaway overlay fs, so both the lock and any
+            # VRF orphan GC it guards fail every time. Same well-known
+            # /var/lib/cni root the CNI plugin's IPAM state
+            # (internal/cni/ipam.DefaultLockDir) already lives under, so it
+            # must be a real, writable directory on every node running this
+            # DaemonSet regardless of this mount's presence.
+            - name: cni-state
+              mountPath: /var/lib/cni
       volumes:
         - name: netns
           hostPath:
             path: /var/run/netns
+            type: DirectoryOrCreate
+        - name: cni-state
+          hostPath:
+            path: /var/lib/cni
             type: DirectoryOrCreate
         - name: bpf-fs
           # The host's bpffs mount, same convention/tradeoff

--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -87,6 +87,22 @@ func parseInterfaceList(v string) []string {
 // -- analogous to the existing GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
 // auto-detection-from-`lo` pattern (internal/plumbing/loaddr), but over
 // routes rather than addresses.
+//
+// Skips wireguard-type links (excludedLinkType): a WireGuard mesh
+// interface can install its own IPv6 default-ish route alongside the real
+// fabric NIC's, and if netlink reports the mesh interface's route first,
+// ResolveNodeSourceAddress would bake the mesh interface's ULA in as this
+// node's SRv6 outer-header source address for every encapsulated packet.
+// That address is never reachable off-node (it's not advertised anywhere
+// outside the WireGuard mesh), so every cross-site SRv6 packet would leave
+// the box correctly SID-routed but with a source no intermediate network
+// would forward on (or a receiving node would recognize as this peer) --
+// silent packet loss with no error on either side. A WireGuard tunnel can
+// never legitimately be "the real fabric NIC" this datapath pushes raw
+// SRv6-encapsulated Ethernet frames onto, so it's excluded categorically
+// rather than by interface name (the specific mesh interface name is
+// deployment-specific; the underlying failure mode -- a tunnel interface
+// racing a real NIC for the default route -- is not).
 func autoDetectInterfaces() ([]string, error) {
 	routes, err := routeListFn()
 	if err != nil {
@@ -106,6 +122,9 @@ func autoDetectInterfaces() ([]string, error) {
 			// detection over one stale/racing route.
 			continue
 		}
+		if link.Type() == excludedLinkType {
+			continue
+		}
 		name := link.Attrs().Name
 		if seen[name] {
 			continue
@@ -121,6 +140,11 @@ func autoDetectInterfaces() ([]string, error) {
 	}
 	return names, nil
 }
+
+// excludedLinkType is the vishvananda/netlink Link.Type() value
+// autoDetectInterfaces never treats as a candidate fabric interface -- see
+// autoDetectInterfaces' own doc comment for why.
+const excludedLinkType = "wireguard"
 
 // isDefaultRoute reports whether r is an IPv6 default route (::/0).
 func isDefaultRoute(r netlink.Route) bool {

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -23,13 +23,21 @@ const (
 	testIfaceEth1 = "eth1"
 )
 
-// fakeLink is a minimal netlink.Link implementation for tests.
+// fakeLink is a minimal netlink.Link implementation for tests. linkType
+// defaults to "fake" when unset, so existing fixtures that never set it
+// don't need updating.
 type fakeLink struct {
-	attrs netlink.LinkAttrs
+	attrs    netlink.LinkAttrs
+	linkType string
 }
 
 func (f *fakeLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
-func (f *fakeLink) Type() string              { return "fake" }
+func (f *fakeLink) Type() string {
+	if f.linkType == "" {
+		return "fake"
+	}
+	return f.linkType
+}
 
 func TestResolveInterfaces_EnvOverride(t *testing.T) {
 	tests := []struct {
@@ -162,6 +170,65 @@ func TestResolveInterfaces_AutoDetect(t *testing.T) {
 		}
 		if !equalStringSlices(got, []string{testIfaceEth0}) {
 			t.Errorf("ResolveInterfaces() = %v, want [%s] (unresolvable route skipped)", got, testIfaceEth0)
+		}
+	})
+
+	t.Run("WireguardLinkExcluded", func(t *testing.T) {
+		// A WireGuard mesh interface can install an IPv6 default-ish
+		// route alongside the real fabric NIC's; ResolveInterfaces must
+		// never return a wireguard-type link even when its default
+		// route sorts ahead of a real NIC's.
+		const wireguardIface = "wg-mesh0"
+		wgLinks := map[int]netlink.Link{
+			2: &fakeLink{attrs: netlink.LinkAttrs{Index: 2, Name: wireguardIface}, linkType: "wireguard"},
+			3: &fakeLink{attrs: netlink.LinkAttrs{Index: 3, Name: testIfaceEth0}},
+		}
+		origLinkByIndexFn := linkByIndexFn
+		linkByIndexFn = func(index int) (netlink.Link, error) {
+			if l, ok := wgLinks[index]; ok {
+				return l, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		defer func() { linkByIndexFn = origLinkByIndexFn }()
+
+		routeListFn = func() ([]netlink.Route, error) {
+			return []netlink.Route{
+				{LinkIndex: 2, Dst: nil}, // the mesh interface's default route, reported first
+				{LinkIndex: 3, Dst: nil}, // the real fabric NIC's
+			}, nil
+		}
+		got, err := ResolveInterfaces()
+		if err != nil {
+			t.Fatalf("ResolveInterfaces() error = %v", err)
+		}
+		if !equalStringSlices(got, []string{testIfaceEth0}) {
+			t.Errorf("ResolveInterfaces() = %v, want [%s] (wireguard link excluded)", got, testIfaceEth0)
+		}
+	})
+
+	t.Run("OnlyWireguardLinkIsActionableError", func(t *testing.T) {
+		const wireguardIface = "wg-mesh0"
+		wgLinks := map[int]netlink.Link{
+			2: &fakeLink{attrs: netlink.LinkAttrs{Index: 2, Name: wireguardIface}, linkType: "wireguard"},
+		}
+		origLinkByIndexFn := linkByIndexFn
+		linkByIndexFn = func(index int) (netlink.Link, error) {
+			if l, ok := wgLinks[index]; ok {
+				return l, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		defer func() { linkByIndexFn = origLinkByIndexFn }()
+
+		routeListFn = func() ([]netlink.Route, error) {
+			return []netlink.Route{
+				{LinkIndex: 2, Dst: nil},
+			}, nil
+		}
+		_, err := ResolveInterfaces()
+		if err == nil {
+			t.Fatal("ResolveInterfaces() error = nil, want an error (only candidate is a wireguard link)")
 		}
 	})
 


### PR DESCRIPTION

## Summary

The router and gateway containers could not reliably coordinate VRF cleanup with the CNI plugin, because their containers wrote lock state to a throwaway filesystem instead of the shared host directory the CNI plugin uses. Separately, interface auto-detection could select a WireGuard mesh interface instead of the real fabric NIC, so SRv6 packets left the node stamped with a source address that was unreachable off-node.

This mounts the real host CNI state directory into both DaemonSets so VRF locking actually serializes with the CNI plugin, and it excludes WireGuard-type links from interface auto-detection so the real fabric NIC is always chosen.

## Test plan

- [ ] VRF orphan GC lock succeeds against the shared host CNI state directory, not a throwaway filesystem
- [ ] Interface auto-detection never selects a WireGuard-type link when a real fabric NIC route also exists