### PR TITLE
feat: Reply to Router Solicitation from tap-attached VM guests

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -51,13 +52,15 @@ var ebpfHealthCheckInterval = 10 * time.Second
 // ARCHITECTURE-ROUTER.md: "ticker-driven, default every 5m").
 var ebpfGCSweepInterval = 5 * time.Minute
 
-// radvNextIntervalFn resolves the delay before Run's next Router
-// Advertisement resend pass (internal/plumbing/radv.NextInterval — a
-// jittered value in [MinRtrAdvInterval, MaxRtrAdvInterval), per RFC 4861
-// §6.2.4). A package-level func var, same override pattern as ebpfStartFn/
-// addrListFn/newK8sClientFn above, so tests can substitute a short fixed
-// delay instead of waiting out a real RFC-sized interval.
-var radvNextIntervalFn = radv.NextInterval
+// radvReconcileInterval controls how often Run diffs the currently recorded
+// tap attachments (internal/plumbing/radv.ListAttachments) against the set
+// of running radv.RunActor goroutines, starting one for each newly recorded
+// attachment and canceling one for each attachment that has disappeared. A
+// package-level var, same override pattern as ebpfHealthCheckInterval
+// above. Kept short (unlike the RFC-sized intervals radv.RunActor itself
+// uses) since it only gates how fast a new attachment starts being served
+// at all -- a guest's own boot time dwarfs a couple of seconds either way.
+var radvReconcileInterval = 2 * time.Second
 
 // ebpfHealthServiceName is the gRPC health service name (see
 // grpc_health_v1.HealthServer) reporting the live status of the eBPF uSID
@@ -493,23 +496,102 @@ func cleanupOldBinaryWrapper() {
 	}
 }
 
-// resendRouterAdvertisements is Run's radvTicker case body, split out
-// solely to keep Run's own cyclomatic complexity within golangci-lint's
-// gocyclo budget -- same reasoning as startEBPFDatapath above; behaviorally
-// this is inlined exactly where it used to live. A failure here is never
-// fatal to Run: resending is best-effort maintenance for already-attached
-// VM guests, not a requirement for anything else this process does.
-func resendRouterAdvertisements() {
+// radvActorSet tracks the currently running radv.RunActor goroutines, keyed
+// by host interface name (radv.Record.HostInterface) -- Run's own local
+// state, reconciled against radv.ListAttachments on every
+// radvReconcileTicker tick (see reconcileRadvActors). The zero value is
+// ready to use.
+//
+// cancel is touched only from Run's own goroutine (reconcileRadvActors and
+// the radvActorFailed case below) -- deliberately not guarded by a mutex,
+// since keeping it single-owner is simpler than synchronizing concurrent
+// access from the actor goroutines themselves. Those goroutines instead
+// report a failed startup back onto failed, which Run's select loop drains
+// on its own turn.
+type radvActorSet struct {
+	cancel map[string]context.CancelFunc
+	failed chan string
+	wg     sync.WaitGroup
+}
+
+// reconcileRadvActors is Run's radvReconcileTicker case body -- also called
+// once before the loop starts, so attachments already recorded when this
+// daemon starts (e.g. a restart while VMs are still attached) are served
+// immediately rather than waiting out the first tick. Split into its own
+// function solely to keep Run's own cyclomatic complexity within
+// golangci-lint's gocyclo budget -- same reasoning as startEBPFDatapath
+// above.
+//
+// Starts one radv.RunActor per newly recorded attachment and cancels one
+// for each attachment that has disappeared since the last reconcile. A
+// listing failure here is never fatal to Run -- resending/soliciting is
+// best-effort maintenance for already-attached VM guests, not a
+// requirement for anything else this process does -- so already-running
+// actors are simply left alone until the next tick succeeds. An actor that
+// fails during startup (e.g. a transient interface lookup failure) reports
+// itself on actors.failed instead of silently leaving its map entry stuck
+// "running" forever -- see radvActorFailed.
+func reconcileRadvActors(ctx context.Context, actors *radvActorSet) {
 	records, err := radv.ListAttachments(radv.DefaultStateDir)
 	if err != nil {
 		slog.Warn("Failed to list router advertisement attachments", "err", err)
 		return
 	}
-	for _, r := range records {
-		if err := radv.SendRouterAdvertisement(r.HostInterface, r.MTU); err != nil {
-			slog.Warn("Failed to resend router advertisement", "err", err, "hostInterface", r.HostInterface)
-		}
+
+	if actors.cancel == nil {
+		actors.cancel = make(map[string]context.CancelFunc)
+		// Buffered generously relative to any realistic node's tap
+		// attachment count, so a run of startup failures can't block an
+		// actor goroutine on this send -- radvActorFailed's own send is
+		// non-blocking besides, so a full channel only delays a retry
+		// rather than deadlocking anything.
+		actors.failed = make(chan string, 256)
 	}
+
+	seen := make(map[string]struct{}, len(records))
+	for _, r := range records {
+		seen[r.HostInterface] = struct{}{}
+		if _, running := actors.cancel[r.HostInterface]; running {
+			continue
+		}
+
+		actorCtx, cancel := context.WithCancel(ctx)
+		actors.cancel[r.HostInterface] = cancel
+		actors.wg.Add(1)
+		go func(iface string, mtu int) {
+			defer actors.wg.Done()
+			if err := radv.RunActor(actorCtx, iface, mtu); err != nil {
+				slog.Warn("Router advertisement actor failed to start, will retry next reconcile",
+					"err", err, "hostInterface", iface)
+				select {
+				case actors.failed <- iface:
+				default:
+					slog.Warn("Router advertisement failed-actor channel full, retry may be delayed",
+						"hostInterface", iface)
+				}
+			}
+		}(r.HostInterface, r.MTU)
+	}
+
+	for iface, cancel := range actors.cancel {
+		if _, ok := seen[iface]; ok {
+			continue
+		}
+		cancel()
+		delete(actors.cancel, iface)
+	}
+}
+
+// radvActorFailed is Run's radvActors.failed case body: an actor that
+// couldn't even start (radv.RunActor returned a non-nil error, meaning it
+// never got past opening its Conn) reported itself here rather than
+// leaving reconcileRadvActors permanently convinced it's still running.
+// Clearing its map entry lets the next reconcile tick see the attachment
+// as unserved again and retry it. A delete on a key already gone (the
+// reconciler noticed the attachment itself disappeared in the meantime) is
+// a safe no-op.
+func radvActorFailed(actors *radvActorSet, iface string) {
+	delete(actors.cancel, iface)
 }
 
 // Run executes the CNI installer main container tasks:
@@ -545,13 +627,15 @@ func resendRouterAdvertisements() {
 //     (internal/controller/gc_controller.go), because the pinned maps
 //     only exist inside this container -- see gc.SweepEBPFVRFTable's own
 //     doc comment for the full reasoning.
-//  8. Periodically resends an IPv6 Router Advertisement (internal/plumbing/
-//     radv) for every tap attachment galactic-tap has recorded
-//     (radv.ListAttachments) since the last tick. This runs from here, not
-//     from galactic-tap's own cmdAdd, because a VM guest's boot almost
-//     always outlives that short-lived process -- see radv's own doc
-//     comment for the full reasoning. Unrelated to, and runs regardless of,
-//     the eBPF datapath above.
+//  8. Runs one internal/plumbing/radv.RunActor goroutine per tap attachment
+//     galactic-tap has recorded (radv.ListAttachments), reconciled against
+//     that list on a short ticker (radvReconcileInterval). Each actor both
+//     resends an IPv6 Router Advertisement on a jittered schedule and
+//     replies to that guest's own Router Solicitations. This runs from
+//     here, not from galactic-tap's own cmdAdd, because a VM guest's boot
+//     almost always outlives that short-lived process -- see radv's own
+//     doc comment for the full reasoning. Unrelated to, and runs
+//     regardless of, the eBPF datapath above.
 func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	slog.Info("Starting CNI installer run daemon", "grpcHealthPort", grpcHealthPort, "metricsPort", metricsPort)
 
@@ -636,17 +720,20 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	ebpfGCSweepTicker := time.NewTicker(ebpfGCSweepInterval)
 	defer ebpfGCSweepTicker.Stop()
 
-	// Router Advertisement resend for tap-attached VM guests (see
+	// Router Advertisement serving for tap-attached VM guests (see
 	// internal/plumbing/radv's own doc comment) -- runs regardless of
 	// whether the eBPF datapath is enabled, since it has nothing to do with
-	// it; harmless no-op ticks whenever no tap attachment currently needs
-	// one (internal/plumbing/radv.ListAttachments returns empty). A Timer,
-	// not a Ticker: RFC 4861 §6.2.4 requires each send to be spaced by a
-	// freshly-jittered interval (radvNextIntervalFn, reset after every
-	// fire below) rather than a fixed period, so routers on the same link
-	// don't synchronize their RAs into bursts.
-	radvTimer := time.NewTimer(radvNextIntervalFn())
-	defer radvTimer.Stop()
+	// it. One radv.RunActor goroutine per currently recorded attachment
+	// (radvActorSet, reconciled on every radvReconcileTicker tick below)
+	// handles both the periodic resend and Router Solicitation replies for
+	// that attachment; reconciled once here too, so attachments already
+	// recorded when this daemon starts don't wait out the first tick.
+	radvActors := &radvActorSet{}
+	reconcileRadvActors(ctx, radvActors)
+	defer radvActors.wg.Wait()
+
+	radvReconcileTicker := time.NewTicker(radvReconcileInterval)
+	defer radvReconcileTicker.Stop()
 
 	for {
 		select {
@@ -712,9 +799,11 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 					"removed", nptv6Result.EBPFNPTv6EntriesRemoved, "errors", nptv6Result.Errors)
 			}
 
-		case <-radvTimer.C:
-			resendRouterAdvertisements()
-			radvTimer.Reset(radvNextIntervalFn())
+		case <-radvReconcileTicker.C:
+			reconcileRadvActors(ctx, radvActors)
+
+		case iface := <-radvActors.failed:
+			radvActorFailed(radvActors, iface)
 		}
 	}
 }

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -355,15 +355,16 @@ func TestRun(t *testing.T) {
 		return &fakeDatapathCloser{}, []string{"eth0"}, nil, nil
 	}
 
-	// Exercise the radv resend ticker too: a short, fixed override (rather
-	// than a real RFC-sized jittered interval) so it fires several times
-	// during this test's lifetime, against an empty, test-local state dir
-	// (radv.SendRouterAdvertisement is never reached with no attachments
-	// recorded, so this needs no root/real interface -- just confirms the
-	// Timer/Reset wiring in Run doesn't panic or block shutdown).
-	origRadvNextIntervalFn := radvNextIntervalFn
-	t.Cleanup(func() { radvNextIntervalFn = origRadvNextIntervalFn })
-	radvNextIntervalFn = func() time.Duration { return 20 * time.Millisecond }
+	// Exercise the radv reconciler too: a short, fixed override (rather
+	// than waiting out a real multi-minute reconcile interval) so it ticks
+	// several times during this test's lifetime, against an empty,
+	// test-local state dir (radv.RunActor is never started with no
+	// attachments recorded, so this needs no root/real interface -- just
+	// confirms the reconcile/shutdown wiring in Run doesn't panic or block
+	// shutdown).
+	origRadvReconcileInterval := radvReconcileInterval
+	t.Cleanup(func() { radvReconcileInterval = origRadvReconcileInterval })
+	radvReconcileInterval = 20 * time.Millisecond
 
 	origRadvStateDir := radv.DefaultStateDir
 	t.Cleanup(func() { radv.DefaultStateDir = origRadvStateDir })
@@ -650,4 +651,61 @@ func TestRun_EBPFDatapathEnabled_MetricsAndHealthReflectRealDatapath(t *testing.
 		t.Fatalf("re-attach ifaces = %v, want [lo]", ifaces)
 	}
 	checkStatus(t, grpc_health_v1.HealthCheckResponse_SERVING)
+}
+
+// TestReconcileRadvActors_FailedStartupIsRetried covers radvActorFailed's
+// whole reason for existing: an attachment whose radv.RunActor can't even
+// open its Conn (here, because "does-not-exist0" is never a real
+// interface) must not get stuck "running" forever in actors.cancel --
+// reconcileRadvActors is expected to try it again on a later reconcile once
+// radvActorFailed has cleared its entry.
+func TestReconcileRadvActors_FailedStartupIsRetried(t *testing.T) {
+	origRadvStateDir := radv.DefaultStateDir
+	t.Cleanup(func() { radv.DefaultStateDir = origRadvStateDir })
+	radv.DefaultStateDir = t.TempDir()
+
+	const iface = "does-not-exist0"
+	if err := radv.RecordAttachment(radv.DefaultStateDir, iface, 1500); err != nil {
+		t.Fatalf("RecordAttachment: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	actors := &radvActorSet{}
+	reconcileRadvActors(ctx, actors)
+
+	if _, ok := actors.cancel[iface]; !ok {
+		t.Fatalf("actors.cancel[%q] missing right after reconcile, want an entry (even if doomed to fail)", iface)
+	}
+
+	select {
+	case failedIface := <-actors.failed:
+		if failedIface != iface {
+			t.Fatalf("actors.failed sent %q, want %q", failedIface, iface)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("actors.failed never received a report for the interface that can't exist")
+	}
+	radvActorFailed(actors, iface)
+
+	if _, ok := actors.cancel[iface]; ok {
+		t.Fatalf("actors.cancel[%q] still present after radvActorFailed, want it cleared so the next reconcile retries",
+			iface)
+	}
+
+	// Retry: reconcile again now that the failed entry is cleared -- same
+	// record is still there, so it should be picked up and fail (and
+	// report) the same way, proving this isn't a one-shot fluke.
+	reconcileRadvActors(ctx, actors)
+	select {
+	case failedIface := <-actors.failed:
+		if failedIface != iface {
+			t.Fatalf("retry: actors.failed sent %q, want %q", failedIface, iface)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry: actors.failed never received a report on the second reconcile")
+	}
+
+	actors.wg.Wait()
 }

--- a/internal/plumbing/radv/actor.go
+++ b/internal/plumbing/radv/actor.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package radv
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/mdlayher/ndp"
+)
+
+// RunActor owns one tap attachment's entire Router Advertisement lifecycle
+// for as long as ctx is not canceled: it sends unsolicited RAs on the
+// jittered schedule NextInterval describes, and it replies to Router
+// Solicitations (RFC 4861 §6.2.6) so a freshly-booted or reconnected guest
+// doesn't have to wait out a full resend cycle to converge. Both jobs share
+// one Conn and one "when did we last send" clock, so a solicited reply also
+// reschedules the next unsolicited send — see the RFC 4861 §6.2.6 combining
+// behavior this mirrors — rather than the guest receiving a redundant
+// unsolicited RA moments after a solicited one.
+//
+// Callers (internal/installer's reconciler) run one RunActor per currently
+// recorded attachment (state.go), start it when a new attachment appears,
+// and cancel ctx when the attachment disappears or the daemon shuts down.
+// RunActor returns nil on a clean ctx cancellation; a non-nil error means it
+// never got the Conn open in the first place (nothing to clean up, and the
+// reconciler is expected to retry on its next tick since the attachment
+// record is still there).
+func RunActor(ctx context.Context, iface string, mtu int) error {
+	ifi, err := net.InterfaceByName(iface)
+	if err != nil {
+		return fmt.Errorf("look up interface %q: %w", iface, err)
+	}
+
+	conn, _, err := ndp.Listen(ifi, ndp.LinkLocal)
+	if err != nil {
+		return fmt.Errorf("open NDP connection on %q: %w", iface, err)
+	}
+
+	// Without joining this group, the kernel never delivers multicast
+	// traffic addressed to ff02::2 to this socket at all — a guest's
+	// Router Solicitation is sent there (RFC 4861 §4.1), not to this
+	// interface's own unicast address.
+	if err := conn.JoinGroup(allRoutersMulticast); err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("join all-routers multicast group on %q: %w", iface, err)
+	}
+
+	rsCh := make(chan netip.Addr)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go readSolicitations(&wg, conn, rsCh)
+
+	runActorLoop(ctx, conn, iface, mtu, ifi.HardwareAddr, rsCh)
+
+	_ = conn.Close()
+	wg.Wait()
+	return nil
+}
+
+// readSolicitations is RunActor's blocking read loop, run on its own
+// goroutine since ndp.Conn.ReadFrom blocks and so can't share a select
+// statement with the resend timer in runActorLoop below. It exits as soon
+// as ReadFrom errors -- which is exactly what happens once runActorLoop
+// closes conn on shutdown, so no separate cancellation signal is needed
+// here.
+func readSolicitations(wg *sync.WaitGroup, conn *ndp.Conn, rsCh chan<- netip.Addr) {
+	defer wg.Done()
+
+	for {
+		msg, _, src, err := conn.ReadFrom()
+		if err != nil {
+			// conn.Close() (runActorLoop shutting down) or a fatal socket
+			// error either way -- this actor is done reading either way.
+			return
+		}
+		if _, ok := msg.(*ndp.RouterSolicitation); !ok {
+			continue
+		}
+
+		select {
+		case rsCh <- src:
+		case <-time.After(time.Second):
+			// The main loop only fails to receive here if it has already
+			// returned (about to close conn) -- drop rather than leak this
+			// goroutine waiting forever on a send nothing will ever read.
+		}
+	}
+}
+
+// runActorLoop is RunActor's own select loop, split out solely so RunActor
+// itself stays a short, readable setup/teardown wrapper. See RunActor's doc
+// comment for the combined resend/solicit behavior this implements.
+func runActorLoop(
+	ctx context.Context, conn *ndp.Conn, iface string, mtu int, hwAddr net.HardwareAddr, rsCh <-chan netip.Addr,
+) {
+	resendTimer := time.NewTimer(NextInterval())
+	defer resendTimer.Stop()
+
+	var lastSent time.Time
+	send := func(dst netip.Addr) {
+		ra := buildAdvertisement(mtu, hwAddr)
+		if err := conn.WriteTo(ra, nil, dst); err != nil {
+			slog.Warn("Failed to send router advertisement", "err", err, "hostInterface", iface, "dst", dst)
+		}
+		lastSent = time.Now()
+		resendTimer.Reset(NextInterval())
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-resendTimer.C:
+			send(allNodesMulticast)
+
+		case src := <-rsCh:
+			select {
+			case <-time.After(nextResponseDelay()):
+			case <-ctx.Done():
+				return
+			}
+
+			if rateLimited(lastSent, time.Now()) {
+				continue
+			}
+			send(responseDestination(src))
+		}
+	}
+}
+
+// rateLimited reports whether now is too soon after lastSent to send another
+// advertisement, per RFC 4861 §6.2.6/§10 (MinDelayBetweenRAs): a router must
+// never send more than one advertisement -- solicited or not -- within that
+// window of the last one. A zero lastSent (no advertisement sent yet this
+// actor's lifetime) is never rate-limited.
+func rateLimited(lastSent, now time.Time) bool {
+	if lastSent.IsZero() {
+		return false
+	}
+	return now.Sub(lastSent) < MinDelayBetweenRAs
+}
+
+// responseDestination returns the address a solicited reply should be sent
+// to for a Router Solicitation whose source address was src. RFC 4861
+// §6.1.1: a solicitation with the unspecified source address (::) means the
+// guest hasn't self-configured any address yet, so there is nothing to
+// unicast a reply to -- fall back to the same all-nodes multicast address
+// unsolicited RAs use. Otherwise, unicast directly back to the soliciting
+// guest: cheaper than multicast, and correct here since there is exactly
+// one guest per tap link, not a shared segment with other listeners to also
+// serve.
+func responseDestination(src netip.Addr) netip.Addr {
+	if src.IsUnspecified() {
+		return allNodesMulticast
+	}
+	return src
+}

--- a/internal/plumbing/radv/actor_test.go
+++ b/internal/plumbing/radv/actor_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package radv
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestRateLimited(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		lastSent time.Time
+		now      time.Time
+		want     bool
+	}{
+		{"NeverSent", time.Time{}, base, false},
+		{"JustSent", base, base.Add(1 * time.Second), true},
+		{"ExactlyAtBoundary", base, base.Add(MinDelayBetweenRAs), false},
+		{"WellPastBoundary", base, base.Add(MinDelayBetweenRAs + time.Second), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rateLimited(tt.lastSent, tt.now); got != tt.want {
+				t.Errorf("rateLimited(%v, %v) = %v, want %v", tt.lastSent, tt.now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponseDestination(t *testing.T) {
+	guestAddr := netip.MustParseAddr("fe80::1")
+
+	tests := []struct {
+		name string
+		src  netip.Addr
+		want netip.Addr
+	}{
+		{"UnspecifiedSourceFallsBackToMulticast", netip.IPv6Unspecified(), allNodesMulticast},
+		{"UnicastSourceIsUsedDirectly", guestAddr, guestAddr},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := responseDestination(tt.src); got != tt.want {
+				t.Errorf("responseDestination(%v) = %v, want %v", tt.src, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/plumbing/radv/radv.go
+++ b/internal/plumbing/radv/radv.go
@@ -62,20 +62,68 @@ var (
 // cap directly because nothing existed to refresh it before then.
 var RouterLifetime = 900 * time.Second
 
-// allNodesMulticast is the RFC 4861 §6.2.3 destination for unsolicited RAs —
-// every host on the link, not just one that solicited.
+// allNodesMulticast is the RFC 4861 §6.2.3 destination for unsolicited RAs
+// and for solicited replies to a solicitation whose source address was
+// unspecified — every host on the link, not just one that solicited.
 var allNodesMulticast = netip.MustParseAddr("ff02::1")
+
+// allRoutersMulticast is the RFC 4861 §4.1 destination a guest sends its
+// Router Solicitations to — an actor (actor.go) joins this group on its tap
+// host interface so its Conn actually receives them; ICMPv6 multicast
+// traffic isn't delivered to a socket that hasn't joined the group it's
+// addressed to.
+var allRoutersMulticast = netip.MustParseAddr("ff02::2")
 
 // NextInterval returns a random delay in [MinRtrAdvInterval,
 // MaxRtrAdvInterval) before the next unsolicited RA should be sent, per RFC
 // 4861 §6.2.4 — routers are required to jitter rather than fire on a fixed
 // clock specifically so that multiple routers on the same link don't
 // synchronize their RAs into bursts. Callers reschedule with a fresh call to
-// this function after every send (see internal/installer's radvTimer),
-// rather than using a fixed-period ticker.
+// this function after every send (see actor.go's resend timer), rather than
+// using a fixed-period ticker.
 func NextInterval() time.Duration {
 	span := MaxRtrAdvInterval - MinRtrAdvInterval
 	return MinRtrAdvInterval + rand.N(span)
+}
+
+// MinDelayBetweenRAs and MaxRADelayTime are RFC 4861 §10's fixed protocol
+// constants governing solicited replies (actor.go): a router MUST NOT send
+// more than one advertisement within MinDelayBetweenRAs of the last one it
+// sent (solicited or not), and MUST wait a random delay in
+// [0, MaxRADelayTime) before replying to a solicitation, so that several
+// solicitations arriving close together don't each provoke an immediate,
+// synchronized reply. Package-level vars (not consts), matching
+// MaxRtrAdvInterval/MinRtrAdvInterval above, so tests can shrink them; unlike
+// those two, the RFC does not intend these to be tunable in production.
+var (
+	MinDelayBetweenRAs = 3 * time.Second
+	MaxRADelayTime     = 500 * time.Millisecond
+)
+
+// nextResponseDelay returns a random delay in [0, MaxRADelayTime) to wait
+// before replying to a Router Solicitation — see MaxRADelayTime's own doc
+// comment.
+func nextResponseDelay() time.Duration {
+	return rand.N(MaxRADelayTime)
+}
+
+// buildAdvertisement constructs the Router Advertisement both the
+// unsolicited resend path and the solicited-reply path (actor.go) send —
+// factored out so the two paths can never drift apart on hop
+// limit/lifetime/options. See SendRouterAdvertisement's doc comment for why
+// there is no Prefix Information option.
+func buildAdvertisement(mtu int, hwAddr net.HardwareAddr) *ndp.RouterAdvertisement {
+	return &ndp.RouterAdvertisement{
+		CurrentHopLimit: 64,
+		RouterLifetime:  RouterLifetime,
+		Options: []ndp.Option{
+			&ndp.LinkLayerAddress{
+				Direction: ndp.Source,
+				Addr:      hwAddr,
+			},
+			ndp.NewMTU(uint32(mtu)),
+		},
+	}
 }
 
 // SendRouterAdvertisement sends a single unsolicited Router Advertisement out
@@ -90,11 +138,14 @@ func NextInterval() time.Duration {
 // The RA carries no Prefix Information option: a tap-attached guest gets its
 // address from IPAM, not IPv6 SLAAC, so the only thing being announced is
 // "this link-local address is your default router" plus the link's MTU —
-// nothing about how to self-assign an address. Callers are expected to
-// invoke this repeatedly, spaced per NextInterval, for as long as the
-// attachment exists (see state.go) rather than relying on one call to be
-// sufficient; a single call at CNI ADD time can race the guest's own boot
-// and land before anything is listening.
+// nothing about how to self-assign an address.
+//
+// This is a standalone, one-shot sender — production use is actor.go's
+// RunActor, which keeps one Conn open per attachment for its whole lifetime
+// (both the periodic resend and Router Solicitation replies) rather than
+// opening and closing a fresh Conn on every send. SendRouterAdvertisement
+// remains for callers that only need a single send with no RS-responsiveness
+// (e.g. a one-off diagnostic).
 func SendRouterAdvertisement(iface string, mtu int) error {
 	ifi, err := net.InterfaceByName(iface)
 	if err != nil {
@@ -109,18 +160,7 @@ func SendRouterAdvertisement(iface string, mtu int) error {
 		_ = conn.Close()
 	}()
 
-	ra := &ndp.RouterAdvertisement{
-		CurrentHopLimit: 64,
-		RouterLifetime:  RouterLifetime,
-		Options: []ndp.Option{
-			&ndp.LinkLayerAddress{
-				Direction: ndp.Source,
-				Addr:      ifi.HardwareAddr,
-			},
-			ndp.NewMTU(uint32(mtu)),
-		},
-	}
-
+	ra := buildAdvertisement(mtu, ifi.HardwareAddr)
 	if err := conn.WriteTo(ra, nil, allNodesMulticast); err != nil {
 		return fmt.Errorf("send router advertisement on %q: %w", iface, err)
 	}


### PR DESCRIPTION
## Summary

A VM guest booting on a tap-attached network interface actively asks for its default gateway the moment it comes up, but previously had to wait out a shared timer's next scheduled advertisement — up to five minutes — before getting an answer. There was no way to react to that request at all. Each attachment now gets its own long-lived responder that replies to a guest's request immediately, following the same timing and rate-limit rules real routers use so a burst of requests can't flood the guest or trigger synchronized responses across a link. A responder that fails to start is retried automatically instead of leaving that guest permanently unserved.

## Test plan

- [ ] A booting VM on the tap path gets a working default route within a second or two of asking, not minutes
- [ ] Detaching a VM stops its responder; a transient startup failure is retried
- [ ] Build, lint, and unit tests pass