### PR TITLE
fix: Let a BGP peer override its own session source address

### DIFF
--- a/docs/router/configuration.md
+++ b/docs/router/configuration.md
@@ -90,6 +90,13 @@ In practice this means every node running `galactic-router` needs a
 global-unicast IPv6 address on `lo` before startup, or an explicit
 `GALACTIC_ROUTER_BGP_LOCAL_ADDRESS`.
 
+This is the process-wide default, applied to every peer this instance
+configures. `BGPPeer.spec.updateSource` overrides it per peer — needed when
+a single node has to source different sessions from different addresses,
+e.g. most peers over the SRv6 loopback but one peer reached over the node's
+own eth0/bond0 link instead, because the SRv6 underlay doesn't route to that
+peer's site.
+
 **Type:** string
 **Default:** _(auto-detected from `lo`)_
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -65,6 +65,11 @@ type DesiredPeer struct {
 	HoldTime        time.Duration
 	KeepaliveTime   time.Duration
 	AuthPassword    string
+	// UpdateSource is the per-peer override of the TCP source address for this
+	// session, carried from BGPPeer.spec.updateSource. When empty, the
+	// runtime's process-wide default (GALACTIC_ROUTER_BGP_LOCAL_ADDRESS)
+	// applies instead.
+	UpdateSource string
 }
 
 // DesiredVRFInstance describes an L2VPN EVPN VRF to configure on the BGP router.

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -207,6 +207,9 @@ func (r *Reconciler) gatherPeers(ctx context.Context, router *bgpv1alpha1.BGPRou
 		if peer.Spec.KeepaliveTime != nil {
 			dp.KeepaliveTime = peer.Spec.KeepaliveTime.Duration
 		}
+		if peer.Spec.UpdateSource != nil {
+			dp.UpdateSource = *peer.Spec.UpdateSource
+		}
 
 		// Resolve auth secret.
 		if peer.Spec.AuthSecretRef != nil {

--- a/internal/reconcile/reconcile_test.go
+++ b/internal/reconcile/reconcile_test.go
@@ -20,9 +20,12 @@ import (
 const (
 	testLocator   = "2001:db8:ff01::/48"
 	testLegacySID = "2001:db8::1234:5678"
+	testNamespace = "default"
 )
 
 func ptrInt32(v int32) *int32 { return &v }
+
+func ptrString(v string) *string { return &v }
 
 func ptrFunction(fn bgpv1alpha1.SRv6Function) *bgpv1alpha1.SRv6Function { return &fn }
 
@@ -104,7 +107,7 @@ func TestBuildDesiredRouter_NodeFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			router := &bgpv1alpha1.BGPRouter{
-				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: testNamespace},
 				Spec: bgpv1alpha1.BGPRouterSpec{
 					TargetRef: bgpv1alpha1.TargetRef{Name: tc.targetNode},
 				},
@@ -164,7 +167,7 @@ func TestBuildDesiredRouter_ListenPort(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			router := &bgpv1alpha1.BGPRouter{
-				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: testNamespace},
 				Spec: bgpv1alpha1.BGPRouterSpec{
 					TargetRef:  bgpv1alpha1.TargetRef{Name: thisNode},
 					ListenPort: tc.listenPort,
@@ -202,6 +205,85 @@ func TestBuildDesiredRouter_ListenPort(t *testing.T) {
 				}
 			case got.ListenPort == nil || *got.ListenPort != *tc.listenPort:
 				t.Errorf("DesiredRouter.ListenPort = %v, want %v", got.ListenPort, *tc.listenPort)
+			}
+		})
+	}
+}
+
+// TestBuildDesiredRouter_PeerUpdateSource verifies BGPPeer.spec.updateSource
+// is carried through to DesiredPeer.UpdateSource, including the unset (nil)
+// case -- this is the field the runtime treats as a per-peer override of its
+// process-wide default local address (see
+// gobgp.peerFromDesired/TestPeerFromDesired_UpdateSourceOverridesLocalAddress).
+// Regression test for it being silently dropped: BuildDesiredRouter's peer
+// loop mapped every other BGPPeerSpec field into DesiredPeer but never read
+// updateSource at all, so a peer sourced from anywhere but the process
+// default could never actually source from there.
+func TestBuildDesiredRouter_PeerUpdateSource(t *testing.T) {
+	const thisNode = "node-a"
+
+	tests := []struct {
+		name         string
+		updateSource *string
+		want         string
+	}{
+		{name: "unset stays empty", updateSource: nil, want: ""},
+		{name: "explicit value carries through", updateSource: ptrString("2607:f740:100::635"), want: "2607:f740:100::635"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			router := &bgpv1alpha1.BGPRouter{
+				ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: testNamespace},
+				Spec: bgpv1alpha1.BGPRouterSpec{
+					TargetRef: bgpv1alpha1.TargetRef{Name: thisNode},
+				},
+			}
+			peer := &bgpv1alpha1.BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: testNamespace},
+				Spec: bgpv1alpha1.BGPPeerSpec{
+					RouterTarget: bgpv1alpha1.RouterTarget{
+						RouterRef: &bgpv1alpha1.RouterRef{Name: "r1"},
+					},
+					Address: "2001:db8:ff01::1",
+					PeerASN: 65000,
+					AddressFamilies: []bgpv1alpha1.AddressFamily{
+						{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+					},
+					UpdateSource: tc.updateSource,
+				},
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(newTestScheme(t)).
+				WithObjects(peer).
+				WithIndex(&bgpv1alpha1.BGPAdvertisement{}, routerRefIndexer, func(obj client.Object) []string {
+					adv := obj.(*bgpv1alpha1.BGPAdvertisement)
+					return []string{adv.Spec.RouterRef.Name}
+				}).
+				WithIndex(&bgpv1alpha1.BGPVRFInstance{}, routerRefIndexer, func(obj client.Object) []string {
+					vrf := obj.(*bgpv1alpha1.BGPVRFInstance)
+					if vrf.Spec.RouterRef == nil {
+						return nil
+					}
+					return []string{vrf.Spec.RouterRef.Name}
+				}).
+				Build()
+
+			r := New(fakeClient, thisNode, "2001:db8::1")
+
+			got, err := r.BuildDesiredRouter(context.Background(), router)
+			if err != nil {
+				t.Fatalf("BuildDesiredRouter() error = %v, want nil", err)
+			}
+			if got == nil {
+				t.Fatal("BuildDesiredRouter() = nil, want a non-nil DesiredRouter")
+			}
+			if len(got.Peers) != 1 {
+				t.Fatalf("DesiredRouter.Peers = %+v, want exactly 1 peer", got.Peers)
+			}
+			if got.Peers[0].UpdateSource != tc.want {
+				t.Errorf("DesiredPeer.UpdateSource = %q, want %q", got.Peers[0].UpdateSource, tc.want)
 			}
 		})
 	}

--- a/internal/runtime/gobgp/peers.go
+++ b/internal/runtime/gobgp/peers.go
@@ -57,7 +57,8 @@ func familyFromModel(af model.AddressFamily) *api.Family {
 }
 
 // peerFromDesired converts a DesiredPeer to a GoBGP api.Peer.
-// localAddress, if non-empty, is set as the TCP source address for the session.
+// localAddress, if non-empty, is the process-wide default TCP source address;
+// p.UpdateSource, if non-empty, overrides it for this peer specifically.
 // routeReflectorMode, when true, marks this peer as an iBGP route-reflector client.
 func peerFromDesired(p model.DesiredPeer, localAddress string, routeReflectorMode bool) *api.Peer {
 	peer := &api.Peer{
@@ -86,14 +87,21 @@ func peerFromDesired(p model.DesiredPeer, localAddress string, routeReflectorMod
 		peer.Conf.AuthPassword = p.AuthPassword
 	}
 
-	// LocalAddress pins the TCP source to the node's SRv6 loopback so the
-	// return path from the RR uses a routed prefix instead of the link address.
-	// RemotePort defaults to 1790 (the overlay BGP port) since port 179 is
-	// occupied by the underlay FRR bgpd on every node.
+	// LocalAddress pins the TCP source to the node's SRv6 loopback by default,
+	// so the return path from the RR uses a routed prefix instead of the link
+	// address. p.UpdateSource overrides this per peer (BGPPeer.spec.updateSource)
+	// for a session that needs to source from somewhere else instead — e.g. a
+	// peer reached over the node's own eth0/bond0 link rather than the SRv6
+	// underlay. RemotePort defaults to 1790 (the overlay BGP port) since port
+	// 179 is occupied by the underlay FRR bgpd on every node.
+	peerLocalAddress := localAddress
+	if p.UpdateSource != "" {
+		peerLocalAddress = p.UpdateSource
+	}
 	peer.Transport = &api.Transport{
 		RemotePort:   uint32(p.RemotePort),
 		PassiveMode:  false,
-		LocalAddress: localAddress,
+		LocalAddress: peerLocalAddress,
 	}
 
 	if routeReflectorMode {

--- a/internal/runtime/gobgp/peers_test.go
+++ b/internal/runtime/gobgp/peers_test.go
@@ -39,3 +39,46 @@ func TestPeerFromDesired_RouteReflectorClientFollowsExplicitFlag(t *testing.T) {
 		})
 	}
 }
+
+// TestPeerFromDesired_UpdateSourceOverridesLocalAddress is the regression
+// test for BGPPeer.spec.updateSource being silently ignored: peerFromDesired
+// always stamped the process-wide localAddress onto every peer's
+// Transport.LocalAddress, with no way for a single peer to source from
+// somewhere else. This broke a peer reached over the node's own eth0/bond0
+// link instead of the SRv6 loopback -- its session kept sourcing from the
+// loopback regardless of what the CR said, and could never establish since
+// the loopback has no route back from a site the SRv6 underlay doesn't
+// reach.
+func TestPeerFromDesired_UpdateSourceOverridesLocalAddress(t *testing.T) {
+	const (
+		processDefault = "2607:ed40:1ff::3"
+		perPeer        = "2607:f740:100::635"
+	)
+
+	tests := []struct {
+		name string
+		peer model.DesiredPeer
+		want string
+	}{
+		{
+			name: "no updateSource falls back to the process-wide default",
+			peer: model.DesiredPeer{Address: testSID1, PeerASN: 65000},
+			want: processDefault,
+		},
+		{
+			name: "updateSource overrides the process-wide default",
+			peer: model.DesiredPeer{Address: testSID1, PeerASN: 65000, UpdateSource: perPeer},
+			want: perPeer,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			peer := peerFromDesired(tc.peer, processDefault, false)
+
+			if got := peer.Transport.LocalAddress; got != tc.want {
+				t.Errorf("peerFromDesired() Transport.LocalAddress = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Every BGP session sourced its outbound connection from one process-wide local address, defaulting to the node's own tenant loopback, with no way to override it per session. The peer API already documented a per-session override for exactly this, but nothing in the controller read it. A session that needs a different source instead, such as a node's own external link rather than the tenant loopback, could never establish and sat stuck indefinitely. This wires that override through so it actually takes effect.

## Test plan

- [ ] Unit tests and lint pass
- [ ] A peer with no override still sources from the process-wide default
- [ ] A peer with the override set sources from that address instead
- [ ] A peer whose override changes gets re-applied, not silently skipped
