### PR TITLE
fix: Stop reaping ingress sidecar's own VRF interfaces

### DIFF
--- a/config/galactic-router/rbac.yaml
+++ b/config/galactic-router/rbac.yaml
@@ -50,6 +50,13 @@ rules:
     resources:
       - nodes
     verbs: ["get", "list", "watch"]
+  # GCReconciler's CollectOrphanedVRFs cross-references tenant EndpointSlices
+  # cluster-wide to avoid reaping a VRF internal/ingresssidecar still owns —
+  # see activeVPCsFromEndpointSlices's own doc comment in internal/gc/gc.go.
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -319,9 +320,57 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 	return result
 }
 
+// activeVPCsFromEndpointSlices returns every VPC named by an EndpointSlice
+// carrying crdnames.LabelTenantID, cluster-wide — the same label
+// internal/ingresssidecar's own controller watches (hasTenantLabel in
+// internal/ingresssidecar/controller.go) to decide it needs a local VRF for
+// that VPC, entirely independent of any BGPAdvertisement/BGPVRFInstance CRD.
+//
+// SweepEBPFVRFTable already exempts that sidecar's own eBPF vrf_table
+// entries by their reserved uformat.BlockMax block (see that function's own
+// doc comment: "confirmed live in us-central-1-staging-lab, where vrf_table
+// sat permanently empty while ifindex_vrf_table... held the same entries").
+// This is the same exemption at the kernel-VRF-interface layer instead,
+// needed because CollectOrphanedVRFs runs inside galactic-router
+// (cmd/galactic-router), which — deliberately, per SweepEBPFVRFTable's own
+// doc comment on why that sweep runs inside galactic-cni instead — has
+// neither the /sys/fs/bpf hostPath mount nor CAP_BPF to read vrf_table
+// itself. Found live: without this, ensureEgressDatapath's own VRF for a
+// real tenant VPC (created for the sidecar's own outbound routing, sharing
+// that VPC's identifier with — but never advertised by — any real CNI
+// attachment) gets reaped as orphaned on this sweep's very next tick,
+// stranding EnsureRoute with "no VRF interface found" on every subsequent
+// reconcile.
+//
+// Deliberately not scoped to this node, unlike the BGPAdvertisement check
+// above: an EndpointSlice carries no node affinity to filter on, so the
+// conservative direction is to err toward not reaping — a VPC claimed by
+// some other node's ingress sidecar is not this function's call to make,
+// the same way an unrelated node's BGPAdvertisement already isn't allowed
+// to vouch for a *different* node's VRF, just inverted (there, cross-node
+// claims are excluded to avoid a false "still alive"; here, they're
+// included to avoid a false "orphaned").
+func activeVPCsFromEndpointSlices(ctx context.Context, k8s client.Client) (map[string]struct{}, error) {
+	sliceList := &discoveryv1.EndpointSliceList{}
+	if err := k8s.List(ctx, sliceList, client.HasLabels{crdnames.LabelTenantID}); err != nil {
+		return nil, fmt.Errorf("list tenant EndpointSlices: %w", err)
+	}
+
+	vpcs := make(map[string]struct{}, len(sliceList.Items))
+	for _, slice := range sliceList.Items {
+		vpc, _, ok := crdnames.ParseTenantIdentifier(slice.Labels[crdnames.LabelTenantID])
+		if !ok {
+			continue
+		}
+		addVPC(vpcs, vpc)
+	}
+	return vpcs, nil
+}
+
 // CollectOrphanedVRFs scans all VRF interfaces on this node and returns the
 // names of VRFs whose VPC has no surviving BGPAdvertisement CRD owned by
-// nodeName's BGPRouter(s) in the given namespace.
+// nodeName's BGPRouter(s) in the given namespace, and no ingress-sidecar
+// EndpointSlice claiming it either (see activeVPCsFromEndpointSlices).
 //
 // A VRF is considered orphaned when:
 //   - Its interface name matches the Galactic VRF naming pattern — either the
@@ -339,6 +388,10 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 //     namespace may coincidentally reuse the same VPC for their own,
 //     unrelated attachment — only this node's own BGPAdvertisements can
 //     vouch for a local VRF.
+//   - No EndpointSlice claims the VPC either, per
+//     activeVPCsFromEndpointSlices's own doc comment — internal/ingresssidecar
+//     creates and owns its own VRF for a VPC entirely independent of any
+//     BGPAdvertisement, and this sweep has no other way to see that claim.
 func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]string, error) {
 	vrfs, err := vrf.ListVRFLinks()
 	if err != nil {
@@ -363,6 +416,14 @@ func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, node
 			continue
 		}
 		addVPC(activeVPCs, vpcFromName(adv.Name))
+	}
+
+	sidecarVPCs, err := activeVPCsFromEndpointSlices(ctx, k8s)
+	if err != nil {
+		return nil, err
+	}
+	for vpc := range sidecarVPCs {
+		addVPC(activeVPCs, vpc)
 	}
 
 	var orphaned []string

--- a/internal/gc/gc_vrf_test.go
+++ b/internal/gc/gc_vrf_test.go
@@ -17,6 +17,8 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 )
 
+const testTenantNamespace = "ns-tenant"
+
 func TestActiveVPCsFromEndpointSlices(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
@@ -26,7 +28,7 @@ func TestActiveVPCsFromEndpointSlices(t *testing.T) {
 	tenantSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tenant-slice",
-			Namespace: "ns-tenant",
+			Namespace: testTenantNamespace,
 			Labels: map[string]string{
 				crdnames.LabelTenantID: "2-JL",
 			},
@@ -38,7 +40,7 @@ func TestActiveVPCsFromEndpointSlices(t *testing.T) {
 	malformedSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "malformed-slice",
-			Namespace: "ns-tenant",
+			Namespace: testTenantNamespace,
 			Labels: map[string]string{
 				crdnames.LabelTenantID: "malformed",
 			},
@@ -50,7 +52,7 @@ func TestActiveVPCsFromEndpointSlices(t *testing.T) {
 	untaggedSlice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "untagged-slice",
-			Namespace: "ns-tenant",
+			Namespace: testTenantNamespace,
 		},
 		AddressType: discoveryv1.AddressTypeIPv6,
 	}
@@ -69,7 +71,8 @@ func TestActiveVPCsFromEndpointSlices(t *testing.T) {
 		t.Errorf("activeVPCsFromEndpointSlices() = %v, want VPC %q present", got, "2")
 	}
 	if len(got) != 1 {
-		t.Errorf("activeVPCsFromEndpointSlices() = %v, want exactly one VPC (malformed/untagged slices must not contribute)", got)
+		t.Errorf("activeVPCsFromEndpointSlices() = %v, want exactly one VPC "+
+			"(malformed/untagged slices must not contribute)", got)
 	}
 }
 

--- a/internal/gc/gc_vrf_test.go
+++ b/internal/gc/gc_vrf_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gc
+
+import (
+	"context"
+	"testing"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.datum.net/galactic/internal/crdnames"
+)
+
+func TestActiveVPCsFromEndpointSlices(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add to scheme: %v", err)
+	}
+
+	tenantSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-slice",
+			Namespace: "ns-tenant",
+			Labels: map[string]string{
+				crdnames.LabelTenantID: "2-JL",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv6,
+	}
+	// A slice with the same label key but a malformed value (no "-") must
+	// not blow up the sweep or silently claim an empty-string VPC.
+	malformedSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "malformed-slice",
+			Namespace: "ns-tenant",
+			Labels: map[string]string{
+				crdnames.LabelTenantID: "malformed",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv6,
+	}
+	// A slice with no tenant label at all must not appear in the result —
+	// confirms the List call's own label selector, not just the parse step.
+	untaggedSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "untagged-slice",
+			Namespace: "ns-tenant",
+		},
+		AddressType: discoveryv1.AddressTypeIPv6,
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tenantSlice, malformedSlice, untaggedSlice).
+		Build()
+
+	got, err := activeVPCsFromEndpointSlices(context.Background(), fakeClient)
+	if err != nil {
+		t.Fatalf("activeVPCsFromEndpointSlices: %v", err)
+	}
+
+	if !vpcInSet(got, "2") {
+		t.Errorf("activeVPCsFromEndpointSlices() = %v, want VPC %q present", got, "2")
+	}
+	if len(got) != 1 {
+		t.Errorf("activeVPCsFromEndpointSlices() = %v, want exactly one VPC (malformed/untagged slices must not contribute)", got)
+	}
+}
+
+func TestActiveVPCsFromEndpointSlices_NoSlices(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add to scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	got, err := activeVPCsFromEndpointSlices(context.Background(), fakeClient)
+	if err != nil {
+		t.Fatalf("activeVPCsFromEndpointSlices: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("activeVPCsFromEndpointSlices() = %v, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

A VPC's VRF interface could vanish on its own shortly after being created, breaking every route reconcile that followed. The node's garbage collector only trusted a BGP advertisement as proof a VRF was still needed, so a VRF created for any other legitimate reason looked orphaned and got deleted. This teaches the collector to also recognize a VPC still claimed by a live backend endpoint, not just one advertised over BGP.

## Test plan

- [ ] A VPC's VRF interface survives the garbage collector's sweep when a backend endpoint still claims it, even with no BGP advertisement
- [ ] The garbage collector still removes a VRF interface once nothing claims that VPC anymore
- [ ] Unit tests pass

Fixes #479
