### PR TITLE
feat(trunk): shared SO_MARK trunk datapath for ingress sidecar

### DIFF
--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -18,7 +18,7 @@ import (
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
-	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/markvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/srv6"
@@ -36,9 +36,9 @@ import (
 var ebpfPinDir = attach.PinDir
 
 // ingressSidecarBlock is the fixed, synthetic uSID Block this file uses for
-// every vrf_table/ifindex_vrf_table entry it registers, standing in for
-// the real, per-router bgp.srv6Locator-derived Block internal/cnibgp's own
-// registerEBPFDatapath uses for a genuine tenant CNI attachment.
+// every vrf_table entry it registers, standing in for the real, per-router
+// bgp.srv6Locator-derived Block internal/cnibgp's own registerEBPFDatapath
+// uses for a genuine tenant CNI attachment.
 //
 // Why a synthetic value is correct here, not a shortcut: vrf_table's key
 // (block<<12 | argument) is consulted by usid_egress purely as a local,
@@ -50,7 +50,7 @@ var ebpfPinDir = attach.PinDir
 // a real (block, argument) pair internal/cnibgp might independently
 // register for some other tenant VPC's CNI attachment sharing this same
 // node, and (b) stay internally consistent between this file's own
-// ifindex_vrf_table and vrf_table writes.
+// mark_vrf_table and vrf_table writes.
 //
 // (a) is what this constant buys: uformat.BlockMax is the all-ones 48-bit
 // value -- as an IPv6 prefix, ffff:ffff:ffff::/48, a pattern no fabric
@@ -70,6 +70,18 @@ var ebpfPinDir = attach.PinDir
 // bgp.srv6Locator the way internal/cnibgp does.
 const ingressSidecarBlock = uformat.BlockMax
 
+// trunkInnerName and trunkPeerName are the fixed names of this pod's one
+// shared trunk veth pair (see ensureTrunk). Fixed, not derived from any
+// per-pod identifier: cmd/galactic-vrf runs one process per pod, in that
+// pod's own network namespace (its own appDesc: "per-pod VPC backend
+// VRF/SRv6 route lifecycle") -- nothing else in that namespace creates
+// interfaces, so "one trunk per pod" already collapses to "one trunk per
+// process" without needing a name unique across pods.
+const (
+	trunkInnerName = "gtrunk"
+	trunkPeerName  = "gtrunkp"
+)
+
 // argumentForTableID derives this file's uSID Argument for vpc's VRF from
 // its own Linux kernel routing table ID, rather than allocating a separate
 // value: vrf.TableID(vpc) already guarantees node-local uniqueness per VPC
@@ -87,6 +99,33 @@ func argumentForTableID(tableID uint32) (uint16, error) {
 			tableID, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax))
 	}
 	return uint16(tableID), nil
+}
+
+// markForTableID derives this VPC's SO_MARK/mark_vrf_table key from its own
+// VRF table ID, mirroring argumentForTableID's exact reasoning:
+// vrf.TableID(vpc) is already guaranteed node-local-unique, so reusing it
+// avoids needing a second, redundant allocator for mark values too. Rejects
+// tableID 0 specifically (never expected in practice -- vrf.Add's own
+// allocator starts from 1) because an unmarked skb's mark is conventionally
+// 0 in the kernel; a mark_vrf_table entry keyed on 0 would make every
+// unmarked packet arriving on the shared trunk silently resolve to
+// whichever VPC happened to get that mark, rather than failing the
+// ifindex/mark lookup the way it should.
+//
+// PLACEHOLDER: this is not the mark value domain network-services-operator
+// will actually stamp via SO_MARK in production -- that is
+// network-services-operator's own phase-2 work (feat/srv6-routing-identity,
+// unmerged as of this file's own last update), which this file has no
+// visibility into and cannot anticipate. Treat this as an opaque uint32
+// lookup key with no protocol meaning, exactly like ingressSidecarBlock and
+// argumentForTableID already are for Block/Argument -- every call site of
+// this function must remain grep-discoverable so it can be swapped for
+// whatever phase 2 settles on.
+func markForTableID(tableID uint32) (uint32, error) {
+	if tableID == 0 {
+		return 0, errors.New("ingresssidecar: VRF table id 0 is not a valid mark source")
+	}
+	return tableID, nil
 }
 
 // vrfLinkForTable returns the kernel VRF link whose own routing table is
@@ -108,87 +147,120 @@ func vrfLinkForTable(tableID uint32) (*netlink.Vrf, error) {
 	return nil, fmt.Errorf("no VRF interface found for table %d", tableID)
 }
 
-// egressVethNames derives this VPC's own veth pair names from tableID
-// alone -- ensureEgressDatapath/removeEgressDatapath only ever carry a
-// tableID forward, not the vpc string vrf.Add itself was keyed on
-// (vrfLinkForTable's own doc comment). Collision-free the same way
-// vrf.TableID(vpc) already is (that is its whole purpose), and
-// comfortably inside IFNAMSIZ: tableID fits uSID Argument's 12-bit range
-// (argumentForTableID's own check), so at most 4 decimal digits.
-func egressVethNames(tableID uint32) (inner, peer string) {
-	return fmt.Sprintf("ivs%d", tableID), fmt.Sprintf("ivp%d", tableID)
-}
-
-// ensureEgressVeth creates (or finds) the one real interface pair
-// usid_egress actually intercepts this VPC's traffic on: inner enslaved
-// into vrfLink itself, with a default route in vrfLink's own table
-// pointed at it, so every destination this VPC's egress_route_table might
-// ever match has somewhere real to go once the kernel's own vrf_xmit()
-// redoes its route lookup inside that table. peer -- left outside the
-// VRF, in this pod's main netns -- is where usid_egress actually attaches
-// (see ensureEgressDatapath's own doc comment for why the VRF's own
-// egress hook doesn't work for that).
+// ensureTrunk creates (or finds) this pod's one shared trunk veth pair and
+// attaches usid_egress to its peer's ingress hook -- the real interception
+// point for every VPC's egress traffic this pod's Envoy Gateway serves, not
+// a dedicated pair per VPC. This replaces the former per-VPC ensureEgressVeth:
+// that approach enslaved each VPC's own inner end into that VPC's own VRF,
+// which doesn't scale to one shared trunk serving many VPCs -- a Linux link
+// can only ever have one master. inner is deliberately left unenslaved
+// here; ensureVRFRoute below installs each VPC's own gateway route into
+// that VPC's own table without requiring inner to be a member of it.
 //
-// Idempotent: LinkAdd against an already-existing name is treated as
-// already-done, and RouteReplace overwrites rather than errors on a
-// second call -- the same "safe on every SetDesired that ensures a VRF"
-// contract every other step in this file already has.
-func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, error) {
-	peerLink, err := netlink.LinkByName(peer)
+// usid_egress attaches on the peer's *ingress* hook, not the trunk's own
+// egress hook: packet capture confirmed (back when this file used a
+// dedicated veth per VPC) that a Linux VRF/veth master device's own TC
+// egress hook never actually fires for traffic routed through it, however
+// correctly every map involved is populated. internal/cnibgp's own
+// attachUsidEgress never attaches to a VRF either, for the same reason --
+// it attaches to a real tenant veth's ingress hook from the host side,
+// because that is where the tenant's own egress traffic actually arrives.
+// This attaches the exact same way, via attach.AttachEgress, not the
+// removed attach.AttachLocalEgress.
+//
+// Attaching on this pod's own shared eth0 instead, tempting since that is
+// where cilium ultimately hands the packet off, was considered and
+// rejected: eth0 is shared by every VPC this sidecar serves, and
+// ifindex_vrf_table can only carry one (block, argument) per ifindex -- a
+// single eth0 registration could resolve at most one of this pod's VPCs
+// correctly. The trunk's own peer ifindex is deliberately never registered
+// into ifindex_vrf_table for the identical reason; that absence is exactly
+// what makes usid_egress's mark_vrf_table fallback (usid.c's own dispatch
+// comment) engage for trunk-arriving traffic instead.
+//
+// Idempotent: LinkAdd against an already-existing name, and
+// attach.AttachEgress's own netlink.FilterReplace, are each already
+// no-ops/overwrites on a repeat call -- safe to call on every
+// ensureEgressDatapath, not just the first VPC a pod activates, and the
+// trunk pair and its attachment are never torn down by removeEgressDatapath;
+// they persist for this process's own lifetime (see removeEgressDatapath's
+// own doc comment).
+func ensureTrunk() (netlink.Link, error) {
+	peerLink, err := netlink.LinkByName(trunkPeerName)
 	if err != nil {
 		var notFound netlink.LinkNotFoundError
 		if !errors.As(err, &notFound) {
-			return nil, fmt.Errorf("look up veth peer %q: %w", peer, err)
+			return nil, fmt.Errorf("look up trunk peer %q: %w", trunkPeerName, err)
 		}
 		veth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{Name: inner},
-			PeerName:  peer,
+			LinkAttrs: netlink.LinkAttrs{Name: trunkInnerName},
+			PeerName:  trunkPeerName,
 		}
 		if err := netlink.LinkAdd(veth); err != nil {
-			return nil, fmt.Errorf("add veth pair %q/%q: %w", inner, peer, err)
+			return nil, fmt.Errorf("add trunk veth pair %q/%q: %w", trunkInnerName, trunkPeerName, err)
 		}
-		peerLink, err = netlink.LinkByName(peer)
+		peerLink, err = netlink.LinkByName(trunkPeerName)
 		if err != nil {
-			return nil, fmt.Errorf("look up newly-created veth peer %q: %w", peer, err)
+			return nil, fmt.Errorf("look up newly-created trunk peer %q: %w", trunkPeerName, err)
 		}
 	}
 
-	innerLink, err := netlink.LinkByName(inner)
+	innerLink, err := netlink.LinkByName(trunkInnerName)
 	if err != nil {
-		return nil, fmt.Errorf("look up veth inner end %q: %w", inner, err)
-	}
-	if err := netlink.LinkSetMaster(innerLink, vrfLink); err != nil {
-		return nil, fmt.Errorf("enslave %q into VRF %q: %w", inner, vrfLink.Attrs().Name, err)
+		return nil, fmt.Errorf("look up trunk inner end %q: %w", trunkInnerName, err)
 	}
 	if err := netlink.LinkSetUp(innerLink); err != nil {
-		return nil, fmt.Errorf("set %q up: %w", inner, err)
+		return nil, fmt.Errorf("set %q up: %w", trunkInnerName, err)
 	}
 	if err := netlink.LinkSetUp(peerLink); err != nil {
-		return nil, fmt.Errorf("set %q up: %w", peer, err)
+		return nil, fmt.Errorf("set %q up: %w", trunkPeerName, err)
 	}
 
-	// The second, inner hop vrf_xmit() takes once a packet actually
-	// enters this VRF -- a route in the VRF's own table, not the main
-	// table ensureRedirectRoute installs, which otherwise has no route of
-	// its own to anywhere.
-	//
-	// Routed via the peer's own link-local address, deliberately not a
-	// bare on-link route (LinkIndex alone, no Gw): an on-link default
-	// forces the kernel to resolve a neighbor for the packet's own final
-	// destination before
-	// it ever reaches usid_egress's TC hook at all -- nothing answers
-	// that (there is no real host at an arbitrary destination this VRF's
-	// egress_route_table is about to rewrite), so the kernel gives up
-	// with "destination unreachable" and the packet never reaches the
-	// interface's qdisc, let alone the ingress filter on it. Routing via
-	// a gateway instead means the kernel only ever has to resolve *one*
-	// neighbor -- the peer, always present and always answerable, the
-	// same real ND exchange proven to complete in under a millisecond
-	// earlier in this investigation -- regardless of what the packet's
-	// own destination address is.
+	program, err := ebpf.LoadPinnedProgram(filepath.Join(ebpfPinDir, attach.UsidEgressPinName), nil)
+	if err != nil {
+		return nil, fmt.Errorf("load pinned usid_egress program: %w", err)
+	}
+	defer func() { _ = program.Close() }()
+
+	if err := attach.AttachEgress(program, peerLink.Attrs().Name); err != nil {
+		return nil, fmt.Errorf("attach usid_egress to trunk peer %q: %w", peerLink.Attrs().Name, err)
+	}
+
+	return peerLink, nil
+}
+
+// ensureVRFRoute installs one VPC's own default route into vrfLink's own
+// table, pointed at the shared trunk's inner end via peer's link-local
+// address as an explicit gateway -- the second, inner hop vrf_xmit() takes
+// once a packet actually enters this VRF, without which this VRF's own
+// table has no route of its own to anywhere. This is the same route the
+// former per-VPC ensureEgressVeth always installed, just no longer paired
+// 1:1 with a dedicated veth per VPC: many VPCs' own ensureVRFRoute calls
+// can all legitimately name the same shared trunk inner end as nexthop,
+// each isolated in its own table.
+//
+// Routed via the peer's own link-local address, deliberately not a bare
+// on-link route (LinkIndex alone, no Gw): an on-link default forces the
+// kernel to resolve a neighbor for the packet's own final destination
+// before it ever reaches usid_egress's TC hook at all -- nothing answers
+// that (there is no real host at an arbitrary destination this VRF's
+// egress_route_table is about to rewrite), so the kernel gives up with
+// "destination unreachable" and the packet never reaches the interface's
+// qdisc, let alone the ingress filter on it. Routing via a gateway instead
+// means the kernel only ever has to resolve *one* neighbor -- the peer,
+// always present and always answerable -- regardless of what the packet's
+// own destination address is.
+//
+// Idempotent: netlink.RouteReplace overwrites rather than errors on a
+// second call for the same table.
+func ensureVRFRoute(vrfLink *netlink.Vrf, peerLink netlink.Link) error {
+	innerLink, err := netlink.LinkByName(trunkInnerName)
+	if err != nil {
+		return fmt.Errorf("look up trunk inner end %q: %w", trunkInnerName, err)
+	}
 	peerLinkLocal, err := waitForLinkLocalAddr(peerLink)
 	if err != nil {
-		return nil, fmt.Errorf("wait for veth peer %q's own link-local address: %w", peer, err)
+		return fmt.Errorf("wait for trunk peer %q's own link-local address: %w", trunkPeerName, err)
 	}
 	defaultRoute := &netlink.Route{
 		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
@@ -197,10 +269,22 @@ func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, e
 		Gw:        peerLinkLocal,
 	}
 	if err := netlink.RouteReplace(defaultRoute); err != nil {
-		return nil, fmt.Errorf("install default route in VRF table %d via %q: %w", vrfLink.Table, inner, err)
+		return fmt.Errorf("install default route in VRF table %d via %q: %w", vrfLink.Table, trunkInnerName, err)
 	}
+	return nil
+}
 
-	return peerLink, nil
+// removeVRFRoute removes the per-VPC route ensureVRFRoute installed in
+// vrfLink's own table -- by Table alone (mirrors srv6.RouteMainDel's
+// identical shape), since only one such route is ever installed per table.
+// It must not, and does not, touch the shared trunk veth pair or
+// usid_egress's attachment to it -- both persist across this and every
+// other VPC's own teardown; see ensureTrunk's own doc comment.
+func removeVRFRoute(vrfLink *netlink.Vrf) error {
+	return netlink.RouteDel(&netlink.Route{
+		Dst:   &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+		Table: int(vrfLink.Table),
+	})
 }
 
 // waitForLinkLocalAddr returns link's own global-scope-eligible link-local
@@ -249,49 +333,25 @@ func ensureNodeSourceAddress() error {
 	return nodeSrc.Set(addr)
 }
 
-// ensureEgressDatapath makes usid_egress's own VRF resolution
-// (ifindex_vrf_table -> vrf_table -> Linux VRF table id, usid.c's own
-// doc comment on usid_egress) resolve correctly for vpc's VRF interface,
-// then attaches usid_egress where it actually intercepts that VRF's
-// traffic -- the actual enforcement point that was entirely missing
-// before this file existed: EnsureRoute's egress_route_table entries had
-// nothing anywhere in this pod's netns ever attached to read them.
+// ensureEgressDatapath makes usid_egress's own VRF resolution resolve
+// correctly for vpc's VRF interface, then makes sure this pod's one shared
+// trunk exists and is attached where it actually intercepts every VPC's
+// traffic -- the actual enforcement point that was entirely missing before
+// this file existed: EnsureRoute's egress_route_table entries had nothing
+// anywhere in this pod's netns ever attached to read them.
 //
-// This used to attach directly to the VRF interface's own TC *egress*
-// hook (attach.AttachLocalEgress). That looked right -- the VRF is where
-// usid_egress's ifindex_vrf_table lookup needs a 1:1 ifindex<->VRF
-// mapping anyway, the same shape internal/cnibgp's own
-// registerEBPFDatapath relies on for a genuine tenant veth/tap attachment
-// -- but did not hold up: packet capture confirmed that a Linux VRF
-// master device's own TC egress hook never actually fires for traffic
-// routed through it, for any tenant, however
-// correctly every map involved is populated. internal/cnibgp's own
-// attachUsidEgress never attaches to a VRF at all; it attaches to a real
-// tenant veth's *ingress* hook from the host side, because that is where
-// the tenant's own egress traffic actually arrives. ensureEgressVeth
-// gives this file the equivalent of that real veth -- enslaved into the
-// VRF so vrf_xmit() has somewhere to send a packet once it resolves
-// there -- and this attaches the exact same way internal/cnibgp already
-// does, on its peer's ingress hook via attach.AttachEgress, not
-// attach.AttachLocalEgress.
-//
-// Attaching on this pod's own shared eth0 instead, tempting since that is
-// where cilium ultimately hands the packet off, was considered and
-// rejected: eth0 is shared by every VPC this sidecar serves, and
-// ifindex_vrf_table can only carry one (block, argument) per ifindex -- a
-// single eth0 registration could resolve at most one of this pod's VPCs
-// correctly.
-//
-// Idempotent: every step here is a plain overwrite/replace operation,
-// safe to call on every SetDesired that ensures a VRF (a repeat call for
-// an already-provisioned VPC, e.g. after this sidecar's own restart, is a
-// no-op in effect).
+// Idempotent: every step here is a plain overwrite/replace/register
+// operation, safe to call on every SetDesired that ensures a VRF (a repeat
+// call for an already-provisioned VPC, e.g. after this sidecar's own
+// restart, is a no-op in effect), and safe to call once per VPC this pod
+// activates even though ensureTrunk's own work only actually needs doing
+// once per process.
 func ensureEgressDatapath(tableID uint32) error {
 	// node_src_addr_table is a per-node singleton, not per-VPC: usid_egress
 	// fails open (TC_ACT_UNSPEC, uncounted) on every encapsulation attempt
 	// until some caller sets it, and internal/cnibgp's own registration
 	// only ever runs as a side effect of a real tenant CNI ADD landing on
-	// this node -- something a node running only this sidecar's synthetic
+	// this node -- something a node running only this sidecar's
 	// attachments, with no real tenant CNI attachment at all, never gets.
 	// An otherwise fully correct attachment (VRF, veth, ifindex_vrf_table,
 	// egress_route_table all resolving) can therefore silently produce no
@@ -311,15 +371,23 @@ func ensureEgressDatapath(tableID uint32) error {
 		return err
 	}
 
+	mark, err := markForTableID(tableID)
+	if err != nil {
+		return err
+	}
+
 	vrfLink, err := vrfLinkForTable(tableID)
 	if err != nil {
 		return err
 	}
 
-	inner, peer := egressVethNames(tableID)
-	peerLink, err := ensureEgressVeth(vrfLink, inner, peer)
+	peerLink, err := ensureTrunk()
 	if err != nil {
-		return fmt.Errorf("ensure egress veth for VRF table %d: %w", tableID, err)
+		return fmt.Errorf("ensure shared trunk: %w", err)
+	}
+
+	if err := ensureVRFRoute(vrfLink, peerLink); err != nil {
+		return fmt.Errorf("ensure VRF route for table %d: %w", tableID, err)
 	}
 
 	registry, closer, err := usidmap.OpenPinnedRegistry(ebpfPinDir)
@@ -328,9 +396,9 @@ func ensureEgressDatapath(tableID uint32) error {
 	}
 	defer func() { _ = closer.Close() }()
 
-	// EgressKindVeth: a don't-care here, not a real claim about this VRF
-	// device's own link type. EgressKind only steers usid_ingress's own
-	// step-9 redirect (usid.c's own doc comment on enum egress_kind), and
+	// EgressKindVeth: a don't-care here, not a real claim about the trunk's
+	// own link type. EgressKind only steers usid_ingress's own step-9
+	// redirect (usid.c's own doc comment on enum egress_kind), and
 	// usid_ingress is never attached anywhere in this pod's netns -- this
 	// sidecar has no ingress/decap side at all (its own package doc
 	// comment). usid_egress, the only program this file's registrations
@@ -339,75 +407,61 @@ func ensureEgressDatapath(tableID uint32) error {
 		return fmt.Errorf("register eBPF vrf_table entry: %w", err)
 	}
 
-	ifindexTable, ifindexCloser, err := ifindexvrfmap.OpenPinned(ebpfPinDir)
+	markTable, markCloser, err := markvrfmap.OpenPinned(ebpfPinDir)
 	if err != nil {
-		return fmt.Errorf("open pinned eBPF ifindex_vrf_table: %w", err)
+		return fmt.Errorf("open pinned eBPF mark_vrf_table: %w", err)
 	}
-	defer func() { _ = ifindexCloser.Close() }()
+	defer func() { _ = markCloser.Close() }()
 
-	// Keyed by the veth peer's ifindex, not the VRF's own -- see this
-	// function's own doc comment for why usid_egress has to see this
-	// traffic arriving on that interface's ingress hook, not the VRF's
-	// egress.
-	if err := ifindexTable.Register(uint32(peerLink.Attrs().Index), ingressSidecarBlock, argument); err != nil {
-		return fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
+	if err := markTable.Register(mark, ingressSidecarBlock, argument); err != nil {
+		return fmt.Errorf("register eBPF mark_vrf_table entry: %w", err)
 	}
 
-	program, err := ebpf.LoadPinnedProgram(filepath.Join(ebpfPinDir, attach.UsidEgressPinName), nil)
-	if err != nil {
-		return fmt.Errorf("load pinned usid_egress program: %w", err)
-	}
-	defer func() { _ = program.Close() }()
-
-	if err := attach.AttachEgress(program, peerLink.Attrs().Name); err != nil {
-		return fmt.Errorf("attach usid_egress to VRF %d's veth peer %q: %w", tableID, peerLink.Attrs().Name, err)
-	}
 	return nil
 }
 
-// removeEgressDatapath undoes ensureEgressDatapath's own registrations for
-// the VPC whose VRF table is tableID -- called before RemoveVRF deletes
-// the VRF interface itself (backend.go's RemoveVRF), while the veth
-// pair's own names can still be derived. Best-effort and idempotent,
-// matching every other teardown step in this package (Unregister is
-// already "absent is not an error"): every step is attempted even if an
-// earlier one failed, and every failure is joined and returned together,
-// rather than a first error aborting the rest of cleanup.
+// removeEgressDatapath undoes ensureEgressDatapath's own per-VPC
+// registrations and route for the VPC whose VRF table is tableID -- called
+// before RemoveVRF deletes the VRF interface itself (backend.go's
+// RemoveVRF), while that interface can still be resolved by table id.
+// Best-effort and idempotent, matching every other teardown step in this
+// package (Unregister is already "absent is not an error"): every step is
+// attempted even if an earlier one failed, and every failure is joined and
+// returned together, rather than a first error aborting the rest of
+// cleanup.
 //
-// No explicit detach call for usid_egress: deleting the veth pair below
-// removes both ends and, with them, every qdisc/filter attached to
-// either -- the same "the interface going away is the detach" contract
-// internal/cnibgp's own teardown already relies on for its real tenant
-// veth (attachUsidEgress's own doc comment has no DetachEgress
-// counterpart at all).
+// Unlike the removed per-VPC veth this replaces, this does NOT delete any
+// interface and does NOT detach usid_egress from anything: the shared
+// trunk and its attachment are this process's own, not this one VPC's, and
+// must survive every individual VPC's own teardown -- they only ever go
+// away with the process itself (cmd/galactic-vrf's root.go: no proactive
+// VRF/route teardown on exit, so the next instance reconciles from
+// scratch).
 func removeEgressDatapath(tableID uint32) error {
 	argument, err := argumentForTableID(tableID)
 	if err != nil {
 		return err
 	}
+	mark, err := markForTableID(tableID)
+	if err != nil {
+		return err
+	}
 
-	inner, peer := egressVethNames(tableID)
 	var errs []error
 
-	if peerLink, lerr := netlink.LinkByName(peer); lerr != nil {
-		var notFound netlink.LinkNotFoundError
-		if !errors.As(lerr, &notFound) {
-			errs = append(errs, fmt.Errorf("look up veth peer %q: %w", peer, lerr))
-		}
-		// Absent is not an error (idempotent teardown) -- nothing more to
-		// unregister or delete for it below.
+	if vrfLink, verr := vrfLinkForTable(tableID); verr != nil {
+		errs = append(errs, fmt.Errorf("look up VRF link for table %d: %w", tableID, verr))
+	} else if err := removeVRFRoute(vrfLink); err != nil {
+		errs = append(errs, fmt.Errorf("remove VRF route for table %d: %w", tableID, err))
+	}
+
+	if markTable, closer, oerr := markvrfmap.OpenPinned(ebpfPinDir); oerr != nil {
+		errs = append(errs, fmt.Errorf("open pinned eBPF mark_vrf_table: %w", oerr))
 	} else {
-		if ifindexTable, closer, oerr := ifindexvrfmap.OpenPinned(ebpfPinDir); oerr != nil {
-			errs = append(errs, fmt.Errorf("open pinned eBPF ifindex_vrf_table: %w", oerr))
-		} else {
-			if err := ifindexTable.Unregister(uint32(peerLink.Attrs().Index)); err != nil {
-				errs = append(errs, fmt.Errorf("unregister eBPF ifindex_vrf_table entry: %w", err))
-			}
-			_ = closer.Close()
+		if err := markTable.Unregister(mark); err != nil {
+			errs = append(errs, fmt.Errorf("unregister eBPF mark_vrf_table entry: %w", err))
 		}
-		if err := netlink.LinkDel(peerLink); err != nil {
-			errs = append(errs, fmt.Errorf("delete veth pair %q/%q: %w", inner, peer, err))
-		}
+		_ = closer.Close()
 	}
 
 	if registry, closer, oerr := usidmap.OpenPinnedRegistry(ebpfPinDir); oerr != nil {

--- a/internal/ingresssidecar/ebpfdatapath_integration_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/markvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
@@ -47,74 +48,103 @@ func setUpTestPinDir(t *testing.T) {
 	t.Cleanup(func() { ebpfPinDir = prev })
 }
 
-// assertVethWiring checks the kernel-side mechanics ensureEgressDatapath is
-// responsible for: inner enslaved into the VRF, a real path out of the
-// VRF's own table, and usid_egress attached where it actually intercepts
-// that traffic -- the peer's ingress hook, never the VRF's own egress.
-func assertVethWiring(vrfLink *netlink.Vrf, innerLink, peerLink netlink.Link, tableID uint32) error {
-	if innerLink.Attrs().MasterIndex != vrfLink.Attrs().Index {
-		return fmt.Errorf("inner veth end master = %d, want VRF ifindex %d",
-			innerLink.Attrs().MasterIndex, vrfLink.Attrs().Index)
-	}
-
-	routes, err := netlink.RouteListFiltered(
-		netlink.FAMILY_V6, &netlink.Route{Table: int(tableID)}, netlink.RT_FILTER_TABLE)
-	if err != nil {
-		return fmt.Errorf("list routes in VRF table %d: %w", tableID, err)
-	}
-	var foundDefault bool
-	for _, r := range routes {
-		if r.LinkIndex == innerLink.Attrs().Index && (r.Dst == nil || r.Dst.String() == "::/0") {
-			foundDefault = true
-		}
-	}
-	if !foundDefault {
-		return fmt.Errorf("no default route via the veth inner end in VRF table %d, want one (routes: %+v)",
-			tableID, routes)
+// assertTrunkWiring checks the kernel-side mechanics ensureTrunk is
+// responsible for, once for the whole shared trunk (not per-VPC, unlike
+// the removed per-VPC veth this test used to assert): inner deliberately
+// NOT enslaved into any VRF (a single trunk cannot belong to more than one
+// VPC's VRF), and usid_egress attached exactly once, on the peer's ingress
+// hook -- never the trunk's own egress hook, the same "never fires" finding
+// this test file has asserted since before the trunk existed (see
+// ensureTrunk's own doc comment).
+func assertTrunkWiring(innerLink, peerLink netlink.Link) error {
+	if innerLink.Attrs().MasterIndex != 0 {
+		return fmt.Errorf("trunk inner end has master ifindex %d, want 0 (unenslaved)", innerLink.Attrs().MasterIndex)
 	}
 
 	peerFilters, err := netlink.FilterList(peerLink, netlink.HANDLE_MIN_INGRESS)
 	if err != nil {
-		return fmt.Errorf("list ingress filters on veth peer: %w", err)
+		return fmt.Errorf("list ingress filters on trunk peer: %w", err)
 	}
-	if len(peerFilters) == 0 {
-		return errors.New("no ingress filter on veth peer, want usid_egress attached there")
+	if len(peerFilters) != 1 {
+		return fmt.Errorf("trunk peer has %d ingress filter(s), want exactly 1 (usid_egress, attached once)",
+			len(peerFilters))
 	}
 
-	vrfFilters, err := netlink.FilterList(vrfLink, netlink.HANDLE_MIN_EGRESS)
+	innerFilters, err := netlink.FilterList(innerLink, netlink.HANDLE_MIN_EGRESS)
 	if err != nil {
-		return fmt.Errorf("list egress filters on VRF: %w", err)
+		return fmt.Errorf("list egress filters on trunk inner end: %w", err)
 	}
-	if len(vrfFilters) != 0 {
-		return fmt.Errorf("VRF has %d egress filter(s), want none -- usid_egress belongs on the veth peer, not here",
-			len(vrfFilters))
+	if len(innerFilters) != 0 {
+		return fmt.Errorf("trunk inner end has %d egress filter(s), want none -- "+
+			"usid_egress belongs on the peer's ingress hook, not here", len(innerFilters))
 	}
 	return nil
 }
 
-// assertMapState checks vrf_table/ifindex_vrf_table read back exactly what
-// ensureEgressDatapath's own doc comment promises: keyed by the veth
-// peer's ifindex, never the VRF's own.
-func assertMapState(
-	ifindexTable *ifindexvrfmap.IfindexVRFTable, registry *usidmap.Registry,
-	vrfLink *netlink.Vrf, peerLink netlink.Link, tableID uint32,
-) error {
-	entry, ok, err := ifindexTable.Get(uint32(peerLink.Attrs().Index))
+// assertVRFRoute checks that vrfLink's own table has the per-VPC default
+// route ensureVRFRoute installs, via the shared trunk's inner end -- every
+// VPC sharing the trunk gets its own route in its own table, all naming
+// the same nexthop device.
+func assertVRFRoute(vrfLink *netlink.Vrf, innerLink netlink.Link) error {
+	routes, err := netlink.RouteListFiltered(
+		netlink.FAMILY_V6, &netlink.Route{Table: int(vrfLink.Table)}, netlink.RT_FILTER_TABLE)
 	if err != nil {
-		return fmt.Errorf("look up ifindex_vrf_table[peer]: %w", err)
+		return fmt.Errorf("list routes in VRF table %d: %w", vrfLink.Table, err)
 	}
-	if !ok {
-		return errors.New("ifindex_vrf_table has no entry for the veth peer's ifindex")
+	for _, r := range routes {
+		if r.LinkIndex == innerLink.Attrs().Index && (r.Dst == nil || r.Dst.String() == "::/0") {
+			return nil
+		}
 	}
-	if entry.Block != ingressSidecarBlock || entry.Argument != uint16(tableID) {
-		return fmt.Errorf("ifindex_vrf_table[peer] = (block=%#x, argument=%d), want (block=%#x, argument=%d)",
-			entry.Block, entry.Argument, ingressSidecarBlock, tableID)
+	return fmt.Errorf("no default route via the trunk inner end in VRF table %d, want one (routes: %+v)",
+		vrfLink.Table, routes)
+}
+
+// assertNoVRFRoute checks that removeVRFRoute actually removed vrfLink's
+// own default route -- without touching the trunk itself.
+func assertNoVRFRoute(vrfLink *netlink.Vrf) error {
+	routes, err := netlink.RouteListFiltered(
+		netlink.FAMILY_V6, &netlink.Route{Table: int(vrfLink.Table)}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("list routes in VRF table %d: %w", vrfLink.Table, err)
+	}
+	for _, r := range routes {
+		if r.Dst == nil || r.Dst.String() == "::/0" {
+			return fmt.Errorf("VRF table %d still has a default route after removeVRFRoute: %+v", vrfLink.Table, r)
+		}
+	}
+	return nil
+}
+
+// assertMapState checks vrf_table/mark_vrf_table read back exactly what
+// ensureEgressDatapath's own doc comment promises for tableID's VPC, and
+// that ifindex_vrf_table has no entry at all for the trunk peer's ifindex
+// -- that absence is exactly what makes usid_egress's mark fallback engage
+// for trunk-arriving traffic (usid.c's own dispatch comment).
+func assertMapState(
+	ifindexTable *ifindexvrfmap.IfindexVRFTable, markTable *markvrfmap.MarkVRFTable, registry *usidmap.Registry,
+	peerLink netlink.Link, tableID uint32,
+) error {
+	if _, ok, err := ifindexTable.Get(uint32(peerLink.Attrs().Index)); err != nil {
+		return fmt.Errorf("look up ifindex_vrf_table[trunk peer]: %w", err)
+	} else if ok {
+		return errors.New("ifindex_vrf_table has an entry for the trunk peer's ifindex, want none")
 	}
 
-	if _, ok, err := ifindexTable.Get(uint32(vrfLink.Attrs().Index)); err != nil {
-		return fmt.Errorf("look up ifindex_vrf_table[VRF]: %w", err)
-	} else if ok {
-		return errors.New("ifindex_vrf_table has an entry keyed by the VRF's own ifindex, want none")
+	mark, err := markForTableID(tableID)
+	if err != nil {
+		return fmt.Errorf("markForTableID(%d): %w", tableID, err)
+	}
+	markEntry, ok, err := markTable.Get(mark)
+	if err != nil {
+		return fmt.Errorf("look up mark_vrf_table[%d]: %w", mark, err)
+	}
+	if !ok {
+		return fmt.Errorf("mark_vrf_table has no entry for mark %d (table %d)", mark, tableID)
+	}
+	if markEntry.Block != ingressSidecarBlock || markEntry.Argument != uint16(tableID) {
+		return fmt.Errorf("mark_vrf_table[%d] = (block=%#x, argument=%d), want (block=%#x, argument=%d)",
+			mark, markEntry.Block, markEntry.Argument, ingressSidecarBlock, tableID)
 	}
 
 	vrfEntry, ok, err := registry.VRF.Get(ingressSidecarBlock, uint16(tableID))
@@ -127,19 +157,25 @@ func assertMapState(
 	return nil
 }
 
-// assertTornDown checks removeEgressDatapath's own contract: the veth
-// pair and both map entries are all gone.
-func assertTornDown(
-	ifindexTable *ifindexvrfmap.IfindexVRFTable, registry *usidmap.Registry,
-	peerName string, peerIfindex uint32, tableID uint32,
+// assertVPCTornDown checks removeEgressDatapath's own per-VPC contract:
+// this VPC's own route and map entries are gone. Unlike the removed
+// per-VPC veth this test used to assert, it does NOT check that any
+// interface is gone -- the shared trunk is this process's own, not this
+// one VPC's, and must survive (see assertTrunkSurvives).
+func assertVPCTornDown(
+	markTable *markvrfmap.MarkVRFTable, registry *usidmap.Registry, vrfLink *netlink.Vrf, tableID uint32,
 ) error {
-	if _, err := netlink.LinkByName(peerName); err == nil {
-		return errors.New("veth peer still exists after removeEgressDatapath")
+	if err := assertNoVRFRoute(vrfLink); err != nil {
+		return err
 	}
-	if _, ok, err := ifindexTable.Get(peerIfindex); err != nil {
-		return fmt.Errorf("look up ifindex_vrf_table[peer] after removal: %w", err)
+	mark, err := markForTableID(tableID)
+	if err != nil {
+		return fmt.Errorf("markForTableID(%d): %w", tableID, err)
+	}
+	if _, ok, err := markTable.Get(mark); err != nil {
+		return fmt.Errorf("look up mark_vrf_table[%d] after removal: %w", mark, err)
 	} else if ok {
-		return errors.New("ifindex_vrf_table[peer] still present after removeEgressDatapath")
+		return fmt.Errorf("mark_vrf_table[%d] still present after removeEgressDatapath", mark)
 	}
 	if _, ok, err := registry.VRF.Get(ingressSidecarBlock, uint16(tableID)); err != nil {
 		return fmt.Errorf("look up vrf_table entry after removal: %w", err)
@@ -149,14 +185,34 @@ func assertTornDown(
 	return nil
 }
 
-// TestEnsureEgressDatapath_AttachesToVethPeerNotVRF is this fix's own exit
-// criterion: usid_egress must end up on a real interface's ingress hook
-// that actually sees this VRF's traffic, not the VRF device's own TC
-// egress hook -- packet-capture confirmed that hook never fires, for any
-// tenant, however correctly vrf_table and egress_route_table were
-// populated (this file's own doc comment on ensureEgressDatapath has the
-// full account).
-func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
+// assertTrunkSurvives checks that the shared trunk veth pair and its
+// usid_egress attachment are both still exactly as they were -- the
+// inverse of the old per-VPC test's "veth gone after removal" assertion,
+// since the trunk is process-lifetime now, not per-VPC-lifetime (see
+// removeEgressDatapath's own doc comment).
+func assertTrunkSurvives() error {
+	innerLink, err := netlink.LinkByName(trunkInnerName)
+	if err != nil {
+		return fmt.Errorf("trunk inner end %q gone, want it to persist: %w", trunkInnerName, err)
+	}
+	peerLink, err := netlink.LinkByName(trunkPeerName)
+	if err != nil {
+		return fmt.Errorf("trunk peer %q gone, want it to persist: %w", trunkPeerName, err)
+	}
+	return assertTrunkWiring(innerLink, peerLink)
+}
+
+// TestEnsureEgressDatapath_SharedTrunkAcrossVPCs is the trunk redesign's
+// own exit criterion: two VPCs sharing this pod's one trunk must both
+// resolve correctly (disambiguated by mark, since the trunk's single
+// ifindex can't disambiguate them the way a per-attachment ifindex does),
+// and tearing one VPC down must not disturb the trunk itself or the other
+// VPC's still-live state -- the trunk only ever goes away with the
+// process. This replaces TestEnsureEgressDatapath_AttachesToVethPeerNotVRF
+// (the per-VPC-veth predecessor this design replaced); its own "attach on
+// the peer's ingress, never the VRF/trunk's own egress" assertion survives
+// here as assertTrunkWiring.
+func TestEnsureEgressDatapath_SharedTrunkAcrossVPCs(t *testing.T) {
 	requireRoot(t)
 	setUpTestPinDir(t)
 
@@ -166,33 +222,53 @@ func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = nsObj.Close() })
 
-	const tableID = uint32(7)
-	const vrfName = "ivstestvrf"
+	const table1 = uint32(7)
+	const table2 = uint32(8)
+	const vrf1Name = "gttestvrf1"
+	const vrf2Name = "gttestvrf2"
 
 	err = nsObj.Do(func(_ ns.NetNS) error {
-		vrfLink := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: vrfName}, Table: tableID}
-		if err := netlink.LinkAdd(vrfLink); err != nil {
-			return fmt.Errorf("add VRF: %w", err)
+		vrf1 := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: vrf1Name}, Table: table1}
+		if err := netlink.LinkAdd(vrf1); err != nil {
+			return fmt.Errorf("add VRF 1: %w", err)
 		}
-		if err := netlink.LinkSetUp(vrfLink); err != nil {
-			return fmt.Errorf("set VRF up: %w", err)
-		}
-
-		if err := ensureEgressDatapath(tableID); err != nil {
-			return fmt.Errorf("ensureEgressDatapath: %w", err)
+		if err := netlink.LinkSetUp(vrf1); err != nil {
+			return fmt.Errorf("set VRF 1 up: %w", err)
 		}
 
-		inner, peer := egressVethNames(tableID)
-		innerLink, err := netlink.LinkByName(inner)
+		vrf2 := &netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: vrf2Name}, Table: table2}
+		if err := netlink.LinkAdd(vrf2); err != nil {
+			return fmt.Errorf("add VRF 2: %w", err)
+		}
+		if err := netlink.LinkSetUp(vrf2); err != nil {
+			return fmt.Errorf("set VRF 2 up: %w", err)
+		}
+
+		// Two VPCs activating on this one pod -- both must converge onto
+		// the same shared trunk, not a dedicated interface each.
+		if err := ensureEgressDatapath(table1); err != nil {
+			return fmt.Errorf("ensureEgressDatapath(table1): %w", err)
+		}
+		if err := ensureEgressDatapath(table2); err != nil {
+			return fmt.Errorf("ensureEgressDatapath(table2): %w", err)
+		}
+
+		innerLink, err := netlink.LinkByName(trunkInnerName)
 		if err != nil {
-			return fmt.Errorf("look up inner veth end %q: %w", inner, err)
+			return fmt.Errorf("look up trunk inner end %q: %w", trunkInnerName, err)
 		}
-		peerLink, err := netlink.LinkByName(peer)
+		peerLink, err := netlink.LinkByName(trunkPeerName)
 		if err != nil {
-			return fmt.Errorf("look up veth peer %q: %w", peer, err)
+			return fmt.Errorf("look up trunk peer %q: %w", trunkPeerName, err)
 		}
 
-		if err := assertVethWiring(vrfLink, innerLink, peerLink, tableID); err != nil {
+		if err := assertTrunkWiring(innerLink, peerLink); err != nil {
+			return err
+		}
+		if err := assertVRFRoute(vrf1, innerLink); err != nil {
+			return err
+		}
+		if err := assertVRFRoute(vrf2, innerLink); err != nil {
 			return err
 		}
 
@@ -202,20 +278,51 @@ func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
 		}
 		defer func() { _ = closer.Close() }()
 
-		registry, closer2, err := usidmap.OpenPinnedRegistry(ebpfPinDir)
+		markTable, mcloser, err := markvrfmap.OpenPinned(ebpfPinDir)
+		if err != nil {
+			return fmt.Errorf("open pinned mark_vrf_table: %w", err)
+		}
+		defer func() { _ = mcloser.Close() }()
+
+		registry, rcloser, err := usidmap.OpenPinnedRegistry(ebpfPinDir)
 		if err != nil {
 			return fmt.Errorf("open pinned vrf_table: %w", err)
 		}
-		defer func() { _ = closer2.Close() }()
+		defer func() { _ = rcloser.Close() }()
 
-		if err := assertMapState(ifindexTable, registry, vrfLink, peerLink, tableID); err != nil {
-			return err
+		if err := assertMapState(ifindexTable, markTable, registry, peerLink, table1); err != nil {
+			return fmt.Errorf("VPC 1: %w", err)
+		}
+		if err := assertMapState(ifindexTable, markTable, registry, peerLink, table2); err != nil {
+			return fmt.Errorf("VPC 2: %w", err)
 		}
 
-		if err := removeEgressDatapath(tableID); err != nil {
-			return fmt.Errorf("removeEgressDatapath: %w", err)
+		// Tear down VPC 1 only.
+		if err := removeEgressDatapath(table1); err != nil {
+			return fmt.Errorf("removeEgressDatapath(table1): %w", err)
 		}
-		return assertTornDown(ifindexTable, registry, peer, uint32(peerLink.Attrs().Index), tableID)
+		if err := assertVPCTornDown(markTable, registry, vrf1, table1); err != nil {
+			return fmt.Errorf("VPC 1 after its own removal: %w", err)
+		}
+		// The trunk, its attachment, and VPC 2's still-live state must all
+		// survive VPC 1's teardown.
+		if err := assertTrunkSurvives(); err != nil {
+			return fmt.Errorf("after removing VPC 1: %w", err)
+		}
+		if err := assertMapState(ifindexTable, markTable, registry, peerLink, table2); err != nil {
+			return fmt.Errorf("VPC 2 after VPC 1's removal: %w", err)
+		}
+
+		// Tear down VPC 2.
+		if err := removeEgressDatapath(table2); err != nil {
+			return fmt.Errorf("removeEgressDatapath(table2): %w", err)
+		}
+		if err := assertVPCTornDown(markTable, registry, vrf2, table2); err != nil {
+			return fmt.Errorf("VPC 2 after its own removal: %w", err)
+		}
+		// Both VPCs are gone, but the shared trunk itself must still exist
+		// -- it is process-lifetime, not per-VPC-lifetime.
+		return assertTrunkSurvives()
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/ingresssidecar/ebpfdatapath_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_test.go
@@ -46,30 +46,55 @@ func TestArgumentForTableID(t *testing.T) {
 	}
 }
 
-// TestEgressVethNames covers the two properties ensureEgressDatapath and
-// removeEgressDatapath both depend on to ever find the same pair twice:
-// deterministic (so a later call derives the identical names a former
-// call used) and collision-free across different table ids (so two VPCs
-// sharing this node never contend for the same interface names).
-func TestEgressVethNames(t *testing.T) {
-	inner1, peer1 := egressVethNames(2)
-	inner2, peer2 := egressVethNames(2)
-	if inner1 != inner2 || peer1 != peer2 {
-		t.Fatalf("egressVethNames(2) is not deterministic: (%s,%s) vs (%s,%s)", inner1, peer1, inner2, peer2)
-	}
-	if inner1 == peer1 {
-		t.Fatalf("egressVethNames(2) returned identical inner/peer names %q", inner1)
-	}
-
-	otherInner, otherPeer := egressVethNames(3)
-	if inner1 == otherInner || peer1 == otherPeer {
-		t.Fatalf("egressVethNames collided across table ids: table 2 = (%s,%s), table 3 = (%s,%s)",
-			inner1, peer1, otherInner, otherPeer)
+// TestMarkForTableID mirrors TestArgumentForTableID's own table-driven
+// shape: markForTableID is a straight uint32-to-uint32 passthrough (no
+// truncation risk the way Argument's 12-bit range has), so its only real
+// edge case is the explicit tableID-0 rejection documented on the function
+// itself.
+func TestMarkForTableID(t *testing.T) {
+	cases := []struct {
+		name    string
+		tableID uint32
+		want    uint32
+		wantErr bool
+	}{
+		{name: "typical small table id", tableID: 1, want: 1},
+		{name: "another typical table id", tableID: 3, want: 3},
+		{name: "large table id", tableID: 1 << 20, want: 1 << 20},
+		{name: "zero table id is rejected (would collide with an unmarked skb)", tableID: 0, wantErr: true},
 	}
 
-	for _, name := range []string{inner1, peer1, otherInner, otherPeer} {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := markForTableID(tc.tableID)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("markForTableID(%d) = %d, nil; want an error", tc.tableID, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("markForTableID(%d) unexpected error: %v", tc.tableID, err)
+			}
+			if got != tc.want {
+				t.Fatalf("markForTableID(%d) = %d, want %d", tc.tableID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTrunkNamesAreFixedAndDistinct documents, in code, the "no per-pod
+// uniqueness needed" decision on trunkInnerName/trunkPeerName's own doc
+// comment: they are plain constants, not derived from any per-pod
+// identifier, and must still be distinct from each other and fit
+// IFNAMSIZ.
+func TestTrunkNamesAreFixedAndDistinct(t *testing.T) {
+	if trunkInnerName == trunkPeerName {
+		t.Fatalf("trunkInnerName and trunkPeerName are identical: %q", trunkInnerName)
+	}
+	for _, name := range []string{trunkInnerName, trunkPeerName} {
 		if len(name) > unix.IFNAMSIZ-1 {
-			t.Errorf("egressVethNames produced %q, %d bytes -- too long for IFNAMSIZ (%d)", name, len(name), unix.IFNAMSIZ)
+			t.Errorf("trunk name %q is %d bytes -- too long for IFNAMSIZ (%d)", name, len(name), unix.IFNAMSIZ)
 		}
 	}
 }

--- a/internal/plumbing/ebpf/markvrfmap/clock.go
+++ b/internal/plumbing/ebpf/markvrfmap/clock.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package markvrfmap
+
+import "golang.org/x/sys/unix"
+
+// monotonicNow returns a nanosecond CLOCK_MONOTONIC reading, used to stamp
+// this process's own in-memory Generation bookkeeping (see doc.go). A
+// deliberate small duplicate of usidmap's and ifindexvrfmap's own copies of
+// the same -- see ifindexvrfmap/clock.go's doc comment for why duplicating
+// this five-line syscall wrapper, rather than exporting it from usidmap, is
+// the intentional choice here.
+func monotonicNow() uint64 {
+	var ts unix.Timespec
+	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/internal/plumbing/ebpf/markvrfmap/doc.go
+++ b/internal/plumbing/ebpf/markvrfmap/doc.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package markvrfmap implements the read/write API for the eBPF uSID
+// datapath's mark_vrf_table map (internal/plumbing/ebpf/prog/usid.c's
+// struct mark_vrf_value comment): one row per VPC a shared trunk interface
+// serves, keyed by the SO_MARK value Envoy stamps on a socket bound to that
+// VPC, mapping it to the (Block, Argument) that VPC's VRF resolves to.
+//
+// usid_egress consults mark_vrf_table only as a fallback, after
+// ifindex_vrf_table (internal/plumbing/ebpf/ifindexvrfmap) has already
+// missed -- an ordinary per-attachment tenant veth/tap always has its own
+// ifindex_vrf_table entry and never reaches this table at all. Mark-based
+// resolution only becomes load-bearing for traffic arriving on a shared
+// trunk interface, where a single ifindex serves many VPCs and therefore
+// cannot disambiguate them the way a per-attachment ifindex does.
+//
+// # Reusing usidmap.Table/KernelTable/Iterator instead of duplicating them
+//
+// Same reasoning as ifindexvrfmap's own doc comment: mark_vrf_table is a
+// map of the same usid.c/prog package as vrf_table and ifindex_vrf_table,
+// not a second datapath, so this package imports and depends on
+// usidmap.Table/KernelTable/Iterator directly rather than re-declaring
+// them.
+//
+// # Lifecycle: driven by internal/ingresssidecar's per-VPC reconciler
+//
+// Register happens from internal/ingresssidecar's ensureEgressDatapath,
+// the same call site that already registers this VPC's vrf_table entry --
+// keyed additionally by a mark value derived from the VPC's own VRF table
+// ID (markForTableID), not by any attachment-scoped ifindex, since the
+// trunk interface backing this mark is shared across every VPC that
+// process's Envoy Gateway pod reaches. Unregister happens from the
+// matching removeEgressDatapath, mirroring ifindex_vrf_table's own
+// register/unregister lifecycle but keyed on mark instead of ifindex, and
+// without ever tearing down the shared trunk interface itself -- that
+// persists for the owning process's lifetime.
+//
+// Register/Unregister/Get/List/Reconcile method shapes mirror
+// ifindexvrfmap.IfindexVRFTable's own for API consistency and testability,
+// including a process-local Generation not persisted in the kernel value.
+package markvrfmap

--- a/internal/plumbing/ebpf/markvrfmap/faketable_test.go
+++ b/internal/plumbing/ebpf/markvrfmap/faketable_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package markvrfmap
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// fakeTable is an in-memory usidmap.Table implementation used across this
+// package's tests -- mirrors ifindexvrfmap's own (unexported, package-local)
+// fakeTable, adapted to mark_vrf_table's own __u32 key -- duplicated here
+// rather than imported since Go test-only helpers in another package's
+// _test.go files are not importable.
+type fakeTable struct {
+	entries map[uint32]any
+	order   []uint32
+}
+
+func newFakeTable() *fakeTable {
+	return &fakeTable{entries: make(map[uint32]any)}
+}
+
+func fakeTableKey(key any) uint32 {
+	k, ok := key.(uint32)
+	if !ok {
+		panic(fmt.Sprintf("fakeTable: key type %T not supported, want uint32", key))
+	}
+	return k
+}
+
+func (f *fakeTable) Put(key, value any) error {
+	k := fakeTableKey(key)
+	if _, exists := f.entries[k]; !exists {
+		f.order = append(f.order, k)
+	}
+	f.entries[k] = value
+	return nil
+}
+
+func (f *fakeTable) Lookup(key, valueOut any) error {
+	k := fakeTableKey(key)
+	v, ok := f.entries[k]
+	if !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(v))
+	return nil
+}
+
+func (f *fakeTable) Delete(key any) error {
+	k := fakeTableKey(key)
+	if _, ok := f.entries[k]; !ok {
+		return ebpf.ErrKeyNotExist
+	}
+	delete(f.entries, k)
+	for i, kk := range f.order {
+		if kk == k {
+			f.order = append(f.order[:i], f.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (f *fakeTable) Iterate() usidmap.Iterator {
+	return &fakeIterator{table: f, idx: -1}
+}
+
+func (f *fakeTable) len() int { return len(f.order) }
+
+type fakeIterator struct {
+	table *fakeTable
+	idx   int
+}
+
+func (it *fakeIterator) Next(keyOut, valueOut any) bool {
+	it.idx++
+	if it.idx >= len(it.table.order) {
+		return false
+	}
+	k := it.table.order[it.idx]
+	reflect.ValueOf(keyOut).Elem().Set(reflect.ValueOf(k))
+	reflect.ValueOf(valueOut).Elem().Set(reflect.ValueOf(it.table.entries[k]))
+	return true
+}
+
+func (it *fakeIterator) Err() error { return nil }

--- a/internal/plumbing/ebpf/markvrfmap/kernel_test.go
+++ b/internal/plumbing/ebpf/markvrfmap/kernel_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package markvrfmap
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// requireRoot skips the test unless running as root (CAP_BPF/CAP_NET_ADMIN
+// are needed to load real BPF maps), mirroring usidmap/kernel_test.go's own
+// helper of the same name and purpose.
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("test requires root (CAP_BPF/CAP_NET_ADMIN) to load real BPF maps; re-run via sudo")
+	}
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatalf("rlimit.RemoveMemlock: %v", err)
+	}
+}
+
+// loadTestObjects loads a fresh, unpinned copy of internal/plumbing/ebpf/
+// prog's compiled maps (and program) into the kernel, cleaned up when the
+// test ends. Unpinned is deliberate: this file tests MarkVRFTable's
+// Put/Lookup/Delete/Iterate wiring against a real kernel map, not
+// attach/pin lifecycle -- so there is no reason to touch the real PinDir
+// (/sys/fs/bpf/galactic) or leave anything behind on the test host. Mirrors
+// usidmap/kernel_test.go's own helper of the same name.
+func loadTestObjects(t *testing.T) *prog.UsidObjects {
+	t.Helper()
+
+	var objs prog.UsidObjects
+	if err := prog.LoadUsidObjects(&objs, nil); err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("load objects: verifier rejected program:\n%+v", ve)
+		}
+		t.Fatalf("load objects: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := objs.Close(); err != nil {
+			t.Errorf("close objects: %v", err)
+		}
+	})
+	return &objs
+}
+
+// TestKernelTable_MarkVRFTable_RealMap exercises MarkVRFTable's full
+// read/write API -- Register, Get, List, Reconcile, Unregister -- against a
+// real, kernel-loaded mark_vrf_table map, not the in-memory fake the rest
+// of this package's tests use. This proves prog.UsidMarkVrfValue's field
+// layout round-trips correctly through the kernel's own binary map
+// encoding, not just through Go struct assignment in a fake -- the same
+// genuine-verification role usidmap/kernel_test.go's
+// TestKernelTable_VRFTable_RealMap plays for vrf_table.
+func TestKernelTable_MarkVRFTable_RealMap(t *testing.T) {
+	requireRoot(t)
+	objs := loadTestObjects(t)
+	mt := NewMarkVRFTable(usidmap.KernelTable{Map: objs.MarkVrfTable})
+	mt.clock = constClock(10)
+
+	if err := mt.Register(4242, testBlock, 0x123); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := mt.Get(4242)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after Register against a real kernel map")
+	}
+	want := MarkVRFEntry{Mark: 4242, Block: testBlock, Argument: 0x123, Generation: 10}
+	if entry != want {
+		t.Errorf("Get (real map) = %+v, want %+v", entry, want)
+	}
+
+	entries, err := mt.List()
+	if err != nil {
+		t.Fatalf("List: unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0] != want {
+		t.Errorf("List (real map) = %+v, want exactly [%+v]", entries, want)
+	}
+
+	// Reconcile against a real map: entry is older than cutoff and absent
+	// from live, so it must be removed for real -- proving Reconcile's
+	// delete path (not just its in-memory bookkeeping) works against the
+	// kernel.
+	removed, err := mt.Reconcile(map[uint32]struct{}{}, 20)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Mark != 4242 {
+		t.Fatalf("Reconcile (real map) removed = %+v, want exactly mark 4242", removed)
+	}
+
+	if _, ok, err := mt.Get(4242); err != nil || ok {
+		t.Errorf("Get after Reconcile (real map): ok=%v err=%v, want ok=false", ok, err)
+	}
+
+	// Unregister on an already-absent real-map entry must still not error
+	// (mirrors TestMarkVRFTable_UnregisterAbsentIsNotError's fake-table
+	// coverage, here against ebpf.ErrKeyNotExist for real).
+	if err := mt.Unregister(4242); err != nil {
+		t.Errorf("Unregister (real map, already absent) = %v, want nil", err)
+	}
+}

--- a/internal/plumbing/ebpf/markvrfmap/markvrf.go
+++ b/internal/plumbing/ebpf/markvrfmap/markvrf.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package markvrfmap
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// MarkVRFEntry is one fully decoded mark_vrf_table row, decoupled from
+// prog.UsidMarkVrfValue's cilium/ebpf/BTF-generated field layout --
+// mirrors ifindexvrfmap.IfindexVRFEntry's own reasoning.
+type MarkVRFEntry struct {
+	Mark  uint32
+	Block uint64
+
+	// Argument is the 12-bit uSID Argument this mark's VRF resolves to.
+	Argument uint16
+
+	// Generation is this process's own in-memory bookkeeping of when this
+	// entry was last (re-)registered -- see doc.go for why this is not
+	// kernel-persisted.
+	Generation uint64
+}
+
+// MarkVRFTable is the read/write API for mark_vrf_table.
+type MarkVRFTable struct {
+	table usidmap.Table
+	clock func() uint64
+
+	mu         sync.Mutex
+	generation map[uint32]uint64
+}
+
+// NewMarkVRFTable wraps table as a MarkVRFTable. Production callers pass a
+// usidmap.KernelTable wrapping a loaded *prog.UsidObjects's MarkVrfTable map
+// (or OpenPinned, below); tests pass a fake usidmap.Table.
+func NewMarkVRFTable(table usidmap.Table) *MarkVRFTable {
+	return &MarkVRFTable{table: table, clock: monotonicNow, generation: make(map[uint32]uint64)}
+}
+
+// OpenPinned opens mark_vrf_table from its pinned path under pinDir and
+// returns a MarkVRFTable wrapping it, mirroring ifindexvrfmap.OpenPinned --
+// for a process (internal/ingresssidecar's ensureEgressDatapath/
+// removeEgressDatapath) that did not itself load the datapath but needs to
+// read/write this one map. The returned *ebpf.Map is also this table's own
+// io.Closer and must be closed once the caller is done; it does not affect
+// the map's pinned lifetime.
+func OpenPinned(pinDir string) (*MarkVRFTable, *ebpf.Map, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapMarkVrfTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("markvrfmap: open pinned map %q: %w", prog.UsidMapMarkVrfTable, err)
+	}
+	return NewMarkVRFTable(usidmap.KernelTable{Map: m}), m, nil
+}
+
+// Generation returns a snapshot of this table's monotonic clock.
+func (t *MarkVRFTable) Generation() uint64 {
+	return t.clock()
+}
+
+// Register writes (or overwrites) the mark_vrf_table entry for mark,
+// mapping it to (block, argument). Like ifindexvrfmap.IfindexVRFTable's own
+// Register, this carries no counters and is always a plain overwrite --
+// there is no read-modify-write step.
+func (t *MarkVRFTable) Register(mark uint32, block uint64, argument uint16) error {
+	if err := uformat.ValidateBlock(block); err != nil {
+		return fmt.Errorf("markvrfmap: mark_vrf_table: register mark=%d: %w", mark, err)
+	}
+	if err := uformat.ValidateArgument(argument); err != nil {
+		return fmt.Errorf("markvrfmap: mark_vrf_table: register mark=%d: %w", mark, err)
+	}
+
+	value := prog.UsidMarkVrfValue{Block: block, Argument: argument}
+	if err := t.table.Put(mark, value); err != nil {
+		return fmt.Errorf("markvrfmap: mark_vrf_table: register mark=%d: %w", mark, err)
+	}
+
+	t.mu.Lock()
+	t.generation[mark] = t.clock()
+	t.mu.Unlock()
+	return nil
+}
+
+// Unregister removes the mark_vrf_table entry for mark, if present. Not an
+// error to unregister an already-absent entry -- every caller of this
+// (internal/ingresssidecar's removeEgressDatapath) treats every cleanup
+// step as best-effort.
+func (t *MarkVRFTable) Unregister(mark uint32) error {
+	if err := t.table.Delete(mark); err != nil {
+		if !errors.Is(err, ebpf.ErrKeyNotExist) {
+			return fmt.Errorf("markvrfmap: mark_vrf_table: unregister mark=%d: %w", mark, err)
+		}
+	}
+	t.mu.Lock()
+	delete(t.generation, mark)
+	t.mu.Unlock()
+	return nil
+}
+
+// Get reads the mark_vrf_table entry for mark, reporting whether it exists.
+func (t *MarkVRFTable) Get(mark uint32) (MarkVRFEntry, bool, error) {
+	var value prog.UsidMarkVrfValue
+	if err := t.table.Lookup(mark, &value); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return MarkVRFEntry{}, false, nil
+		}
+		return MarkVRFEntry{}, false, fmt.Errorf("markvrfmap: mark_vrf_table: get mark=%d: %w", mark, err)
+	}
+	return t.decode(mark, value), true, nil
+}
+
+// List returns every entry currently in mark_vrf_table, in unspecified
+// order.
+func (t *MarkVRFTable) List() ([]MarkVRFEntry, error) {
+	var (
+		entries []MarkVRFEntry
+		rawKey  uint32
+		value   prog.UsidMarkVrfValue
+	)
+	it := t.table.Iterate()
+	for it.Next(&rawKey, &value) {
+		entries = append(entries, t.decode(rawKey, value))
+	}
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("markvrfmap: mark_vrf_table: list: %w", err)
+	}
+	return entries, nil
+}
+
+// Reconcile brings mark_vrf_table into agreement with live -- the caller's
+// current set of marks that should have an entry -- removing every entry
+// whose key is absent from live, except an entry whose Generation is >=
+// cutoff. Mirrors ifindexvrfmap.IfindexVRFTable.Reconcile's exact
+// semantics; not wired into any production sweep today for the same reason
+// that table's own Reconcile isn't -- exists for parity, test coverage, and
+// as a future defense-in-depth backstop.
+func (t *MarkVRFTable) Reconcile(live map[uint32]struct{}, cutoff uint64) (removed []MarkVRFEntry, err error) {
+	entries, err := t.List()
+	if err != nil {
+		return nil, fmt.Errorf("markvrfmap: mark_vrf_table: reconcile: %w", err)
+	}
+
+	var errs []error
+	for _, e := range entries {
+		if _, ok := live[e.Mark]; ok {
+			continue
+		}
+		if e.Generation >= cutoff {
+			continue
+		}
+		if err := t.Unregister(e.Mark); err != nil {
+			errs = append(errs, fmt.Errorf("markvrfmap: mark_vrf_table: reconcile: delete stale entry %+v: %w",
+				e, err))
+			continue
+		}
+		removed = append(removed, e)
+	}
+	return removed, errors.Join(errs...)
+}
+
+func (t *MarkVRFTable) decode(mark uint32, value prog.UsidMarkVrfValue) MarkVRFEntry {
+	t.mu.Lock()
+	gen := t.generation[mark]
+	t.mu.Unlock()
+
+	return MarkVRFEntry{
+		Mark:       mark,
+		Block:      value.Block,
+		Argument:   value.Argument,
+		Generation: gen,
+	}
+}

--- a/internal/plumbing/ebpf/markvrfmap/markvrf_test.go
+++ b/internal/plumbing/ebpf/markvrfmap/markvrf_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package markvrfmap
+
+import (
+	"errors"
+	"testing"
+)
+
+const testBlock uint64 = 0x2001_0DB8_FF01
+
+var errIntentionalTestFailure = errors.New("markvrfmap: intentional test failure")
+
+func newTestMarkVRFTable(clock func() uint64) (*MarkVRFTable, *fakeTable) {
+	ft := newFakeTable()
+	return &MarkVRFTable{table: ft, clock: clock, generation: make(map[uint32]uint64)}, ft
+}
+
+func constClock(value uint64) func() uint64 {
+	return func() uint64 { return value }
+}
+
+func TestMarkVRFTable_RegisterAndGet(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(7))
+
+	if err := mt.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := mt.Get(42)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Get: entry not found after Register")
+	}
+	want := MarkVRFEntry{Mark: 42, Block: testBlock, Argument: 0x123, Generation: 7}
+	if entry != want {
+		t.Errorf("Get = %+v, want %+v", entry, want)
+	}
+}
+
+func TestMarkVRFTable_GetMissingEntry(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(1))
+
+	_, ok, err := mt.Get(42)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if ok {
+		t.Errorf("Get: ok = true for an entry never registered")
+	}
+}
+
+func TestMarkVRFTable_RegisterRejectsReservedArgumentZero(t *testing.T) {
+	mt, ft := newTestMarkVRFTable(constClock(1))
+
+	if err := mt.Register(42, testBlock, 0x000); err == nil {
+		t.Errorf("Register(argument=0x000) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(argument=0x000) wrote %d entries, want 0", ft.len())
+	}
+}
+
+func TestMarkVRFTable_RegisterRejectsBlockOverflow(t *testing.T) {
+	mt, ft := newTestMarkVRFTable(constClock(1))
+
+	const overflowBlock = uint64(1) << 48
+	if err := mt.Register(42, overflowBlock, 0x123); err == nil {
+		t.Errorf("Register(overflowing block) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(overflowing block) wrote an entry, want none")
+	}
+}
+
+func TestMarkVRFTable_RegisterOverwrites(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(1))
+
+	if err := mt.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("first Register: unexpected error: %v", err)
+	}
+	mt.clock = constClock(99)
+	if err := mt.Register(42, testBlock, 0x456); err != nil {
+		t.Fatalf("second Register: unexpected error: %v", err)
+	}
+
+	entry, ok, err := mt.Get(42)
+	if err != nil || !ok {
+		t.Fatalf("Get after re-register: ok=%v err=%v", ok, err)
+	}
+	if entry.Argument != 0x456 {
+		t.Errorf("Argument = %#x after re-register, want %#x", entry.Argument, 0x456)
+	}
+	if entry.Generation != 99 {
+		t.Errorf("Generation = %d after re-register, want 99", entry.Generation)
+	}
+}
+
+func TestMarkVRFTable_Unregister(t *testing.T) {
+	mt, ft := newTestMarkVRFTable(constClock(1))
+
+	if err := mt.Register(42, testBlock, 0x123); err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if err := mt.Unregister(42); err != nil {
+		t.Fatalf("Unregister: unexpected error: %v", err)
+	}
+	if ft.len() != 0 {
+		t.Errorf("table has %d entries after Unregister, want 0", ft.len())
+	}
+	if _, ok, err := mt.Get(42); err != nil || ok {
+		t.Errorf("Get after Unregister: ok=%v err=%v, want ok=false", ok, err)
+	}
+}
+
+func TestMarkVRFTable_UnregisterAbsentIsNotError(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(1))
+
+	if err := mt.Unregister(42); err != nil {
+		t.Errorf("Unregister(never-registered entry) = %v, want nil", err)
+	}
+}
+
+func TestMarkVRFTable_List(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(1))
+
+	if err := mt.Register(42, testBlock, 0x001); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := mt.Register(43, testBlock, 0x002); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	entries, err := mt.List()
+	if err != nil {
+		t.Fatalf("List: unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("List returned %d entries, want 2: %+v", len(entries), entries)
+	}
+}
+
+func TestMarkVRFTable_Generation(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(123))
+	if got := mt.Generation(); got != 123 {
+		t.Errorf("Generation() = %d, want 123", got)
+	}
+}
+
+func TestMarkVRFTable_Reconcile_RemovesStaleKeepsLive(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(10))
+
+	if err := mt.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := mt.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	live := map[uint32]struct{}{43: {}}
+	removed, err := mt.Reconcile(live, 20)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Mark != 42 {
+		t.Fatalf("Reconcile removed = %+v, want exactly mark 42", removed)
+	}
+	if _, ok, err := mt.Get(42); err != nil || ok {
+		t.Errorf("Get(42) after Reconcile: ok=%v err=%v, want gone", ok, err)
+	}
+	if _, ok, err := mt.Get(43); err != nil || !ok {
+		t.Errorf("Get(43) after Reconcile: ok=%v err=%v, want it to survive", ok, err)
+	}
+}
+
+func TestMarkVRFTable_Reconcile_RegistrationMidSweepSurvives(t *testing.T) {
+	mt, _ := newTestMarkVRFTable(constClock(10))
+
+	if err := mt.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register(stale): unexpected error: %v", err)
+	}
+
+	const cutoff = 20
+	mt.clock = constClock(30)
+	if err := mt.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register(mid-sweep): unexpected error: %v", err)
+	}
+
+	removed, err := mt.Reconcile(map[uint32]struct{}{}, cutoff)
+	if err != nil {
+		t.Fatalf("Reconcile: unexpected error: %v", err)
+	}
+	if len(removed) != 1 || removed[0].Mark != 42 {
+		t.Fatalf("Reconcile removed = %+v, want exactly mark 42", removed)
+	}
+	if _, ok, err := mt.Get(43); err != nil || !ok {
+		t.Fatalf("Get(43) after Reconcile: ok=%v err=%v, want the mid-sweep registration to have survived", ok, err)
+	}
+}
+
+func TestMarkVRFTable_Reconcile_ContinuesPastDeleteFailure(t *testing.T) {
+	mt, ft := newTestMarkVRFTable(constClock(10))
+
+	if err := mt.Register(42, testBlock, 0x100); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := mt.Register(43, testBlock, 0x200); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	sabotaged := &deleteFailingTable{fakeTable: ft, failKey: 42}
+	sabotagedMT := &MarkVRFTable{table: sabotaged, clock: mt.clock, generation: mt.generation}
+
+	removed, err := sabotagedMT.Reconcile(map[uint32]struct{}{}, 20)
+	if err == nil {
+		t.Fatalf("Reconcile: want a non-nil error when a delete fails")
+	}
+	if !errors.Is(err, errIntentionalTestFailure) {
+		t.Errorf("Reconcile error = %v, want it to wrap errIntentionalTestFailure", err)
+	}
+	if len(removed) != 1 || removed[0].Mark != 43 {
+		t.Fatalf("Reconcile removed = %+v, want exactly mark 43", removed)
+	}
+}
+
+type deleteFailingTable struct {
+	*fakeTable
+	failKey uint32
+}
+
+func (d *deleteFailingTable) Delete(key any) error {
+	if k, ok := key.(uint32); ok && k == d.failKey {
+		return errIntentionalTestFailure
+	}
+	return d.fakeTable.Delete(key)
+}

--- a/internal/plumbing/ebpf/prog/doc.go
+++ b/internal/plumbing/ebpf/prog/doc.go
@@ -67,4 +67,4 @@ package prog
 // directive needing to change, while everyone else keeps getting plain
 // "clang" off their PATH.
 //
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value -type ifindex_vrf_value -type nptv6_value -type vip_xlat_key -type vip_xlat_value -type egress_route_key -type egress_route_value -type public_uplink_value Usid usid.c
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value -type ifindex_vrf_value -type mark_vrf_value -type nptv6_value -type vip_xlat_key -type vip_xlat_value -type egress_route_key -type egress_route_value -type public_uplink_value Usid usid.c

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -411,6 +411,17 @@ struct ifindex_vrf_value {
 	__u16 argument;
 };
 
+// struct mark_vrf_value is mark_vrf_table's value: the same (Block,
+// Argument) shape as struct ifindex_vrf_value above, keyed by skb->mark
+// instead of skb->ifindex. usid_egress consults mark_vrf_table only as a
+// fallback when ifindex_vrf_table misses -- see mark_vrf_table's own
+// comment below for why a single ifindex can't disambiguate this case the
+// way it does for an ordinary per-attachment veth/tap.
+struct mark_vrf_value {
+	__u64 block;
+	__u16 argument;
+};
+
 // struct nptv6_value is nptv6_table's value: one VRF's RFC 6296 mapping,
 // mirroring internal/plumbing/nptv6.Mapping/Adjustment on the control-plane
 // side -- see that package's doc comment for the checksum-neutral math this
@@ -691,6 +702,11 @@ enum drop_reason {
 	DROP_REASON_TRACE_ETH_BOUNDS_FAILED = 26,
 	DROP_REASON_TRACE_ETHERTYPE_MISMATCH = 27,
 	DROP_REASON_TRACE_IFINDEX_HIT = 28,
+	// mark_vrf_table fallback, only reached once ifindex_vrf_table has
+	// already missed (a shared trunk interface, not an ordinary
+	// per-attachment veth/tap -- see mark_vrf_table's own comment).
+	DROP_REASON_TRACE_MARK_MISS = 29,
+	DROP_REASON_TRACE_MARK_HIT = 30,
 	__DROP_REASON_MAX,
 };
 
@@ -760,6 +776,21 @@ struct {
 	__type(key, __u32); // ifindex
 	__type(value, struct ifindex_vrf_value);
 } ifindex_vrf_table SEC(".maps");
+
+// mark_vrf_table: the SO_MARK/shared-trunk analog of ifindex_vrf_table
+// above. usid_egress consults this only when ifindex_vrf_table misses --
+// i.e. only for traffic arriving on a shared trunk interface (one ifindex
+// serving many VPCs, so ifindex alone can't disambiguate them), never for
+// an ordinary tenant veth/tap, which always has its own ifindex_vrf_table
+// entry and never reaches this fallback. Sized like vrf_table (one row per
+// VPC a node's trunk(s) serve), not like ifindex_vrf_table (one row per
+// attachment).
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 8192);
+	__type(key, __u32); // skb->mark
+	__type(value, struct mark_vrf_value);
+} mark_vrf_table SEC(".maps");
 
 // nptv6_table: one row per VRF with NPTv6 configured, keyed identically to
 // vrf_table (block<<12|argument) -- both usid_ingress (which already has
@@ -1530,13 +1561,35 @@ int usid_egress(struct __sk_buff *skb)
 	__u32 ifindex = skb->ifindex;
 	struct ifindex_vrf_value *iv = bpf_map_lookup_elem(&ifindex_vrf_table, &ifindex);
 
-	if (!iv) {
-		count_drop(DROP_REASON_TRACE_IFINDEX_MISS);
-		return TC_ACT_UNSPEC; // no attachment registered on this ifindex at all
-	}
-	count_drop(DROP_REASON_TRACE_IFINDEX_HIT);
+	__u64 block;
+	__u16 argument;
 
-	__u64 vrf_key = (iv->block << 12) | iv->argument;
+	if (iv) {
+		count_drop(DROP_REASON_TRACE_IFINDEX_HIT);
+		block = iv->block;
+		argument = iv->argument;
+	} else {
+		count_drop(DROP_REASON_TRACE_IFINDEX_MISS);
+
+		// Fallback path: only reached for traffic on an interface with no
+		// ifindex_vrf_table entry at all -- i.e. a shared trunk, whose
+		// peer ifindex is deliberately never registered into
+		// ifindex_vrf_table (mark_vrf_table's own comment above). An
+		// ordinary tenant veth/tap always has an ifindex_vrf_table entry
+		// and never reaches this branch.
+		__u32 mark = skb->mark;
+		struct mark_vrf_value *mv = bpf_map_lookup_elem(&mark_vrf_table, &mark);
+
+		if (!mv) {
+			count_drop(DROP_REASON_TRACE_MARK_MISS);
+			return TC_ACT_UNSPEC; // no attachment registered on this ifindex or mark
+		}
+		count_drop(DROP_REASON_TRACE_MARK_HIT);
+		block = mv->block;
+		argument = mv->argument;
+	}
+
+	__u64 vrf_key = (block << 12) | argument;
 
 	__u8 route_family;
 	__u8 dst_addr[16];
@@ -1559,7 +1612,7 @@ int usid_egress(struct __sk_buff *skb)
 
 			if ((void *) (ports + 1) <= data_end) {
 				struct vip_xlat_key vkey = {
-					.block = iv->block, .argument = iv->argument,
+					.block = block, .argument = argument,
 					.proto = ip6->nexthdr, .port = ports->source,
 					.direction = USID_VIP_XLAT_DIR_EGRESS,
 				};


### PR DESCRIPTION
internal/ingresssidecar (the second container in the shared Envoy
Gateway fleet's pod) created one synthetic veth pair per VPC it needed
backend connectivity to, dispatching usid_egress by that attachment's
own ifindex. That doesn't scale: interface count grows linearly with
the number of backend VPCs one Envoy pod serves.

Replaces the per-VPC veth with one shared trunk interface per pod,
disambiguated by SO_MARK (skb->mark on egress) instead of by which
interface a packet arrived on:

- usid.c: new mark_vrf_table map (skb->mark -> (Block, Argument)) and
  a usid_egress dispatch fallback -- consulted only when
  ifindex_vrf_table misses, so ordinary per-attachment tenant
  veth/tap traffic is unaffected by construction. Two new drop
  reasons for observability.
- internal/plumbing/ebpf/markvrfmap: new package wrapping
  mark_vrf_table, mirroring ifindexvrfmap's Register/Unregister/
  Get/List/Reconcile/OpenPinned API shape.
- internal/ingresssidecar/ebpfdatapath.go: ensureEgressVeth/
  egressVethNames (one veth pair per VPC, enslaved into that VPC's
  own VRF) are replaced by ensureTrunk (one shared, unenslaved veth
  pair per pod, attached once) plus ensureVRFRoute/removeVRFRoute
  (each VPC's own gateway route into its own table, all naming the
  same shared trunk as nexthop -- the existing "gateway, not
  on-link" route mechanism never required the nexthop device to be a
  member of the table's own VRF). markForTableID derives a
  placeholder mark value from the VPC's own VRF table ID, explicitly
  flagged for network-services-operator's own phase-2 work
  (feat/srv6-routing-identity) to replace.

cmd/galactic-vrf runs one process per pod, in that pod's own network
namespace, so "one trunk per pod" collapses to "one trunk per
process" -- no new pod-identifier-keyed interface naming scheme is
needed; trunkInnerName/trunkPeerName are plain fixed constants.

The trunk and its usid_egress attachment are now process-lifetime,
not per-VPC-lifetime: removeEgressDatapath tears down only the
calling VPC's own route and map entries, never the shared interface
or its attachment.

## Testing

`TestEnsureEgressDatapath_SharedTrunkAcrossVPCs` (rewritten from
`TestEnsureEgressDatapath_AttachesToVethPeerNotVRF`) is this change's
own exit criterion: two VPCs sharing one trunk both resolve
correctly, and tearing one VPC down disturbs neither the trunk nor
the other VPC's still-live state. This also empirically confirms the
one assumption this design rests on that wasn't obvious from Linux
networking theory alone -- an unenslaved trunk inner end still
routes correctly across multiple VRF tables via the peer's
link-local gateway.

Verified locally: `task build`, `task lint`, `task test:unit`, and
`bash scripts/ci.sh unittest-root` (root-gated suite, including the
new markvrfmap package and the rewritten integration test above) all
pass clean.

Scoped entirely to internal/ingresssidecar and the shared
internal/plumbing/ebpf/* packages -- internal/cni and
internal/cnibgp (ordinary tenant CNI ADD/DEL) are untouched; tenant
pods keep today's per-attachment veth path.

## Known gap

No test in this repo sends an actual packet through the compiled
`usid_egress` program with a non-zero `skb->mark` to exercise the new
mark-hit C branch directly (mark-miss is exercised implicitly by
existing tests). Doing so would require a new Go mirror of the
kernel's `__sk_buff` UAPI struct for `cilium/ebpf`'s `Program.Run` --
no such harness exists in this repo today, so it wasn't added as a
side effect of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXtDd2iQycCviDx89Tq8to