### PR TITLE
fix(attach): exclude VRF slaves from fabric-interface auto-detection

### DIFF
--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -126,6 +126,23 @@ func parseInterfaceList(v string) []string {
 // rather than by interface name (the specific mesh interface name is
 // deployment-specific; the underlying failure mode -- a tunnel interface
 // racing a real NIC for the default route -- is not).
+//
+// Also skips any interface enslaved to a Linux VRF master (excludedMasterType),
+// for the identical reasoning, confirmed live: internal/ingresssidecar's
+// own per-VPC veth pair (ensureEgressDatapath's ivpN/ivsN, enslaved into
+// that VPC's VRF so usid_egress has a real ingress hook to attach to --
+// see that function's own doc comment) picks up a spurious
+// `default via fe80::... dev ivsN table <vrf>` route, almost certainly
+// from IPv6 router-solicitation/advertisement between the veth peers. With
+// six VPCs' VRFs present, that put ivs1 (the lowest VRF table id) ahead of
+// eth0 in this function's own result, so ResolveNodeSourceAddress
+// permanently resolved a link-local-only interface instead of the real
+// fabric NIC -- ensureEgressDatapath's own doc comment confirms the
+// consequence isn't cosmetic: usid_egress fails open (TC_ACT_UNSPEC,
+// uncounted) on every encapsulation attempt until this resolves. A VRF
+// slave -- this sidecar's own internal plumbing or a real tenant
+// attachment either one -- can never legitimately be "the real fabric NIC"
+// any more than a WireGuard mesh interface can.
 func autoDetectInterfaces() ([]string, error) {
 	routes, err := routeListFn()
 	if err != nil {
@@ -148,6 +165,9 @@ func autoDetectInterfaces() ([]string, error) {
 		if link.Type() == excludedLinkType {
 			continue
 		}
+		if isVRFSlave(link) {
+			continue
+		}
 		name := link.Attrs().Name
 		if seen[name] {
 			continue
@@ -168,6 +188,35 @@ func autoDetectInterfaces() ([]string, error) {
 // autoDetectInterfaces never treats as a candidate fabric interface -- see
 // autoDetectInterfaces' own doc comment for why.
 const excludedLinkType = "wireguard"
+
+// excludedMasterType is the vishvananda/netlink Link.Type() value a link's
+// *master* is checked against by isVRFSlave -- see autoDetectInterfaces'
+// own doc comment for why a VRF slave is excluded the same way a
+// WireGuard link is.
+const excludedMasterType = "vrf"
+
+// isVRFSlave reports whether link is enslaved to a Linux VRF master.
+// Resolves the master via linkByIndexFn rather than trusting link's own
+// Type() (a VRF slave is still reported as its real underlying type --
+// "veth", "bond", etc. -- only the separate MasterIndex/master-side
+// SlaveKind marks the enslavement), so this only ever excludes a link that
+// genuinely belongs to a VRF, not every enslaved link (a bond slave, which
+// expandBondSlaves deliberately wants included, is never itself a VRF
+// slave at the same time on any topology this codebase creates).
+func isVRFSlave(link netlink.Link) bool {
+	idx := link.Attrs().MasterIndex
+	if idx <= 0 {
+		return false
+	}
+	master, err := linkByIndexFn(idx)
+	if err != nil {
+		// Master unresolvable isn't actionable here; don't exclude on a
+		// guess -- matches autoDetectInterfaces' own stance on an
+		// unresolvable route target just above.
+		return false
+	}
+	return master.Type() == excludedMasterType
+}
 
 // bondLinkType is the vishvananda/netlink Link.Type() value expandBondSlaves
 // checks for -- see its own doc comment for why.

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -228,6 +228,51 @@ func TestResolveInterfaces_AutoDetect(t *testing.T) {
 		}
 	})
 
+	t.Run("VRFSlaveExcluded", func(t *testing.T) {
+		// Reproduces the live bug found in internal/ingresssidecar: a VRF
+		// slave (its own per-VPC veth pair, ensureEgressDatapath's
+		// ivpN/ivsN) picked up a spurious default route in its VRF's own
+		// table, sorting ahead of the real fabric NIC's -- see
+		// autoDetectInterfaces' own doc comment. isVRFSlave's fakeLink
+		// still reports its real Type() ("fake" here, "veth" live) --
+		// only its MasterIndex plus the separately-resolved master's own
+		// Type() ("vrf") mark the enslavement, exactly as isVRFSlave
+		// requires.
+		const (
+			vrfSlaveIface = "ivs1"
+			vrfMasterIdx  = 99
+		)
+		vrfLinks := map[int]netlink.Link{
+			2: &fakeLink{attrs: netlink.LinkAttrs{Index: 2, Name: vrfSlaveIface, MasterIndex: vrfMasterIdx}},
+			3: &fakeLink{attrs: netlink.LinkAttrs{Index: 3, Name: testIfaceEth0}},
+			vrfMasterIdx: &fakeLink{
+				attrs: netlink.LinkAttrs{Index: vrfMasterIdx, Name: "G000000002V"}, linkType: excludedMasterType,
+			},
+		}
+		origLinkByIndexFn := linkByIndexFn
+		linkByIndexFn = func(index int) (netlink.Link, error) {
+			if l, ok := vrfLinks[index]; ok {
+				return l, nil
+			}
+			return nil, errFixtureNotFound
+		}
+		defer func() { linkByIndexFn = origLinkByIndexFn }()
+
+		routeListFn = func() ([]netlink.Route, error) {
+			return []netlink.Route{
+				{LinkIndex: 2, Dst: nil}, // the VRF slave's spurious default route, reported first
+				{LinkIndex: 3, Dst: nil}, // the real fabric NIC's
+			}, nil
+		}
+		got, err := ResolveInterfaces()
+		if err != nil {
+			t.Fatalf("ResolveInterfaces() error = %v", err)
+		}
+		if !equalStringSlices(got, []string{testIfaceEth0}) {
+			t.Errorf("ResolveInterfaces() = %v, want [%s] (VRF slave excluded)", got, testIfaceEth0)
+		}
+	})
+
 	t.Run("OnlyWireguardLinkIsActionableError", func(t *testing.T) {
 		const wireguardIface = "wg-mesh0"
 		wgLinks := map[int]netlink.Link{


### PR DESCRIPTION
## Summary

`autoDetectInterfaces()` deliberately scans every routing table, not just main, for the node's own IPv6 default route. That's needed since the real fabric interface can legitimately live inside a VRF on some topologies. It had no way to tell that apart from a VRF-internal default route that isn't the real fabric NIC at all.

## What happened

Confirmed live on `us-central-1-staging-lab`, while validating the #492/#4408/#4409 rollout: `internal/ingresssidecar`'s own per-VPC veth pair (`ensureEgressDatapath`'s `ivpN`/`ivsN`, enslaved into that VPC's VRF so `usid_egress` has a real hook to attach to) picks up a spurious default route in that VPC's own VRF table:

```
default via fe80::b000:28ff:fe1e:491a dev ivs1 table 1
default via fe80::4c30:77ff:fe20:f503 dev ivs2 table 2
...
default via fd20::43f6 dev eth0
```

Almost certainly from router solicitation/advertisement between the veth peers. With six VPCs' VRFs present on one pod, that put `ivs1` (the lowest VRF table id) ahead of `eth0` in `autoDetectInterfaces`' own result, so `ResolveNodeSourceAddress` permanently resolved a link-local-only interface instead of the real fabric NIC:

```
WARN ensureEgressDatapath: could not register this node's own SRv6 source address; egress routing will fail open until this succeeds err="resolve node source address: no global-scope IPv6 address found on ivs1 (the SRv6/underlay-facing interface)"
```

`ensureEgressDatapath`'s own doc comment confirms the consequence isn't cosmetic: `usid_egress` fails open (`TC_ACT_UNSPEC`, uncounted) on every encapsulation attempt until this resolves.

## Why nothing broke visibly today

This node also runs `galactic-cni`, which registers the correct node source address into the same pinned, node-level map for real tenant traffic. That's masking the gap, not fixing it. A gateway node running only this sidecar — the exact scenario `ensureEgressDatapath`'s own doc comment already names as the reason `ensureNodeSourceAddress` exists — would have no such fallback.

## Fix

Excludes any link enslaved to a Linux VRF master, the same categorical way `autoDetectInterfaces` already excludes WireGuard links. A VRF slave, this sidecar's own internal plumbing or a real tenant attachment either one, can never legitimately be the real fabric NIC.

## Testing

- New subtest `TestResolveInterfaces_AutoDetect/VRFSlaveExcluded`, mirroring the existing `WireguardLinkExcluded` case.
- `go build ./...`, `go vet ./...`, `go test $(go list ./... | grep -v /tests/e2e)` all clean.
- `golangci-lint run` clean on the touched package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)