### PR TITLE
fix(bgp): key BGPAdvertisement by (vpc, vpcAttachment, node)

### DIFF
--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -500,7 +500,7 @@ func publishBGPState(
 
 		adv := &bgpv1alpha1.BGPAdvertisement{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crdnames.BGPAdvertisementName(cfg.vpc, cfg.vpcAttachment),
+				Name:      crdnames.BGPAdvertisementName(cfg.vpc, cfg.vpcAttachment, nodeName),
 				Namespace: namespace,
 			},
 		}

--- a/internal/cnibgp/bgp_test.go
+++ b/internal/cnibgp/bgp_test.go
@@ -554,7 +554,7 @@ func TestPublishBGPStateReplacedPodDoesNotDuplicatePrefix(t *testing.T) {
 	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
 
 	router := routerForNode(testRouterName, nodeName, namespace, 65000)
-	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment, nodeName)
 	ipv6Subnet := mustParseCIDR(t, "fd00:40:ff01::100:0/96")
 
 	// Simulate the first pod's ADD, whose netns has since gone away, but
@@ -606,7 +606,7 @@ func TestPublishBGPStateNilIPAMMarksNoAddressing(t *testing.T) {
 	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
 
 	router := routerForNode(testRouterName, nodeName, namespace, 65000)
-	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment, nodeName)
 	k8s := fakeClient(router)
 
 	cfg := publishConfig{vpc: testVPC, vpcAttachment: testAttachment, ifaceType: ifaceTypeTap}
@@ -641,7 +641,7 @@ func TestPublishBGPStateIPAMClearsNoAddressing(t *testing.T) {
 	withNetNSExistsFn(t, func(path string) bool { return path == testNetns })
 
 	router := routerForNode(testRouterName, nodeName, namespace, 65000)
-	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment, nodeName)
 	existing := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      advName,
@@ -789,7 +789,7 @@ func TestPublishBGPStateAdvertisementCreatedGatedOnCreate(t *testing.T) {
 	})
 
 	t.Run("sibling attachment reusing an already-live BGPAdvertisement: update only", func(t *testing.T) {
-		advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+		advName := crdnames.BGPAdvertisementName(testVPC, testAttachment, nodeName)
 		existing := &bgpv1alpha1.BGPAdvertisement{
 			ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: namespace},
 		}

--- a/internal/cnibgp/ops_check.go
+++ b/internal/cnibgp/ops_check.go
@@ -78,7 +78,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 
 	adv := &bgpv1alpha1.BGPAdvertisement{}
-	advName := crdnames.BGPAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment)
+	advName := crdnames.BGPAdvertisementName(pluginConf.VPC, pluginConf.VPCAttachment, cniConfig.NodeName)
 	if err := k8s.Get(ctx, client.ObjectKey{Name: advName, Namespace: pluginConf.Namespace}, adv); err != nil {
 		errs = append(errs, fmt.Errorf("BGPAdvertisement %s: %w", advName, err))
 	}

--- a/internal/cnibgp/resource.go
+++ b/internal/cnibgp/resource.go
@@ -92,7 +92,7 @@ func (rt *resourceTracker) cleanup(ctx context.Context) {
 	if rt.advertisementCreated && rt.k8s != nil {
 		adv := &bgpv1alpha1.BGPAdvertisement{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crdnames.BGPAdvertisementName(rt.vpc, rt.vpcAttachment),
+				Name:      crdnames.BGPAdvertisementName(rt.vpc, rt.vpcAttachment, rt.nodeName),
 				Namespace: rt.namespace,
 			},
 		}

--- a/internal/cnibgp/resource_test.go
+++ b/internal/cnibgp/resource_test.go
@@ -95,7 +95,7 @@ func TestResourceTrackerCleanup_NeverUnregistersEBPFEntry(t *testing.T) {
 // BGPVRFInstance case, so the two don't regress into sharing the same
 // on/off switch.
 func TestResourceTrackerCleanup_DeletesOwnAdvertisementOnly(t *testing.T) {
-	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment)
+	advName := crdnames.BGPAdvertisementName(testVPC, testAttachment, testNodeName)
 	existing := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: testNamespace},
 	}

--- a/internal/controller/networkrule_controller_test.go
+++ b/internal/controller/networkrule_controller_test.go
@@ -124,7 +124,10 @@ func newBackendFixtures(
 		},
 	}
 	adv := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcRef, "attach-1")},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      crdnames.BGPAdvertisementName(vpcRef, "attach-1", testComputeNodeName),
+		},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: testBackendRouterName},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},

--- a/internal/controller/usidresolver_test.go
+++ b/internal/controller/usidresolver_test.go
@@ -174,7 +174,10 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 	}
 
 	advA := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcA, "attach-a", "node-a")},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      crdnames.BGPAdvertisementName(vpcA, "attach-a", "node-a"),
+		},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: routerA.Name},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
@@ -184,7 +187,10 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 		},
 	}
 	advB := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcB, "attach-b", "node-b")},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      crdnames.BGPAdvertisementName(vpcB, "attach-b", "node-b"),
+		},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: routerB.Name},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},

--- a/internal/controller/usidresolver_test.go
+++ b/internal/controller/usidresolver_test.go
@@ -174,7 +174,7 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 	}
 
 	advA := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcA, "attach-a")},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcA, "attach-a", "node-a")},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: routerA.Name},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
@@ -184,7 +184,7 @@ func TestBackendSIDIndex_TenantOwnershipDisambiguatesCollidingPrefixes(t *testin
 		},
 	}
 	advB := &bgpv1alpha1.BGPAdvertisement{
-		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcB, "attach-b")},
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: crdnames.BGPAdvertisementName(vpcB, "attach-b", "node-b")},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: routerB.Name},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},

--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -136,24 +136,47 @@ func VPCSegment(vpc string) string {
 }
 
 // BGPVRFInstanceName returns the deterministic name for a BGPVRFInstance.
-// Unlike BGPAdvertisementName, this is keyed by (vpc, node) rather than
-// (vpc, vpcAttachment): the underlying kernel VRF is shared by every
+// This is keyed by (vpc, node): the underlying kernel VRF is shared by every
 // attachment (pod or VM) on this VPC on this node (see internal/plumbing/vrf
 // and internal/plumbing/intf's GenerateInterfaceNameVRF), so every attachment
 // on the same VPC/node must resolve to the same BGPVRFInstance rather than
-// creating its own. This is the one CRD name that needs node identity at
-// all — the kernel side never does, since interface names only need to be
-// unique within one host's own namespace.
+// creating its own.
 func BGPVRFInstanceName(vpc, nodeName string) string {
 	return fmt.Sprintf("%s-%s", VPCSegment(vpc), nodeName)
 }
 
 // BGPAdvertisementName returns the deterministic name for a
-// BGPAdvertisement. Each VPCAttachment is unique per interface across the
-// cluster, so the (vpc, vpcAttachment) pair is a reliable 1:1 key. Both segments
-// are encoded by nameSegment, the VPC one identically to BGPVRFInstanceName.
-func BGPAdvertisementName(vpc, vpcAttachment string) string {
-	return fmt.Sprintf("%s-%s", VPCSegment(vpc), nameSegment(vpcAttachment))
+// BGPAdvertisement. Keyed by (vpc, vpcAttachment, node) -- node included for
+// the same reason BGPVRFInstanceName needs it (see that function's own
+// doc comment): a VPCAttachment identifies one logical attachment, but
+// nothing about that guarantees it is unique per *node* -- a multi-replica
+// Deployment scheduled across several nodes is the ordinary case, not an
+// edge case, and every replica's CNI ADD shares the very same VPCAttachment
+// identity from the CNI config on its own node.
+//
+// Before node was part of this key, every node with a live attachment to
+// the same VPCAttachment raced to CreateOrUpdate the *same* BGPAdvertisement
+// object: each write clobbered the previous node's RouterRef/prefixes
+// wholesale, so only the last writer's node was ever actually advertised —
+// every other node's own attachment silently vanished from BGP the moment
+// a second node's ADD ran. Found live in us-central-1-staging-lab: a
+// second node's attachment to a VPC that already had one elsewhere
+// overwrote the first's BGPAdvertisement, and from that point on BGP
+// advertised only the second node's SID for both — traffic destined for
+// the first node's own local pod got redirected to the second node's own
+// uSID SID instead of ever being delivered locally, and the second node's
+// own egress_route_table registration for its "own" prefix then collided
+// with itself for the same underlying reason (two attachments, one shared
+// key, one winner). This is also why VRF-level address overlap across
+// nodes must be tolerated, not prevented: two nodes are allowed to each
+// have their own local traffic to/from the same VPC, and neither one's
+// BGPAdvertisement is allowed to silently displace the other's.
+//
+// All three segments are encoded by nameSegment (the VPC one identically to
+// BGPVRFInstanceName); node is included raw, unencoded, matching
+// BGPVRFInstanceName's own convention.
+func BGPAdvertisementName(vpc, vpcAttachment, nodeName string) string {
+	return fmt.Sprintf("%s-%s-%s", VPCSegment(vpc), nameSegment(vpcAttachment), nodeName)
 }
 
 // vipNameReplacer sanitizes an IP address for use inside a Kubernetes

--- a/internal/crdnames/crdnames_test.go
+++ b/internal/crdnames/crdnames_test.go
@@ -84,15 +84,32 @@ func TestBGPVRFInstanceNameSharedAcrossAttachments(t *testing.T) {
 }
 
 func TestBGPAdvertisementName(t *testing.T) {
-	tests := []struct{ vpc, attachment, want string }{
-		{testVPC, testAttachment, "98de-c6a7"},
-		{testVPCBase62, testAttachmentBase62, "4d2-2a"},
+	tests := []struct{ vpc, attachment, nodeName, want string }{
+		{testVPC, testAttachment, "worker-1", "98de-c6a7-worker-1"},
+		{testVPCBase62, testAttachmentBase62, "dfw-worker", "4d2-2a-dfw-worker"},
 	}
 	for _, tt := range tests {
-		got := BGPAdvertisementName(tt.vpc, tt.attachment)
+		got := BGPAdvertisementName(tt.vpc, tt.attachment, tt.nodeName)
 		if got != tt.want {
-			t.Errorf("BGPAdvertisementName(%q, %q) = %q, want %q", tt.vpc, tt.attachment, got, tt.want)
+			t.Errorf("BGPAdvertisementName(%q, %q, %q) = %q, want %q", tt.vpc, tt.attachment, tt.nodeName, got, tt.want)
 		}
+	}
+}
+
+// TestBGPAdvertisementNameDistinguishesNodes verifies that the same
+// (vpc, vpcAttachment) pair on two different nodes produces two different
+// BGPAdvertisement names -- the whole point of adding node to this key: a
+// multi-replica Deployment scheduled across nodes shares one VPCAttachment
+// identity, and each replica's own node must get its own BGPAdvertisement
+// rather than the two clobbering each other (see BGPAdvertisementName's own
+// doc comment for the bug this fixes).
+func TestBGPAdvertisementNameDistinguishesNodes(t *testing.T) {
+	const vpc, attachment = testVPC, testAttachment
+	first := BGPAdvertisementName(vpc, attachment, "worker-a")
+	second := BGPAdvertisementName(vpc, attachment, "worker-b")
+	if first == second {
+		t.Errorf("BGPAdvertisementName(%q, %q, ...) produced the same name %q for two different nodes",
+			vpc, attachment, first)
 	}
 }
 
@@ -118,8 +135,8 @@ func TestTenantIdentifier(t *testing.T) {
 // unencoded — see its own doc comment for why a plain string split
 // recovering the original vpc depends on that.
 func TestTenantIdentifierDoesNotMatchBGPAdvertisementName(t *testing.T) {
-	const vpc, attachment = testVPC, testAttachment
-	if got, other := TenantIdentifier(vpc, attachment), BGPAdvertisementName(vpc, attachment); got == other {
+	const vpc, attachment, nodeName = testVPC, testAttachment, "worker-1"
+	if got, other := TenantIdentifier(vpc, attachment), BGPAdvertisementName(vpc, attachment, nodeName); got == other {
 		t.Errorf("TenantIdentifier(%q, %q) = %q unexpectedly matches BGPAdvertisementName() -- "+
 			"if nameSegment's encoding changed to make these equal again, TenantIdentifier's "+
 			"raw-value recoverability guarantee needs re-verifying, not just this test updating",
@@ -236,7 +253,9 @@ func TestCRDNamesAreValidObjectNames(t *testing.T) {
 			assertValidObjectName(t, "BGPVRFInstanceName", BGPVRFInstanceName(vpc, node))
 		}
 		for _, att := range attachments {
-			assertValidObjectName(t, "BGPAdvertisementName", BGPAdvertisementName(vpc, att))
+			for _, node := range nodes {
+				assertValidObjectName(t, "BGPAdvertisementName", BGPAdvertisementName(vpc, att, node))
+			}
 		}
 	}
 }
@@ -271,7 +290,7 @@ func TestNameSegmentDistinguishesCase(t *testing.T) {
 // identically — including when the node name itself contains '-'.
 func TestVPCSegmentSharedByBothNames(t *testing.T) {
 	const vpc, att, node = "1dLaEmCAp", "2Bc", "dfw-worker-control"
-	advVPC, _, _ := strings.Cut(BGPAdvertisementName(vpc, att), "-")
+	advVPC, _, _ := strings.Cut(BGPAdvertisementName(vpc, att, node), "-")
 	vrfVPC, _, _ := strings.Cut(BGPVRFInstanceName(vpc, node), "-")
 	if advVPC != vrfVPC || advVPC != VPCSegment(vpc) {
 		t.Errorf("VPC segments disagree: advertisement %q, VRF instance %q, VPCSegment %q", advVPC, vrfVPC, VPCSegment(vpc))

--- a/internal/crdnames/crdnames_test.go
+++ b/internal/crdnames/crdnames_test.go
@@ -47,6 +47,7 @@ const (
 	testVPCBase62        = "0000000jU"
 	testAttachment       = "def"
 	testAttachmentBase62 = "00G"
+	testNodeName         = "dfw-worker"
 
 	// testTenantID and testTenantIDBase62 are the already-joined
 	// (vpc, attachment) identifiers for the pairs above -- shared across
@@ -59,7 +60,7 @@ const (
 func TestBGPVRFInstanceName(t *testing.T) {
 	tests := []struct{ vpc, nodeName, want string }{
 		{testVPC, "worker-1", "98de-worker-1"},
-		{testVPCBase62, "dfw-worker", "4d2-dfw-worker"},
+		{testVPCBase62, testNodeName, "4d2-" + testNodeName},
 	}
 	for _, tt := range tests {
 		got := BGPVRFInstanceName(tt.vpc, tt.nodeName)
@@ -74,7 +75,7 @@ func TestBGPVRFInstanceName(t *testing.T) {
 // the identical BGPVRFInstance name — the whole point of keying this by
 // (vpc, node) instead of (vpc, vpcAttachment).
 func TestBGPVRFInstanceNameSharedAcrossAttachments(t *testing.T) {
-	const vpc, nodeName = testVPC, "dfw-worker"
+	const vpc, nodeName = testVPC, testNodeName
 	first := BGPVRFInstanceName(vpc, nodeName)
 	second := BGPVRFInstanceName(vpc, nodeName)
 	if first != second {
@@ -86,7 +87,7 @@ func TestBGPVRFInstanceNameSharedAcrossAttachments(t *testing.T) {
 func TestBGPAdvertisementName(t *testing.T) {
 	tests := []struct{ vpc, attachment, nodeName, want string }{
 		{testVPC, testAttachment, "worker-1", "98de-c6a7-worker-1"},
-		{testVPCBase62, testAttachmentBase62, "dfw-worker", "4d2-2a-dfw-worker"},
+		{testVPCBase62, testAttachmentBase62, testNodeName, "4d2-2a-" + testNodeName},
 	}
 	for _, tt := range tests {
 		got := BGPAdvertisementName(tt.vpc, tt.attachment, tt.nodeName)
@@ -246,7 +247,7 @@ func TestCRDNamesAreValidObjectNames(t *testing.T) {
 	// values that produce an uppercase character at all.
 	vpcs := []string{"1dLaEmCAp", testVPCBase62, "A", "zZ", "ZZZZZZZZZ", "10"}
 	attachments := []string{"A", "00G", "ZZZ", "20"}
-	nodes := []string{"dfw-worker", "iad-worker-control-plane"}
+	nodes := []string{testNodeName, "iad-worker-control-plane"}
 
 	for _, vpc := range vpcs {
 		for _, node := range nodes {

--- a/internal/gc/gc_test.go
+++ b/internal/gc/gc_test.go
@@ -307,7 +307,7 @@ func TestVRFNameJoinsCRDNames(t *testing.T) {
 		if !ok {
 			t.Fatalf("vpcFromVRFName(%q) did not match", intf.GenerateInterfaceNameVRF(vpc))
 		}
-		advVPC := vpcFromName(crdnames.BGPAdvertisementName(vpc, "2Bc"))
+		advVPC := vpcFromName(crdnames.BGPAdvertisementName(vpc, "2Bc", "dfw-worker"))
 		if got := crdnames.VPCSegment(parsed); got != advVPC {
 			t.Errorf("kernel VRF for VPC %q resolves to %q, but its BGPAdvertisements are named after %q", vpc, got, advVPC)
 		}


### PR DESCRIPTION
## Summary

`crdnames.BGPAdvertisementName` was keyed by `(vpc, vpcAttachment)` alone. Its doc comment called this "a reliable 1:1 key," assuming a VPCAttachment is unique per interface across the cluster.

That assumption fails for a multi-replica Deployment scheduled across nodes. Every replica's CNI ADD shares the same VPCAttachment identity from its NAD config, regardless of which node it lands on.

Every node with a live attachment to that shared VPCAttachment raced to `CreateOrUpdate` the same `BGPAdvertisement` object. Each write clobbered the previous node's `RouterRef` and prefixes. Only the last writer's node was ever advertised. Every other node's own attachment silently vanished from BGP the instant a second node's ADD ran.

Found live in `us-central-1-staging-lab` while troubleshooting a `ServiceVIPBinding` that never became reachable end to end. A second node's attachment to a VPC that already had one elsewhere overwrote the first's `BGPAdvertisement`. From that point, BGP advertised only the second node's SID for both. Traffic destined for the first node's own local pod got redirected to the second node's SID instead of being delivered locally. The second node's own `egress_route_table` registration for its own prefix then collided with itself for the same reason: two attachments, one shared key, one winner.

This is a VRF-layer bug, not an IPAM one. Two nodes are allowed to each carry their own local traffic for the same VPC. Address-space overlap across VRF nodes is something the platform must tolerate, not prevent. Neither node's `BGPAdvertisement` may silently displace the other's.

## Fix

Key `BGPAdvertisementName` on `(vpc, vpcAttachment, node)`, mirroring `BGPVRFInstanceName`'s existing `(vpc, node)` precedent.

Pods sharing one vpcAttachment on the same node still converge on the same `BGPAdvertisement`. The existing pod-churn/replacement annotation-merge behavior in `internal/cnibgp/bgp.go` is unaffected. Pods on different nodes now each get and maintain their own.

`internal/gc`'s `vpcFromName` is the only other place that parses this name apart. It only reads the first `-`-delimited segment, which is unchanged.

## Testing

1. `go build ./...`
2. `go vet ./internal/crdnames/... ./internal/cnibgp/... ./internal/gc/... ./internal/controller/...`
3. `go test ./...` — all pass except `tests/e2e`, which fails identically on `main` without a live Kind cluster, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)