### PR TITLE
chore: Remove OnDelete strategy from router DaemonSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,27 +63,9 @@ kubectl apply -k config/galactic-gateway/
 
 - **`config/fabric-router/`: per-node `frr.conf`.** Unlike every other component under `config/`, `config/fabric-router/daemonset.yaml` has no generic default config — the underlay eBGP session (interface addresses, remote-AS, etc.) is different for every physical node, and this DaemonSet's `nodeAffinity` (`galactic.datumapis.com/fabric: router`) can legitimately match more than one node per cluster. Before applying `config/fabric-router/`, create a `fabric-config` ConfigMap in the `galactic-system` namespace with one `frr.conf.<nodename>` key per matching node (`<nodename>` is the Kubernetes node name, e.g. `frr.conf.worker-1`) — `frr-init` picks the right key at pod start via the pod's `NODE_NAME` downward-API env var. The other two files FRR needs, `daemons` and `vtysh.conf`, are already baked into the `fabric-router` image (see `containers/fabric-router/Dockerfile`); include them in the ConfigMap too only if you need to override the image defaults. `deploy/containerlab/resources/fabric/{dfw,iad,sjc}/frr.conf` are worked examples from the lab, not something you can apply as-is.
 
-- **`config/fabric-router/` and `config/galactic-router/`: rolling out updates is manual.** Both `config/fabric-router/daemonset.yaml` and `config/galactic-router/base/daemonset.yaml` use `updateStrategy: OnDelete` — a `kubectl apply` (new image tag, or a spec change) will not restart any pod on its own. This is deliberate for both: each is a BGP speaker whose liveness/health probe only reflects "the process is up," not "the BGP session has reconverged," so `RollingUpdate` would advance to the next node on exactly the wrong signal — see the comment above `updateStrategy` in each manifest for the full reasoning. To actually roll out a change, delete pods one at a time and confirm the new pod's session(s) have reconverged before moving to the next node, e.g. for `fabric-router`:
+- **`config/fabric-router/` and `config/galactic-router/`: rollouts are now automatic (`RollingUpdate`).** Both `config/fabric-router/daemonset.yaml` and `config/galactic-router/base/daemonset.yaml` use the DaemonSet default `updateStrategy` (`RollingUpdate`) rather than `OnDelete`, so a `kubectl apply` (new image tag, or a spec change) will restart pods on its own, one node at a time, gated only by each pod's liveness/health probe — which reflects "the process is up," not "the BGP session has reconverged." Watch session state after any rollout rather than assuming the controller's pacing was safe: for `fabric-router`, `vtysh -c "show bgp summary"` on the new pod; for `galactic-router`, the `BGPPeer` CRD's `STATE` column (`kubectl get bgppeer`) — there's no `vtysh` in that binary, it reports session state itself. For `galactic-router-rr`, every compute node's iBGP session pivots through that one pod, so its rollout is a fleet-wide route flap, not a single-node one; confirm every client has re-peered before considering it done.
 
-  ```bash
-  kubectl -n galactic-system get pods -l app.kubernetes.io/name=fabric-router -o wide
-  kubectl -n galactic-system delete pod <fabric-router-pod-on-one-node>
-  # wait for the new pod to be Ready, then confirm on that node:
-  kubectl -n galactic-system exec <new-pod> -- vtysh -c "show bgp summary"
-  # repeat for the next node only once the above shows the session Established
-  ```
-
-  A ConfigMap edit to `fabric-config` behaves the same way today regardless of `updateStrategy` — there's no checksum annotation wiring pod restarts to ConfigMap changes, so a config change also requires this same manual, node-by-node pod bounce to take effect.
-
-- **`config/galactic-router/`: rollout order — `rr` last, one compute node at a time.** For `rr`, every compute node's iBGP session pivots through that one pod, so bouncing it is a fleet-wide route flap, not a single-node one — roll it only after all compute nodes are already on the new version, and confirm every client has re-peered before considering the rollout done. For the default role, a bounce only withdraws that one node's own advertised prefixes, so it's safe to go node-by-node as with `fabric-router`. Check session state via the `BGPPeer` CRD's `STATE` column rather than `vtysh` (there's no `vtysh` in this binary — `galactic-router` reports session state itself):
-
-  ```bash
-  kubectl -n galactic-system get pods -l app.kubernetes.io/name=galactic-router -o wide
-  kubectl -n galactic-system delete pod <galactic-router-pod-on-one-node>
-  # wait for the new pod to be Ready, then confirm its BGPPeer CRDs are back to STATE=Established
-  kubectl get bgppeer
-  # repeat for the next compute node, then only last roll galactic-router-rr the same way
-  ```
+  A ConfigMap edit to `fabric-config` still does not trigger a rollout — there's no checksum annotation wiring pod restarts to ConfigMap changes — so a config-only change still requires a manual, node-by-node pod bounce to take effect.
 
 - **`config/galactic-gateway/`: per-node public interface and SRv6 address.** `config/galactic-gateway/base/daemonset.yaml`'s `galactic-gateway` container requires `GALACTIC_GATEWAY_PUBLIC_INTERFACE` and `GALACTIC_GATEWAY_SRV6_ADDRESS` — the latter must be unique per gateway node and has no generic default (there's no in-cluster mechanism yet that derives it automatically; see `publishSelfAddress`'s doc comment in `internal/controller/networkgateway_controller.go`). Applying `base/` as shipped, without pinning both per node, produces a crash-looping container. Instantiate `base/` via a further overlay that pins it to one node (`kubernetes.io/hostname`) and sets that node's values — see `deploy/containerlab/resources/galactic-gateway/` for a worked two-node example.
 

--- a/config/fabric-router/daemonset.yaml
+++ b/config/fabric-router/daemonset.yaml
@@ -9,27 +9,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: fabric-router
-  # Unlike every other DaemonSet in config/ (galactic-cni, galactic-router,
-  # galactic-gateway), this one owns the eBGP session to the
-  # physical fabric switch, not an in-cluster control-plane relationship.
-  # Bouncing FRR here drops the node's only underlay path, so every overlay
-  # SRv6/EVPN path riding on it blackholes until the eBGP session
-  # re-establishes and reconverges -- and galactic-router-rr/
-  # galactic-gateway crash-loop per the toleration comment below if it
-  # doesn't come back. The startupProbe/livenessProbe below only check that
-  # zebra/bgpd answer vtysh (the daemon is alive), not that the eBGP
-  # session to the fabric peer has reconverged, so a RollingUpdate would
-  # let the DaemonSet controller advance to the next node on that same
-  # shallow signal -- too early for a component this foundational.
-  # OnDelete puts pod recreation under explicit control (a human or a
-  # future automated rollout runbook, one node at a time, verifying
-  # reconvergence in between) instead of the controller auto-advancing.
-  # This also matches how fabric-config changes already work today: there's
-  # no checksum annotation on the pod template, so editing the fabric-config
-  # ConfigMap doesn't trigger a rollout either -- both config and image
-  # updates require a deliberate pod bounce.
-  updateStrategy:
-    type: OnDelete
   template:
     metadata:
       labels:

--- a/config/galactic-router/base/daemonset.yaml
+++ b/config/galactic-router/base/daemonset.yaml
@@ -9,19 +9,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: galactic-router
-  # Like config/fabric-router/daemonset.yaml, this is a BGP speaker whose
-  # gRPC health probe (below) only reflects "the process is up" --
-  # cmd/galactic-router/root.go sets SERVING unconditionally right after
-  # the server starts, never tied to iBGP session/route state -- so
-  # RollingUpdate would advance to the next node on exactly the wrong
-  # signal. A restart implicitly withdraws routes (no BGP graceful restart
-  # support in internal/runtime/gobgp), and for the rr role every compute
-  # node's iBGP session pivots through this one pod, so an automatic
-  # rollout there is a fleet-wide route flap, not a single-node one --
-  # worse than fabric-router's per-node blast radius. OnDelete puts pod
-  # recreation under explicit, node-by-node control instead.
-  updateStrategy:
-    type: OnDelete
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary

Both router DaemonSets used a manual `OnDelete` update strategy, so applying a new image or spec change never restarted a pod on its own — rolling out required deleting pods one at a time by hand and checking BGP reconvergence in between. That strategy override is removed, so both DaemonSets fall back to the default rolling update. The README's rollout guidance is updated to match, and still calls out the cases where automatic rollout isn't the whole story: a config-only change still needs a manual bounce, and the route-reflector role is a fleet-wide event rather than a per-node one.

## Test plan

- [ ] `kubectl apply -k config/` rolls pods automatically on a spec/image change instead of leaving them untouched
