### PR TITLE
fix(bgp): skip re-applying unchanged peers to stop session reset loop

### DIFF
--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -102,6 +102,15 @@ type GoBGPRuntime struct {
 	// Established for status reporting, this one records the current state
 	// of every peer regardless of what it is, for transition logging.
 	lastPeerState map[string]model.BGPPeerState
+	// appliedPeers tracks the last-applied DesiredPeer per address so
+	// applyPeers can skip re-adding/updating a peer whose config hasn't
+	// actually changed. Without this, applyPeers called AddPeer/UpdatePeer
+	// for every desired peer on every Apply() — including reconciles where
+	// nothing changed — and GoBGP's UpdatePeer resets the session
+	// unconditionally, so a peer could never stay Established: any
+	// watch-triggered reconcile (including one caused by this router's own
+	// BGPPeer status write) tore every session back down before it converged.
+	appliedPeers map[string]model.DesiredPeer
 	// wg tracks the server.Start and watchEVPNRIB goroutines so Stop can block
 	// until both have actually exited instead of merely cancelling srvCtx and
 	// returning. GoBGP keeps some path-selection state (table.SelectionOptions,
@@ -133,6 +142,7 @@ func NewRuntimeFactory(listenPort int32, reflector bool, localAddress string) ru
 			localAddress:          localAddress,
 			establishedAt:         make(map[string]time.Time),
 			lastPeerState:         make(map[string]model.BGPPeerState),
+			appliedPeers:          make(map[string]model.DesiredPeer),
 			appliedPolicies:       make(map[string]model.BGPPolicyDirection),
 			appliedVRFs:           make(map[string]uint32),
 			appliedVRFImportRTs:   make(map[string][]string),
@@ -259,6 +269,10 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 	}
 
 	for _, p := range peers {
+		if !peerNeedsApply(r.appliedPeers, currentPeers, p) {
+			continue
+		}
+
 		peer := peerFromDesired(p, r.localAddress, r.reflector)
 		addErr := b.AddPeer(ctx, &api.AddPeerRequest{Peer: peer})
 		if addErr != nil {
@@ -270,14 +284,29 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 				return fmt.Errorf("add peer %s: %w", p.Address, addErr)
 			}
 		}
+		r.appliedPeers[p.Address] = p
 	}
 
 	for addr := range currentPeers {
 		if _, ok := desiredPeers[addr]; !ok {
 			_ = b.DeletePeer(ctx, &api.DeletePeerRequest{Address: addr})
+			delete(r.appliedPeers, addr)
 		}
 	}
 	return nil
+}
+
+// peerNeedsApply reports whether p must be (re-)pushed to GoBGP via
+// AddPeer/UpdatePeer: either it was never applied, its desired config
+// changed since the last apply, or GoBGP no longer reports it as configured
+// (e.g. silently dropped by an unrelated churn elsewhere, such as a GC cycle
+// recreating the BGPVRFInstance/BGPAdvertisement CRs backing it). Any other
+// case is a true no-op — skipping it matters because AddPeer/UpdatePeer
+// reset the BGP session unconditionally, even when the pushed config is
+// identical to what's already running.
+func peerNeedsApply(applied map[string]model.DesiredPeer, current map[string]bool, p model.DesiredPeer) bool {
+	last, ok := applied[p.Address]
+	return !ok || !current[p.Address] || !reflect.DeepEqual(last, p)
 }
 
 // applyVRFs configures every desired VRF instance and removes stale ones. A

--- a/internal/runtime/gobgp/runtime_test.go
+++ b/internal/runtime/gobgp/runtime_test.go
@@ -105,6 +105,70 @@ func TestApplyGlobal_ListenPortUnsetFallsBackToFactoryDefault(t *testing.T) {
 	}
 }
 
+// TestPeerNeedsApply guards the fix for a bug where applyPeers called
+// AddPeer/UpdatePeer for every desired peer on every Apply(), including
+// reconciles where nothing about the peer had changed. GoBGP's UpdatePeer
+// resets the BGP session unconditionally, so that made every peer flap
+// continuously under any watch-triggered reconcile storm (e.g. one caused by
+// the router's own BGPPeer status write) — no session ever stayed
+// Established. peerNeedsApply must say "skip" only when the peer's config is
+// truly unchanged and GoBGP still reports it as configured.
+func TestPeerNeedsApply(t *testing.T) {
+	const addr = "2607:ed40:1ff::1"
+	peer := model.DesiredPeer{
+		Name:       "to-worker",
+		PeerASN:    33438,
+		Address:    addr,
+		RemotePort: 1790,
+		HoldTime:   30,
+	}
+
+	tests := []struct {
+		name    string
+		applied map[string]model.DesiredPeer
+		current map[string]bool
+		peer    model.DesiredPeer
+		want    bool
+	}{
+		{
+			name:    "never applied before",
+			applied: map[string]model.DesiredPeer{},
+			current: map[string]bool{},
+			peer:    peer,
+			want:    true,
+		},
+		{
+			name:    "unchanged and still configured in GoBGP: skip",
+			applied: map[string]model.DesiredPeer{addr: peer},
+			current: map[string]bool{addr: true},
+			peer:    peer,
+			want:    false,
+		},
+		{
+			name:    "config changed since last apply",
+			applied: map[string]model.DesiredPeer{addr: peer},
+			current: map[string]bool{addr: true},
+			peer:    func() model.DesiredPeer { p := peer; p.HoldTime = 90; return p }(),
+			want:    true,
+		},
+		{
+			name:    "applied but silently dropped by GoBGP (e.g. unrelated GC churn)",
+			applied: map[string]model.DesiredPeer{addr: peer},
+			current: map[string]bool{},
+			peer:    peer,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := peerNeedsApply(tt.applied, tt.current, tt.peer); got != tt.want {
+				t.Errorf("peerNeedsApply() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestApplyVRFDerivesRouteDistinguisher verifies applyVRF derives the RFC 4364
 // Type 1 route distinguisher as "routerID:vrfID" from the routerID parameter
 // and vrf.VRFID, rather than reading a RouteDistinguisher field off the model


### PR DESCRIPTION
## Problem

`galactic-router`'s BGP sessions could not reach `Established` and stay there. Every `BGPPeer` flapped between `Idle` and `Active`, or briefly hit `Established` before being torn down with a `notification-received code 6(cease) subcode 3(peer deconfigured)`.

## Root cause

`applyPeers` called `AddPeer` (falling back to `UpdatePeer` on `"can't overwrite"`) for every desired peer on every `Apply()`, including reconciles where nothing about the peer had changed. GoBGP's `UpdatePeer` resets the session on every call, whether or not the pushed config differs from what's already running.

`BGPRouterReconciler` writes each targeted `BGPPeer`'s status on every reconcile, and watches `BGPPeer` to re-enqueue its `BGPRouter`. That status write triggered another reconcile of the same router right away. Combined with the unconditional peer push, this became a loop that never let a session finish its handshake:

1. Reconcile runs.
2. `Apply()` resets every peer.
3. Each `BGPPeer`'s status gets written.
4. The watch re-enqueues the `BGPRouter`.
5. Back to step 1, before any session settles.

## Fix

Track the last-applied `DesiredPeer` per address, the same way this runtime already tracks `appliedVRFs` and `appliedAdvertisements`. Skip `AddPeer`/`UpdatePeer` when the desired config is unchanged and GoBGP still reports the peer as configured.

Still re-apply when a peer was silently dropped by GoBGP, e.g. an unrelated GC churn recreating the CRDs behind it. That's the case the outer reconciler's `allDesiredPeersPresent` no-op guard was added for. The guard stays, but a redundant `Apply()` call is now a true no-op, so it no longer matters whether that guard passes or not.

The diff decision lives in `peerNeedsApply`, a small pure function, so it's unit-testable without a live GoBGP session.

## Testing

- `task lint`: clean.
- `task test:unit`: clean.
- Added `TestPeerNeedsApply`, covering first apply, unchanged/skip, config changed, and re-apply after GoBGP silently drops the peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)