### PR TITLE
chore: Refresh third-party NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2516,6 +2516,36 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ```
 
+## github.com/mdlayher/ndp
+
+* Name: github.com/mdlayher/ndp
+* Version: v1.1.0
+* License: MIT
+
+```
+# MIT License
+
+Copyright (C) 2017-2022 Matt Layher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
 ## github.com/modern-go/concurrent
 
 * Name: github.com/modern-go/concurrent
@@ -5008,7 +5038,7 @@ THE SOFTWARE.
 ## github.com/vishvananda/netlink
 
 * Name: github.com/vishvananda/netlink
-* Version: v1.3.2-0.20260803231012-156a440d85e5
+* Version: v1.3.2-0.20260830232854-cf01b55a4a4b
 * License: Apache-2.0
 
 ```
@@ -5444,7 +5474,7 @@ SOFTWARE.
 ## go.datum.net/network/api/v1alpha1
 
 * Name: go.datum.net/network/api/v1alpha1
-* Version: v0.0.0-20260812184454-6e8a6c4cbd40
+* Version: v0.0.0-20260825185725-392ac243999b
 * License: AGPL-3.0
 
 ```
@@ -7108,7 +7138,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## google.golang.org/grpc
 
 * Name: google.golang.org/grpc
-* Version: v1.83.0
+* Version: v1.83.1
 * License: Apache-2.0
 
 ```


### PR DESCRIPTION
## Summary

Recent dependency bumps had left the NOTICE file out of date, and a new transitive dependency, mdlayher/ndp, was missing its license entry entirely. This regenerates NOTICE to match go.mod.

## Test plan

- [ ] NOTICE reflects current go.mod dependency versions and licenses
