### PR TITLE
fix(gateway): grant galactic-gateway RBAC to watch BGPVRFInstance

### DIFF
--- a/config/galactic-gateway/rbac.yaml
+++ b/config/galactic-gateway/rbac.yaml
@@ -44,6 +44,21 @@ rules:
     resources:
       - bgprouters
     verbs: ["get", "list", "watch"]
+  # NetworkGatewayReconciler.SetupWithManager watches BGPVRFInstance
+  # (alongside BGPRouter/BGPAdvertisement above) to re-reconcile every
+  # NetworkGateway in the namespace once a backend's owning VRF/advertisement
+  # data actually exists -- closing a startup race where the reconciler's own
+  # first pass can otherwise run before that data does and never get
+  # retriggered (see internal/controller/networkgateway_controller.go's
+  # SetupWithManager doc comment). That watch was added without this rule,
+  # so the informer it starts had no RBAC to actually list/watch
+  # BGPVRFInstance -- found live as the manager never finishing
+  # WaitForCacheSync (no controller ever started reconciling, silently,
+  # behind a "bgpvrfinstances ... is forbidden" reflector error loop).
+  - apiGroups: ["network.datumapis.com"]
+    resources:
+      - bgpvrfinstances
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary
- Commit 3533ee8 added `NetworkGatewayReconciler.SetupWithManager` watches on `BGPRouter`/`BGPAdvertisement`/`BGPVRFInstance` (closing a startup race in backend resolution), but never updated `config/galactic-gateway/rbac.yaml`.
- `bgprouters`/`bgpadvertisements` were already granted for other reasons. Only the new `bgpvrfinstances` watch was left without RBAC.
- Went unnoticed because the deployed `galactic-gateway` image predated 3533ee8 until it was just rolled forward (see #481). Once on current code, the `BGPVRFInstance` informer's reflector fails forever with `bgpvrfinstances.network.datumapis.com is forbidden ... at the cluster scope`, and the manager never finishes `WaitForCacheSync` — no `NetworkGateway`/`NetworkRule` ever reconciles, silently (no `Reconciler error` logged, since `Reconcile` is never even called).

## Fix
Grant `get`/`list`/`watch` on `bgpvrfinstances` to the `galactic-gateway` `ClusterRole`, mirroring the existing `bgprouters` entry.

## Testing
- YAML validated.
- Verified live in the cluster this was found in: after applying the equivalent RBAC change and rolling the image, `galactic-gateway`'s manager starts its controllers and `NetworkGateway`/`NetworkRule` reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)