### PR TITLE
fix: Repair missing eBPF vrf_table entries after a map reload

### DIFF
--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -159,16 +159,16 @@ func BGPVRFInstanceName(vpc, nodeName string) string {
 // object: each write clobbered the previous node's RouterRef/prefixes
 // wholesale, so only the last writer's node was ever actually advertised —
 // every other node's own attachment silently vanished from BGP the moment
-// a second node's ADD ran. Found live in us-central-1-staging-lab: a
-// second node's attachment to a VPC that already had one elsewhere
-// overwrote the first's BGPAdvertisement, and from that point on BGP
-// advertised only the second node's SID for both — traffic destined for
-// the first node's own local pod got redirected to the second node's own
-// uSID SID instead of ever being delivered locally, and the second node's
-// own egress_route_table registration for its "own" prefix then collided
-// with itself for the same underlying reason (two attachments, one shared
-// key, one winner). This is also why VRF-level address overlap across
-// nodes must be tolerated, not prevented: two nodes are allowed to each
+// a second node's ADD ran: a second node's attachment to a VPC that already
+// had one elsewhere would overwrite the first's BGPAdvertisement, and from
+// that point on BGP would advertise only the second node's SID for both —
+// traffic destined for the first node's own local pod would get redirected
+// to the second node's own uSID SID instead of ever being delivered
+// locally, and the second node's own egress_route_table registration for
+// its "own" prefix would then collide with itself for the same underlying
+// reason (two attachments, one shared key, one winner). This is also why
+// VRF-level address overlap across nodes must be tolerated, not prevented:
+// two nodes are allowed to each
 // have their own local traffic to/from the same VPC, and neither one's
 // BGPAdvertisement is allowed to silently displace the other's.
 //

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -51,6 +51,10 @@ type CleanupResult struct {
 	// from OrphanedVRFsRemoved's kernel VRF *interfaces* above (Milestone
 	// 7.3).
 	EBPFVRFEntriesRemoved int
+	// EBPFVRFEntriesRegistered counts vrf_table entries SweepEBPFVRFTable
+	// (re-)registered for a live BGPVRFInstance CRD that had no
+	// corresponding vrf_table row -- see its repair-loop doc comment.
+	EBPFVRFEntriesRegistered int
 	// EBPFNPTv6EntriesRemoved counts stale eBPF uSID datapath nptv6_table
 	// map entries removed by SweepEBPFNPTv6Table.
 	EBPFNPTv6EntriesRemoved int
@@ -328,9 +332,10 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 //
 // SweepEBPFVRFTable already exempts that sidecar's own eBPF vrf_table
 // entries by their reserved uformat.BlockMax block (see that function's own
-// doc comment: "confirmed live in us-central-1-staging-lab, where vrf_table
-// sat permanently empty while ifindex_vrf_table... held the same entries").
-// This is the same exemption at the kernel-VRF-interface layer instead,
+// doc comment on the ingress sidecar's BlockMax exemption: without it,
+// every entry the sidecar registers is invisible to the CRD-built live set
+// and gets reaped as an orphan on the very next sweep). This is the same
+// exemption at the kernel-VRF-interface layer instead,
 // needed because CollectOrphanedVRFs runs inside galactic-router
 // (cmd/galactic-router), which — deliberately, per SweepEBPFVRFTable's own
 // doc comment on why that sweep runs inside galactic-cni instead — has
@@ -582,6 +587,12 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	}
 
 	live := make(map[usidmap.VRFKey]struct{}, len(vrfInstList.Items))
+	// liveCRDNames tracks, for every CRD-derived key above, the
+	// BGPVRFInstance name it came from -- the registration-repair step
+	// below needs the name back (to re-derive vrfTableID/egressKind via
+	// resolveVRFKernelState) but Reconcile only needs the key, so this
+	// stays a separate map rather than changing live's value type.
+	liveCRDNames := make(map[usidmap.VRFKey]string, len(vrfInstList.Items))
 	for _, inst := range vrfInstList.Items {
 		if inst.Spec.RouterRef == nil {
 			continue
@@ -615,8 +626,9 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 				"vrfInstance", inst.Name, "vrfID", inst.Spec.VRFID)
 			continue
 		}
-		argument := uint16(inst.Spec.VRFID)
-		live[usidmap.VRFKey{Block: block, Argument: argument}] = struct{}{}
+		key := usidmap.VRFKey{Block: block, Argument: uint16(inst.Spec.VRFID)}
+		live[key] = struct{}{}
+		liveCRDNames[key] = inst.Name
 	}
 
 	// internal/ingresssidecar registers its own vrf_table entries under
@@ -626,22 +638,64 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	// itself (ensureEgressDatapath/removeEgressDatapath), independent of
 	// any BGPVRFInstance CRD. Without this, every entry it ever registers
 	// is invisible to the CRD-built live set above and gets reaped as an
-	// orphan on this sweep's very next tick: confirmed live in
-	// us-central-1-staging-lab, where vrf_table sat permanently empty
-	// while ifindex_vrf_table (which this sweep never touches) held the
-	// same entries, silently blackholing that sidecar's own outbound
-	// connections to VPC backends. Preserve every entry in that block
-	// unconditionally, the same way an entry with a live CRD is preserved.
+	// orphan on this sweep's very next tick: with nothing preserving them,
+	// vrf_table would sit permanently empty for that sidecar's entries
+	// while ifindex_vrf_table (which this sweep never touches) kept
+	// holding the same entries, silently blackholing that sidecar's own
+	// outbound connections to VPC backends. Preserve every entry in that
+	// block unconditionally, the same way an entry with a live CRD is
+	// preserved.
 	existing, err := reg.VRF.List()
 	if err != nil {
 		slog.Error("GC: failed to list eBPF vrf_table for sweep", "err", err)
 		result.Errors++
 		return result
 	}
+	existingKeys := make(map[usidmap.VRFKey]struct{}, len(existing))
 	for _, e := range existing {
+		existingKeys[e.VRFKey] = struct{}{}
 		if e.Block == uformat.BlockMax {
 			live[e.VRFKey] = struct{}{}
 		}
+	}
+
+	// Repair vrf_table entries that a live BGPVRFInstance CRD expects but
+	// vrf_table does not currently have -- most notably attach.Load's own
+	// incompatible-map-schema reload (see its doc comment), which wipes
+	// every pinned map, including vrf_table, and leaves nothing behind for
+	// a *pre-existing* attachment to repopulate from: registerEBPFDatapath
+	// only ever runs once, at CNI ADD time, and nothing re-invokes it for
+	// an attachment that already succeeded. Reconcile above only ever
+	// deletes; this is vrf_table's only self-healing path for an entry
+	// that a live CRD says should exist but doesn't.
+	for key, instName := range liveCRDNames {
+		if _, ok := existingKeys[key]; ok {
+			continue // already present -- Reconcile above is what handles this one
+		}
+		vrfTableID, egressKind, ok, err := resolveVRFKernelState(nodeName, instName)
+		if err != nil {
+			slog.Error("GC: failed to resolve kernel VRF state while repairing eBPF vrf_table entry",
+				"vrfInstance", instName, "block", key.Block, "argument", key.Argument, "err", err)
+			result.Errors++
+			continue
+		}
+		if !ok {
+			// No matching kernel VRF interface exists right now -- e.g. the
+			// attachment's own teardown is in flight, or the CNI ADD that
+			// will create it hasn't run yet. Nothing to repopulate from;
+			// leave it missing for this tick.
+			continue
+		}
+		if err := reg.VRF.Register(key.Block, key.Argument, vrfTableID, egressKind); err != nil {
+			slog.Error("GC: failed to repair missing eBPF vrf_table entry",
+				"vrfInstance", instName, "block", key.Block, "argument", key.Argument, "err", err)
+			result.Errors++
+			continue
+		}
+		slog.Info("GC: repaired missing eBPF vrf_table entry",
+			"vrfInstance", instName, "block", key.Block, "argument", key.Argument,
+			"vrfTableID", vrfTableID, "egressKind", egressKind)
+		result.EBPFVRFEntriesRegistered++
 	}
 
 	removed, err := reg.VRF.Reconcile(live, cutoff)
@@ -655,6 +709,92 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	}
 
 	return result
+}
+
+// listVRFLinksFn/listAllLinksFn indirect the two netlink calls
+// resolveVRFKernelState needs, so tests can substitute fabricated
+// *netlink.Vrf/netlink.Link values -- plain structs needing no real kernel
+// VRF interface or CAP_NET_ADMIN -- the same way attach.go's
+// preflightCheckFn lets tests substitute a kernel-touching call it makes.
+var (
+	listVRFLinksFn = vrf.ListVRFLinks
+	listAllLinksFn = netlink.LinkList
+)
+
+// resolveVRFKernelState recovers the (Linux VRF routing table id, egress
+// kind) a live BGPVRFInstance named instName should register in vrf_table,
+// by matching it against a real, currently existing kernel VRF interface.
+// SweepEBPFVRFTable uses this to repair an entry vrf_table is missing for a
+// still-live CRD (see that function's own doc comment on the repair loop).
+//
+// instName alone doesn't carry vrfTableID or egressKind -- BGPVRFInstance's
+// Spec has neither field, only RouterRef/VRFID/route targets -- so this
+// goes the other way: list every real kernel VRF interface (an ordinary,
+// independently-persisted kernel object, unaffected by an eBPF map wipe),
+// and check whether re-deriving its own CRD name -- via
+// crdnames.BGPVRFInstanceName, the exact forward computation the CNI ADD
+// path used to name instName in the first place -- reproduces instName.
+// vpcKeys accepts both the current (nameSegment-encoded) and legacy (raw)
+// CRD name shapes, the same as CollectOrphanedVRFs already does when going
+// in the opposite direction (kernel VRF -> live VPC set).
+//
+// ok is false, not an error, when no matching kernel VRF interface exists
+// right now -- the ordinary case for a BGPVRFInstance whose attachment has
+// already been torn down (there is nothing left to repopulate an entry
+// from; Reconcile's own stale-entry sweep, not this function, is what
+// eventually removes its CRD).
+//
+// The egress kind is read off whichever interface is currently enslaved to
+// the matched VRF: a "tuntap" link (internal/cnitap's tap-mode attachment)
+// yields EgressKindTap, anything else (ordinarily a "veth" link) yields
+// EgressKindVeth -- the same veth/tap distinction registerEBPFDatapath's
+// own egressKindForInterfaceType makes from the CNI config's interface
+// type, just read back from the kernel instead of from that config, which
+// this call site does not have. A VRF with no enslaved interface at all
+// (a narrow, transient window) falls back to EgressKindVeth, vrf_table's
+// own zero value and by far the common case.
+func resolveVRFKernelState(nodeName, instName string) (vrfTableID uint32, egressKind uint32, ok bool, err error) {
+	links, err := listVRFLinksFn()
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("list kernel VRF interfaces: %w", err)
+	}
+
+	var match *netlink.Vrf
+	for _, link := range links {
+		vpc, vpcOK := parseVRFName(link.Name)
+		if !vpcOK {
+			continue
+		}
+		for _, key := range vpcKeys(vpc) {
+			if key+"-"+nodeName == instName {
+				match = link
+				break
+			}
+		}
+		if match != nil {
+			break
+		}
+	}
+	if match == nil {
+		return 0, 0, false, nil
+	}
+
+	kind := usidmap.EgressKindVeth
+	allLinks, err := listAllLinksFn()
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("list kernel interfaces: %w", err)
+	}
+	for _, l := range allLinks {
+		if l.Attrs().MasterIndex != match.Attrs().Index {
+			continue
+		}
+		if l.Type() == "tuntap" {
+			kind = usidmap.EgressKindTap
+		}
+		break
+	}
+
+	return match.Table, kind, true, nil
 }
 
 // SweepEBPFNPTv6Table registers/reconciles the eBPF uSID datapath's

--- a/internal/gc/gc_ebpf_test.go
+++ b/internal/gc/gc_ebpf_test.go
@@ -158,8 +158,8 @@ func TestSweepEBPFVRFTable_RemovesStaleKeepsLive(t *testing.T) {
 }
 
 // TestSweepEBPFVRFTable_PreservesIngressSidecarReservedBlock reproduces the
-// bug confirmed live in us-central-1-staging-lab: internal/ingresssidecar
-// registers its own vrf_table entries under uformat.BlockMax, a block
+// bug this exemption fixes: internal/ingresssidecar registers its own
+// vrf_table entries under uformat.BlockMax, a block
 // deliberately reserved so it never collides with a real BGPRouter locator,
 // with no BGPVRFInstance CRD behind it at all -- that sidecar owns their
 // lifecycle itself. Before the fix, every such entry was invisible to this

--- a/internal/gc/gc_vrf_repair_test.go
+++ b/internal/gc/gc_vrf_repair_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package gc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// withFakeLinks temporarily overrides listVRFLinksFn/listAllLinksFn for the
+// duration of one test, restoring the real (kernel-touching) functions on
+// cleanup -- the same seam attach.go's preflightCheckFn gives its own
+// callers, so resolveVRFKernelState is testable without CAP_NET_ADMIN or a
+// real kernel VRF interface.
+func withFakeLinks(t *testing.T, vrfLinks []*netlink.Vrf, allLinks []netlink.Link) {
+	t.Helper()
+	origVRF, origAll := listVRFLinksFn, listAllLinksFn
+	listVRFLinksFn = func() ([]*netlink.Vrf, error) { return vrfLinks, nil }
+	listAllLinksFn = func() ([]netlink.Link, error) { return allLinks, nil }
+	t.Cleanup(func() { listVRFLinksFn, listAllLinksFn = origVRF, origAll })
+}
+
+func TestResolveVRFKernelState(t *testing.T) {
+	const nodeName = "worker-a"
+	const vpc = "jU"
+	instName := crdnames.BGPVRFInstanceName(vpc, nodeName)
+
+	vrfLink := &netlink.Vrf{
+		LinkAttrs: netlink.LinkAttrs{Name: testVRFName, Index: 42},
+		Table:     7,
+	}
+
+	t.Run("matches and reads egress kind from an enslaved veth", func(t *testing.T) {
+		vethSlave := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "G000000jUabcH", MasterIndex: vrfLink.Index},
+		}
+		withFakeLinks(t, []*netlink.Vrf{vrfLink}, []netlink.Link{vethSlave})
+
+		tableID, kind, ok, err := resolveVRFKernelState(nodeName, instName)
+		if err != nil {
+			t.Fatalf("resolveVRFKernelState: %v", err)
+		}
+		if !ok {
+			t.Fatalf("resolveVRFKernelState() ok = false, want true")
+		}
+		if tableID != vrfLink.Table {
+			t.Errorf("vrfTableID = %d, want %d", tableID, vrfLink.Table)
+		}
+		if kind != usidmap.EgressKindVeth {
+			t.Errorf("egressKind = %d, want EgressKindVeth (%d)", kind, usidmap.EgressKindVeth)
+		}
+	})
+
+	t.Run("matches and reads egress kind from an enslaved tap", func(t *testing.T) {
+		tapSlave := &netlink.Tuntap{
+			LinkAttrs: netlink.LinkAttrs{Name: "G000000jUabcH", MasterIndex: vrfLink.Index},
+		}
+		withFakeLinks(t, []*netlink.Vrf{vrfLink}, []netlink.Link{tapSlave})
+
+		_, kind, ok, err := resolveVRFKernelState(nodeName, instName)
+		if err != nil {
+			t.Fatalf("resolveVRFKernelState: %v", err)
+		}
+		if !ok {
+			t.Fatalf("resolveVRFKernelState() ok = false, want true")
+		}
+		if kind != usidmap.EgressKindTap {
+			t.Errorf("egressKind = %d, want EgressKindTap (%d)", kind, usidmap.EgressKindTap)
+		}
+	})
+
+	t.Run("matches with no enslaved interface defaults to veth", func(t *testing.T) {
+		withFakeLinks(t, []*netlink.Vrf{vrfLink}, nil)
+
+		tableID, kind, ok, err := resolveVRFKernelState(nodeName, instName)
+		if err != nil {
+			t.Fatalf("resolveVRFKernelState: %v", err)
+		}
+		if !ok {
+			t.Fatalf("resolveVRFKernelState() ok = false, want true")
+		}
+		if tableID != vrfLink.Table {
+			t.Errorf("vrfTableID = %d, want %d", tableID, vrfLink.Table)
+		}
+		if kind != usidmap.EgressKindVeth {
+			t.Errorf("egressKind = %d, want EgressKindVeth (%d) as the no-slave default", kind, usidmap.EgressKindVeth)
+		}
+	})
+
+	t.Run("no matching kernel VRF interface is not an error", func(t *testing.T) {
+		other := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: "G000000otherV", Index: 99}, Table: 3}
+		withFakeLinks(t, []*netlink.Vrf{other}, nil)
+
+		_, _, ok, err := resolveVRFKernelState(nodeName, instName)
+		if err != nil {
+			t.Fatalf("resolveVRFKernelState: %v", err)
+		}
+		if ok {
+			t.Errorf("resolveVRFKernelState() ok = true, want false (no matching kernel VRF)")
+		}
+	})
+
+	t.Run("propagates a listVRFLinksFn error", func(t *testing.T) {
+		orig := listVRFLinksFn
+		t.Cleanup(func() { listVRFLinksFn = orig })
+		wantErr := errors.New("netlink boom")
+		listVRFLinksFn = func() ([]*netlink.Vrf, error) { return nil, wantErr }
+
+		_, _, _, err := resolveVRFKernelState(nodeName, instName)
+		if !errors.Is(err, wantErr) {
+			t.Errorf("resolveVRFKernelState() err = %v, want wrapping %v", err, wantErr)
+		}
+	})
+
+	t.Run("legacy-encoded CRD name still resolves", func(t *testing.T) {
+		// vpcKeys(vpc) joins both the raw VPC and its nameSegment-encoded
+		// form, so a CRD named from the pre-encoding-change convention
+		// (raw vpc, not crdnames.VPCSegment(vpc)) must resolve exactly the
+		// same way a current-shape name does.
+		legacyInstName := vpc + "-" + nodeName
+		withFakeLinks(t, []*netlink.Vrf{vrfLink}, nil)
+
+		_, _, ok, err := resolveVRFKernelState(nodeName, legacyInstName)
+		if err != nil {
+			t.Fatalf("resolveVRFKernelState: %v", err)
+		}
+		if !ok {
+			t.Errorf("resolveVRFKernelState() ok = false, want true for legacy-shaped CRD name")
+		}
+	})
+}

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -173,9 +173,9 @@ func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, e
 	// its own to anywhere.
 	//
 	// Routed via the peer's own link-local address, deliberately not a
-	// bare on-link route (LinkIndex alone, no Gw): confirmed live in
-	// us-central-1-staging-lab, an on-link default forces the kernel to
-	// resolve a neighbor for the packet's own final destination before
+	// bare on-link route (LinkIndex alone, no Gw): an on-link default
+	// forces the kernel to resolve a neighbor for the packet's own final
+	// destination before
 	// it ever reaches usid_egress's TC hook at all -- nothing answers
 	// that (there is no real host at an arbitrary destination this VRF's
 	// egress_route_table is about to rewrite), so the kernel gives up
@@ -262,9 +262,9 @@ func ensureNodeSourceAddress() error {
 // usid_egress's ifindex_vrf_table lookup needs a 1:1 ifindex<->VRF
 // mapping anyway, the same shape internal/cnibgp's own
 // registerEBPFDatapath relies on for a genuine tenant veth/tap attachment
-// -- but did not hold up: confirmed live in us-central-1-staging-lab via
-// packet capture, a Linux VRF master device's own TC egress hook never
-// actually fires for traffic routed through it, for any tenant, however
+// -- but did not hold up: packet capture confirmed that a Linux VRF
+// master device's own TC egress hook never actually fires for traffic
+// routed through it, for any tenant, however
 // correctly every map involved is populated. internal/cnibgp's own
 // attachUsidEgress never attaches to a VRF at all; it attaches to a real
 // tenant veth's *ingress* hook from the host side, because that is where
@@ -293,10 +293,10 @@ func ensureEgressDatapath(tableID uint32) error {
 	// only ever runs as a side effect of a real tenant CNI ADD landing on
 	// this node -- something a node running only this sidecar's synthetic
 	// attachments, with no real tenant CNI attachment at all, never gets.
-	// Confirmed live in us-central-1-staging-lab: an otherwise fully
-	// correct attachment (VRF, veth, ifindex_vrf_table, egress_route_table
-	// all resolving) silently produced no encapsulated traffic at all,
-	// traced to this exact gap. Non-fatal on failure, same as
+	// An otherwise fully correct attachment (VRF, veth, ifindex_vrf_table,
+	// egress_route_table all resolving) can therefore silently produce no
+	// encapsulated traffic at all, traced to this exact gap. Non-fatal on
+	// failure, same as
 	// internal/cnibgp's own call site and for the identical reason --
 	// ResolveNodeSourceAddress needs a converged underlay default route,
 	// which this pod can transiently lack right after this sidecar itself

--- a/internal/ingresssidecar/ebpfdatapath_integration_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_integration_test.go
@@ -152,10 +152,10 @@ func assertTornDown(
 // TestEnsureEgressDatapath_AttachesToVethPeerNotVRF is this fix's own exit
 // criterion: usid_egress must end up on a real interface's ingress hook
 // that actually sees this VRF's traffic, not the VRF device's own TC
-// egress hook -- confirmed live in us-central-1-staging-lab via packet
-// capture to never fire, for any tenant, however correctly vrf_table and
-// egress_route_table were populated (this file's own doc comment on
-// ensureEgressDatapath has the full account).
+// egress hook -- packet-capture confirmed that hook never fires, for any
+// tenant, however correctly vrf_table and egress_route_table were
+// populated (this file's own doc comment on ensureEgressDatapath has the
+// full account).
 func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
 	requireRoot(t)
 	setUpTestPinDir(t)

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -783,10 +783,7 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 				continue
 			}
 			result := gc.SweepEBPFVRFTable(ctx, ebpfState.k8sClient, ebpfState.namespace, ebpfState.nodeName, attach.PinDir)
-			if result.EBPFVRFEntriesRemoved > 0 || result.Errors > 0 {
-				slog.Info("eBPF vrf_table GC sweep complete",
-					"removed", result.EBPFVRFEntriesRemoved, "errors", result.Errors)
-			}
+			logEBPFVRFSweepResult(result)
 
 			// nptv6_table's own sweep: unlike vrf_table above, this is the
 			// map's *only* writer (see gc.SweepEBPFNPTv6Table's own doc
@@ -805,6 +802,20 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 		case iface := <-radvActors.failed:
 			radvActorFailed(radvActors, iface)
 		}
+	}
+}
+
+// logEBPFVRFSweepResult logs one gc.SweepEBPFVRFTable tick's result, if
+// there's anything worth logging -- split out of Run's own select loop
+// (rather than inlined there like every other ticker case) purely to keep
+// that branch out of Run's own cyclomatic complexity count, now that this
+// result carries a third field (EBPFVRFEntriesRegistered) alongside the
+// original two.
+func logEBPFVRFSweepResult(result gc.CleanupResult) {
+	if result.EBPFVRFEntriesRemoved > 0 || result.EBPFVRFEntriesRegistered > 0 || result.Errors > 0 {
+		slog.Info("eBPF vrf_table GC sweep complete",
+			"removed", result.EBPFVRFEntriesRemoved, "registered", result.EBPFVRFEntriesRegistered,
+			"errors", result.Errors)
 	}
 }
 

--- a/internal/plumbing/ebpf/egressroutemap/egressroute.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute.go
@@ -22,10 +22,9 @@ import (
 // neighborResolveTimeout/neighborResolvePollInterval bound how long
 // resolveNeighbor will wait for a solicited neighbor entry to resolve --
 // see that function's own doc comment for why an active solicit is
-// needed at all. Real ND round-trips on the fabric links this runs
-// against are sub-100ms (confirmed live in us-central-1-staging-lab);
-// this budget is generous headroom above that, not an expected steady-
-// state wait.
+// needed at all. Real ND round-trips on a healthy fabric link are
+// sub-100ms; this budget is generous headroom above that, not an
+// expected steady-state wait.
 const (
 	neighborResolveTimeout      = 2 * time.Second
 	neighborResolvePollInterval = 100 * time.Millisecond
@@ -184,11 +183,10 @@ func resolveLinkAndL2(sid net.IP) (linkIndex int, dmac, smac net.HardwareAddr, e
 // A cache read alone is not enough: a brand-new pod netns (or any link
 // that has simply never sent traffic toward nextHop) starts with an
 // empty neighbor cache, and installing an SRv6 egress route generates no
-// traffic of its own that would populate it. Confirmed live in
-// us-central-1-staging-lab: a freshly started gateway pod's egress route
-// for a same-node SID next-hop failed to resolve for its entire uptime
-// -- restarts included -- purely because nothing ever asked the kernel
-// to actually solicit it; a single manual ping resolved it instantly. See
+// traffic of its own that would populate it -- a same-node SID next-hop's
+// egress route can otherwise fail to resolve for a gateway pod's entire
+// uptime, restarts included, purely because nothing ever asks the kernel
+// to actually solicit it; a single manual ping resolves it instantly. See
 // solicitNeighbor's own doc comment for how the solicit itself is done.
 func resolveNeighbor(linkIndex int, nextHop net.IP) (net.HardwareAddr, error) {
 	if mac, err := lookupNeighbor(linkIndex, nextHop); err != nil {

--- a/internal/plumbing/ebpf/egressroutemap/neighbor_test.go
+++ b/internal/plumbing/ebpf/egressroutemap/neighbor_test.go
@@ -171,10 +171,10 @@ func setUpVethPairNoFarSide(t *testing.T, nearIface, nearAddr, farIface string) 
 	return nearNS, nearLinkIndex
 }
 
-// TestResolveNeighbor_ActivelySolicitsColdCache reproduces the exact
-// failure confirmed live in us-central-1-staging-lab: a link with a real,
-// reachable peer whose neighbor cache is empty because nothing has ever
-// sent traffic toward it. The pre-fix implementation (a bare
+// TestResolveNeighbor_ActivelySolicitsColdCache reproduces the failure
+// mode this package exists to fix: a link with a real, reachable peer
+// whose neighbor cache is empty because nothing has ever sent traffic
+// toward it. The pre-fix implementation (a bare
 // netlink.NeighList read) fails this every time; so, empirically, does an
 // administrative netlink.NeighSet(NUD_NONE, NTF_USE) solicit with no real
 // packet behind it (see solicitNeighbor's own doc comment) -- only

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -662,9 +662,9 @@ enum drop_reason {
 	// is a real registration miss or a redirect failure) but the
 	// redirect to the resolved fabric-uplink interface failed.
 	DROP_REASON_PUBLIC_UPLINK_REDIRECT_FAILED = 15,
-	// TEMPORARY diagnostic checkpoints for the live us-central-1-staging-lab
-	// bpf_redirect investigation -- not counted drops, just markers of how
-	// far usid_egress's egress-routing extension got. Remove once resolved.
+	// TEMPORARY diagnostic checkpoints for an ongoing bpf_redirect
+	// investigation -- not counted drops, just markers of how far
+	// usid_egress's egress-routing extension got. Remove once resolved.
 	DROP_REASON_TRACE_MULTICAST_LL_BAIL = 16,
 	DROP_REASON_TRACE_MISS_VRF = 17,
 	DROP_REASON_TRACE_MISS_ROUTE = 18,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -366,8 +366,13 @@ func testChainedGalacticBGP(t *testing.T, podName string, tapResult map[string]a
 	t.Helper()
 
 	const vpc, vpcAttachment = "1", "1"
-	vrfCRDName := vpc + "-" + nodeName()    // BGPVRFInstance keyed by (vpc, node)
-	advCRDName := vpc + "-" + vpcAttachment // BGPAdvertisement keyed by (vpc, vpcAttachment)
+	vrfCRDName := vpc + "-" + nodeName() // BGPVRFInstance keyed by (vpc, node)
+	// BGPAdvertisement keyed by (vpc, vpcAttachment, node) -- see
+	// crdnames.BGPAdvertisementName's own doc comment for why node is part
+	// of this key: two nodes attaching to the same VPCAttachment (e.g. a
+	// multi-replica Deployment) must each get their own BGPAdvertisement,
+	// not race to overwrite one shared object.
+	advCRDName := vpc + "-" + vpcAttachment + "-" + nodeName()
 	t.Cleanup(func() {
 		//nolint:errcheck // best-effort cleanup, mirrors deletePod
 		kubectl(context.Background(), "delete", "bgpvrfinstance", vrfCRDName, "--ignore-not-found")


### PR DESCRIPTION
## Summary

A VPC attachment could stay marked healthy in Kubernetes while every packet destined to it on that node was silently dropped. This happened when the node's eBPF forwarding maps were wiped and recreated during a data plane schema upgrade, because only brand new attachments re-registered their forwarding entry afterward; existing ones never did. The periodic cleanup pass now also repairs a missing forwarding entry for any still-live attachment, recovering the values it needs from the real kernel state instead of guessing. A few code comments naming an internal test environment were also rewritten to describe the general failure mode instead of where it was observed.

## Test plan

- [ ] Build, lint, and unit tests pass
- [ ] A live attachment missing its forwarding entry gets it restored on the next cleanup pass, using the real kernel VRF interface's table id and interface type
- [ ] A stale forwarding entry with no live attachment is still removed
- [ ] The ingress sidecar's own reserved entries are still preserved
