### PR TITLE
feat(ingresssidecar): provision the sidecar's own return-path gateway address

### DIFF
--- a/cmd/galactic-vrf/root.go
+++ b/cmd/galactic-vrf/root.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"time"
 
@@ -85,6 +86,27 @@ func runCmd(cfg *config.VRFConfig) error {
 			ingresssidecar.NewK8sGatewayPublisher(mgr.GetClient(), cfg.NodeName, cfg.Namespace),
 			ingresssidecar.NetlinkGatewayAddressResolver{},
 		)
+
+		// Gateway address *provisioning* is a second, independent opt-in on
+		// top of the publisher above -- see internal/config.VRFConfig's own
+		// GatewayPrefix doc comment for why it needs its own explicit
+		// platform-addressing decision, not a default. Without this, the
+		// publisher above stays permanently idle: NetlinkGatewayAddressResolver
+		// has nothing to find, so PublishGateway never actually fires.
+		if cfg.GatewayPrefix != "" {
+			_, network, err := net.ParseCIDR(cfg.GatewayPrefix)
+			if err != nil {
+				// cfg.Validate() already checked this parses; a failure here
+				// would mean Validate and this call disagree, a real bug --
+				// fail loudly rather than silently run with no provisioning.
+				return fmt.Errorf("parse gateway prefix %q: %w", cfg.GatewayPrefix, err)
+			}
+			ingresssidecar.SetGatewayAddressAssignment(network, cfg.NodeName)
+		} else {
+			log.Printf("no gateway prefix configured (%s) -- "+
+				"return-path gateway address provisioning is disabled; PublishGateway will never fire",
+				config.EnvVRFGatewayPrefix)
+		}
 	} else {
 		log.Printf("no node name configured (%s / legacy NODE_NAME) -- "+
 			"return-path gateway advertisement publishing is disabled", config.EnvVRFNodeName)
@@ -171,6 +193,11 @@ func newRootCommand() *cobra.Command {
 			"enables return-path gateway advertisement publishing when set (env "+config.EnvVRFNodeName+" or legacy NODE_NAME)")
 	cmd.Flags().StringP("namespace", "", config.DefaultNamespace,
 		"Namespace to read BGPRouter/BGPVRFInstance and write BGPAdvertisement CRDs in")
+	cmd.Flags().StringP("gateway-prefix", "", "",
+		"Reserved, byte-aligned IPv6 CIDR (e.g. a /80 or /96) this sidecar derives its own per-VPC "+
+			"return-path gateway address from -- must be address space no tenant IPAM (this repo's own or "+
+			"external) ever allocates from; only takes effect when --node-name is also set (env "+
+			config.EnvVRFGatewayPrefix+")")
 	cmd.Flags().Bool("build-info", false, "Print build information and exit")
 	cmd.Flags().BoolP("version", "V", false, "Print version and exit")
 	return cmd

--- a/docs/plans/855-return-path-gateway-advertisement.md
+++ b/docs/plans/855-return-path-gateway-advertisement.md
@@ -2,7 +2,7 @@
 
 - **Parent:** [datum-cloud/enhancements#796](https://github.com/datum-cloud/enhancements/issues/796) — HTTP Ingress for VPC Networks
 - **Sibling plan:** [docs/plans/855-ingress-sidecar-vpc-backend-connectivity.md](855-ingress-sidecar-vpc-backend-connectivity.md) — the accepted #855 design this plan extends. Read that one first; this doc only covers the gap it left open.
-- **Status:** `GatewayPublisher`/`GatewayAddressResolver` implemented and unit-tested in `internal/ingresssidecar` (`gateway.go`, `gateway_test.go`, `store_gateway_test.go`); wired into `Store` (opt-in, see "Backward compatibility" below) and `cmd/galactic-vrf`. **Address provisioning is explicitly not implemented** — see "Not implemented here."
+- **Status:** `GatewayPublisher`/`GatewayAddressResolver` implemented and unit-tested in `internal/ingresssidecar` (`gateway.go`, `gateway_test.go`, `store_gateway_test.go`); wired into `Store` (opt-in, see "Backward compatibility" below) and `cmd/galactic-vrf`. **Address provisioning is now implemented too** (`gatewayaddress.go`, `DeriveGatewayAddress`/`ensureGatewayAddress`), opt-in on a second, independent env var — see "Address provisioning" below, which supersedes this doc's original "Not implemented here" section.
 
 ## What's broken, and how it was found
 
@@ -35,12 +35,17 @@ Every piece above is inert by default:
 
 No existing deployment of this sidecar is affected by this change until both a node identity is configured *and* something provisions a gateway address per VPC.
 
-## Not implemented here
+## Address provisioning (supersedes "Not implemented here")
 
-**Provisioning the gateway address itself** — creating a veth-style attachment into each VPC this sidecar handles, with its own IPAM allocation, so `NetlinkGatewayAddressResolver` has something to find — is a real, separate gap, deliberately left open:
+This doc originally left address provisioning as an open gap, citing an unresolved IPAM coordination question: "whether the sidecar requests its own allocation the way `galactic-cni` does for a pod, or a fixed reserved slot per VPC subnet, or something else." Investigating that question found the real answer is neither option as originally framed:
 
-- It needs real kernel-level work (interface creation, address assignment) inside Envoy's own netns, which the sibling plan's own §7 already treats as requiring "a real-kernel verification pass... not possible from this sandbox" for the *forward*-path mechanism it does implement — the same constraint applies here, more so, since this is new kernel-facing code rather than a call into already-proven `internal/plumbing` primitives.
-- It needs an IPAM coordination story this plan doesn't have: whether the sidecar requests its own allocation the way `galactic-cni` does for a pod, or a fixed reserved slot per VPC subnet, or something else, is an open design question, not a detail to improvise silently.
-- The live demo/test environment this gap was found in had a manually created veth (`gwatt1`, address `fd20:0:2::4:0:0/96`) standing in for this — evidence the *symptom* is real, not evidence of how provisioning should actually work in production.
+- **A real tenant VPC's address space is not owned by this repo.** `internal/cniipam`'s only *computed* allocation path (`internal/cni/ipam.PoolAllocator`, sequential first-fit over a configured pool CIDR) is used for lab/self-managed deployments; the production addressing scheme (`ipam.addresses`) takes pre-decided addresses from an external system this repo has no visibility into. A live tenant address's own bit layout doesn't match `PoolAllocator`'s own increment logic, confirming this directly rather than by inference from the docs alone. So there is no "reserved slot" inside a VPC's own subnet this repo can prove is safe to claim — the allocator that would need to avoid it isn't code this repo can read.
+- **The fix doesn't need one.** BGP import into a VPC's VRF is driven entirely by Route Target community, computed from the VPC id (`vpcRouteTarget` in `gateway.go`) — never by whether an advertised prefix's address value falls inside any particular subnet. A gateway address only needs to be (a) globally unique and (b) advertised with the correct RT; it never needs to be a member of the tenant's own pool at all.
 
-Filing this as its own follow-up (a sub-issue of #855 or a new #796 sub-issue, matching how #859's health-checking gap was handled) is the right next step, not bundling it into this change.
+`gatewayaddress.go`'s `DeriveGatewayAddress(prefix, vpc, nodeID)` acts on that: `prefix` is a reserved, byte-aligned IPv6 CIDR that is disjoint *by construction* from tenant space (never handed to any IPAM, local or external, as a pool to allocate from), not disjoint by avoidance within it. The host bits are filled deterministically from `sha256(vpcHex + "|" + nodeID)` — collision-safe against another VPC's or another node's own derived address with overwhelming probability, which is sufficient here since nothing else ever contends for a specific value the way a live IPAM allocation call does.
+
+`ensureGatewayAddress`, called from `ensureEgressDatapath` right after `ensureEgressVeth`, assigns the derived address to the same VRF-slave veth (`ivsN`) that function already creates for `usid_egress`'s own attachment — so `NetlinkGatewayAddressResolver` (already implemented, unchanged) finds it with zero further wiring, and IPv6 source-address selection picks it up for the forward path too (closing a second, related symptom found live: with no global address anywhere in the VRF, the kernel fell back to a link-local source for Envoy's own outbound connections into the VPC).
+
+**Opt-in on a second, independent env var (`GALACTIC_VRF_GATEWAY_PREFIX` / `internal/config.VRFConfig.GatewayPrefix`), only takes effect when `NodeName` is also set.** Deliberately no compiled-in default: *which* reserved prefix to use is a real platform-addressing decision — the exact kind of thing this doc's own "Not implemented here" section was right to flag as not-to-improvise-silently — for whoever owns this deployment's IPAM plan to make explicitly, then configure. The code closes the mechanism; picking and rolling out an actual prefix value is a deployment decision, not a code change.
+
+Both `GALACTIC_VRF_NODE_NAME` and `GALACTIC_VRF_GATEWAY_PREFIX` are unset in every deployment today, so this remains fully inert until an operator configures both — no existing behavior changes.

--- a/internal/config/vrf.go
+++ b/internal/config/vrf.go
@@ -6,6 +6,8 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -61,6 +63,14 @@ const (
 	// GALACTIC_GATEWAY_NODE_NAME have none either.
 	EnvVRFNodeName  = "GALACTIC_VRF_NODE_NAME"
 	EnvVRFNamespace = "GALACTIC_VRF_NAMESPACE"
+
+	// EnvVRFGatewayPrefix configures return-path gateway *address
+	// provisioning* (docs/plans/855-return-path-gateway-advertisement.md's
+	// "Not implemented here" gap) -- see GatewayPrefix's own doc comment.
+	// Unset by default, same as EnvVRFNodeName and for the identical
+	// reason: no generic value could ever be right for "which address
+	// space is reserved for this on this platform."
+	EnvVRFGatewayPrefix = "GALACTIC_VRF_GATEWAY_PREFIX"
 )
 
 // --- VRFConfig -----------------------------------------------------------
@@ -102,6 +112,35 @@ type VRFConfig struct {
 	// is enabled -- defaults to DefaultNamespace ("galactic-system"),
 	// matching every other galactic-* binary's own default.
 	Namespace string
+	// GatewayPrefix is a reserved IPv6 CIDR (a byte-aligned mask, e.g. a
+	// /80 or /96) this sidecar derives its own per-VPC return-path gateway
+	// address from (see internal/ingresssidecar.DeriveGatewayAddress) and
+	// assigns to the VRF-slave interface it already creates for
+	// usid_egress (see ensureEgressDatapath's own doc comment) -- closing
+	// docs/plans/855-return-path-gateway-advertisement.md's "Not
+	// implemented here" gap.
+	//
+	// This must be address space nothing else -- not this repo's own
+	// internal/cniipam, not whatever external system allocates a VPC's
+	// real tenant subnets -- ever hands out as a tenant pool. It is
+	// deliberately not derived from, or carved out of, any tenant VPC's
+	// own subnet: that space is owned by an allocator outside this
+	// repo's visibility (confirmed live: a real tenant address's own bit
+	// layout doesn't match this repo's own internal/cni/ipam allocator,
+	// so nothing here can prove a "reserved" sub-range of it is safe),
+	// so the only way to guarantee no collision is a prefix that's
+	// structurally disjoint from all of it, not merely improbable to
+	// collide. "" (the default) leaves gateway-address provisioning
+	// disabled entirely -- the same inert-by-default stance NodeName's own
+	// doc comment describes, and deliberately no compiled-in value: this
+	// is a real platform-addressing decision for whoever owns this
+	// deployment's IPAM plan to make explicitly, not a default to
+	// silently pick here. Only takes effect when NodeName is also set
+	// (GatewayPrefix alone would derive one, unadvertisable address, and
+	// an empty NodeName would make every replica of this sidecar collide
+	// on the identical address for a given VPC -- see
+	// DeriveGatewayAddress's own nodeID parameter).
+	GatewayPrefix string
 }
 
 // NewVRFConfig creates a config resolver with the GALACTIC_VRF env prefix
@@ -137,6 +176,7 @@ func (c *VRFConfig) BindFlags(flags *pflag.FlagSet) {
 		{"sweep-interval", "sweep_interval"},
 		{"node-name", "node_name"},
 		{"namespace", "namespace"},
+		{"gateway-prefix", "gateway_prefix"},
 	}
 	for _, b := range bindings {
 		if flags.Changed(b.flag) {
@@ -164,6 +204,7 @@ func (c *VRFConfig) readFields() {
 		// GALACTIC_VRF prefix for AutomaticEnv to match.
 		c.NodeName = os.Getenv(EnvNodeNameLegacy)
 	}
+	c.GatewayPrefix = c.v.GetString("gateway_prefix")
 }
 
 // Validate checks that the resolved configuration is usable.
@@ -179,6 +220,18 @@ func (c *VRFConfig) Validate() error {
 	}
 	if c.SweepInterval > c.TeardownGracePeriod {
 		return errors.New("sweep interval must not be greater than the teardown grace period")
+	}
+	if c.GatewayPrefix != "" {
+		ip, network, err := net.ParseCIDR(c.GatewayPrefix)
+		if err != nil {
+			return fmt.Errorf("gateway prefix %q: %w", c.GatewayPrefix, err)
+		}
+		if ip.To4() != nil {
+			return fmt.Errorf("gateway prefix %q must be an IPv6 CIDR", c.GatewayPrefix)
+		}
+		if ones, _ := network.Mask.Size(); ones%8 != 0 {
+			return fmt.Errorf("gateway prefix %q must be byte-aligned (a multiple of /8)", c.GatewayPrefix)
+		}
 	}
 	return nil
 }

--- a/internal/config/vrf_test.go
+++ b/internal/config/vrf_test.go
@@ -22,12 +22,19 @@ func TestVRFConfigDefaults(t *testing.T) {
 	if cfg.SweepInterval != DefaultVRFSweepInterval {
 		t.Errorf("SweepInterval = %v, want %v", cfg.SweepInterval, DefaultVRFSweepInterval)
 	}
+	if cfg.NodeName != "" {
+		t.Errorf("NodeName = %q, want empty (no generic default)", cfg.NodeName)
+	}
+	if cfg.GatewayPrefix != "" {
+		t.Errorf("GatewayPrefix = %q, want empty (no generic default)", cfg.GatewayPrefix)
+	}
 }
 
 func TestVRFConfigEnvOverride(t *testing.T) {
 	t.Setenv(EnvVRFMetricsPort, "9999")
 	t.Setenv(EnvVRFTeardownGracePeriod, "45s")
 	t.Setenv(EnvVRFSweepInterval, "10s")
+	t.Setenv(EnvVRFGatewayPrefix, "fd00:6741:7761::/48")
 
 	cfg := NewVRFConfig()
 
@@ -39,6 +46,9 @@ func TestVRFConfigEnvOverride(t *testing.T) {
 	}
 	if cfg.SweepInterval != 10*time.Second {
 		t.Errorf("SweepInterval = %v, want 10s", cfg.SweepInterval)
+	}
+	if cfg.GatewayPrefix != "fd00:6741:7761::/48" {
+		t.Errorf("GatewayPrefix = %q, want fd00:6741:7761::/48", cfg.GatewayPrefix)
 	}
 }
 
@@ -70,6 +80,26 @@ func TestVRFConfigValidate(t *testing.T) {
 				EnvVRFSweepInterval:       "10s",
 			},
 			wantErr: "sweep interval must not be greater than",
+		},
+		{
+			name:    "invalid gateway prefix",
+			envVars: map[string]string{EnvVRFGatewayPrefix: "not-a-cidr"},
+			wantErr: "gateway prefix",
+		},
+		{
+			name:    "gateway prefix must be IPv6",
+			envVars: map[string]string{EnvVRFGatewayPrefix: "10.0.0.0/24"},
+			wantErr: "must be an IPv6 CIDR",
+		},
+		{
+			name:    "gateway prefix must be byte-aligned",
+			envVars: map[string]string{EnvVRFGatewayPrefix: "fd00:6741:7761::/50"},
+			wantErr: "byte-aligned",
+		},
+		{
+			name:    "valid gateway prefix",
+			envVars: map[string]string{EnvVRFGatewayPrefix: "fd00:6741:7761::/48"},
+			wantErr: "",
 		},
 		{
 			name:    testCaseValidConfig,

--- a/internal/ingresssidecar/backend.go
+++ b/internal/ingresssidecar/backend.go
@@ -77,8 +77,11 @@ func (kernelBackend) EnsureVRF(vpc string) (uint32, error) {
 	}
 	// See ensureEgressDatapath's own doc comment (ebpfdatapath.go): without
 	// this, EnsureRoute's egress_route_table entries below have nothing in
-	// this pod's netns ever attached to read them.
-	if err := ensureEgressDatapath(tableID); err != nil {
+	// this pod's netns ever attached to read them. vpc is threaded through
+	// (not just tableID) so ensureEgressDatapath can also derive and assign
+	// this VPC's own return-path gateway address, when configured -- see
+	// ensureGatewayAddress in gatewayaddress.go.
+	if err := ensureEgressDatapath(vpc, tableID); err != nil {
 		return 0, fmt.Errorf("attach eBPF egress datapath for vpc %s: %w", vpc, err)
 	}
 	return tableID, nil

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -286,7 +286,13 @@ func ensureNodeSourceAddress() error {
 // safe to call on every SetDesired that ensures a VRF (a repeat call for
 // an already-provisioned VPC, e.g. after this sidecar's own restart, is a
 // no-op in effect).
-func ensureEgressDatapath(tableID uint32) error {
+//
+// vpc (added alongside tableID, not derived from it) is used for exactly
+// one thing beyond this doc comment's own long-standing "vpc's VRF
+// interface" description: deriving vpc's own return-path gateway address,
+// when SetGatewayAddressAssignment has configured one -- see
+// ensureGatewayAddress in gatewayaddress.go.
+func ensureEgressDatapath(vpc string, tableID uint32) error {
 	// node_src_addr_table is a per-node singleton, not per-VPC: usid_egress
 	// fails open (TC_ACT_UNSPEC, uncounted) on every encapsulation attempt
 	// until some caller sets it, and internal/cnibgp's own registration
@@ -320,6 +326,16 @@ func ensureEgressDatapath(tableID uint32) error {
 	peerLink, err := ensureEgressVeth(vrfLink, inner, peer)
 	if err != nil {
 		return fmt.Errorf("ensure egress veth for VRF table %d: %w", tableID, err)
+	}
+
+	// Assigns this VPC's own return-path gateway address (if configured,
+	// see SetGatewayAddressAssignment) to inner -- the same VRF-slave veth
+	// just enslaved above. Non-fatal on failure, same stance as
+	// ensureNodeSourceAddress just above: a still-missing gateway address
+	// degrades the return path (or, unconfigured, is simply a no-op), it
+	// does not make the forward path this function exists for any worse.
+	if err := ensureGatewayAddress(vpc, inner); err != nil {
+		slog.Warn("ensureEgressDatapath: could not assign this VPC's own gateway address", "vpc", vpc, "err", err)
 	}
 
 	registry, closer, err := usidmap.OpenPinnedRegistry(ebpfPinDir)

--- a/internal/ingresssidecar/ebpfdatapath_integration_test.go
+++ b/internal/ingresssidecar/ebpfdatapath_integration_test.go
@@ -178,7 +178,7 @@ func TestEnsureEgressDatapath_AttachesToVethPeerNotVRF(t *testing.T) {
 			return fmt.Errorf("set VRF up: %w", err)
 		}
 
-		if err := ensureEgressDatapath(tableID); err != nil {
+		if err := ensureEgressDatapath("testvpc", tableID); err != nil {
 			return fmt.Errorf("ensureEgressDatapath: %w", err)
 		}
 

--- a/internal/ingresssidecar/gatewayaddress.go
+++ b/internal/ingresssidecar/gatewayaddress.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/intf"
+)
+
+// gatewayAssignmentMu guards gatewayPrefix/gatewayNodeID -- the same
+// package-level-var-as-configuration-seam pattern internal/plumbing/srv6's
+// own pinDir and this package's own ebpfPinDir already use, chosen over
+// threading a new parameter through Backend/kernelBackend's existing
+// signatures (see SetGatewayAddressAssignment's own doc comment for why).
+var (
+	gatewayAssignmentMu sync.Mutex
+	gatewayPrefix       *net.IPNet
+	gatewayNodeID       string
+)
+
+// SetGatewayAddressAssignment enables ensureEgressDatapath to assign this
+// node's own deterministic return-path gateway address (see
+// DeriveGatewayAddress) to the VRF-slave veth it already creates for
+// usid_egress, for every VPC this sidecar subsequently reconciles a VRF
+// for. nodeID must be stable and unique per node (cmd/galactic-vrf passes
+// its own cfg.NodeName, the same identity GatewayPublisher already
+// attributes its BGPAdvertisements to) -- see DeriveGatewayAddress's own
+// doc comment for why an empty or shared nodeID would make every replica
+// of this sidecar collide on the identical address for a given VPC.
+//
+// prefix == nil (the default, never called) leaves address assignment
+// disabled entirely: ensureEgressDatapath's own call site no-ops, and
+// NetlinkGatewayAddressResolver keeps returning
+// ErrGatewayAddressNotProvisioned exactly as it does today -- this is
+// purely additive to the existing opt-in GatewayPublisher wiring, not a
+// replacement for it; both must be configured for the return path to
+// actually work end to end.
+//
+// A package-level setter rather than a new Backend/kernelBackend
+// constructor parameter: ensureEgressDatapath(vpc, tableID) is an
+// unexported function called from exactly one production site
+// (kernelBackend.EnsureVRF) with no vpc-scoped Backend state to carry this
+// through today, and adding a stateful field to kernelBackend (currently
+// the empty struct{} NewKernelBackend returns) to thread one optional,
+// process-wide value through every EnsureVRF call is more invasive than
+// this seam, for a value that is genuinely process-global (one node, one
+// prefix, one identity) exactly like ebpfPinDir already is.
+func SetGatewayAddressAssignment(prefix *net.IPNet, nodeID string) {
+	gatewayAssignmentMu.Lock()
+	defer gatewayAssignmentMu.Unlock()
+	gatewayPrefix = prefix
+	gatewayNodeID = nodeID
+}
+
+// gatewayAddressAssignment returns the currently configured prefix/nodeID
+// pair -- prefix == nil means disabled. Callers must not mutate the
+// returned *net.IPNet.
+func gatewayAddressAssignment() (*net.IPNet, string) {
+	gatewayAssignmentMu.Lock()
+	defer gatewayAssignmentMu.Unlock()
+	return gatewayPrefix, gatewayNodeID
+}
+
+// DeriveGatewayAddress deterministically computes this node's own
+// return-path gateway address for vpc inside prefix, a reserved,
+// byte-aligned IPv6 CIDR that is disjoint by construction from any tenant
+// address space -- see internal/config.VRFConfig's GatewayPrefix doc
+// comment for why it must never be carved out of, or derived from, a real
+// tenant VPC's own subnet: that space is allocated by a system this repo
+// has no visibility into (confirmed live: a real tenant address's own bit
+// layout does not match this repo's own internal/cni/ipam allocator), so
+// the only structural collision-safety guarantee available here is a
+// prefix that no tenant IPAM -- this repo's own or the external one --
+// is ever handed as a pool to allocate from in the first place.
+//
+// The host bits (everything after prefix's own mask) are filled from
+// sha256(vpcHex + "|" + nodeID), truncated to fit -- collision-safe against
+// another VPC's own derived address, or another node's own address for the
+// same VPC, with overwhelming probability for any realistic (vpc, nodeID)
+// cardinality (a birthday bound over the mask's own free bit width), not
+// deterministically unique the way galactic-ipam's on-disk-marker
+// allocator is. That's an acceptable tradeoff here specifically because
+// nothing else ever contends for a specific value the way a live IPAM
+// allocation call does -- there is no "already claimed by someone else"
+// state to race against, only two independent hashes landing on the same
+// bytes.
+//
+// vpc is base62-encoded (the same form crdnames/gateway.go's own
+// vpcRouteTarget already takes); nodeID is any caller-stable per-node
+// identity string (SetGatewayAddressAssignment's own doc comment).
+func DeriveGatewayAddress(prefix *net.IPNet, vpc, nodeID string) (net.IP, error) {
+	vpcHex, err := intf.Base62ToHex(vpc)
+	if err != nil {
+		return nil, fmt.Errorf("convert vpc %q to hex: %w", vpc, err)
+	}
+	if prefix == nil {
+		return nil, errors.New("gateway prefix is nil")
+	}
+	ones, bits := prefix.Mask.Size()
+	if bits != net.IPv6len*8 {
+		return nil, fmt.Errorf("gateway prefix %s is not an IPv6 prefix", prefix)
+	}
+	if ones%8 != 0 {
+		return nil, fmt.Errorf("gateway prefix %s must be byte-aligned (a multiple of /8)", prefix)
+	}
+	networkBytes := ones / 8
+	hostBytes := net.IPv6len - networkBytes
+	if hostBytes == 0 {
+		return nil, fmt.Errorf("gateway prefix %s leaves no host bits to derive an address into", prefix)
+	}
+
+	base := prefix.IP.To16()
+	if base == nil {
+		return nil, fmt.Errorf("gateway prefix %s has no valid IPv6 network address", prefix)
+	}
+
+	sum := sha256.Sum256([]byte(vpcHex + "|" + nodeID))
+	addr := make(net.IP, net.IPv6len)
+	copy(addr, base[:networkBytes])
+	copy(addr[networkBytes:], sum[:hostBytes])
+	return addr, nil
+}
+
+// ensureGatewayAddress assigns this node's derived gateway address for vpc
+// (DeriveGatewayAddress) to the named interface -- ensureEgressDatapath's
+// own VRF-slave veth (ensureEgressVeth's inner end), already enslaved into
+// vpc's VRF for usid_egress's own attachment. Doing so is what lets
+// NetlinkGatewayAddressResolver (gateway.go) find a global-scope address
+// there with no further wiring: it already scans every interface enslaved
+// to a VPC's VRF for exactly this.
+//
+// No-ops (returns nil) when address assignment isn't configured
+// (SetGatewayAddressAssignment never called) -- callers must treat that
+// identically to success, matching ensureNodeSourceAddress's own
+// non-fatal-on-not-yet-available stance just above it in
+// ensureEgressDatapath.
+func ensureGatewayAddress(vpc, inner string) error {
+	prefix, nodeID := gatewayAddressAssignment()
+	if prefix == nil {
+		return nil
+	}
+
+	addr, err := DeriveGatewayAddress(prefix, vpc, nodeID)
+	if err != nil {
+		return fmt.Errorf("derive gateway address for vpc %s: %w", vpc, err)
+	}
+
+	link, err := netlink.LinkByName(inner)
+	if err != nil {
+		return fmt.Errorf("look up %q: %w", inner, err)
+	}
+
+	// /128, matching exactly what GatewayPublisher.PublishGateway
+	// advertises (gateway.go's own addr.String()+"/128") -- a host route,
+	// not a claim on prefix's own subnet as a whole.
+	nladdr := &netlink.Addr{IPNet: &net.IPNet{IP: addr, Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8)}}
+	if err := netlink.AddrReplace(link, nladdr); err != nil {
+		return fmt.Errorf("assign gateway address %s to %q: %w", addr, inner, err)
+	}
+	return nil
+}

--- a/internal/ingresssidecar/gatewayaddress_test.go
+++ b/internal/ingresssidecar/gatewayaddress_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ingresssidecar
+
+import (
+	"net"
+	"testing"
+)
+
+func mustParseCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, network, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("net.ParseCIDR(%q): %v", s, err)
+	}
+	return network
+}
+
+func TestDeriveGatewayAddress_Deterministic(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/48")
+
+	got1, err := DeriveGatewayAddress(prefix, "2", "worker-1")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress: %v", err)
+	}
+	got2, err := DeriveGatewayAddress(prefix, "2", "worker-1")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress (second call): %v", err)
+	}
+	if !got1.Equal(got2) {
+		t.Errorf("DeriveGatewayAddress is not deterministic: %v != %v", got1, got2)
+	}
+}
+
+func TestDeriveGatewayAddress_WithinPrefix(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/48")
+	addr, err := DeriveGatewayAddress(prefix, "2", "worker-1")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress: %v", err)
+	}
+	if !prefix.Contains(addr) {
+		t.Errorf("derived address %v is not contained in prefix %v", addr, prefix)
+	}
+}
+
+func TestDeriveGatewayAddress_DiffersByVPCAndNode(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/48")
+
+	base, err := DeriveGatewayAddress(prefix, "2", "worker-1")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress: %v", err)
+	}
+
+	otherVPC, err := DeriveGatewayAddress(prefix, "70", "worker-1")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress (other vpc): %v", err)
+	}
+	if base.Equal(otherVPC) {
+		t.Error("different VPCs derived the same gateway address")
+	}
+
+	otherNode, err := DeriveGatewayAddress(prefix, "2", "worker-2")
+	if err != nil {
+		t.Fatalf("DeriveGatewayAddress (other node): %v", err)
+	}
+	if base.Equal(otherNode) {
+		t.Error("different nodes derived the same gateway address for the same VPC")
+	}
+}
+
+func TestDeriveGatewayAddress_RejectsNonByteAlignedPrefix(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/50") // not a multiple of 8
+	if _, err := DeriveGatewayAddress(prefix, "2", "worker-1"); err == nil {
+		t.Fatal("expected an error for a non-byte-aligned prefix, got nil")
+	}
+}
+
+func TestDeriveGatewayAddress_RejectsIPv4Prefix(t *testing.T) {
+	_, v4prefix, err := net.ParseCIDR("10.0.0.0/24")
+	if err != nil {
+		t.Fatalf("net.ParseCIDR: %v", err)
+	}
+	if _, err := DeriveGatewayAddress(v4prefix, "2", "worker-1"); err == nil {
+		t.Fatal("expected an error for an IPv4 prefix, got nil")
+	}
+}
+
+func TestDeriveGatewayAddress_RejectsHostPrefix(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::1/128") // no host bits left
+	if _, err := DeriveGatewayAddress(prefix, "2", "worker-1"); err == nil {
+		t.Fatal("expected an error for a /128 prefix (no host bits), got nil")
+	}
+}
+
+func TestDeriveGatewayAddress_RejectsInvalidVPC(t *testing.T) {
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/48")
+	if _, err := DeriveGatewayAddress(prefix, "!!!", "worker-1"); err == nil {
+		t.Fatal("expected an error for a non-base62 vpc, got nil")
+	}
+}
+
+func TestDeriveGatewayAddress_RejectsNilPrefix(t *testing.T) {
+	if _, err := DeriveGatewayAddress(nil, "2", "worker-1"); err == nil {
+		t.Fatal("expected an error for a nil prefix, got nil")
+	}
+}
+
+func TestGatewayAddressAssignment_DefaultDisabled(t *testing.T) {
+	prefix, nodeID := gatewayAddressAssignment()
+	if prefix != nil {
+		t.Errorf("gatewayAddressAssignment() prefix = %v, want nil by default", prefix)
+	}
+	if nodeID != "" {
+		t.Errorf("gatewayAddressAssignment() nodeID = %q, want empty by default", nodeID)
+	}
+}
+
+func TestSetGatewayAddressAssignment_RoundTrips(t *testing.T) {
+	t.Cleanup(func() { SetGatewayAddressAssignment(nil, "") })
+
+	prefix := mustParseCIDR(t, "fd00:6741:7761::/48")
+	SetGatewayAddressAssignment(prefix, "worker-1")
+
+	gotPrefix, gotNodeID := gatewayAddressAssignment()
+	if gotPrefix.String() != prefix.String() {
+		t.Errorf("gatewayAddressAssignment() prefix = %v, want %v", gotPrefix, prefix)
+	}
+	if gotNodeID != "worker-1" {
+		t.Errorf("gatewayAddressAssignment() nodeID = %q, want worker-1", gotNodeID)
+	}
+
+	SetGatewayAddressAssignment(nil, "")
+	gotPrefix, gotNodeID = gatewayAddressAssignment()
+	if gotPrefix != nil || gotNodeID != "" {
+		t.Errorf("gatewayAddressAssignment() after reset = (%v, %q), want (nil, \"\")", gotPrefix, gotNodeID)
+	}
+}
+
+// TestEnsureGatewayAddress_NoopWhenDisabled verifies ensureGatewayAddress
+// doesn't attempt any netlink call at all (which would fail without
+// CAP_NET_ADMIN / a real interface) when address assignment isn't
+// configured -- the default state, and the only path exercised outside a
+// root-gated integration test.
+func TestEnsureGatewayAddress_NoopWhenDisabled(t *testing.T) {
+	t.Cleanup(func() { SetGatewayAddressAssignment(nil, "") })
+	SetGatewayAddressAssignment(nil, "")
+
+	if err := ensureGatewayAddress("2", "does-not-exist"); err != nil {
+		t.Errorf("ensureGatewayAddress with assignment disabled: %v, want nil (no-op)", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the root cause of the return-path gap [#492](https://github.com/datum-cloud/galactic/pull/492) left open. Nothing gave the ingress sidecar a real address of its own inside a VPC. Its outbound connections fell back to a link-local source, and `PublishGateway` had nothing to find.

## What changed from the original plan

The design doc left an open question: does address provisioning need a slot inside the tenant's own subnet, or something else? I investigated the tenant-subnet-slot option and ruled it out.

A real tenant VPC's address space is allocated by a system outside this repo. Confirmed live: a real tenant address's own bit layout doesn't match this repo's own `internal/cni/ipam` allocator. There is no range inside that space this repo can prove is safe to carve out.

BGP import into a VPC's VRF is driven by Route Target community, computed from the VPC id, never by whether an advertised prefix's address value falls inside any particular subnet. A gateway address never needs to be a member of the tenant's own pool. It only needs to be globally unique and correctly advertised.

## Implementation

- `DeriveGatewayAddress(prefix, vpc, nodeID)`: a deterministic address inside a reserved, byte-aligned IPv6 prefix that's disjoint by construction from tenant space, never disjoint by avoidance within it. Host bits filled from `sha256(vpcHex + "|" + nodeID)`.
- `ensureGatewayAddress`, called from `ensureEgressDatapath` right after `ensureEgressVeth`: assigns the derived address to the same VRF-slave veth (`ivsN`) that function already creates for `usid_egress`'s own attachment. `NetlinkGatewayAddressResolver` (unchanged) finds it with no further wiring, and normal IPv6 source-address selection picks it up for the forward path too — this also closes a second symptom found live: with no global address anywhere in the VRF, the kernel fell back to a link-local source for Envoy's own outbound connections into the VPC.
- `internal/config.VRFConfig.GatewayPrefix` / `GALACTIC_VRF_GATEWAY_PREFIX`: opt-in on a second, independent env var, only takes effect when `NodeName` is also set. No compiled-in default. Which reserved prefix to use is a real platform-addressing decision for whoever owns this deployment's IPAM plan, not something to pick silently in code.

## Backward compatibility

Every deployment today has neither `NodeName` nor `GatewayPrefix` set, so this is fully inert until both are explicitly configured.

## Testing

- `go build ./...`, `go vet ./...`, `go test $(go list ./... | grep -v /tests/e2e)`, `golangci-lint run` all clean.
- New tests: `internal/ingresssidecar/gatewayaddress_test.go` (deterministic derivation, differs by VPC/node, byte-alignment/IPv6/host-bits/vpc validation, disabled-by-default no-op) and `internal/config/vrf_test.go` additions (prefix validation, env override).
