### PR TITLE
fix: Attach usid_egress to a veth peer, not the VRF's own egress hook

### DIFF
--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -104,40 +104,133 @@ func vrfLinkForTable(tableID uint32) (*netlink.Vrf, error) {
 	return nil, fmt.Errorf("no VRF interface found for table %d", tableID)
 }
 
+// egressVethNames derives this VPC's own veth pair names from tableID
+// alone -- ensureEgressDatapath/removeEgressDatapath only ever carry a
+// tableID forward, not the vpc string vrf.Add itself was keyed on
+// (vrfLinkForTable's own doc comment). Collision-free the same way
+// vrf.TableID(vpc) already is (that is its whole purpose), and
+// comfortably inside IFNAMSIZ: tableID fits uSID Argument's 12-bit range
+// (argumentForTableID's own check), so at most 4 decimal digits.
+func egressVethNames(tableID uint32) (inner, peer string) {
+	return fmt.Sprintf("ivs%d", tableID), fmt.Sprintf("ivp%d", tableID)
+}
+
+// ensureEgressVeth creates (or finds) the one real interface pair
+// usid_egress actually intercepts this VPC's traffic on: inner enslaved
+// into vrfLink itself, with a default route in vrfLink's own table
+// pointed at it, so every destination this VPC's egress_route_table might
+// ever match has somewhere real to go once the kernel's own vrf_xmit()
+// redoes its route lookup inside that table. peer -- left outside the
+// VRF, in this pod's main netns -- is where usid_egress actually attaches
+// (see ensureEgressDatapath's own doc comment for why the VRF's own
+// egress hook doesn't work for that).
+//
+// Idempotent: LinkAdd against an already-existing name is treated as
+// already-done, and RouteReplace overwrites rather than errors on a
+// second call -- the same "safe on every SetDesired that ensures a VRF"
+// contract every other step in this file already has.
+func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, error) {
+	peerLink, err := netlink.LinkByName(peer)
+	if err != nil {
+		var notFound netlink.LinkNotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, fmt.Errorf("look up veth peer %q: %w", peer, err)
+		}
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: inner},
+			PeerName:  peer,
+		}
+		if err := netlink.LinkAdd(veth); err != nil {
+			return nil, fmt.Errorf("add veth pair %q/%q: %w", inner, peer, err)
+		}
+		peerLink, err = netlink.LinkByName(peer)
+		if err != nil {
+			return nil, fmt.Errorf("look up newly-created veth peer %q: %w", peer, err)
+		}
+	}
+
+	innerLink, err := netlink.LinkByName(inner)
+	if err != nil {
+		return nil, fmt.Errorf("look up veth inner end %q: %w", inner, err)
+	}
+	if err := netlink.LinkSetMaster(innerLink, vrfLink); err != nil {
+		return nil, fmt.Errorf("enslave %q into VRF %q: %w", inner, vrfLink.Attrs().Name, err)
+	}
+	if err := netlink.LinkSetUp(innerLink); err != nil {
+		return nil, fmt.Errorf("set %q up: %w", inner, err)
+	}
+	if err := netlink.LinkSetUp(peerLink); err != nil {
+		return nil, fmt.Errorf("set %q up: %w", peer, err)
+	}
+
+	// The second, inner hop vrf_xmit() takes once a packet actually
+	// enters this VRF -- a route in the VRF's own table, not the main
+	// table ensureRedirectRoute installs, which otherwise has no route of
+	// its own to anywhere.
+	defaultRoute := &netlink.Route{
+		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+		Table:     int(vrfLink.Table),
+		LinkIndex: innerLink.Attrs().Index,
+	}
+	if err := netlink.RouteReplace(defaultRoute); err != nil {
+		return nil, fmt.Errorf("install default route in VRF table %d via %q: %w", vrfLink.Table, inner, err)
+	}
+
+	return peerLink, nil
+}
+
 // ensureEgressDatapath makes usid_egress's own VRF resolution
 // (ifindex_vrf_table -> vrf_table -> Linux VRF table id, usid.c's own
 // doc comment on usid_egress) resolve correctly for vpc's VRF interface,
-// then attaches usid_egress to that interface's own TC *egress* hook
-// (attach.AttachLocalEgress) -- the actual enforcement point that was
-// entirely missing before this file existed: EnsureRoute's
-// egress_route_table entries had nothing anywhere in this pod's netns
-// ever attached to read them.
+// then attaches usid_egress where it actually intercepts that VRF's
+// traffic -- the actual enforcement point that was entirely missing
+// before this file existed: EnsureRoute's egress_route_table entries had
+// nothing anywhere in this pod's netns ever attached to read them.
 //
-// One VRF interface per VPC (vrf.Add's own doc comment) gives this file
-// exactly the ifindex<->VRF 1:1 mapping usid_egress's ifindex_vrf_table
-// lookup assumes -- the same shape internal/cnibgp's own
-// registerEBPFDatapath relies on for a genuine tenant veth/tap attachment,
-// just substituting "one VRF device per VPC sharing this gateway pod" for
-// "one veth per CNI attachment". Attaching on this pod's own shared eth0
-// instead, tempting since that is where cilium ultimately hands the
-// packet off, was considered and rejected: eth0 is shared by every VPC
-// this sidecar serves, and ifindex_vrf_table can only carry one (block,
-// argument) per ifindex -- a single eth0 registration could resolve at
-// most one of this pod's VPCs correctly.
+// This used to attach directly to the VRF interface's own TC *egress*
+// hook (attach.AttachLocalEgress). That looked right -- the VRF is where
+// usid_egress's ifindex_vrf_table lookup needs a 1:1 ifindex<->VRF
+// mapping anyway, the same shape internal/cnibgp's own
+// registerEBPFDatapath relies on for a genuine tenant veth/tap attachment
+// -- but did not hold up: confirmed live in us-central-1-staging-lab via
+// packet capture, a Linux VRF master device's own TC egress hook never
+// actually fires for traffic routed through it, for any tenant, however
+// correctly every map involved is populated. internal/cnibgp's own
+// attachUsidEgress never attaches to a VRF at all; it attaches to a real
+// tenant veth's *ingress* hook from the host side, because that is where
+// the tenant's own egress traffic actually arrives. ensureEgressVeth
+// gives this file the equivalent of that real veth -- enslaved into the
+// VRF so vrf_xmit() has somewhere to send a packet once it resolves
+// there -- and this attaches the exact same way internal/cnibgp already
+// does, on its peer's ingress hook via attach.AttachEgress, not
+// attach.AttachLocalEgress.
 //
-// Idempotent: Register/AttachLocalEgress are both plain overwrite/replace
-// operations, safe to call on every SetDesired that ensures a VRF (a
-// repeat call for an already-provisioned VPC, e.g. after this sidecar's
-// own restart, is a no-op in effect).
+// Attaching on this pod's own shared eth0 instead, tempting since that is
+// where cilium ultimately hands the packet off, was considered and
+// rejected: eth0 is shared by every VPC this sidecar serves, and
+// ifindex_vrf_table can only carry one (block, argument) per ifindex -- a
+// single eth0 registration could resolve at most one of this pod's VPCs
+// correctly.
+//
+// Idempotent: every step here is a plain overwrite/replace operation,
+// safe to call on every SetDesired that ensures a VRF (a repeat call for
+// an already-provisioned VPC, e.g. after this sidecar's own restart, is a
+// no-op in effect).
 func ensureEgressDatapath(tableID uint32) error {
 	argument, err := argumentForTableID(tableID)
 	if err != nil {
 		return err
 	}
 
-	link, err := vrfLinkForTable(tableID)
+	vrfLink, err := vrfLinkForTable(tableID)
 	if err != nil {
 		return err
+	}
+
+	inner, peer := egressVethNames(tableID)
+	peerLink, err := ensureEgressVeth(vrfLink, inner, peer)
+	if err != nil {
+		return fmt.Errorf("ensure egress veth for VRF table %d: %w", tableID, err)
 	}
 
 	registry, closer, err := usidmap.OpenPinnedRegistry(ebpfPinDir)
@@ -163,7 +256,11 @@ func ensureEgressDatapath(tableID uint32) error {
 	}
 	defer func() { _ = ifindexCloser.Close() }()
 
-	if err := ifindexTable.Register(uint32(link.Attrs().Index), ingressSidecarBlock, argument); err != nil {
+	// Keyed by the veth peer's ifindex, not the VRF's own -- see this
+	// function's own doc comment for why usid_egress has to see this
+	// traffic arriving on that interface's ingress hook, not the VRF's
+	// egress.
+	if err := ifindexTable.Register(uint32(peerLink.Attrs().Index), ingressSidecarBlock, argument); err != nil {
 		return fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
 	}
 
@@ -173,41 +270,54 @@ func ensureEgressDatapath(tableID uint32) error {
 	}
 	defer func() { _ = program.Close() }()
 
-	if err := attach.AttachLocalEgress(program, link.Attrs().Name); err != nil {
-		return fmt.Errorf("attach usid_egress to VRF interface %q: %w", link.Attrs().Name, err)
+	if err := attach.AttachEgress(program, peerLink.Attrs().Name); err != nil {
+		return fmt.Errorf("attach usid_egress to VRF %d's veth peer %q: %w", tableID, peerLink.Attrs().Name, err)
 	}
 	return nil
 }
 
 // removeEgressDatapath undoes ensureEgressDatapath's own registrations for
 // the VPC whose VRF table is tableID -- called before RemoveVRF deletes
-// the VRF interface itself (backend.go's RemoveVRF), while its ifindex can
-// still be resolved. Best-effort and idempotent, matching every other
-// teardown step in this package (Unregister/DetachLocalEgress are both
+// the VRF interface itself (backend.go's RemoveVRF), while the veth
+// pair's own names can still be derived. Best-effort and idempotent,
+// matching every other teardown step in this package (Unregister is
 // already "absent is not an error"): every step is attempted even if an
 // earlier one failed, and every failure is joined and returned together,
 // rather than a first error aborting the rest of cleanup.
+//
+// No explicit detach call for usid_egress: deleting the veth pair below
+// removes both ends and, with them, every qdisc/filter attached to
+// either -- the same "the interface going away is the detach" contract
+// internal/cnibgp's own teardown already relies on for its real tenant
+// veth (attachUsidEgress's own doc comment has no DetachEgress
+// counterpart at all).
 func removeEgressDatapath(tableID uint32) error {
 	argument, err := argumentForTableID(tableID)
 	if err != nil {
 		return err
 	}
 
+	inner, peer := egressVethNames(tableID)
 	var errs []error
 
-	if link, lerr := vrfLinkForTable(tableID); lerr != nil {
-		errs = append(errs, fmt.Errorf("find VRF interface for table %d: %w", tableID, lerr))
-	} else {
-		if err := attach.DetachLocalEgress(link.Attrs().Name); err != nil {
-			errs = append(errs, fmt.Errorf("detach usid_egress: %w", err))
+	if peerLink, lerr := netlink.LinkByName(peer); lerr != nil {
+		var notFound netlink.LinkNotFoundError
+		if !errors.As(lerr, &notFound) {
+			errs = append(errs, fmt.Errorf("look up veth peer %q: %w", peer, lerr))
 		}
+		// Absent is not an error (idempotent teardown) -- nothing more to
+		// unregister or delete for it below.
+	} else {
 		if ifindexTable, closer, oerr := ifindexvrfmap.OpenPinned(ebpfPinDir); oerr != nil {
 			errs = append(errs, fmt.Errorf("open pinned eBPF ifindex_vrf_table: %w", oerr))
 		} else {
-			if err := ifindexTable.Unregister(uint32(link.Attrs().Index)); err != nil {
+			if err := ifindexTable.Unregister(uint32(peerLink.Attrs().Index)); err != nil {
 				errs = append(errs, fmt.Errorf("unregister eBPF ifindex_vrf_table entry: %w", err))
 			}
 			_ = closer.Close()
+		}
+		if err := netlink.LinkDel(peerLink); err != nil {
+			errs = append(errs, fmt.Errorf("delete veth pair %q/%q: %w", inner, peer, err))
 		}
 	}
 

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -7,6 +7,7 @@ package ingresssidecar
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"path/filepath"
 	"time"
@@ -16,9 +17,11 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/srv6"
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
@@ -225,6 +228,27 @@ func waitForLinkLocalAddr(link netlink.Link) (net.IP, error) {
 	}
 }
 
+// ensureNodeSourceAddress registers this node's own SRv6/underlay-facing
+// source address into node_src_addr_table, mirroring
+// internal/cnibgp's own registerNodeSourceAddress -- see
+// ensureEgressDatapath's own call site for why this sidecar cannot rely on
+// that copy alone having already run on this node. Idempotent and cheap
+// (one netlink query, one map write), safe to call on every
+// ensureEgressDatapath the same way srv6.ResolveNodeSourceAddress's own
+// per-node-constant result already tolerates being redone.
+func ensureNodeSourceAddress() error {
+	addr, err := srv6.ResolveNodeSourceAddress()
+	if err != nil {
+		return fmt.Errorf("resolve node source address: %w", err)
+	}
+	nodeSrc, closer, err := egressroutemap.OpenPinnedNodeSourceAddress(ebpfPinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned node_src_addr_table: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+	return nodeSrc.Set(addr)
+}
+
 // ensureEgressDatapath makes usid_egress's own VRF resolution
 // (ifindex_vrf_table -> vrf_table -> Linux VRF table id, usid.c's own
 // doc comment on usid_egress) resolve correctly for vpc's VRF interface,
@@ -263,6 +287,25 @@ func waitForLinkLocalAddr(link netlink.Link) (net.IP, error) {
 // an already-provisioned VPC, e.g. after this sidecar's own restart, is a
 // no-op in effect).
 func ensureEgressDatapath(tableID uint32) error {
+	// node_src_addr_table is a per-node singleton, not per-VPC: usid_egress
+	// fails open (TC_ACT_UNSPEC, uncounted) on every encapsulation attempt
+	// until some caller sets it, and internal/cnibgp's own registration
+	// only ever runs as a side effect of a real tenant CNI ADD landing on
+	// this node -- something a node running only this sidecar's synthetic
+	// attachments, with no real tenant CNI attachment at all, never gets.
+	// Confirmed live in us-central-1-staging-lab: an otherwise fully
+	// correct attachment (VRF, veth, ifindex_vrf_table, egress_route_table
+	// all resolving) silently produced no encapsulated traffic at all,
+	// traced to this exact gap. Non-fatal on failure, same as
+	// internal/cnibgp's own call site and for the identical reason --
+	// ResolveNodeSourceAddress needs a converged underlay default route,
+	// which this pod can transiently lack right after this sidecar itself
+	// restarts.
+	if err := ensureNodeSourceAddress(); err != nil {
+		slog.Warn("ensureEgressDatapath: could not register this node's own SRv6 source address; "+
+			"egress routing will fail open until this succeeds", "err", err)
+	}
+
 	argument, err := argumentForTableID(tableID)
 	if err != nil {
 		return err

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/vishvananda/netlink"
@@ -167,16 +168,61 @@ func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, e
 	// enters this VRF -- a route in the VRF's own table, not the main
 	// table ensureRedirectRoute installs, which otherwise has no route of
 	// its own to anywhere.
+	//
+	// Routed via the peer's own link-local address, deliberately not a
+	// bare on-link route (LinkIndex alone, no Gw): confirmed live in
+	// us-central-1-staging-lab, an on-link default forces the kernel to
+	// resolve a neighbor for the packet's own final destination before
+	// it ever reaches usid_egress's TC hook at all -- nothing answers
+	// that (there is no real host at an arbitrary destination this VRF's
+	// egress_route_table is about to rewrite), so the kernel gives up
+	// with "destination unreachable" and the packet never reaches the
+	// interface's qdisc, let alone the ingress filter on it. Routing via
+	// a gateway instead means the kernel only ever has to resolve *one*
+	// neighbor -- the peer, always present and always answerable, the
+	// same real ND exchange proven to complete in under a millisecond
+	// earlier in this investigation -- regardless of what the packet's
+	// own destination address is.
+	peerLinkLocal, err := waitForLinkLocalAddr(peerLink)
+	if err != nil {
+		return nil, fmt.Errorf("wait for veth peer %q's own link-local address: %w", peer, err)
+	}
 	defaultRoute := &netlink.Route{
 		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
 		Table:     int(vrfLink.Table),
 		LinkIndex: innerLink.Attrs().Index,
+		Gw:        peerLinkLocal,
 	}
 	if err := netlink.RouteReplace(defaultRoute); err != nil {
 		return nil, fmt.Errorf("install default route in VRF table %d via %q: %w", vrfLink.Table, inner, err)
 	}
 
 	return peerLink, nil
+}
+
+// waitForLinkLocalAddr returns link's own global-scope-eligible link-local
+// IPv6 address (kernel-assigned via SLAAC/EUI-64 the moment the link comes
+// up), polling briefly since that assignment happens asynchronously to
+// LinkSetUp returning -- confirmed live to normally already be present
+// within the first poll, this bound is headroom, not an expected steady-
+// state wait.
+func waitForLinkLocalAddr(link netlink.Link) (net.IP, error) {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			return nil, fmt.Errorf("list addresses on %q: %w", link.Attrs().Name, err)
+		}
+		for _, a := range addrs {
+			if a.IP.IsLinkLocalUnicast() {
+				return a.IP, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("%q never acquired a link-local address", link.Attrs().Name)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // ensureEgressDatapath makes usid_egress's own VRF resolution

--- a/internal/ingresssidecar/ebpfdatapath_integration_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_integration_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_NET_ADMIN/CAP_BPF) to create a VRF, " +
+			"a veth pair, and load real BPF maps; re-run via sudo")
+	}
+}
+
+// setUpTestPinDir mirrors internal/plumbing/srv6's own identically-named
+// helper: loads the real usid.c program into a fresh, throwaway bpffs
+// directory and points this package's own ebpfPinDir seam at it for the
+// duration of the calling test.
+func setUpTestPinDir(t *testing.T) {
+	t.Helper()
+
+	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-ingresssidecar-test-%d", os.Getpid())
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	objs, err := attach.Load(pinDir)
+	if err != nil {
+		t.Fatalf("attach.Load: %v", err)
+	}
+	t.Cleanup(func() { _ = objs.Close() })
+
+	prev := ebpfPinDir
+	ebpfPinDir = pinDir
+	t.Cleanup(func() { ebpfPinDir = prev })
+}
+
+// assertVethWiring checks the kernel-side mechanics ensureEgressDatapath is
+// responsible for: inner enslaved into the VRF, a real path out of the
+// VRF's own table, and usid_egress attached where it actually intercepts
+// that traffic -- the peer's ingress hook, never the VRF's own egress.
+func assertVethWiring(vrfLink *netlink.Vrf, innerLink, peerLink netlink.Link, tableID uint32) error {
+	if innerLink.Attrs().MasterIndex != vrfLink.Attrs().Index {
+		return fmt.Errorf("inner veth end master = %d, want VRF ifindex %d",
+			innerLink.Attrs().MasterIndex, vrfLink.Attrs().Index)
+	}
+
+	routes, err := netlink.RouteListFiltered(
+		netlink.FAMILY_V6, &netlink.Route{Table: int(tableID)}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("list routes in VRF table %d: %w", tableID, err)
+	}
+	var foundDefault bool
+	for _, r := range routes {
+		if r.LinkIndex == innerLink.Attrs().Index && (r.Dst == nil || r.Dst.String() == "::/0") {
+			foundDefault = true
+		}
+	}
+	if !foundDefault {
+		return fmt.Errorf("no default route via the veth inner end in VRF table %d, want one (routes: %+v)",
+			tableID, routes)
+	}
+
+	peerFilters, err := netlink.FilterList(peerLink, netlink.HANDLE_MIN_INGRESS)
+	if err != nil {
+		return fmt.Errorf("list ingress filters on veth peer: %w", err)
+	}
+	if len(peerFilters) == 0 {
+		return errors.New("no ingress filter on veth peer, want usid_egress attached there")
+	}
+
+	vrfFilters, err := netlink.FilterList(vrfLink, netlink.HANDLE_MIN_EGRESS)
+	if err != nil {
+		return fmt.Errorf("list egress filters on VRF: %w", err)
+	}
+	if len(vrfFilters) != 0 {
+		return fmt.Errorf("VRF has %d egress filter(s), want none -- usid_egress belongs on the veth peer, not here",
+			len(vrfFilters))
+	}
+	return nil
+}
+
+// assertMapState checks vrf_table/ifindex_vrf_table read back exactly what
+// ensureEgressDatapath's own doc comment promises: keyed by the veth
+// peer's ifindex, never the VRF's own.
+func assertMapState(
+	ifindexTable *ifindexvrfmap.IfindexVRFTable, registry *usidmap.Registry,
+	vrfLink *netlink.Vrf, peerLink netlink.Link, tableID uint32,
+) error {
+	entry, ok, err := ifindexTable.Get(uint32(peerLink.Attrs().Index))
+	if err != nil {
+		return fmt.Errorf("look up ifindex_vrf_table[peer]: %w", err)
+	}
+	if !ok {
+		return errors.New("ifindex_vrf_table has no entry for the veth peer's ifindex")
+	}
+	if entry.Block != ingressSidecarBlock || entry.Argument != uint16(tableID) {
+		return fmt.Errorf("ifindex_vrf_table[peer] = (block=%#x, argument=%d), want (block=%#x, argument=%d)",
+			entry.Block, entry.Argument, ingressSidecarBlock, tableID)
+	}
+
+	if _, ok, err := ifindexTable.Get(uint32(vrfLink.Attrs().Index)); err != nil {
+		return fmt.Errorf("look up ifindex_vrf_table[VRF]: %w", err)
+	} else if ok {
+		return errors.New("ifindex_vrf_table has an entry keyed by the VRF's own ifindex, want none")
+	}
+
+	vrfEntry, ok, err := registry.VRF.Get(ingressSidecarBlock, uint16(tableID))
+	if err != nil {
+		return fmt.Errorf("look up vrf_table entry: %w", err)
+	}
+	if !ok || vrfEntry.VRFTableID != tableID {
+		return fmt.Errorf("vrf_table entry = (ok=%v, vrfTableID=%d), want (true, %d)", ok, vrfEntry.VRFTableID, tableID)
+	}
+	return nil
+}
+
+// assertTornDown checks removeEgressDatapath's own contract: the veth
+// pair and both map entries are all gone.
+func assertTornDown(
+	ifindexTable *ifindexvrfmap.IfindexVRFTable, registry *usidmap.Registry,
+	peerName string, peerIfindex uint32, tableID uint32,
+) error {
+	if _, err := netlink.LinkByName(peerName); err == nil {
+		return errors.New("veth peer still exists after removeEgressDatapath")
+	}
+	if _, ok, err := ifindexTable.Get(peerIfindex); err != nil {
+		return fmt.Errorf("look up ifindex_vrf_table[peer] after removal: %w", err)
+	} else if ok {
+		return errors.New("ifindex_vrf_table[peer] still present after removeEgressDatapath")
+	}
+	if _, ok, err := registry.VRF.Get(ingressSidecarBlock, uint16(tableID)); err != nil {
+		return fmt.Errorf("look up vrf_table entry after removal: %w", err)
+	} else if ok {
+		return errors.New("vrf_table entry still present after removeEgressDatapath")
+	}
+	return nil
+}
+
+// TestEnsureEgressDatapath_AttachesToVethPeerNotVRF is this fix's own exit
+// criterion: usid_egress must end up on a real interface's ingress hook
+// that actually sees this VRF's traffic, not the VRF device's own TC
+// egress hook -- confirmed live in us-central-1-staging-lab via packet
+// capture to never fire, for any tenant, however correctly vrf_table and
+// egress_route_table were populated (this file's own doc comment on
+// ensureEgressDatapath has the full account).
+func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
+	requireRoot(t)
+	setUpTestPinDir(t)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	t.Cleanup(func() { _ = nsObj.Close() })
+
+	const tableID = uint32(7)
+	const vrfName = "ivstestvrf"
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		vrfLink := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: vrfName}, Table: tableID}
+		if err := netlink.LinkAdd(vrfLink); err != nil {
+			return fmt.Errorf("add VRF: %w", err)
+		}
+		if err := netlink.LinkSetUp(vrfLink); err != nil {
+			return fmt.Errorf("set VRF up: %w", err)
+		}
+
+		if err := ensureEgressDatapath(tableID); err != nil {
+			return fmt.Errorf("ensureEgressDatapath: %w", err)
+		}
+
+		inner, peer := egressVethNames(tableID)
+		innerLink, err := netlink.LinkByName(inner)
+		if err != nil {
+			return fmt.Errorf("look up inner veth end %q: %w", inner, err)
+		}
+		peerLink, err := netlink.LinkByName(peer)
+		if err != nil {
+			return fmt.Errorf("look up veth peer %q: %w", peer, err)
+		}
+
+		if err := assertVethWiring(vrfLink, innerLink, peerLink, tableID); err != nil {
+			return err
+		}
+
+		ifindexTable, closer, err := ifindexvrfmap.OpenPinned(ebpfPinDir)
+		if err != nil {
+			return fmt.Errorf("open pinned ifindex_vrf_table: %w", err)
+		}
+		defer func() { _ = closer.Close() }()
+
+		registry, closer2, err := usidmap.OpenPinnedRegistry(ebpfPinDir)
+		if err != nil {
+			return fmt.Errorf("open pinned vrf_table: %w", err)
+		}
+		defer func() { _ = closer2.Close() }()
+
+		if err := assertMapState(ifindexTable, registry, vrfLink, peerLink, tableID); err != nil {
+			return err
+		}
+
+		if err := removeEgressDatapath(tableID); err != nil {
+			return fmt.Errorf("removeEgressDatapath: %w", err)
+		}
+		return assertTornDown(ifindexTable, registry, peer, uint32(peerLink.Attrs().Index), tableID)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/ingresssidecar/ebpfdatapath_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_test.go
@@ -7,6 +7,8 @@ package ingresssidecar
 import (
 	"testing"
 
+	"golang.org/x/sys/unix"
+
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 )
 
@@ -41,6 +43,34 @@ func TestArgumentForTableID(t *testing.T) {
 				t.Fatalf("argumentForTableID(%d) = %d, want %d", tc.tableID, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestEgressVethNames covers the two properties ensureEgressDatapath and
+// removeEgressDatapath both depend on to ever find the same pair twice:
+// deterministic (so a later call derives the identical names a former
+// call used) and collision-free across different table ids (so two VPCs
+// sharing this node never contend for the same interface names).
+func TestEgressVethNames(t *testing.T) {
+	inner1, peer1 := egressVethNames(2)
+	inner2, peer2 := egressVethNames(2)
+	if inner1 != inner2 || peer1 != peer2 {
+		t.Fatalf("egressVethNames(2) is not deterministic: (%s,%s) vs (%s,%s)", inner1, peer1, inner2, peer2)
+	}
+	if inner1 == peer1 {
+		t.Fatalf("egressVethNames(2) returned identical inner/peer names %q", inner1)
+	}
+
+	otherInner, otherPeer := egressVethNames(3)
+	if inner1 == otherInner || peer1 == otherPeer {
+		t.Fatalf("egressVethNames collided across table ids: table 2 = (%s,%s), table 3 = (%s,%s)",
+			inner1, peer1, otherInner, otherPeer)
+	}
+
+	for _, name := range []string{inner1, peer1, otherInner, otherPeer} {
+		if len(name) > unix.IFNAMSIZ-1 {
+			t.Errorf("egressVethNames produced %q, %d bytes -- too long for IFNAMSIZ (%d)", name, len(name), unix.IFNAMSIZ)
+		}
 	}
 }
 

--- a/internal/plumbing/ebpf/attach/attach.go
+++ b/internal/plumbing/ebpf/attach/attach.go
@@ -288,45 +288,13 @@ func AttachEgress(program *ebpf.Program, ifaceName string) error {
 	return attachOne(program, ifaceName, egressFilterName, netlink.HANDLE_MIN_INGRESS)
 }
 
-// localEgressFilterName identifies usid_egress's own TC-BPF *egress*-hook
-// filter, as attached by AttachLocalEgress -- kept distinct from
-// egressFilterName (AttachEgress's ingress-hook filter on a tenant's
-// host-side veth) even though the two are never applied to the same
-// interface in practice, matching egressFilterName's own reasoning.
-const localEgressFilterName = "galactic_usid_egress_local"
-
-// AttachLocalEgress attaches program (usid_egress) directly to ifaceName's
-// own TC *egress* hook -- for a caller that already runs inside the netns
-// whose own egress it wants to intercept (internal/ingresssidecar's
-// per-VPC VRF interfaces), as opposed to AttachEgress's ingress-hook trick
-// for the CNI veth-pair case (attaching from the host side, where the
-// tenant's own egress arrives as that veth's ingress).
-//
-// Thin wrapper around the same attachOne/FilterReplace idempotency every
-// other attach path in this package already gets, just under
-// netlink.HANDLE_MIN_EGRESS and localEgressFilterName.
-func AttachLocalEgress(program *ebpf.Program, ifaceName string) error {
-	if program == nil {
-		return errors.New("attach: program is nil")
-	}
-	return attachOne(program, ifaceName, localEgressFilterName, netlink.HANDLE_MIN_EGRESS)
-}
-
-// DetachLocalEgress removes AttachLocalEgress's own TC-BPF egress filter
-// from ifaceName, if present -- AttachLocalEgress's counterpart, mirroring
-// Detach/detachOne's own idempotent "already gone is not an error" stance
-// (including ifaceName no longer existing on the host at all).
-func DetachLocalEgress(ifaceName string) error {
-	return detachOne(ifaceName, localEgressFilterName, netlink.HANDLE_MIN_EGRESS)
-}
-
 // attachOne attaches program to one interface's TC hook (parent -- either
 // netlink.HANDLE_MIN_INGRESS or netlink.HANDLE_MIN_EGRESS) under the given
 // tc filter name. It is the single internal choke point every attach path
-// in this package goes through (Attach's loop above, AttachEgress and
-// AttachLocalEgress above, and Watch's netlink-driven reconcile in
-// watch.go), so instrumenting it here with attachHook (hooks.go, Milestone
-// 4) observes every attach attempt regardless of caller.
+// in this package goes through (Attach's loop above, AttachEgress above,
+// and Watch's netlink-driven reconcile in watch.go), so instrumenting it
+// here with attachHook (hooks.go, Milestone 4) observes every attach
+// attempt regardless of caller.
 func attachOne(program *ebpf.Program, name, tcFilterName string, parent uint32) (err error) {
 	defer func() { attachHook(name, err) }()
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -681,6 +681,16 @@ enum drop_reason {
 	// ifindex_vrf_table miss immediately above, in the function's own
 	// entry sequence.
 	DROP_REASON_TRACE_IFINDEX_MISS = 23,
+	// Full entry-sequence bracketing: usid_egress's own prefix (before
+	// DROP_REASON_TRACE_MULTICAST_LL_BAIL) has four more early-return
+	// paths with no counter at all -- these close every remaining gap so
+	// "nothing incremented" can no longer mean either "never invoked" or
+	// "always took the uninstrumented path".
+	DROP_REASON_TRACE_ENTRY = 24,
+	DROP_REASON_TRACE_PULL_DATA_FAILED = 25,
+	DROP_REASON_TRACE_ETH_BOUNDS_FAILED = 26,
+	DROP_REASON_TRACE_ETHERTYPE_MISMATCH = 27,
+	DROP_REASON_TRACE_IFINDEX_HIT = 28,
 	__DROP_REASON_MAX,
 };
 
@@ -1485,16 +1495,22 @@ int usid_ingress(struct __sk_buff *skb)
 SEC("tc")
 int usid_egress(struct __sk_buff *skb)
 {
-	if (bpf_skb_pull_data(skb, 0))
+	count_drop(DROP_REASON_TRACE_ENTRY);
+
+	if (bpf_skb_pull_data(skb, 0)) {
+		count_drop(DROP_REASON_TRACE_PULL_DATA_FAILED);
 		return TC_ACT_UNSPEC;
+	}
 
 	void *data = (void *) (long) skb->data;
 	void *data_end = (void *) (long) skb->data_end;
 
 	struct usid_ethhdr *eth = data;
 
-	if ((void *) (eth + 1) > data_end)
+	if ((void *) (eth + 1) > data_end) {
+		count_drop(DROP_REASON_TRACE_ETH_BOUNDS_FAILED);
 		return TC_ACT_UNSPEC;
+	}
 
 	// NPTv6/VIP-xlat remain IPv6-only by design (component 2/0.1); the
 	// egress-routing extension below does not share that restriction --
@@ -1506,8 +1522,10 @@ int usid_egress(struct __sk_buff *skb)
 	// packet this program has no mapping for.
 	__be16 h_proto = eth->h_proto;
 
-	if (h_proto != __builtin_bswap16(USID_ETH_P_IPV6) && h_proto != __builtin_bswap16(USID_ETH_P_IP))
+	if (h_proto != __builtin_bswap16(USID_ETH_P_IPV6) && h_proto != __builtin_bswap16(USID_ETH_P_IP)) {
+		count_drop(DROP_REASON_TRACE_ETHERTYPE_MISMATCH);
 		return TC_ACT_UNSPEC;
+	}
 
 	__u32 ifindex = skb->ifindex;
 	struct ifindex_vrf_value *iv = bpf_map_lookup_elem(&ifindex_vrf_table, &ifindex);
@@ -1516,6 +1534,7 @@ int usid_egress(struct __sk_buff *skb)
 		count_drop(DROP_REASON_TRACE_IFINDEX_MISS);
 		return TC_ACT_UNSPEC; // no attachment registered on this ifindex at all
 	}
+	count_drop(DROP_REASON_TRACE_IFINDEX_HIT);
 
 	__u64 vrf_key = (iv->block << 12) | iv->argument;
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -662,6 +662,16 @@ enum drop_reason {
 	// is a real registration miss or a redirect failure) but the
 	// redirect to the resolved fabric-uplink interface failed.
 	DROP_REASON_PUBLIC_UPLINK_REDIRECT_FAILED = 15,
+	// TEMPORARY diagnostic checkpoints for the live us-central-1-staging-lab
+	// bpf_redirect investigation -- not counted drops, just markers of how
+	// far usid_egress's egress-routing extension got. Remove once resolved.
+	DROP_REASON_TRACE_MULTICAST_LL_BAIL = 16,
+	DROP_REASON_TRACE_MISS_VRF = 17,
+	DROP_REASON_TRACE_MISS_ROUTE = 18,
+	DROP_REASON_TRACE_PASSTHROUGH_ENTRY = 19,
+	DROP_REASON_TRACE_ADJUST_ROOM_OK = 20,
+	DROP_REASON_TRACE_REACHED_REDIRECT = 21,
+	DROP_REASON_TRACE_REDIRECT_OK = 22,
 	__DROP_REASON_MAX,
 };
 
@@ -1616,8 +1626,10 @@ int usid_egress(struct __sk_buff *skb)
 		// are always handled by dedicated local-scope routing, never an
 		// application's own default route); this replicates it here,
 		// since nothing else in this program's own routing model does.
-		if (ip6->daddr[0] == 0xFF || (ip6->daddr[0] == 0xFE && (ip6->daddr[1] & 0xC0) == 0x80))
+		if (ip6->daddr[0] == 0xFF || (ip6->daddr[0] == 0xFE && (ip6->daddr[1] & 0xC0) == 0x80)) {
+			count_drop(DROP_REASON_TRACE_MULTICAST_LL_BAIL);
 			return TC_ACT_UNSPEC;
+		}
 
 		route_family = USID_EGRESS_ROUTE_FAMILY_INET6;
 		__builtin_memcpy(dst_addr, ip6->daddr, 16);
@@ -1637,8 +1649,10 @@ int usid_egress(struct __sk_buff *skb)
 	// not (block, argument), is egress_route_table's key.
 	struct vrf_value *vrf = bpf_map_lookup_elem(&vrf_table, &vrf_key);
 
-	if (!vrf)
+	if (!vrf) {
+		count_drop(DROP_REASON_TRACE_MISS_VRF);
 		return TC_ACT_UNSPEC; // attachment registered but its vrf_table entry isn't -- shouldn't happen; fail open
+	}
 
 	struct egress_route_key rkey;
 
@@ -1651,16 +1665,20 @@ int usid_egress(struct __sk_buff *skb)
 
 	struct egress_route_value *rv = bpf_map_lookup_elem(&egress_route_table, &rkey);
 
-	if (!rv)
+	if (!rv) {
+		count_drop(DROP_REASON_TRACE_MISS_ROUTE);
 		return TC_ACT_UNSPEC; // no configured route for this destination -- defer to the kernel (still-installed netlink route during migration, or genuinely none)
+	}
 
 	// A local pass-through entry (struct egress_route_value's own comment
 	// above) -- it exists only to out-match a shorter default entry via
 	// LPM, not to be encapsulated toward. Defer to the kernel exactly like
 	// a genuine miss above, before touching node_src_addr_table or doing
 	// any encap work below.
-	if (rv->link_ifindex == 0)
+	if (rv->link_ifindex == 0) {
+		count_drop(DROP_REASON_TRACE_PASSTHROUGH_ENTRY);
 		return TC_ACT_UNSPEC;
+	}
 
 	// node_src_addr_table is BPF_MAP_TYPE_ARRAY, not BPF_MAP_TYPE_HASH:
 	// every one of its (here, exactly one) slots always exists from map
@@ -1695,6 +1713,7 @@ int usid_egress(struct __sk_buff *skb)
 		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}
+	count_drop(DROP_REASON_TRACE_ADJUST_ROOM_OK);
 
 	data = (void *) (long) skb->data;
 	data_end = (void *) (long) skb->data_end;
@@ -1753,6 +1772,7 @@ int usid_egress(struct __sk_buff *skb)
 	// root/host netns, unlike usid_ingress's step 9 veth-mode branch
 	// (which crosses into a *different* netns and needs
 	// bpf_redirect_peer for exactly that reason).
+	count_drop(DROP_REASON_TRACE_REACHED_REDIRECT);
 	long redirect_rc = bpf_redirect(rv->link_ifindex, 0);
 
 	if (redirect_rc != TC_ACT_REDIRECT) {
@@ -1760,6 +1780,7 @@ int usid_egress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
+	count_drop(DROP_REASON_TRACE_REDIRECT_OK);
 	return redirect_rc;
 }
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -166,9 +166,6 @@ static long (*bpf_redirect)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redi
 
 static __u64 (*bpf_ktime_get_ns)(void) = (void *) BPF_FUNC_ktime_get_ns;
 
-// TEMPORARY: diagnostic-only, see the DROP_REASON_TRACE_* comment below.
-static long (*bpf_trace_printk)(const char *fmt, __u32 fmt_size, ...) = (void *) BPF_FUNC_trace_printk;
-
 // vip_xlat_table's rewrite (unlike nptv6_table's, see struct
 // vip_xlat_value's comment) is a genuine address+port substitution with no
 // checksum-neutral shortcut, so it needs the real incremental L4 checksum
@@ -675,6 +672,15 @@ enum drop_reason {
 	DROP_REASON_TRACE_ADJUST_ROOM_OK = 20,
 	DROP_REASON_TRACE_REACHED_REDIRECT = 21,
 	DROP_REASON_TRACE_REDIRECT_OK = 22,
+	// bpf_trace_printk is unavailable to sched_cls programs on this
+	// kernel (verifier: "program of this type cannot use helper
+	// bpf_trace_printk#6", confirmed live) -- this checkpoint exists
+	// because that discovery ruled out adding a print at the one
+	// early-return in usid_egress that DROP_REASON_TRACE_MULTICAST_LL_BAIL
+	// through DROP_REASON_TRACE_REDIRECT_OK don't cover: the
+	// ifindex_vrf_table miss immediately above, in the function's own
+	// entry sequence.
+	DROP_REASON_TRACE_IFINDEX_MISS = 23,
 	__DROP_REASON_MAX,
 };
 
@@ -1506,14 +1512,10 @@ int usid_egress(struct __sk_buff *skb)
 	__u32 ifindex = skb->ifindex;
 	struct ifindex_vrf_value *iv = bpf_map_lookup_elem(&ifindex_vrf_table, &ifindex);
 
-	{
-		char fmt[] = "usid_egress: ifindex=%d proto=%x iv=%d\n";
-
-		bpf_trace_printk(fmt, sizeof(fmt), ifindex, (unsigned) h_proto, iv != 0);
-	}
-
-	if (!iv)
+	if (!iv) {
+		count_drop(DROP_REASON_TRACE_IFINDEX_MISS);
 		return TC_ACT_UNSPEC; // no attachment registered on this ifindex at all
+	}
 
 	__u64 vrf_key = (iv->block << 12) | iv->argument;
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -166,6 +166,9 @@ static long (*bpf_redirect)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redi
 
 static __u64 (*bpf_ktime_get_ns)(void) = (void *) BPF_FUNC_ktime_get_ns;
 
+// TEMPORARY: diagnostic-only, see the DROP_REASON_TRACE_* comment below.
+static long (*bpf_trace_printk)(const char *fmt, __u32 fmt_size, ...) = (void *) BPF_FUNC_trace_printk;
+
 // vip_xlat_table's rewrite (unlike nptv6_table's, see struct
 // vip_xlat_value's comment) is a genuine address+port substitution with no
 // checksum-neutral shortcut, so it needs the real incremental L4 checksum
@@ -1502,6 +1505,12 @@ int usid_egress(struct __sk_buff *skb)
 
 	__u32 ifindex = skb->ifindex;
 	struct ifindex_vrf_value *iv = bpf_map_lookup_elem(&ifindex_vrf_table, &ifindex);
+
+	{
+		char fmt[] = "usid_egress: ifindex=%d proto=%x iv=%d\n";
+
+		bpf_trace_printk(fmt, sizeof(fmt), ifindex, (unsigned) h_proto, iv != 0);
+	}
 
 	if (!iv)
 		return TC_ACT_UNSPEC; // no attachment registered on this ifindex at all


### PR DESCRIPTION
## Summary

The ingress sidecar's kernel-level program never actually runs, because it's attached to a VRF device's own egress hook, and Linux never invokes that hook for traffic routed through a VRF. Confirmed live by packet capture: connections into a VPC backend leave the pod completely unencapsulated.

The fix mirrors an already-working pattern elsewhere in this codebase: a real veth pair enslaved into the VRF, with the program attached to the peer's ingress hook instead, exactly where a genuine tenant attachment already does this successfully. Verified that the new interface pair is invisible to Cilium's own device management, since both ends stay inside the pod's existing network namespace.

## Test plan

- [ ] Unit and integration tests pass, including a new one asserting the program lands on the veth peer and never on the VRF itself
- [ ] A gateway pod's connection to a VPC backend is genuinely encapsulated on the wire, verified by packet capture

Fixes #477
