### PR TITLE
fix: Attach the eBPF ingress hook to bond slaves, not just the master

### DIFF
--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -6,6 +6,7 @@ package attach
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -38,6 +39,12 @@ var (
 	linkByIndexFn = func(index int) (netlink.Link, error) {
 		return netlink.LinkByIndex(index)
 	}
+	// linkListFn enumerates every link on the host, for expandBondSlaves'
+	// slave lookup below. linkByNameFn (resolving one name to its Link) is
+	// already declared in health.go -- reused here rather than redeclared.
+	linkListFn = func() ([]netlink.Link, error) {
+		return netlink.LinkList()
+	}
 )
 
 // ResolveInterfaces returns the set of interface names the uSID datapath
@@ -45,25 +52,41 @@ var (
 //
 // If config.EnvCNIEBPFInterfaces is set, it is parsed as a comma-separated
 // list of interface names (whitespace trimmed, duplicates and empty
-// entries removed) and returned directly -- no auto-detection is
-// performed. This is the explicit override for multi-homed nodes where
-// auto-detection is ambiguous.
+// entries removed) and used directly -- no auto-detection is performed.
+// This is the explicit override for multi-homed nodes where auto-detection
+// is ambiguous.
 //
 // Otherwise, the interface(s) carrying the default IPv6 route are
 // auto-detected. Attaching to the wrong (or too few) interfaces fails as
 // silent blackholing of overlay traffic (design plan §4.1), so callers
 // that get an error here must not proceed with a partial or empty
 // interface set.
+//
+// Either way, the resolved set is then run through expandBondSlaves: any
+// interface that is itself a Linux bonding master is expanded to include
+// its slave interfaces too, since ingress tc/eBPF classification on a
+// bonded interface happens on the slaves, not the master -- see
+// expandBondSlaves' own doc comment. This applies uniformly to both paths
+// above, so an operator using the override only needs to name the bond
+// master, not hand-list every slave alongside it.
 func ResolveInterfaces() ([]string, error) {
+	var (
+		names []string
+		err   error
+	)
 	if override := strings.TrimSpace(os.Getenv(config.EnvCNIEBPFInterfaces)); override != "" {
-		names := parseInterfaceList(override)
+		names = parseInterfaceList(override)
 		if len(names) == 0 {
 			return nil, fmt.Errorf("attach: %s is set to %q but contains no usable interface names",
 				config.EnvCNIEBPFInterfaces, override)
 		}
-		return names, nil
+	} else {
+		names, err = autoDetectInterfaces()
+		if err != nil {
+			return nil, err
+		}
 	}
-	return autoDetectInterfaces()
+	return expandBondSlaves(names)
 }
 
 // parseInterfaceList splits a comma-separated interface list, trimming
@@ -145,6 +168,94 @@ func autoDetectInterfaces() ([]string, error) {
 // autoDetectInterfaces never treats as a candidate fabric interface -- see
 // autoDetectInterfaces' own doc comment for why.
 const excludedLinkType = "wireguard"
+
+// bondLinkType is the vishvananda/netlink Link.Type() value expandBondSlaves
+// checks for -- see its own doc comment for why.
+const bondLinkType = "bond"
+
+// expandBondSlaves expands any bonding-master interface in names to also
+// include its slave interfaces, leaving every non-bond interface unchanged.
+//
+// On a Linux bonding master, RX ingress tc/eBPF classification happens on
+// the slave devices, not the bond master itself -- a well-known kernel
+// behavior (confirmed live: `tc filter show dev bond0 ingress` showed this
+// package's own filter correctly attached, `tc filter show dev <slave>
+// ingress` showed nothing on either slave, and every uSID datapath map
+// counter -- locator_table, function_table, vrf_table, drop_reasons --
+// stayed at zero despite tcpdump confirming packets arriving on the wire).
+// The bond master still carries the IP/route configuration ResolveInterfaces
+// resolves from (auto-detect) or an operator names directly (the
+// GALACTIC_CNI_EBPF_INTERFACES override), but attaching the ingress hook to
+// only the master silently never sees any traffic that arrives while
+// bonded -- so both master and slaves are attached, mirroring the
+// tc/bonding gotcha this replaces the historical per-node "list the master
+// plus every slave name in GALACTIC_CNI_EBPF_INTERFACES by hand" workaround.
+//
+// A name that can't be resolved at all is passed through unchanged (logged,
+// not failed): ResolveInterfaces' override path has never required its
+// named interfaces to actually exist on the host at resolution time (e.g.
+// internal/installer's static-conflist generation resolves this purely to
+// produce a config string, independent of whether/when this init
+// container's netns can see the interface) -- callers that do need the
+// interface to genuinely exist still get that failure from attachOne at
+// actual attach time, unchanged from before this function existed. Once a
+// name does resolve to a real bonding master, though, failing to enumerate
+// its slaves is treated as fatal -- silently falling back to "just the
+// master" would reproduce the exact bug this function exists to fix.
+func expandBondSlaves(names []string) ([]string, error) {
+	var out []string
+	seen := make(map[string]bool)
+	add := func(name string) {
+		if seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+
+	for _, name := range names {
+		add(name)
+
+		link, err := linkByNameFn(name)
+		if err != nil {
+			slog.Warn("attach: could not resolve interface to check whether it's a bonding master, "+
+				"leaving it as-is", "interface", name, "err", err)
+			continue
+		}
+		if link.Type() != bondLinkType {
+			continue
+		}
+
+		slaves, err := bondSlaveNames(link)
+		if err != nil {
+			return nil, fmt.Errorf("attach: enumerate slaves of bonding master %q: %w", name, err)
+		}
+		for _, slave := range slaves {
+			add(slave)
+		}
+	}
+	return out, nil
+}
+
+// bondSlaveNames returns the names of every link enslaved to master (i.e.
+// every link whose MasterIndex, populated from netlink's IFLA_MASTER
+// attribute, equals master's own index), in whatever order linkListFn
+// reports them.
+func bondSlaveNames(master netlink.Link) ([]string, error) {
+	links, err := linkListFn()
+	if err != nil {
+		return nil, err
+	}
+
+	masterIndex := master.Attrs().Index
+	var slaves []string
+	for _, l := range links {
+		if l.Attrs().MasterIndex == masterIndex {
+			slaves = append(slaves, l.Attrs().Name)
+		}
+	}
+	return slaves, nil
+}
 
 // isDefaultRoute reports whether r is an IPv6 default route (::/0).
 func isDefaultRoute(r netlink.Route) bool {

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -39,7 +39,27 @@ func (f *fakeLink) Type() string {
 	return f.linkType
 }
 
+// stubNonBondLinks configures linkByNameFn/linkListFn so ResolveInterfaces'
+// expandBondSlaves pass is a no-op: every name resolves to a non-bond
+// fakeLink, and there are no other links on the host to enumerate as
+// slaves. Tests that only care about override-parsing or auto-detection
+// behavior (not bond expansion itself) use this so expandBondSlaves' own
+// netlink lookups don't need per-test fixtures.
+func stubNonBondLinks(t *testing.T) {
+	t.Helper()
+	origLinkByNameFn, origLinkListFn := linkByNameFn, linkListFn
+	t.Cleanup(func() {
+		linkByNameFn, linkListFn = origLinkByNameFn, origLinkListFn
+	})
+	linkByNameFn = func(name string) (netlink.Link, error) {
+		return &fakeLink{attrs: netlink.LinkAttrs{Name: name}}, nil
+	}
+	linkListFn = func() ([]netlink.Link, error) { return nil, nil }
+}
+
 func TestResolveInterfaces_EnvOverride(t *testing.T) {
+	stubNonBondLinks(t)
+
 	tests := []struct {
 		name      string
 		envValue  string
@@ -94,6 +114,7 @@ func TestResolveInterfaces_EnvOverride(t *testing.T) {
 
 func TestResolveInterfaces_AutoDetect(t *testing.T) {
 	t.Setenv(config.EnvCNIEBPFInterfaces, "")
+	stubNonBondLinks(t)
 
 	origRouteListFn, origLinkByIndexFn := routeListFn, linkByIndexFn
 	t.Cleanup(func() {
@@ -249,6 +270,186 @@ func TestResolveInterfaces_AutoDetect(t *testing.T) {
 		_, err := ResolveInterfaces()
 		if err == nil {
 			t.Fatal("ResolveInterfaces() error = nil, want the underlying route-list error surfaced")
+		}
+	})
+}
+
+// TestExpandBondSlaves exercises expandBondSlaves directly against a faked
+// netlink view (linkByNameFn/linkListFn), covering the live bug: on a Linux
+// bonding master, RX ingress tc/eBPF classification happens on the slave
+// devices, not the master -- see expandBondSlaves' own doc comment.
+func TestExpandBondSlaves(t *testing.T) {
+	origLinkByNameFn, origLinkListFn := linkByNameFn, linkListFn
+	t.Cleanup(func() {
+		linkByNameFn, linkListFn = origLinkByNameFn, origLinkListFn
+	})
+
+	const (
+		bondName  = "bond0"
+		bondIndex = 10
+		slave1    = "ens1f1np1"
+		slave2    = "ens2f1np1"
+	)
+
+	slave1Link := &fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 11, MasterIndex: bondIndex}}
+	bondLinks := map[string]netlink.Link{
+		testIfaceEth0: &fakeLink{attrs: netlink.LinkAttrs{Name: testIfaceEth0, Index: 2}},
+		bondName:      &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bondLinkType},
+		slave1:        slave1Link, // also named explicitly, in MixedBondAndNonBondDeduped below
+	}
+	allLinks := []netlink.Link{
+		bondLinks[testIfaceEth0],
+		bondLinks[bondName],
+		slave1Link,
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave2, Index: 12, MasterIndex: bondIndex}},
+		// A link enslaved to some other, unrelated master must never leak in.
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "unrelated-slave", Index: 13, MasterIndex: 999}},
+	}
+
+	linkByNameFn = func(name string) (netlink.Link, error) {
+		if l, ok := bondLinks[name]; ok {
+			return l, nil
+		}
+		return nil, errFixtureNotFound
+	}
+	linkListFn = func() ([]netlink.Link, error) { return allLinks, nil }
+
+	t.Run("NonBondUnchanged", func(t *testing.T) {
+		got, err := expandBondSlaves([]string{testIfaceEth0})
+		if err != nil {
+			t.Fatalf("expandBondSlaves() error = %v", err)
+		}
+		if !equalStringSlices(got, []string{testIfaceEth0}) {
+			t.Errorf("expandBondSlaves() = %v, want [%s] (non-bond interface unchanged)", got, testIfaceEth0)
+		}
+	})
+
+	t.Run("BondExpandsToMasterAndSlaves", func(t *testing.T) {
+		got, err := expandBondSlaves([]string{bondName})
+		if err != nil {
+			t.Fatalf("expandBondSlaves() error = %v", err)
+		}
+		want := []string{bondName, slave1, slave2}
+		if !equalStringSlices(got, want) {
+			t.Errorf("expandBondSlaves() = %v, want %v (master plus both real slaves, unrelated slave excluded)", got, want)
+		}
+	})
+
+	t.Run("MixedBondAndNonBondDeduped", func(t *testing.T) {
+		got, err := expandBondSlaves([]string{testIfaceEth0, bondName, slave1})
+		if err != nil {
+			t.Fatalf("expandBondSlaves() error = %v", err)
+		}
+		want := []string{testIfaceEth0, bondName, slave1, slave2}
+		if !equalStringSlices(got, want) {
+			t.Errorf("expandBondSlaves() = %v, want %v (slave1 named explicitly must not be duplicated)", got, want)
+		}
+	})
+
+	t.Run("UnresolvableInterfacePassedThrough", func(t *testing.T) {
+		// A name that can't be resolved at all (e.g. this init container's
+		// netns can't yet see it) is passed through unchanged rather than
+		// failing the whole call -- ResolveInterfaces' override path has
+		// never required its named interfaces to actually exist on the
+		// host at resolution time (installer_test.go's TestResolveEBPFInterfaces
+		// asserts exactly this for the pre-bond-expansion behavior).
+		const name = "does-not-exist"
+		got, err := expandBondSlaves([]string{name})
+		if err != nil {
+			t.Fatalf("expandBondSlaves() error = %v, want no error (unresolvable name passed through)", err)
+		}
+		if !equalStringSlices(got, []string{name}) {
+			t.Errorf("expandBondSlaves() = %v, want [%s] unchanged", got, name)
+		}
+	})
+
+	t.Run("LinkListErrorPropagated", func(t *testing.T) {
+		origLinkListFn := linkListFn
+		linkListFn = func() ([]netlink.Link, error) { return nil, errFixtureNotFound }
+		defer func() { linkListFn = origLinkListFn }()
+
+		_, err := expandBondSlaves([]string{bondName})
+		if err == nil {
+			t.Fatal("expandBondSlaves() error = nil, want the underlying link-list error surfaced")
+		}
+	})
+}
+
+// TestResolveInterfaces_BondExpansion exercises bond expansion end-to-end
+// through ResolveInterfaces itself, for both the env-override and
+// auto-detect paths -- so an operator naming only a bond master (or a
+// default route resolving to one) gets its slaves attached too, without
+// needing to hand-list them.
+func TestResolveInterfaces_BondExpansion(t *testing.T) {
+	const (
+		bondName  = "bond0"
+		bondIndex = 5
+		slave1    = "ens1f1np1"
+		slave2    = "ens2f1np1"
+	)
+
+	bondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bondLinkType}
+	slaveLinks := []netlink.Link{
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 6, MasterIndex: bondIndex}},
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave2, Index: 7, MasterIndex: bondIndex}},
+	}
+	want := []string{bondName, slave1, slave2}
+
+	t.Run("EnvOverride", func(t *testing.T) {
+		t.Setenv(config.EnvCNIEBPFInterfaces, bondName)
+
+		origLinkByNameFn, origLinkListFn := linkByNameFn, linkListFn
+		t.Cleanup(func() { linkByNameFn, linkListFn = origLinkByNameFn, origLinkListFn })
+		linkByNameFn = func(name string) (netlink.Link, error) {
+			if name == bondName {
+				return bondLink, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		linkListFn = func() ([]netlink.Link, error) { return slaveLinks, nil }
+
+		got, err := ResolveInterfaces()
+		if err != nil {
+			t.Fatalf("ResolveInterfaces() error = %v", err)
+		}
+		if !equalStringSlices(got, want) {
+			t.Errorf("ResolveInterfaces() = %v, want %v (override naming only the bond master expands to its slaves)", got, want)
+		}
+	})
+
+	t.Run("AutoDetect", func(t *testing.T) {
+		t.Setenv(config.EnvCNIEBPFInterfaces, "")
+
+		origRouteListFn, origLinkByIndexFn := routeListFn, linkByIndexFn
+		origLinkByNameFn, origLinkListFn := linkByNameFn, linkListFn
+		t.Cleanup(func() {
+			routeListFn, linkByIndexFn = origRouteListFn, origLinkByIndexFn
+			linkByNameFn, linkListFn = origLinkByNameFn, origLinkListFn
+		})
+
+		routeListFn = func() ([]netlink.Route, error) {
+			return []netlink.Route{{LinkIndex: bondIndex, Dst: nil}}, nil
+		}
+		linkByIndexFn = func(index int) (netlink.Link, error) {
+			if index == bondIndex {
+				return bondLink, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		linkByNameFn = func(name string) (netlink.Link, error) {
+			if name == bondName {
+				return bondLink, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		linkListFn = func() ([]netlink.Link, error) { return slaveLinks, nil }
+
+		got, err := ResolveInterfaces()
+		if err != nil {
+			t.Fatalf("ResolveInterfaces() error = %v", err)
+		}
+		if !equalStringSlices(got, want) {
+			t.Errorf("ResolveInterfaces() = %v, want %v (auto-detected bond master expands to its slaves)", got, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

On a Linux bonding master, RX ingress tc/eBPF classification runs on the slave devices, not the master itself, so the uSID datapath's ingress hook silently saw no traffic on bonded fabric NICs even though the attach itself never reported an error. Interface resolution now expands any resolved bonding master to itself plus its slaves before attaching, for both auto-detected and explicitly overridden interfaces. This replaces the need to hand-list every bond slave in GALACTIC_CNI_EBPF_INTERFACES per node.

## Test plan

- [ ] A bonding master named via GALACTIC_CNI_EBPF_INTERFACES or auto-detected from its default route attaches the ingress hook to itself and all of its slaves
- [ ] A non-bond interface (explicit or auto-detected) resolves unchanged
