### PR TITLE
fix(ingresssidecar): publish return-path gateway advertisement

### DIFF
--- a/cmd/galactic-vrf/root.go
+++ b/cmd/galactic-vrf/root.go
@@ -23,6 +23,7 @@ import (
 	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/ingresssidecar"
 	"go.datum.net/galactic/internal/metadata"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
 const (
@@ -36,15 +37,18 @@ const (
 // runCmd contains the application startup logic: it registers
 // internal/ingresssidecar's Reconciler against a cluster-scoped
 // EndpointSlice watch, then seeds Store from the live API state and runs
-// its startup inventory and periodic sweep. There is no BGP runtime, CRD
-// scheme beyond clientgoscheme's built-in discoveryv1 registration, or
-// per-node identity of any kind here — see internal/config.VRFConfig's own
-// doc comment for why.
+// its startup inventory and periodic sweep. There is no BGP runtime here —
+// bgpv1alpha1 is registered on the scheme solely so the optional gateway
+// publisher below can read BGPRouter/BGPVRFInstance and write
+// BGPAdvertisement CRDs; see internal/config.VRFConfig's own doc comment
+// for why cfg.NodeName, unlike everything else this binary reads, has no
+// default and leaves that one feature off when unset.
 func runCmd(cfg *config.VRFConfig) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(bgpv1alpha1.AddToScheme(scheme))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -68,6 +72,23 @@ func runCmd(cfg *config.VRFConfig) error {
 
 	backend := ingresssidecar.NewKernelBackend()
 	store := ingresssidecar.NewStore(backend, cfg.TeardownGracePeriod, metrics)
+
+	// Return-path gateway-advertisement publishing (docs/plans/855-return-
+	// path-gateway-advertisement.md) is opt-in on cfg.NodeName alone: most
+	// deployments of this sidecar don't set it yet, and leaving it unset
+	// here is exactly the no-op SetGatewayPublisher's own doc comment
+	// describes -- Store behaves identically to before this feature
+	// existed. mgr.GetClient() (the cached client) is fine for this: unlike
+	// the reconcile hot path, publishing only runs once per VRF's lifetime.
+	if cfg.NodeName != "" {
+		store.SetGatewayPublisher(
+			ingresssidecar.NewK8sGatewayPublisher(mgr.GetClient(), cfg.NodeName, cfg.Namespace),
+			ingresssidecar.NetlinkGatewayAddressResolver{},
+		)
+	} else {
+		log.Printf("no node name configured (%s / legacy NODE_NAME) -- "+
+			"return-path gateway advertisement publishing is disabled", config.EnvVRFNodeName)
+	}
 
 	if err := (&ingresssidecar.Reconciler{Store: store}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup EndpointSlice controller: %w", err)
@@ -145,6 +166,11 @@ func newRootCommand() *cobra.Command {
 	cmd.Flags().DurationP("sweep-interval", "",
 		config.DefaultVRFSweepInterval,
 		"How often to re-check pending teardowns")
+	cmd.Flags().StringP("node-name", "", "",
+		"This node's name, as it appears in a BGPRouter's spec.targetRef.name -- "+
+			"enables return-path gateway advertisement publishing when set (env "+config.EnvVRFNodeName+" or legacy NODE_NAME)")
+	cmd.Flags().StringP("namespace", "", config.DefaultNamespace,
+		"Namespace to read BGPRouter/BGPVRFInstance and write BGPAdvertisement CRDs in")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
 	return cmd

--- a/docs/plans/855-return-path-gateway-advertisement.md
+++ b/docs/plans/855-return-path-gateway-advertisement.md
@@ -1,0 +1,46 @@
+# Implementation plan — #855 follow-up: return-path gateway advertisement
+
+- **Parent:** [datum-cloud/enhancements#796](https://github.com/datum-cloud/enhancements/issues/796) — HTTP Ingress for VPC Networks
+- **Sibling plan:** [docs/plans/855-ingress-sidecar-vpc-backend-connectivity.md](855-ingress-sidecar-vpc-backend-connectivity.md) — the accepted #855 design this plan extends. Read that one first; this doc only covers the gap it left open.
+- **Status:** `GatewayPublisher`/`GatewayAddressResolver` implemented and unit-tested in `internal/ingresssidecar` (`gateway.go`, `gateway_test.go`, `store_gateway_test.go`); wired into `Store` (opt-in, see "Backward compatibility" below) and `cmd/galactic-vrf`. **Address provisioning is explicitly not implemented** — see "Not implemented here."
+
+## What's broken, and how it was found
+
+Testing an end-to-end request through `envoy-datum-downstream-gateway` into a VPC-hosted backend (`demo2loc-dfw-dfw-0`, `us-central-1-staging-lab`) showed the request entering Envoy correctly, and — once a separate, unrelated sysctl gap on the same DaemonSet was worked around live — the forward path working exactly as #855 designed it:
+
+1. `vpc-vrf-sidecar` (this sidecar) creates a per-VPC VRF in Envoy's own pod netns and installs a `seg6 ENCAP_RED` egress route for the backend pod's address, toward that pod's own SID — all per the sibling plan.
+2. A request from Envoy's netns to the backend address is correctly SRv6-encapsulated (confirmed by packet capture on the node's uplink: outer header addressed to the backend node's computed uSID, inner header the real TCP SYN).
+3. The backend pod receives it and replies with a SYN-ACK (confirmed by packet capture on the backend node's own uplink).
+4. **The reply never reaches Envoy.** Captured leaving the backend node's uplink, it's a *plain, unencapsulated* IPv6 packet addressed to Envoy's own local gateway address inside the VPC (the source address the kernel picked for Envoy's outbound connection, e.g. `fd20:0:2::4:0:0`) — not SRv6-wrapped toward Envoy's node at all.
+
+The reason: the backend node's own copy of this VPC's VRF only re-encapsulates traffic toward destinations it has an EVPN route for — and **nothing publishes a `BGPAdvertisement` for Envoy's own local gateway address**. `galactic-cni` publishes one for every pod's own address (`internal/cnibgp/bgp.go`), which is exactly why the *forward* direction already works — but this sidecar's own address, on the *return* side, has no equivalent. Confirmed live: `kubectl get bgpadvertisement -A` on the edge node hosting Envoy showed nothing referencing that address at all.
+
+This is a real gap in the accepted design (PR #851), not a bug in existing code: neither #855's own plan nor #856's does not mention publishing anything for the sidecar's own address — see the sibling plan's §1 "Attach/detach VPC network lifecycle" row, which scopes pod IP/attachment publishing to `galactic-cni` alone and says nothing about the sidecar's own reverse path.
+
+## What this plan adds
+
+Mirrors `internal/cnibgp/bgp.go`'s own pod-address publish pattern (`lookupBGPRouter`, `allocateArgument`/`checkArgumentCollision`, `routeTarget`, `buildVRFInstanceSpec`/`buildAdvertisementSpec`), reimplemented in miniature in `internal/ingresssidecar/gateway.go` rather than imported — `cnibgp`'s version is entangled with CNI-only concerns (prevResult, IPAM, per-container-ID annotations, ADD/DEL rollback tracking) this sidecar has none of. Consolidating the two into one shared package is a reasonable follow-up, not done here to avoid touching `cnibgp`'s existing, heavily-relied-upon publish path in the same change that introduces this new caller.
+
+- **`GatewayPublisher`** (`PublishGateway`/`WithdrawGateway`): given a VPC and this node's own local address in it, publishes/withdraws a `BGPAdvertisement` for that address, reusing the *same* `(vpc, node)`-keyed `BGPVRFInstance` a real CNI attachment on this node would use (so a coincidentally-colocated tenant pod's own VRFID bookkeeping is never disturbed), and the *same* route-target formula every other advertisement for that VPC uses — so any node importing that VPC's RT picks this up too, with no coordination needed beyond both sides computing the identical value. Never deletes the (possibly shared) `BGPVRFInstance` on withdraw — that stays `galactic-router`'s GC controller's job, same as every other CRD this codebase leaves for GC to reap.
+- **`GatewayAddressResolver`** (`ResolveGatewayAddress`): discovers this sidecar's own local address for a VPC by scanning the VPC's Linux VRF device (the one `internal/plumbing/vrf.Add` creates) for a slave interface carrying a global-scope IPv6 address. Returns `ErrGatewayAddressNotProvisioned` when none exists yet — the common case today, see below.
+- **`Store` wiring**: `SetGatewayPublisher` is an opt-in setter, not a constructor argument — every existing `NewStore` call site is unchanged. Publish is attempted once per VPC's VRF lifetime (alongside `EnsureVRF`); withdraw once per VRF teardown (alongside `RemoveVRF`, best-effort — a failed withdraw never blocks the kernel-side cleanup that follows it). A resolver reporting `ErrGatewayAddressNotProvisioned` is logged at debug and left to retry on the next reconcile for that VPC, never treated as a route-reconcile failure.
+- **`cmd/galactic-vrf`**: wires the two together only when `GALACTIC_VRF_NODE_NAME` (or legacy `NODE_NAME`) is set — see `internal/config.VRFConfig`'s `NodeName`/`Namespace` fields.
+
+## Backward compatibility
+
+Every piece above is inert by default:
+
+- `Store.SetGatewayPublisher` is never called unless `cfg.NodeName != ""`.
+- Even when called, `NetlinkGatewayAddressResolver` returns `ErrGatewayAddressNotProvisioned` for every VPC today, since nothing provisions the address it looks for (see next section) — so `PublishGateway` never actually runs against a real deployment yet.
+
+No existing deployment of this sidecar is affected by this change until both a node identity is configured *and* something provisions a gateway address per VPC.
+
+## Not implemented here
+
+**Provisioning the gateway address itself** — creating a veth-style attachment into each VPC this sidecar handles, with its own IPAM allocation, so `NetlinkGatewayAddressResolver` has something to find — is a real, separate gap, deliberately left open:
+
+- It needs real kernel-level work (interface creation, address assignment) inside Envoy's own netns, which the sibling plan's own §7 already treats as requiring "a real-kernel verification pass... not possible from this sandbox" for the *forward*-path mechanism it does implement — the same constraint applies here, more so, since this is new kernel-facing code rather than a call into already-proven `internal/plumbing` primitives.
+- It needs an IPAM coordination story this plan doesn't have: whether the sidecar requests its own allocation the way `galactic-cni` does for a pod, or a fixed reserved slot per VPC subnet, or something else, is an open design question, not a detail to improvise silently.
+- The live demo/test environment this gap was found in had a manually created veth (`gwatt1`, address `fd20:0:2::4:0:0/96`) standing in for this — evidence the *symptom* is real, not evidence of how provisioning should actually work in production.
+
+Filing this as its own follow-up (a sub-issue of #855 or a new #796 sub-issue, matching how #859's health-checking gap was handled) is the right next step, not bundling it into this change.

--- a/internal/config/vrf.go
+++ b/internal/config/vrf.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"errors"
+	"os"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -50,6 +51,16 @@ const (
 	EnvVRFMetricsPort         = "GALACTIC_VRF_METRICS_PORT"
 	EnvVRFTeardownGracePeriod = "GALACTIC_VRF_TEARDOWN_GRACE_PERIOD"
 	EnvVRFSweepInterval       = "GALACTIC_VRF_SWEEP_INTERVAL"
+
+	// EnvVRFNodeName and EnvVRFNamespace configure the return-path gateway
+	// BGPAdvertisement publisher (see NodeName/Namespace's own doc
+	// comments below) -- unset by default, matching every env var above,
+	// but unlike them this pair has no compiled-in default for NodeName:
+	// there is no generic value that could ever be right for "which node
+	// is this", the same reason GALACTIC_ROUTER_NODE_NAME/
+	// GALACTIC_GATEWAY_NODE_NAME have none either.
+	EnvVRFNodeName  = "GALACTIC_VRF_NODE_NAME"
+	EnvVRFNamespace = "GALACTIC_VRF_NAMESPACE"
 )
 
 // --- VRFConfig -----------------------------------------------------------
@@ -59,11 +70,18 @@ const (
 // Create once via NewVRFConfig(), call BindFlags() to layer CLI flags, then
 // read the exported fields.
 //
-// Unlike RouterConfig/GatewayConfig, there is no NodeName field: this
-// sidecar has no CRD identity keyed by node (no BGPRouter TargetRef to
-// match) and no ConfigMap/CRD configuration surface at all -- desired state
-// derives entirely from the EndpointSlice watch (see §1 of the plan's
-// acceptance-criteria table).
+// NodeName/Namespace are the exception to that precedence and to
+// RouterConfig/GatewayConfig's own pattern: this sidecar's *route*
+// reconciliation still has no CRD identity keyed by node and no
+// ConfigMap/CRD configuration surface (desired state derives entirely from
+// the EndpointSlice watch, per §1 of docs/plans/855-ingress-sidecar-vpc-
+// backend-connectivity.md's acceptance-criteria table) -- but publishing
+// this node's own return-path gateway advertisement (docs/plans/855-
+// return-path-gateway-advertisement.md) does need to know which BGPRouter
+// to attribute it to. NodeName's default is "" (feature disabled -- see
+// cmd/galactic-vrf's own startup logic, which only wires up a
+// GatewayPublisher when NodeName is non-empty), not a Validate failure,
+// since most deployments of this sidecar don't set it at all yet.
 type VRFConfig struct {
 	v      *viper.Viper
 	prefix string
@@ -72,6 +90,18 @@ type VRFConfig struct {
 	MetricsPort         int
 	TeardownGracePeriod time.Duration
 	SweepInterval       time.Duration
+	// NodeName is this node's name, as it appears in a BGPRouter's
+	// spec.targetRef.name -- required only to enable the return-path
+	// gateway-advertisement publisher (see this type's own doc comment);
+	// "" leaves that feature disabled. Resolved from EnvVRFNodeName,
+	// falling back to the same EnvNodeNameLegacy ("NODE_NAME") downward-API
+	// convention internal/config.CNIConfig's own NodeName uses.
+	NodeName string
+	// Namespace is where this sidecar reads BGPRouter/BGPVRFInstance and
+	// writes BGPAdvertisement CRDs when the gateway-advertisement publisher
+	// is enabled -- defaults to DefaultNamespace ("galactic-system"),
+	// matching every other galactic-* binary's own default.
+	Namespace string
 }
 
 // NewVRFConfig creates a config resolver with the GALACTIC_VRF env prefix
@@ -85,6 +115,7 @@ func NewVRFConfig() *VRFConfig {
 	v.SetDefault(keyMetricsPort, DefaultVRFMetricsPort)
 	v.SetDefault("teardown_grace_period", DefaultVRFTeardownGracePeriod.String())
 	v.SetDefault("sweep_interval", DefaultVRFSweepInterval.String())
+	v.SetDefault("namespace", DefaultNamespace)
 
 	cfg := &VRFConfig{
 		v:      v,
@@ -104,6 +135,8 @@ func (c *VRFConfig) BindFlags(flags *pflag.FlagSet) {
 		{flagMetricsPort, keyMetricsPort},
 		{"teardown-grace-period", "teardown_grace_period"},
 		{"sweep-interval", "sweep_interval"},
+		{"node-name", "node_name"},
+		{"namespace", "namespace"},
 	}
 	for _, b := range bindings {
 		if flags.Changed(b.flag) {
@@ -121,6 +154,16 @@ func (c *VRFConfig) readFields() {
 	c.MetricsPort = c.v.GetInt(keyMetricsPort)
 	c.TeardownGracePeriod = c.v.GetDuration("teardown_grace_period")
 	c.SweepInterval = c.v.GetDuration("sweep_interval")
+	c.Namespace = c.v.GetString("namespace")
+
+	c.NodeName = c.v.GetString("node_name")
+	if c.NodeName == "" {
+		// Same downward-API fallback internal/config.CNIConfig's own
+		// NodeName resolution uses -- a plain os.Getenv, not viper, since
+		// EnvNodeNameLegacy ("NODE_NAME") deliberately carries no
+		// GALACTIC_VRF prefix for AutomaticEnv to match.
+		c.NodeName = os.Getenv(EnvNodeNameLegacy)
+	}
 }
 
 // Validate checks that the resolved configuration is usable.

--- a/internal/ingresssidecar/gateway.go
+++ b/internal/ingresssidecar/gateway.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/intf"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// ingressVPCAttachment is the synthetic "vpcAttachment" segment
+// crdnames.BGPAdvertisementName needs a third argument for. This sidecar
+// has no real VPCAttachment of its own (that identity belongs to a CNI
+// attachment — see internal/cnibgp) — it uses this fixed, valid-base62
+// literal so its own advertisement's name still follows the established
+// (vpc, vpcAttachment, node) convention and can never collide with a real
+// CNI-derived attachment's own advertisement for the same (vpc, node),
+// which always shares this sidecar's own BGPVRFInstance (see
+// PublishGateway) but never its BGPAdvertisement.
+const ingressVPCAttachment = "ingress"
+
+// ErrGatewayAddressNotProvisioned is returned by a GatewayAddressResolver
+// when this VPC has no local gateway address to advertise yet. Callers
+// (Store) treat this as "nothing to do yet", not a reconcile error — see
+// Store's own gateway-publish call site.
+var ErrGatewayAddressNotProvisioned = errors.New("ingresssidecar: no gateway address provisioned for this VPC yet")
+
+// GatewayAddressResolver discovers this sidecar's own local address inside
+// a managed VPC's subnet — the source address Envoy's outbound connections
+// into that VPC use (see internal/plumbing/srv6.ResolveNodeSourceAddress's
+// doc comment for why the kernel, not this codebase, picks that address).
+// GatewayPublisher advertises whatever this returns so that a VPC backend's
+// reply traffic has an SRv6 route back to it.
+//
+// This interface deliberately does not create that address: provisioning
+// it (a veth-style attachment into the VPC, with its own IPAM allocation)
+// is a real, unimplemented gap — see docs/plans/855-return-path-gateway-
+// advertisement.md's "Not implemented here" section. NetlinkGatewayAddressResolver
+// only discovers an address some other mechanism already provisioned.
+type GatewayAddressResolver interface {
+	// ResolveGatewayAddress returns this node's own local address for vpc,
+	// or ErrGatewayAddressNotProvisioned (wrapped) if none exists yet.
+	ResolveGatewayAddress(vpc string) (net.IP, error)
+}
+
+// NetlinkGatewayAddressResolver is the production GatewayAddressResolver:
+// it looks for a global-scope IPv6 address on some interface enslaved to
+// vpc's own Linux VRF device (the same device internal/plumbing/vrf.Add
+// creates) — the shape a veth-style ingress attachment would take if one
+// exists. Requires CAP_NET_ADMIN, like internal/plumbing/vrf itself.
+type NetlinkGatewayAddressResolver struct{}
+
+// ResolveGatewayAddress implements GatewayAddressResolver.
+func (NetlinkGatewayAddressResolver) ResolveGatewayAddress(vpc string) (net.IP, error) {
+	vrfName := intf.GenerateInterfaceNameVRF(vpc)
+	vrfLink, err := netlink.LinkByName(vrfName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: VRF interface %q: %w", ErrGatewayAddressNotProvisioned, vrfName, err)
+	}
+	vrfIndex := vrfLink.Attrs().Index
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("list links: %w", err)
+	}
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs.Index == vrfIndex || attrs.MasterIndex != vrfIndex {
+			continue // not a slave of this VPC's VRF
+		}
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			return nil, fmt.Errorf("list addresses on %s: %w", attrs.Name, err)
+		}
+		for _, a := range addrs {
+			if a.Scope == unix.RT_SCOPE_UNIVERSE && !a.IP.IsUnspecified() {
+				return a.IP, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("%w: no globally-scoped address found on any interface enslaved to %q",
+		ErrGatewayAddressNotProvisioned, vrfName)
+}
+
+// GatewayPublisher advertises (and withdraws) this sidecar's own local
+// gateway address for a VPC via a BGPAdvertisement CRD, so that a backend
+// pod's reply traffic — addressed back to that gateway address — has an
+// SRv6 route to follow. Mirrors internal/cnibgp/bgp.go's own
+// BGPVRFInstance/BGPAdvertisement publish pattern (lookupBGPRouter,
+// allocateArgument, routeTarget, buildVRFInstanceSpec/buildAdvertisementSpec)
+// for a pod's own address; deliberately reimplemented here in miniature
+// rather than imported, since cnibgp's version is entangled with CNI-only
+// concerns (prevResult, IPAM, container-ID-keyed annotations, rollback
+// tracking) this sidecar has none of. Consolidating the two into one shared
+// package is a reasonable follow-up, not done here to avoid touching
+// cnibgp's existing, heavily-relied-upon publish path in the same change
+// that introduces this new caller.
+type GatewayPublisher interface {
+	// PublishGateway ensures a BGPAdvertisement exists for addr, the local
+	// gateway address for vpc, originated from this node's own BGPRouter.
+	// Idempotent: safe to call every time Store creates vpc's VRF.
+	PublishGateway(ctx context.Context, vpc string, addr net.IP) error
+	// WithdrawGateway removes the BGPAdvertisement PublishGateway created
+	// for vpc, if any. Never removes the (possibly shared) BGPVRFInstance
+	// PublishGateway reused or created — see its own doc comment for why
+	// that's galactic-router's GC controller's job, not this one's.
+	WithdrawGateway(ctx context.Context, vpc string) error
+}
+
+// k8sGatewayPublisher is the production GatewayPublisher.
+type k8sGatewayPublisher struct {
+	client    client.Client
+	nodeName  string
+	namespace string
+}
+
+// NewK8sGatewayPublisher returns a GatewayPublisher that reads/writes BGP
+// CRDs in namespace via c, attributing every advertisement it creates to
+// the BGPRouter targeting nodeName.
+func NewK8sGatewayPublisher(c client.Client, nodeName, namespace string) GatewayPublisher {
+	return &k8sGatewayPublisher{client: c, nodeName: nodeName, namespace: namespace}
+}
+
+// gatewayBGPConfig is the subset of a matched BGPRouter's spec PublishGateway
+// needs — mirrors internal/cnibgp/bgp.go's own unexported bgpConfig, minus
+// the SRv6Locator/NodeID fields that caller doesn't need: unlike a pod's own
+// advertisement, this one never computes a SID directly (see
+// internal/reconcile.resolveSRv6SID, which derives it from the
+// BGPAdvertisement's own VRFID/Function plus the BGPRouter it targets, at
+// reconcile time, not here).
+type gatewayBGPConfig struct {
+	asNumber   int64
+	routerName string
+}
+
+func (p *k8sGatewayPublisher) lookupBGPRouter(ctx context.Context) (gatewayBGPConfig, error) {
+	routerList := &bgpv1alpha1.BGPRouterList{}
+	if err := p.client.List(ctx, routerList, client.InNamespace(p.namespace)); err != nil {
+		return gatewayBGPConfig{}, fmt.Errorf("list BGPRouters in namespace %s: %w", p.namespace, err)
+	}
+	var matches []bgpv1alpha1.BGPRouter
+	for _, r := range routerList.Items {
+		if r.Spec.TargetRef.Name == p.nodeName {
+			matches = append(matches, r)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return gatewayBGPConfig{}, fmt.Errorf("no BGPRouter found for node %s in namespace %s", p.nodeName, p.namespace)
+	case 1:
+		return gatewayBGPConfig{asNumber: matches[0].Spec.LocalASN, routerName: matches[0].Name}, nil
+	default:
+		return gatewayBGPConfig{}, fmt.Errorf("ambiguous BGP config: %d BGPRouters target node %s in namespace %s",
+			len(matches), p.nodeName, p.namespace)
+	}
+}
+
+// vpcRouteTarget mirrors internal/cnibgp/bgp.go's own routeTarget: the RT in
+// "ASN:NN" format using the low 32 bits of the VPC identifier, so this
+// advertisement's community matches every other advertisement for the same
+// VPC (whichever node/attachment originated them) bit for bit — that
+// equality, not any shared code path, is what makes a receiving node's own
+// ImportRouteTargets pick this advertisement up.
+func vpcRouteTarget(asNumber int64, vpc string) (string, error) {
+	vpcHex, err := intf.Base62ToHex(vpc)
+	if err != nil {
+		return "", fmt.Errorf("convert vpc %q to hex: %w", vpc, err)
+	}
+	v, err := strconv.ParseUint(vpcHex, 16, 64)
+	if err != nil {
+		return "", fmt.Errorf("parse VPC hex %q: %w", vpcHex, err)
+	}
+	return fmt.Sprintf("%d:%d", asNumber, uint32(v)), nil
+}
+
+// allocateGatewayArgument mirrors internal/cnibgp/bgp.go's own
+// allocateArgument: the value already registered under vrfName if a
+// BGPVRFInstance by that name exists, otherwise the lowest value in
+// [uformat.ArgumentMin, uformat.ArgumentMax] not already used by routerName's
+// other BGPVRFInstances.
+func allocateGatewayArgument(
+	ctx context.Context, k8s client.Client, namespace, routerName, vrfName string,
+) (int32, error) {
+	list := &bgpv1alpha1.BGPVRFInstanceList{}
+	if err := k8s.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		return 0, fmt.Errorf("list BGPVRFInstances in namespace %s: %w", namespace, err)
+	}
+	used := make(map[int32]struct{}, len(list.Items))
+	for _, inst := range list.Items {
+		if inst.Spec.RouterRef == nil || inst.Spec.RouterRef.Name != routerName {
+			continue
+		}
+		if inst.Name == vrfName {
+			return inst.Spec.VRFID, nil
+		}
+		used[inst.Spec.VRFID] = struct{}{}
+	}
+	for arg := int32(uformat.ArgumentMin); arg <= int32(uformat.ArgumentMax); arg++ {
+		if _, ok := used[arg]; !ok {
+			return arg, nil
+		}
+	}
+	return 0, fmt.Errorf("allocate SID argument: router %s has no free Argument in [%#x,%#x]",
+		routerName, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax))
+}
+
+// PublishGateway implements GatewayPublisher.
+func (p *k8sGatewayPublisher) PublishGateway(ctx context.Context, vpc string, addr net.IP) error {
+	if addr == nil || addr.IsUnspecified() {
+		return fmt.Errorf("refusing to publish gateway advertisement for vpc %s: address %s is not usable", vpc, addr)
+	}
+
+	bgp, err := p.lookupBGPRouter(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Same (vpc, node)-keyed BGPVRFInstance a real CNI attachment on this
+	// node would use (crdnames.BGPVRFInstanceName's own doc comment) —
+	// CreateOrUpdate here reuses one that already exists (a tenant pod
+	// sharing this node and VPC) rather than creating a competing entry, or
+	// creates one for the shared VRFID/route-target bookkeeping if none
+	// does yet.
+	vrfName := crdnames.BGPVRFInstanceName(vpc, p.nodeName)
+	vrfID, err := allocateGatewayArgument(ctx, p.client, p.namespace, bgp.routerName, vrfName)
+	if err != nil {
+		return err
+	}
+	rtValue, err := vpcRouteTarget(bgp.asNumber, vpc)
+	if err != nil {
+		return fmt.Errorf("compute route target for vpc %s: %w", vpc, err)
+	}
+
+	vrfInst := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: vrfName, Namespace: p.namespace},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, p.client, vrfInst, func() error {
+		vrfInst.Spec = bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: bgp.routerName}},
+			VRFID:              vrfID,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: rtValue}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: rtValue}},
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("apply BGPVRFInstance %s: %w", vrfName, err)
+	}
+
+	function := bgpv1alpha1.SRv6FunctionEndDT46
+	advName := crdnames.BGPAdvertisementName(vpc, ingressVPCAttachment, p.nodeName)
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: p.namespace},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, p.client, adv, func() error {
+		adv.Spec = bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef:     bgpv1alpha1.RouterRef{Name: bgp.routerName},
+			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},
+			Prefixes:      []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(addr.String() + "/128")},
+			Communities:   []bgpv1alpha1.Community{bgpv1alpha1.Community(rtValue)},
+			VRFID:         &vrfID,
+			Function:      &function,
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("apply BGPAdvertisement %s: %w", advName, err)
+	}
+	return nil
+}
+
+// WithdrawGateway implements GatewayPublisher.
+func (p *k8sGatewayPublisher) WithdrawGateway(ctx context.Context, vpc string) error {
+	advName := crdnames.BGPAdvertisementName(vpc, ingressVPCAttachment, p.nodeName)
+	adv := &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: p.namespace},
+	}
+	if err := p.client.Delete(ctx, adv); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete BGPAdvertisement %s: %w", advName, err)
+	}
+	return nil
+}

--- a/internal/ingresssidecar/gateway_test.go
+++ b/internal/ingresssidecar/gateway_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/plumbing/intf"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	gatewayTestNamespace = "galactic-system"
+	gatewayTestNode      = "worker-1"
+	gatewayTestVPC       = "2"
+	gatewayTestRT        = "65000:2"
+	gatewayTestASN       = 65000
+)
+
+func gatewayTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := bgpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return scheme
+}
+
+// newGatewayTestRouter returns a BGPRouter named after, and targeting,
+// gatewayTestNode -- every test in this file uses a single-router, single-
+// node fixture, so router name and target node are always the same value.
+func newGatewayTestRouter() *bgpv1alpha1.BGPRouter {
+	return &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Namespace: gatewayTestNamespace, Name: gatewayTestNode},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef: bgpv1alpha1.TargetRef{Kind: "Node", Name: gatewayTestNode},
+			LocalASN:  gatewayTestASN,
+			RouterID:  "10.0.0.1",
+		},
+	}
+}
+
+func TestPublishGateway_CreatesVRFInstanceAndAdvertisement(t *testing.T) {
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	addr := net.ParseIP("fd20:0:2::4:0:0")
+	if err := pub.PublishGateway(ctx, gatewayTestVPC, addr); err != nil {
+		t.Fatalf("PublishGateway: %v", err)
+	}
+
+	vrfName := crdnames.BGPVRFInstanceName(gatewayTestVPC, gatewayTestNode)
+	vrf := &bgpv1alpha1.BGPVRFInstance{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: vrfName}, vrf); err != nil {
+		t.Fatalf("get BGPVRFInstance %s: %v", vrfName, err)
+	}
+	if vrf.Spec.VRFID != 1 {
+		t.Errorf("VRFID = %d, want 1 (first free slot)", vrf.Spec.VRFID)
+	}
+	if len(vrf.Spec.ImportRouteTargets) != 1 || vrf.Spec.ImportRouteTargets[0].Value != gatewayTestRT {
+		t.Errorf("ImportRouteTargets = %v, want [%s]", vrf.Spec.ImportRouteTargets, gatewayTestRT)
+	}
+
+	advName := crdnames.BGPAdvertisementName(gatewayTestVPC, ingressVPCAttachment, gatewayTestNode)
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: advName}, adv); err != nil {
+		t.Fatalf("get BGPAdvertisement %s: %v", advName, err)
+	}
+	if adv.Spec.RouterRef.Name != gatewayTestNode {
+		t.Errorf("RouterRef.Name = %q, want %s", adv.Spec.RouterRef.Name, gatewayTestNode)
+	}
+	if len(adv.Spec.Prefixes) != 1 || string(adv.Spec.Prefixes[0]) != "fd20:0:2::4:0:0/128" {
+		t.Errorf("Prefixes = %v, want [fd20:0:2::4:0:0/128]", adv.Spec.Prefixes)
+	}
+	if len(adv.Spec.Communities) != 1 || string(adv.Spec.Communities[0]) != gatewayTestRT {
+		t.Errorf("Communities = %v, want [%s]", adv.Spec.Communities, gatewayTestRT)
+	}
+	if adv.Spec.VRFID == nil || *adv.Spec.VRFID != 1 {
+		t.Errorf("VRFID = %v, want 1", adv.Spec.VRFID)
+	}
+	if adv.Spec.Function == nil || *adv.Spec.Function != bgpv1alpha1.SRv6FunctionEndDT46 {
+		t.Errorf("Function = %v, want End.DT46", adv.Spec.Function)
+	}
+}
+
+func TestPublishGateway_ReusesExistingVRFID(t *testing.T) {
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	existingVRF := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gatewayTestNamespace,
+			Name:      crdnames.BGPVRFInstanceName(gatewayTestVPC, gatewayTestNode),
+		},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: gatewayTestNode}},
+			VRFID:              7,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: gatewayTestRT}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: gatewayTestRT}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, existingVRF).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.PublishGateway(ctx, gatewayTestVPC, net.ParseIP("fd20:0:2::4:0:0")); err != nil {
+		t.Fatalf("PublishGateway: %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	advName := crdnames.BGPAdvertisementName(gatewayTestVPC, ingressVPCAttachment, gatewayTestNode)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: advName}, adv); err != nil {
+		t.Fatalf("get BGPAdvertisement: %v", err)
+	}
+	if adv.Spec.VRFID == nil || *adv.Spec.VRFID != 7 {
+		t.Errorf("VRFID = %v, want 7 (reused from existing BGPVRFInstance)", adv.Spec.VRFID)
+	}
+}
+
+func TestPublishGateway_AvoidsCollisionWithOtherVPCOnSameNode(t *testing.T) {
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	otherVPCVRF := &bgpv1alpha1.BGPVRFInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gatewayTestNamespace,
+			Name:      crdnames.BGPVRFInstanceName("70", gatewayTestNode),
+		},
+		Spec: bgpv1alpha1.BGPVRFInstanceSpec{
+			RouterTarget:       bgpv1alpha1.RouterTarget{RouterRef: &bgpv1alpha1.RouterRef{Name: gatewayTestNode}},
+			VRFID:              1,
+			ImportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:70"}},
+			ExportRouteTargets: []bgpv1alpha1.RouteTarget{{Value: "65000:70"}},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router, otherVPCVRF).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.PublishGateway(ctx, gatewayTestVPC, net.ParseIP("fd20:0:2::4:0:0")); err != nil {
+		t.Fatalf("PublishGateway: %v", err)
+	}
+
+	vrfName := crdnames.BGPVRFInstanceName(gatewayTestVPC, gatewayTestNode)
+	vrf := &bgpv1alpha1.BGPVRFInstance{}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: vrfName}, vrf); err != nil {
+		t.Fatalf("get BGPVRFInstance: %v", err)
+	}
+	if vrf.Spec.VRFID != 2 {
+		t.Errorf("VRFID = %d, want 2 (1 already used by VPC 70 on this node)", vrf.Spec.VRFID)
+	}
+}
+
+func TestPublishGateway_NoBGPRouterForNode(t *testing.T) {
+	scheme := gatewayTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.PublishGateway(context.Background(), gatewayTestVPC, net.ParseIP("fd20:0:2::4:0:0")); err == nil {
+		t.Fatal("expected an error when no BGPRouter targets this node, got nil")
+	}
+}
+
+func TestPublishGateway_RejectsUnspecifiedAddress(t *testing.T) {
+	scheme := gatewayTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.PublishGateway(context.Background(), gatewayTestVPC, net.IPv6zero); err == nil {
+		t.Fatal("expected an error for an unspecified address, got nil")
+	}
+	if err := pub.PublishGateway(context.Background(), gatewayTestVPC, nil); err == nil {
+		t.Fatal("expected an error for a nil address, got nil")
+	}
+}
+
+func TestWithdrawGateway_DeletesAdvertisementOnlyNotVRFInstance(t *testing.T) {
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router).Build()
+
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.PublishGateway(ctx, gatewayTestVPC, net.ParseIP("fd20:0:2::4:0:0")); err != nil {
+		t.Fatalf("PublishGateway: %v", err)
+	}
+	if err := pub.WithdrawGateway(ctx, gatewayTestVPC); err != nil {
+		t.Fatalf("WithdrawGateway: %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	advName := crdnames.BGPAdvertisementName(gatewayTestVPC, ingressVPCAttachment, gatewayTestNode)
+	err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: advName}, adv)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("BGPAdvertisement still exists after WithdrawGateway (err=%v), want NotFound", err)
+	}
+
+	vrf := &bgpv1alpha1.BGPVRFInstance{}
+	vrfName := crdnames.BGPVRFInstanceName(gatewayTestVPC, gatewayTestNode)
+	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: gatewayTestNamespace, Name: vrfName}, vrf); err != nil {
+		t.Errorf("BGPVRFInstance was removed by WithdrawGateway (it's shared, not this publisher's to delete): %v", err)
+	}
+}
+
+func TestWithdrawGateway_NotFoundIsNoop(t *testing.T) {
+	scheme := gatewayTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	pub := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+	if err := pub.WithdrawGateway(context.Background(), gatewayTestVPC); err != nil {
+		t.Fatalf("WithdrawGateway on a never-published vpc: %v", err)
+	}
+}
+
+func TestVpcRouteTarget(t *testing.T) {
+	for _, vpc := range []string{"2", "70", "1b4"} {
+		hex, err := intf.Base62ToHex(vpc)
+		if err != nil {
+			t.Fatalf("intf.Base62ToHex(%q): %v", vpc, err)
+		}
+		v, err := strconv.ParseUint(hex, 16, 64)
+		if err != nil {
+			t.Fatalf("parse hex %q: %v", hex, err)
+		}
+		want := fmt.Sprintf("65000:%d", uint32(v))
+
+		got, err := vpcRouteTarget(65000, vpc)
+		if err != nil {
+			t.Fatalf("vpcRouteTarget(65000, %q): unexpected error: %v", vpc, err)
+		}
+		if got != want {
+			t.Errorf("vpcRouteTarget(65000, %q) = %q, want %q", vpc, got, want)
+		}
+	}
+
+	if _, err := vpcRouteTarget(65000, "!!!"); err == nil {
+		t.Error("vpcRouteTarget with a non-base62 vpc: expected an error, got nil")
+	}
+}
+
+// fakeGatewayPublisher/fakeGatewayResolver back the Store-level wiring
+// tests in store_test.go — no real k8s or kernel calls, matching
+// fakeBackend's own rationale.
+type fakeGatewayPublisher struct {
+	published   map[string]net.IP
+	withdrawn   []string
+	publishErr  error
+	withdrawErr error
+}
+
+func newFakeGatewayPublisher() *fakeGatewayPublisher {
+	return &fakeGatewayPublisher{published: make(map[string]net.IP)}
+}
+
+func (f *fakeGatewayPublisher) PublishGateway(_ context.Context, vpc string, addr net.IP) error {
+	if f.publishErr != nil {
+		return f.publishErr
+	}
+	f.published[vpc] = addr
+	return nil
+}
+
+func (f *fakeGatewayPublisher) WithdrawGateway(_ context.Context, vpc string) error {
+	if f.withdrawErr != nil {
+		return f.withdrawErr
+	}
+	f.withdrawn = append(f.withdrawn, vpc)
+	delete(f.published, vpc)
+	return nil
+}
+
+type fakeGatewayResolver struct {
+	addrs map[string]net.IP
+}
+
+func newFakeGatewayResolver() *fakeGatewayResolver {
+	return &fakeGatewayResolver{addrs: make(map[string]net.IP)}
+}
+
+func (f *fakeGatewayResolver) ResolveGatewayAddress(vpc string) (net.IP, error) {
+	if addr, ok := f.addrs[vpc]; ok {
+		return addr, nil
+	}
+	return nil, fmt.Errorf("vpc %s: %w", vpc, ErrGatewayAddressNotProvisioned)
+}

--- a/internal/ingresssidecar/store.go
+++ b/internal/ingresssidecar/store.go
@@ -6,6 +6,7 @@ package ingresssidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -36,6 +37,12 @@ type vrfState struct {
 	// period — see Sweep). Only once every such route is gone does this
 	// VPC's own teardown grace period start.
 	absentSince time.Time
+	// gatewayPublished is true once this VPC's return-path BGPAdvertisement
+	// has been published (see Store.publishGateway) — set at most once per
+	// VRF lifetime, alongside installed, so a transient resolve/publish
+	// failure retries on the next SetDesired for this VPC rather than being
+	// silently abandoned for the VRF's whole remaining lifetime.
+	gatewayPublished bool
 }
 
 // Store is the in-process desired/applied-state reconciler for this
@@ -55,6 +62,12 @@ type Store struct {
 	grace   time.Duration
 	metrics *Metrics
 
+	// gatewayPublisher and gatewayResolver are both nil by default — see
+	// SetGatewayPublisher's doc comment for what enabling them does and why
+	// leaving them unset is a safe, fully backward-compatible no-op.
+	gatewayPublisher GatewayPublisher
+	gatewayResolver  GatewayAddressResolver
+
 	routes map[string]*routeState
 	vrfs   map[string]*vrfState
 }
@@ -70,6 +83,75 @@ func NewStore(backend Backend, grace time.Duration, metrics *Metrics) *Store {
 		metrics: metrics,
 		routes:  make(map[string]*routeState),
 		vrfs:    make(map[string]*vrfState),
+	}
+}
+
+// SetGatewayPublisher enables this Store to publish (and withdraw) a
+// return-path BGPAdvertisement for each VPC it manages a VRF for — see
+// GatewayPublisher/GatewayAddressResolver's own doc comments for the
+// mechanism and docs/plans/855-return-path-gateway-advertisement.md for why
+// it's needed: without it, a VPC backend's reply traffic has no SRv6 route
+// back to this node, confirmed live by packet capture (see that doc).
+//
+// Both arguments default to nil (the zero Store), which is a fully inert,
+// backward-compatible no-op — every existing deployment of this sidecar
+// today has no gateway address provisioned for resolver to find anyway
+// (see GatewayAddressResolver's own doc comment on what provisioning it
+// still needs), so leaving this unset changes nothing about how Store
+// already behaves. Call this once, before the first SetDesired, from
+// cmd/galactic-vrf's own startup only when both a node identity and a real
+// resolver are actually configured.
+func (s *Store) SetGatewayPublisher(publisher GatewayPublisher, resolver GatewayAddressResolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gatewayPublisher = publisher
+	s.gatewayResolver = resolver
+}
+
+// publishGateway attempts to publish vpc's return-path gateway
+// advertisement once, the first time its VRF is created. Called with s.mu
+// already held (from SetDesired). A resolve failure because nothing has
+// provisioned a gateway address yet (ErrGatewayAddressNotProvisioned) is
+// logged at debug and left for the next SetDesired to retry — not a
+// reconcile error, since most deployments have no such provisioning
+// mechanism at all yet (see SetGatewayPublisher's doc comment). Any other
+// error is logged at warn and also left to retry, rather than failing the
+// route reconcile that triggered it — a missing return path degrades this
+// VPC's ingress traffic, it doesn't make it worse to also install the
+// forward-path route while it's unresolved.
+func (s *Store) publishGateway(ctx context.Context, vpc string, v *vrfState) {
+	if s.gatewayPublisher == nil || s.gatewayResolver == nil || v.gatewayPublished {
+		return
+	}
+	addr, err := s.gatewayResolver.ResolveGatewayAddress(vpc)
+	if err != nil {
+		if errors.Is(err, ErrGatewayAddressNotProvisioned) {
+			slog.Debug("ingresssidecar: no gateway address provisioned yet, will retry", "vpc", vpc, "err", err)
+		} else {
+			slog.Warn("ingresssidecar: resolve gateway address", "vpc", vpc, "err", err)
+		}
+		return
+	}
+	if err := s.gatewayPublisher.PublishGateway(ctx, vpc, addr); err != nil {
+		slog.Warn("ingresssidecar: publish gateway advertisement", "vpc", vpc, "err", err)
+		return
+	}
+	v.gatewayPublished = true
+}
+
+// withdrawGateway is publishGateway's teardown counterpart, called with
+// s.mu already held (from Sweep) once a VPC's VRF is actually about to be
+// removed. Best-effort: a failure here is logged, not propagated — it must
+// never block the kernel-side vrf.Delete that follows it, or a transient
+// k8s API error would leave a VPC's VRF permanently stuck mid-teardown.
+// galactic-router's GC controller reaps a BGPAdvertisement left behind by a
+// failed withdraw the same way it already reaps any other orphaned one.
+func (s *Store) withdrawGateway(ctx context.Context, vpc string, v *vrfState) {
+	if s.gatewayPublisher == nil || !v.gatewayPublished {
+		return
+	}
+	if err := s.gatewayPublisher.WithdrawGateway(ctx, vpc); err != nil {
+		slog.Warn("ingresssidecar: withdraw gateway advertisement", "vpc", vpc, "err", err)
 	}
 }
 
@@ -117,6 +199,7 @@ func (s *Store) SetDesired(ctx context.Context, key string, desired *DesiredRout
 		v.tableID = tableID
 		s.vrfActiveDelta(1)
 	}
+	s.publishGateway(ctx, desired.VPC, v)
 
 	if rerr := s.backend.EnsureRoute(desired.Prefix, desired.SID, v.tableID); rerr != nil {
 		s.countError("ensure_route")
@@ -196,6 +279,7 @@ func (s *Store) Sweep(ctx context.Context, now time.Time) {
 			continue
 		}
 		if v.installed {
+			s.withdrawGateway(ctx, vpc, v)
 			if err := s.backend.RemoveVRF(vpc); err != nil {
 				s.countError("remove_vrf")
 				slog.Error("ingresssidecar: remove VRF", "vpc", vpc, "error", err)

--- a/internal/ingresssidecar/store_gateway_test.go
+++ b/internal/ingresssidecar/store_gateway_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestStoreNoGatewayPublisherIsNoop verifies that a Store with no
+// SetGatewayPublisher call — every deployment of this sidecar today —
+// behaves exactly as it did before this feature existed: no panic, no
+// error, route/VRF reconcile unaffected.
+func TestStoreNoGatewayPublisherIsNoop(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+
+	desired := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::1"), SID: net.ParseIP("fd00:99::1")}
+	if err := store.SetDesired(ctx, "ns/pod-a", desired); err != nil {
+		t.Fatalf("SetDesired: %v", err)
+	}
+	if got := backend.vrfCount(); got != 1 {
+		t.Errorf("vrfCount = %d, want 1", got)
+	}
+}
+
+// TestStorePublishesGatewayOnceOnFirstVRFCreation verifies the gateway
+// advertisement is published exactly once per VPC's VRF lifetime, not once
+// per pod/route reconciled against it.
+func TestStorePublishesGatewayOnceOnFirstVRFCreation(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+	pub := newFakeGatewayPublisher()
+	resolver := newFakeGatewayResolver()
+	gatewayAddr := net.ParseIP("fd00:99::4")
+	resolver.addrs[testVPC1] = gatewayAddr
+	store.SetGatewayPublisher(pub, resolver)
+
+	first := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::1"), SID: net.ParseIP("fd00:99::1")}
+	second := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::2"), SID: net.ParseIP("fd00:99::2")}
+
+	if err := store.SetDesired(ctx, "ns/pod-a", first); err != nil {
+		t.Fatalf("SetDesired(pod-a): %v", err)
+	}
+	if err := store.SetDesired(ctx, "ns/pod-b", second); err != nil {
+		t.Fatalf("SetDesired(pod-b): %v", err)
+	}
+
+	if got := pub.published[testVPC1]; got == nil || !got.Equal(gatewayAddr) {
+		t.Errorf("published[%s] = %v, want %v", testVPC1, got, gatewayAddr)
+	}
+	if got := len(pub.published); got != 1 {
+		t.Errorf("PublishGateway call count (via map size after 2 SetDesired calls for the same VPC) = %d, want 1", got)
+	}
+}
+
+// TestStoreGatewayNotProvisionedYetIsNotAReconcileError verifies that a
+// resolver reporting ErrGatewayAddressNotProvisioned — the common case,
+// since no deployment provisions a gateway address yet (see
+// GatewayAddressResolver's own doc comment) — never fails the route
+// reconcile that triggered it, and leaves the VPC eligible to retry on the
+// next SetDesired.
+func TestStoreGatewayNotProvisionedYetIsNotAReconcileError(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+	pub := newFakeGatewayPublisher()
+	resolver := newFakeGatewayResolver() // no address seeded for testVPC1
+
+	store.SetGatewayPublisher(pub, resolver)
+
+	desired := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::1"), SID: net.ParseIP("fd00:99::1")}
+	if err := store.SetDesired(ctx, "ns/pod-a", desired); err != nil {
+		t.Fatalf("SetDesired: %v", err)
+	}
+	if got := backend.routeCount(); got != 1 {
+		t.Errorf("routeCount = %d, want 1 (route reconcile must proceed despite the unresolved gateway)", got)
+	}
+	if got := len(pub.published); got != 0 {
+		t.Errorf("published = %v, want empty (nothing to publish yet)", pub.published)
+	}
+
+	// Once an address becomes available, the next SetDesired for this VPC
+	// retries and succeeds -- gatewayPublished must not have been latched
+	// true on the earlier failed attempt.
+	resolver.addrs[testVPC1] = net.ParseIP("fd00:99::4")
+	if err := store.SetDesired(ctx, "ns/pod-b", &DesiredRoute{
+		VPC: testVPC1, Prefix: mustPrefix(t, "fd00::2"), SID: net.ParseIP("fd00:99::2"),
+	}); err != nil {
+		t.Fatalf("SetDesired(pod-b): %v", err)
+	}
+	if got := pub.published[testVPC1]; got == nil {
+		t.Error("gateway was never published once an address became available on retry")
+	}
+}
+
+// TestStorePublishErrorDoesNotFailRouteReconcile verifies a real
+// GatewayPublisher error (e.g. a transient k8s API failure) is logged, not
+// propagated: a degraded return path must not also block the forward-path
+// route this sidecar exists to install.
+func TestStorePublishErrorDoesNotFailRouteReconcile(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+	pub := newFakeGatewayPublisher()
+	pub.publishErr = errors.New("simulated transient k8s API failure")
+	resolver := newFakeGatewayResolver()
+	resolver.addrs[testVPC1] = net.ParseIP("fd00:99::4")
+	store.SetGatewayPublisher(pub, resolver)
+
+	desired := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::1"), SID: net.ParseIP("fd00:99::1")}
+	if err := store.SetDesired(ctx, "ns/pod-a", desired); err != nil {
+		t.Fatalf("SetDesired: %v", err)
+	}
+	if got := backend.routeCount(); got != 1 {
+		t.Errorf("routeCount = %d, want 1", got)
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("published = %v, want empty (PublishGateway failed)", pub.published)
+	}
+}
+
+// TestStoreWithdrawsGatewayOnVRFTeardown verifies WithdrawGateway is called
+// once a VPC's VRF is actually torn down (its teardown grace period has
+// elapsed), not before.
+func TestStoreWithdrawsGatewayOnVRFTeardown(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+	pub := newFakeGatewayPublisher()
+	resolver := newFakeGatewayResolver()
+	resolver.addrs[testVPC1] = net.ParseIP("fd00:99::4")
+	store.SetGatewayPublisher(pub, resolver)
+
+	desired := &DesiredRoute{VPC: testVPC1, Prefix: mustPrefix(t, "fd00::1"), SID: net.ParseIP("fd00:99::1")}
+	if err := store.SetDesired(ctx, "ns/pod-a", desired); err != nil {
+		t.Fatalf("SetDesired: %v", err)
+	}
+	if len(pub.published) != 1 {
+		t.Fatalf("expected gateway published before teardown, got %v", pub.published)
+	}
+
+	if err := store.SetDesired(ctx, "ns/pod-a", nil); err != nil {
+		t.Fatalf("SetDesired(nil): %v", err)
+	}
+
+	// Before the route's own grace period elapses: nothing torn down yet.
+	start := time.Now()
+	store.Sweep(ctx, start)
+	if len(pub.withdrawn) != 0 {
+		t.Errorf("withdrawn = %v before grace period elapsed, want empty", pub.withdrawn)
+	}
+
+	// Once the route's grace period elapses, Sweep removes the route and
+	// only then starts the VRF's own grace period (Sweep's own doc
+	// comment: the two timers never overlap) -- so the VRF, and this
+	// gateway withdrawal, needs one more full grace period after that.
+	store.Sweep(ctx, start.Add(testGrace+time.Second))
+	if len(pub.withdrawn) != 0 {
+		t.Errorf("withdrawn = %v after only the route's grace period, want empty "+
+			"(VRF grace hasn't started yet)", pub.withdrawn)
+	}
+
+	store.Sweep(ctx, start.Add(2*testGrace+2*time.Second))
+	if len(pub.withdrawn) != 1 || pub.withdrawn[0] != testVPC1 {
+		t.Errorf("withdrawn = %v, want [%s]", pub.withdrawn, testVPC1)
+	}
+	if _, ok := pub.published[testVPC1]; ok {
+		t.Errorf("published still contains %s after withdrawal", testVPC1)
+	}
+}


### PR DESCRIPTION
## Summary

The forward path from Envoy's ingress sidecar (`internal/ingresssidecar`, `galactic-vrf`) into a VPC backend already works. `galactic-cni` publishes a `BGPAdvertisement` per pod (#854). The sidecar's own `seg6` egress route (#855) correctly encapsulates toward it.

Nothing published a `BGPAdvertisement` for the sidecar's own local gateway address. A backend's reply traffic had no SRv6 route back to Envoy's node.

Confirmed live in `us-central-1-staging-lab`, by packet capture on both ends:

- The backend receives the forward-path request and replies with a SYN-ACK.
- That reply leaves the backend node as a plain, unencapsulated IPv6 packet. No route back to Envoy's node exists in the backend node's own VRF import table. It's lost.

This is a gap in the accepted #851 design, not a regression. See `docs/plans/855-return-path-gateway-advertisement.md` for the full writeup.

## Changes

- `internal/ingresssidecar/gateway.go` (new): `GatewayPublisher`/`GatewayAddressResolver`. Mirrors `internal/cnibgp/bgp.go`'s own `BGPVRFInstance`/`BGPAdvertisement` publish pattern for a pod's own address, reimplemented in miniature rather than imported (see the plan doc for why).
- `internal/ingresssidecar/store.go`: opt-in `Store.SetGatewayPublisher`. Publishes once per VPC's VRF creation, withdraws once per VRF teardown. Every existing `NewStore` call site is unchanged.
- `internal/config/vrf.go`: adds `NodeName`/`Namespace` to `VRFConfig`, both optional. `NodeName` defaults to `""`, which leaves this feature disabled.
- `cmd/galactic-vrf/root.go`: wires the publisher only when a node name is configured.
- `docs/plans/855-return-path-gateway-advertisement.md` (new): the design doc, including what's not implemented here (provisioning the gateway address itself, below).

## Out of scope

Address provisioning, a veth-style attachment giving the sidecar its own routable address inside each VPC with its own IPAM allocation, is a separate gap. It needs kernel-level work and an IPAM story this PR doesn't invent. See the plan doc's "Not implemented here" section.

`GatewayAddressResolver`'s production implementation (`NetlinkGatewayAddressResolver`) only discovers an address some other mechanism has already provisioned, and returns a sentinel "not provisioned yet" error otherwise. `Store` treats that as nothing to do yet, not a failure.

## Backward compatibility

Opt-in and inert by default:
- `Store.SetGatewayPublisher` is only called by `cmd/galactic-vrf` when `GALACTIC_VRF_NODE_NAME` (or legacy `NODE_NAME`) is set.
- Even then, no VPC has a provisioned gateway address today, so `PublishGateway` never fires against a real deployment yet. This lands inert until the provisioning follow-up exists.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test $(go list ./... | grep -v /tests/e2e)`: all unit tests pass. e2e requires a live Kind cluster, unaffected by this change.
- `golangci-lint run` clean on every touched package.
- New tests: `internal/ingresssidecar/gateway_test.go` (publisher CRD lifecycle, VRFID allocation/reuse/collision-avoidance, withdraw semantics) and `internal/ingresssidecar/store_gateway_test.go` (Store wiring: no-op when unset, publish-once semantics, not-provisioned-yet is not a reconcile error, withdraw-on-teardown timing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)