### PR TITLE
fix(gateway): register only the BGPRouter index galactic-gateway needs

### DIFF
--- a/cmd/galactic-gateway/root.go
+++ b/cmd/galactic-gateway/root.go
@@ -114,7 +114,23 @@ func runCmd(cfg *config.GatewayConfig) error {
 	// NetworkGateway reconcile here failed outright ("Index with name
 	// field:.spec.targetRef.name does not exist") until this call was added --
 	// found via a live containerlab deploy's own reconciler error loop.
-	if err := controller.RegisterIndexes(ctx, mgr); err != nil {
+	//
+	// RegisterBGPRouterTargetIndex, not the full RegisterIndexes: galactic-
+	// gateway's reconcilers (networkgateway_controller.go,
+	// networkrule_controller.go, usidresolver.go) only ever query
+	// BGPRouterByTargetName -- never BGPPeerBySecretName/BGPPeerByRouterName/
+	// BGPPolicyByRouterName/BGPVRFInstanceByRouterName, which RegisterIndexes
+	// also registers. Calling the full RegisterIndexes here was wrong: it
+	// starts a live informer for BGPPeer/BGPPolicy/BGPVRFInstance too
+	// (RegisterIndexes' own doc comment explains why that's eager and
+	// unconditional), and config/galactic-gateway/rbac.yaml's ClusterRole
+	// grants none of those -- found live as a permanently-stuck manager
+	// (every controller blocked forever on WaitForCacheSync, logging nothing
+	// but "bgppeers ... is forbidden" reflector errors) the moment this was
+	// deployed. RegisterBGPRouterTargetIndex is the same narrower function
+	// cmd/galactic-nat66 already uses for exactly this reason -- see its own
+	// doc comment.
+	if err := controller.RegisterBGPRouterTargetIndex(ctx, mgr); err != nil {
 		return fmt.Errorf("register field indexes: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `cmd/galactic-gateway/root.go` (added in #1eb1842) called `controller.RegisterIndexes(ctx, mgr)`, the full BGPPeer/BGPPolicy/BGPAdvertisement/BGPVRFInstance/BGPRouter index set.
- galactic-gateway's reconcilers (`networkgateway_controller.go`, `networkrule_controller.go`, `usidresolver.go`) only ever query `BGPRouterByTargetName` — never the other four indexes.
- `RegisterIndexes` starts a live informer for every type it indexes, unconditionally. `config/galactic-gateway/rbac.yaml`'s `ClusterRole` grants galactic-gateway `networkgateways`/`networkrules`/`bgpadvertisements`/`bgprouters` only — not `bgppeers`/`bgppolicies`/`bgpvrfinstances`.
- Net effect found live: after redeploying with `RegisterIndexes`, the manager's controllers never started at all — every controller blocks on `WaitForCacheSync` until every registered informer syncs, and the BGPPeer/BGPPolicy/BGPVRFInstance informers never do, spinning forever on `bgppeers.network.datumapis.com is forbidden ... at the cluster scope` reflector errors instead.

## Fix
Call `controller.RegisterBGPRouterTargetIndex(ctx, mgr)` instead — the single-index function already documented for exactly this narrower-RBAC case, and already used by `cmd/galactic-nat66` for the same reason.

## Testing
- `go build ./cmd/galactic-gateway/...`
- `go vet ./cmd/galactic-gateway/...`
- `go test ./cmd/galactic-gateway/... ./internal/controller/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)