### PR TITLE
fix(gateway): attach XDP to bond slaves, never the bonding master

### DIFF
--- a/cmd/galactic-gateway/gateway.go
+++ b/cmd/galactic-gateway/gateway.go
@@ -18,12 +18,14 @@ import (
 	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
-// gatewayDatapathKeepAlive holds the loaded *edgeprog.EdgedsrObjects and the
-// attached link.Link for the life of this process, once
-// setupGatewayDatapath's attach path succeeds. Neither is Closed anywhere
-// in this file — see setupGatewayDatapath's doc comment for why — but a
-// value that isn't stored somewhere reachable is exactly as good as
-// Closed: cilium/ebpf's *ebpf.Program, *ebpf.Map, and link.Link types all
+// gatewayDatapathKeepAlive holds the loaded *edgeprog.EdgedsrObjects and
+// every attached link.Link (one per public-interface XDP attach target --
+// see setupGatewayDatapath's doc comment on why there can be more than one)
+// for the life of this process, once setupGatewayDatapath's attach path
+// succeeds. Neither is Closed anywhere in this file — see
+// setupGatewayDatapath's doc comment for why — but a value that isn't
+// stored somewhere reachable is exactly as good as Closed: cilium/ebpf's
+// *ebpf.Program, *ebpf.Map, and link.Link types all
 // register a runtime finalizer that closes their underlying fd once the
 // garbage collector determines nothing reachable still points at them,
 // with no error surfaced anywhere when that happens. gateway.KernelDatapath
@@ -47,8 +49,8 @@ import (
 // lives in its own process rather than sharing one with the tenant BGP
 // reconcilers.
 var gatewayDatapathKeepAlive struct {
-	objs *edgeprog.EdgedsrObjects
-	link link.Link
+	objs  *edgeprog.EdgedsrObjects
+	links []link.Link
 }
 
 // setupGatewayDatapath loads and attaches the edge Maglev/DSR eBPF datapath
@@ -60,7 +62,14 @@ var gatewayDatapathKeepAlive struct {
 // rejects either being empty before runCmd ever calls this function, since
 // this binary only exists to run the gateway role.
 //
-// The loaded *edgeprog.EdgedsrObjects and the returned link.Link are
+// publicInterface is usually attached to directly, but if it names a Linux
+// bonding master, edgeattach.ResolveTargets expands it to that bond's slave
+// interfaces instead (native-mode XDP cannot attach to a bonding master at
+// all) -- so this may end up loading and attaching to more than one
+// interface. Every resulting sysctl configuration and XDP attachment
+// targets the same resolved set, not publicInterface itself in that case.
+//
+// The loaded *edgeprog.EdgedsrObjects and every returned link.Link are
 // stashed in gatewayDatapathKeepAlive (see that var's doc comment for why)
 // rather than Closed here: they, and the XDP attachment itself, must
 // survive for the life of this process — same convention as
@@ -84,15 +93,27 @@ func setupGatewayDatapath(
 		return nil, fmt.Errorf("parse gateway SRv6 address %q: %w", srv6Address, err)
 	}
 
+	targets, err := edgeattach.ResolveTargets(publicInterface)
+	if err != nil {
+		return nil, fmt.Errorf("resolve edge gateway public interface %q: %w", publicInterface, err)
+	}
+
 	// Required for bpf_fib_lookup() (edgedsr.c's push_outer_header) to
-	// ever succeed on this interface -- see
-	// ConfigureFIBLookupUplinkSysctls's own doc comment for why (a real,
-	// previously-undiagnosed blocker, not a hypothetical one). Best-effort/
-	// non-fatal, matching this package's own established
+	// ever succeed on the interface the XDP program actually runs on --
+	// see ConfigureFIBLookupUplinkSysctls's own doc comment for why (a
+	// real, previously-undiagnosed blocker, not a hypothetical one).
+	// edgedsr.c looks up ctx->ingress_ifindex, i.e. whichever interface in
+	// targets the packet actually arrived on, so this must be applied to
+	// every resolved target, not publicInterface itself -- once
+	// publicInterface names a bond, its slaves (not the bond master) are
+	// what the kernel actually reports as the ingress interface. Best-
+	// effort/non-fatal, matching this package's own established
 	// sysctl-configuration convention (internal/cni already calls
 	// ConfigureInterfaceSysctls the same way for VRF interfaces).
-	if err := sysctl.ConfigureFIBLookupUplinkSysctls(publicInterface); err != nil {
-		return nil, fmt.Errorf("configure IPv6 forwarding on public interface %q: %w", publicInterface, err)
+	for _, target := range targets {
+		if err := sysctl.ConfigureFIBLookupUplinkSysctls(target); err != nil {
+			return nil, fmt.Errorf("configure IPv6 forwarding on public interface %q: %w", target, err)
+		}
 	}
 
 	objs, err := edgeattach.Load(edgeattach.PinDir)
@@ -100,7 +121,7 @@ func setupGatewayDatapath(
 		return nil, fmt.Errorf("load edge gateway eBPF datapath: %w", err)
 	}
 
-	xdpLink, err := edgeattach.Attach(objs.EdgeLb, publicInterface)
+	xdpLinks, err := edgeattach.Attach(objs.EdgeLb, targets)
 	if err != nil {
 		_ = objs.Close()
 		return nil, fmt.Errorf("attach edge gateway datapath to public interface %q: %w", publicInterface, err)
@@ -108,19 +129,28 @@ func setupGatewayDatapath(
 
 	datapath, err := gateway.NewKernelDatapath(objs, encapSrc)
 	if err != nil {
-		_ = xdpLink.Close()
+		closeAll(xdpLinks)
 		_ = objs.Close()
 		return nil, fmt.Errorf("construct kernel datapath: %w", err)
 	}
 
 	if err := metricsReg.Register(edgemetrics.NewCollectorFromObjects(objs)); err != nil {
-		_ = xdpLink.Close()
+		closeAll(xdpLinks)
 		_ = objs.Close()
 		return nil, fmt.Errorf("register edge gateway metrics collector: %w", err)
 	}
 
 	gatewayDatapathKeepAlive.objs = objs
-	gatewayDatapathKeepAlive.link = xdpLink
+	gatewayDatapathKeepAlive.links = xdpLinks
 
 	return datapath, nil
+}
+
+// closeAll best-effort Closes every link in links, e.g. to unwind a
+// partially-set-up datapath after edgeattach.Attach already succeeded but a
+// later setupGatewayDatapath step failed.
+func closeAll(links []link.Link) {
+	for _, l := range links {
+		_ = l.Close()
+	}
 }

--- a/docs/agents/ARCHITECTURE-GATEWAY.md
+++ b/docs/agents/ARCHITECTURE-GATEWAY.md
@@ -342,25 +342,35 @@ to resolve backend uSIDs).
 
 ### `cmd/galactic-gateway/gateway.go` — datapath setup
 
-`setupGatewayDatapath` first calls
-`sysctl.ConfigureFIBLookupUplinkSysctls(publicInterface)` — required for
-`bpf_fib_lookup()` (`edgedsr.c`'s `push_outer_header`) to ever succeed on
-this interface: without it the kernel returns
-`BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup, correctly refusing to
-resolve a forwarding route on an interface not configured as a router. This
-was found via live-kernel investigation of a pre-existing containerlab
-veth/XDP_TX blocker — the sysctl gap, not `XDP_TX` itself, was what
-actually prevented every gateway node's `bpf_fib_lookup` from ever
-succeeding in that lab (see [Known Constraints](#known-constraints) below
-for the related, lab-only `XDP_TX` observability quirk this investigation
-also turned up). It then loads `edgeprog.EdgedsrObjects`
-(`edgeattach.Load`), attaches it to `PublicInterface`
-(`edgeattach.Attach` — native XDP driver mode only, no generic/SKB-mode
-fallback), and constructs a `gateway.KernelDatapath` over it, writing this
-node's SRv6 encap-source address into `encap_config_table` once at
-construction time.
+`setupGatewayDatapath` first resolves `PublicInterface` via
+`edgeattach.ResolveTargets`: usually that's just `[PublicInterface]`
+unchanged, but if `PublicInterface` names a Linux bonding master, it
+resolves to that bond's slave interfaces instead — native-mode XDP against
+a bonding master is not reliable (see [Known Constraints](#known-constraints)
+below for the confirmed failure and why it isn't simply "bonding never
+implements `ndo_bpf`"), unlike `internal/plumbing/ebpf/attach`'s TC-BPF
+path, which attaches to both the master and its slaves (see
+[ARCHITECTURE-CNI.md](ARCHITECTURE-CNI.md) for that side). It then calls
+`sysctl.ConfigureFIBLookupUplinkSysctls` once per resolved target —
+required for `bpf_fib_lookup()` (`edgedsr.c`'s `push_outer_header`) to
+ever succeed on the interface the XDP program actually runs on: without it
+the kernel returns `BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup,
+correctly refusing to resolve a forwarding route on an interface not
+configured as a router. This was found via live-kernel investigation of a
+pre-existing containerlab veth/XDP_TX blocker — the sysctl gap, not
+`XDP_TX` itself, was what actually prevented every gateway node's
+`bpf_fib_lookup` from ever succeeding in that lab (see
+[Known Constraints](#known-constraints) below for the related, lab-only
+`XDP_TX` observability quirk this investigation also turned up, and for
+why the sysctl targets the resolved bond slave rather than
+`PublicInterface` itself when the two differ). It then loads
+`edgeprog.EdgedsrObjects` (`edgeattach.Load`), attaches it to every
+resolved target (`edgeattach.Attach` — native XDP driver mode only, no
+generic/SKB-mode fallback, one `link.Link` per target), and constructs a
+`gateway.KernelDatapath` over it, writing this node's SRv6 encap-source
+address into `encap_config_table` once at construction time.
 
-The loaded objects and the returned `link.Link` are stashed in a
+The loaded objects and every returned `link.Link` are stashed in a
 package-level `gatewayDatapathKeepAlive` var rather than ever being
 `Close`d — see that var's doc comment for a concrete, previously-live
 incident: `cilium/ebpf`'s program/map/link types register a runtime
@@ -380,7 +390,7 @@ normal while ingress traffic quietly stopped being intercepted at all.
 | Variable                            | Required | Default | Description                                                                                                                                        |
 | ----------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GALACTIC_GATEWAY_NODE_NAME`        | Yes      | —       | Kubernetes node name                                                                                                                                |
-| `GALACTIC_GATEWAY_PUBLIC_INTERFACE` | Yes      | —       | Public/underlay-facing uplink interface the XDP program attaches to                                                                                 |
+| `GALACTIC_GATEWAY_PUBLIC_INTERFACE` | Yes      | —       | Public/underlay-facing uplink interface the XDP program attaches to. May name a Linux bonding master (`edgeattach.ResolveTargets` expands it to that bond's slaves — see [Known Constraints](#known-constraints)) |
 | `GALACTIC_GATEWAY_SRV6_ADDRESS`     | Yes      | —       | This node's own plain SRv6-reachable IPv6 address, used as the DSR outer-header encap source (`encap_config_table`) — never a NAT/SNAT source and never compared against anything on a receive path; must be a native IPv6 address (rejected if IPv4 or 4-in-6) |
 | `GALACTIC_GATEWAY_METRICS_PORT`     | No       | `8081`  | Prometheus metrics port                                                                                                                             |
 | `GALACTIC_GATEWAY_GRPC_HEALTH_PORT` | No       | `5181`  | gRPC health check port                                                                                                                              |
@@ -613,9 +623,9 @@ not a supported configuration).
 
 | Layer           | Command                               | Framework                       | Scope                                                                                                                                                                                                                                                                                                                                    |
 | --------------- | -------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unit            | `task test:unit`                      | `go test -race`                 | `internal/config` (`gateway_test.go`), `internal/controller` (`networkgateway_controller_test.go`, `networkrule_controller_test.go`, `usidresolver_test.go`), `internal/gateway` (`engine_test.go`, `diff_test.go`, `kerneldatapath_test.go`, `quota_test.go`, `recovery_test.go`, `telemetry_test.go`), `internal/maglev` (`table_test.go`), `internal/plumbing/ebpf/edgemap` (`viptable_test.go`, in-memory fake `Table`, no kernel required), `internal/plumbing/ebpf/edgemetrics` (`collector_test.go`), `internal/plumbing/ebpf/edgepreflight` (`preflight_test.go`, `kernel_prober_test.go`) |
+| Unit            | `task test:unit`                      | `go test -race`                 | `internal/config` (`gateway_test.go`), `internal/controller` (`networkgateway_controller_test.go`, `networkrule_controller_test.go`, `usidresolver_test.go`), `internal/gateway` (`engine_test.go`, `diff_test.go`, `kerneldatapath_test.go`, `quota_test.go`, `recovery_test.go`, `telemetry_test.go`), `internal/maglev` (`table_test.go`), `internal/plumbing/bond` (`bond_test.go`, faked `netlink.Link`s, no kernel required — shared bond-master/slave detection used by both this package's `edgeattach.ResolveTargets` and `internal/plumbing/ebpf/attach`'s CNI TC-BPF path), `internal/plumbing/ebpf/edgemap` (`viptable_test.go`, in-memory fake `Table`, no kernel required), `internal/plumbing/ebpf/edgemetrics` (`collector_test.go`), `internal/plumbing/ebpf/edgepreflight` (`preflight_test.go`, `kernel_prober_test.go`); `edgeattach.ResolveTargets` also has its own faked-netlink `TestResolveTargets` (non-bond passthrough, bond-expands-to-slaves-only, no-slaves error) |
 | Kernel-required | `task test:unit` (root/CAP_BPF gated) | `go test` + `BPF_PROG_TEST_RUN` | `internal/plumbing/ebpf/edgeprog/edgedsr_test.go` — exercises the compiled program directly, including the version-nibble/payload_len regression tests; `internal/plumbing/ebpf/edgeattach/attach_test.go`                                                                                                                                |
-| E2E             | —                                     | —                                | **Not yet covered.** `deploy/containerlab/`'s `iad-gateway1`/`iad-gateway2` nodes are a manifests-and-live-pod canary, not a scripted e2e test — see Known Constraints.                                                                                                                                                                    |
+| E2E             | —                                     | —                                | **Not yet covered.** `deploy/containerlab/`'s `iad-gateway1`/`iad-gateway2` nodes are a manifests-and-live-pod canary, not a scripted e2e test — see Known Constraints. No bonded-uplink scenario exists there either, deliberately: `iad-gateway1`/`iad-gateway2`'s uplinks are veth pairs, and (confirmed while adding `TestResolveTargetsAndAttach_RealBondDevice` above) veth slaves accept a native XDP attach on a real bond master directly on at least some kernels, since veth itself supports native XDP and some kernels' bonding driver forwards the attach through to slaves that do — the opposite of the real igb/tg3 failure this whole feature exists for. A containerlab veth-bond scenario would not exercise the bug it would be built to guard against; the root-gated real-bond-device unit test does, without that false sense of coverage. |
 
 ---
 
@@ -654,6 +664,7 @@ since that base's DaemonSet runs both images in one pod.
 - **`GALACTIC_GATEWAY_SRV6_ADDRESS` has no in-cluster derivation mechanism.** It is operator-supplied per gateway node today; nothing in this repo yet computes it automatically from a node's own `BGPRouter` locator/node-ID. See [SRv6 encap-source address](#srv6-encap-source-address) above.
 - **The uSID TC-BPF/XDP FIB-lookup PMTUD gap applies here too.** When `bpf_fib_lookup()` returns `BPF_FIB_LKUP_RET_FRAG_NEEDED`, `edgedsr.c` counts `DROP_REASON_FIB_FRAG_NEEDED` and drops rather than emitting an ICMPv6 Packet Too Big — the same accepted gap `internal/plumbing/ebpf/prog/usid.c` has for the SRv6 uSID datapath (see [ARCHITECTURE-CNI.md#known-constraints](ARCHITECTURE-CNI.md#known-constraints)), not yet scheduled to be closed on either side.
 - **`bpf_fib_lookup()` requires IPv6 forwarding sysctls on the public uplink, not just XDP driver support.** `setupGatewayDatapath` calls `sysctl.ConfigureFIBLookupUplinkSysctls` before attaching the datapath — without `net.ipv6.conf.<iface>.forwarding` and `net.ipv6.conf.all.forwarding` both set, the kernel returns `BPF_FIB_LKUP_RET_NOT_FWDED` for every lookup regardless of anything this program does, which `edgedsr.c`'s own drop-reason accounting cannot distinguish from a generic FIB lookup failure. Found via live-kernel investigation of a pre-existing containerlab veth/XDP_TX blocker: the sysctl gap, not `XDP_TX` itself, was the actual cause. A related, lab-only characteristic the same investigation turned up: native `XDP_TX` on a veth pair only promotes a frame into the peer's normal receive stack (visible to `tcpdump`) if the peer *also* runs an XDP program — otherwise delivery uses a raw fast-path invisible to normal tools. This does not apply to a real physical NIC uplink in production, where there is no "peer's own XDP program" question to begin with.
+- **A bonded public uplink attaches per-slave, with per-slave FIB-lookup sysctls to match.** Native-mode XDP against a Linux bonding master is not reliable: confirmed failing outright with "operation not supported" on a real gateway node (802.3ad over an igb/tg3 slave pair). Not every kernel's bonding driver categorically lacks `ndo_bpf` — some do implement it by forwarding the attach to every slave — but that still requires each slave's own driver to support native XDP itself, which not every NIC driver does (tg3 is a commonly cited example that doesn't), so this codebase never relies on attaching to the master working, on any kernel. `edgeattach.ResolveTargets` expands a bonding-master `GALACTIC_GATEWAY_PUBLIC_INTERFACE` to its slave interfaces (never the master itself — see `internal/plumbing/bond`, shared with `internal/plumbing/ebpf/attach`'s TC-BPF path, which attaches to the master *and* its slaves instead), and `setupGatewayDatapath` attaches to and configures FIB-lookup sysctls on every one of them. This is not cosmetic: `edgedsr.c`'s `push_outer_header` calls `bpf_fib_lookup()` with `ctx->ingress_ifindex` — confirmed against the source, not assumed — which for a native XDP program attached to a bond slave is that slave's own ifindex, not the bond master's, so `net.ipv6.conf.<slave>.forwarding` (not `net.ipv6.conf.<bond-master>.forwarding`) is what the kernel actually checks. A bonding master with no resolvable slaves is a hard startup error, not a silent fallback to attaching the master (which would only risk repeating the same failure). `edgeattach.Attach` is all-or-nothing across every resolved slave in one call — if any single slave's driver can't accept a native XDP attach (a real possibility per the tg3 note above, not independently confirmed against that node specifically), the whole datapath startup fails rather than running in a degraded, missing-that-slave's-traffic state; this has not been exercised against real igb/tg3 hardware, only veth in tests, so whether all of a real bonded pair's slaves actually accept native XDP on the affected class of hardware is still open. One further accepted tradeoff: attaching per-slave rather than to the bond as a whole means a slave failing over (LACP renegotiation, a link flap) is not automatically picked up — there is no Watch-style re-resolution here, matching the rest of this package's "resolved once at startup" design (see `edgeattach`'s package doc comment).
 - **`vip_table` has no active GC beyond crash-recovery reconcile.** By design (see Key Design Decisions above) — DSR keeps no flow state to leak in the first place, unlike the removed Full-NAT predecessor's `conn_table`, which relied on `BPF_MAP_TYPE_LRU_HASH` self-eviction for the same purpose.
 - **Egress is out of this binary's scope, not unimplemented.** An earlier plan (`docs/plans/865-edge-gateway-nat66-egress.md`) proposed adding a second, egress-masquerading XDP personality to this same program and process; that approach was superseded by a separate, sharded stateful NAT66 tier (`galactic-nat66`, its own binary — see `cmd/galactic-nat66` and `internal/controller/nat66shard_controller.go`) rather than built here. `NetworkRule`/this datapath remain ingress-only: external client → VIP → tenant backend.
 

--- a/internal/plumbing/bond/bond.go
+++ b/internal/plumbing/bond/bond.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package bond holds the pure, netlink-view-agnostic logic for recognizing
+// a Linux bonding master and enumerating its slave interfaces. It exists so
+// internal/plumbing/ebpf/attach (the CNI's TC-BPF ingress path, which
+// attaches to both a bond master and its slaves -- ingress tc/eBPF
+// classification on a bonded interface happens on the slaves, not the
+// master) and internal/plumbing/ebpf/edgeattach (the gateway's XDP path,
+// which must attach to the slaves only -- native-mode XDP cannot attach to
+// a bonding master at all, since bonding doesn't implement ndo_bpf) share
+// one implementation of "is this a bond, and if so what are its slaves"
+// instead of each maintaining its own copy. See
+// internal/plumbing/ebpf/edgeattach.ResolveTargets' own doc comment for the
+// more precise statement of why XDP can't rely on the bond master itself:
+// it isn't simply "bonding never implements ndo_bpf" on every kernel, but
+// attaching to the master is never something this codebase relies on
+// working either way.
+//
+// Each caller keeps its own package-level netlink override vars for
+// testability (matching the existing linkByNameFn/linkListFn pattern in
+// both packages above); this package takes plain netlink.Link/[]netlink.Link
+// values rather than function vars of its own, so it has no test-only
+// indirection to carry.
+package bond
+
+import "github.com/vishvananda/netlink"
+
+// LinkType is the vishvananda/netlink Link.Type() value reported for a
+// Linux bonding master.
+const LinkType = "bond"
+
+// IsMaster reports whether link is a Linux bonding master.
+func IsMaster(link netlink.Link) bool {
+	return link.Type() == LinkType
+}
+
+// SlaveNames returns the names of every link in links enslaved to master
+// (i.e. whose MasterIndex, populated from netlink's IFLA_MASTER attribute,
+// equals master's own index), in whatever order links itself is in. Returns
+// nil if master has no slaves in links.
+func SlaveNames(master netlink.Link, links []netlink.Link) []string {
+	masterIndex := master.Attrs().Index
+	var slaves []string
+	for _, l := range links {
+		if l.Attrs().MasterIndex == masterIndex {
+			slaves = append(slaves, l.Attrs().Name)
+		}
+	}
+	return slaves
+}

--- a/internal/plumbing/bond/bond_test.go
+++ b/internal/plumbing/bond/bond_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package bond
+
+import (
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// fakeLink is a minimal netlink.Link implementation for tests -- mirrors
+// internal/plumbing/ebpf/attach's identical test fixture.
+type fakeLink struct {
+	attrs    netlink.LinkAttrs
+	linkType string
+}
+
+func (f *fakeLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
+func (f *fakeLink) Type() string {
+	if f.linkType == "" {
+		return "fake"
+	}
+	return f.linkType
+}
+
+const testBondName = "bond0"
+
+func TestIsMaster(t *testing.T) {
+	bondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: testBondName}, linkType: LinkType}
+	nonBondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: "eth0"}}
+
+	if !IsMaster(bondLink) {
+		t.Error("IsMaster(bond link) = false, want true")
+	}
+	if IsMaster(nonBondLink) {
+		t.Error("IsMaster(non-bond link) = true, want false")
+	}
+}
+
+func TestSlaveNames(t *testing.T) {
+	const bondIndex = 10
+	master := &fakeLink{attrs: netlink.LinkAttrs{Name: testBondName, Index: bondIndex}, linkType: LinkType}
+
+	links := []netlink.Link{
+		master,
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "slave1", Index: 11, MasterIndex: bondIndex}},
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "slave2", Index: 12, MasterIndex: bondIndex}},
+		// Enslaved to a different master -- must never leak into the result.
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "unrelated-slave", Index: 13, MasterIndex: 999}},
+		// Not enslaved to anything.
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "eth0", Index: 14}},
+	}
+
+	got := SlaveNames(master, links)
+	want := []string{"slave1", "slave2"}
+	if len(got) != len(want) {
+		t.Fatalf("SlaveNames() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SlaveNames()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSlaveNames_NoSlaves(t *testing.T) {
+	master := &fakeLink{attrs: netlink.LinkAttrs{Name: testBondName, Index: 10}, linkType: LinkType}
+	if got := SlaveNames(master, nil); got != nil {
+		t.Errorf("SlaveNames() = %v, want nil", got)
+	}
+}

--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/plumbing/bond"
 )
 
 // routeListFn and linkByIndexFn are package-level function variables so
@@ -218,10 +219,6 @@ func isVRFSlave(link netlink.Link) bool {
 	return master.Type() == excludedMasterType
 }
 
-// bondLinkType is the vishvananda/netlink Link.Type() value expandBondSlaves
-// checks for -- see its own doc comment for why.
-const bondLinkType = "bond"
-
 // expandBondSlaves expands any bonding-master interface in names to also
 // include its slave interfaces, leaving every non-bond interface unchanged.
 //
@@ -271,39 +268,19 @@ func expandBondSlaves(names []string) ([]string, error) {
 				"leaving it as-is", "interface", name, "err", err)
 			continue
 		}
-		if link.Type() != bondLinkType {
+		if !bond.IsMaster(link) {
 			continue
 		}
 
-		slaves, err := bondSlaveNames(link)
+		links, err := linkListFn()
 		if err != nil {
 			return nil, fmt.Errorf("attach: enumerate slaves of bonding master %q: %w", name, err)
 		}
-		for _, slave := range slaves {
+		for _, slave := range bond.SlaveNames(link, links) {
 			add(slave)
 		}
 	}
 	return out, nil
-}
-
-// bondSlaveNames returns the names of every link enslaved to master (i.e.
-// every link whose MasterIndex, populated from netlink's IFLA_MASTER
-// attribute, equals master's own index), in whatever order linkListFn
-// reports them.
-func bondSlaveNames(master netlink.Link) ([]string, error) {
-	links, err := linkListFn()
-	if err != nil {
-		return nil, err
-	}
-
-	masterIndex := master.Attrs().Index
-	var slaves []string
-	for _, l := range links {
-		if l.Attrs().MasterIndex == masterIndex {
-			slaves = append(slaves, l.Attrs().Name)
-		}
-	}
-	return slaves, nil
 }
 
 // isDefaultRoute reports whether r is an IPv6 default route (::/0).

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/config"
+	"go.datum.net/galactic/internal/plumbing/bond"
 )
 
 // testIfaceEth0 and testIfaceEth1 are shared interface-name fixtures used
@@ -339,7 +340,7 @@ func TestExpandBondSlaves(t *testing.T) {
 	slave1Link := &fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 11, MasterIndex: bondIndex}}
 	bondLinks := map[string]netlink.Link{
 		testIfaceEth0: &fakeLink{attrs: netlink.LinkAttrs{Name: testIfaceEth0, Index: 2}},
-		bondName:      &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bondLinkType},
+		bondName:      &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bond.LinkType},
 		slave1:        slave1Link, // also named explicitly, in MixedBondAndNonBondDeduped below
 	}
 	allLinks := []netlink.Link{
@@ -433,7 +434,7 @@ func TestResolveInterfaces_BondExpansion(t *testing.T) {
 		slave2    = "ens2f1np1"
 	)
 
-	bondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bondLinkType}
+	bondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bond.LinkType}
 	slaveLinks := []netlink.Link{
 		&fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 6, MasterIndex: bondIndex}},
 		&fakeLink{attrs: netlink.LinkAttrs{Name: slave2, Index: 7, MasterIndex: bondIndex}},

--- a/internal/plumbing/ebpf/edgeattach/attach.go
+++ b/internal/plumbing/ebpf/edgeattach/attach.go
@@ -16,8 +16,18 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/plumbing/bond"
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgepreflight"
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
+)
+
+// linkByNameFn and linkListFn are package-level override points, the same
+// pattern internal/plumbing/ebpf/attach uses for its own identically-named
+// vars, so ResolveTargets' tests can substitute a fake netlink view without
+// touching the real host network stack.
+var (
+	linkByNameFn = netlink.LinkByName
+	linkListFn   = netlink.LinkList
 )
 
 // PinDir is the default bpffs directory every edgeprog map is pinned
@@ -110,16 +120,87 @@ func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
 	return errors.Join(errs...)
 }
 
-// Attach attaches program (edgeprog.EdgedsrObjects.EdgeLb) to ifaceName's
-// XDP hook in native (driver) mode, returning the resulting link.Link for
-// the caller to hold open and Close on shutdown -- see doc.go for why
-// native mode is required, not merely preferred, and why no pinning or
-// Watch-style re-attachment is needed here.
-func Attach(program *ebpf.Program, ifaceName string) (link.Link, error) {
+// ResolveTargets resolves ifaceName to the set of interface names Attach
+// should actually attach the XDP program to.
+//
+// If ifaceName is not a Linux bonding master, the result is just
+// []string{ifaceName} -- the common case. If it is a bonding master, the
+// result is its slave interfaces instead, with ifaceName itself excluded:
+// unlike internal/plumbing/ebpf/attach's TC-BPF path (which attaches to
+// both a bond master and its slaves, since the master still carries the
+// route/tc-filter attachment point), native-mode XDP against a bonding
+// master is not reliable -- confirmed failing outright ("operation not
+// supported") on a real gateway node (802.3ad over an igb/tg3 slave pair).
+// Some kernels' bonding driver does implement ndo_bpf by forwarding the
+// attach to every slave, but that still requires each slave's own driver
+// to support native XDP -- not a given for every NIC driver (tg3 is a
+// commonly cited example that doesn't) -- so attaching to the master
+// remains something this package never relies on working, only to real
+// slaves whose own native XDP support this package can reason about
+// directly. A bonding master with no slaves is an error: silently falling
+// back to attaching nothing (or to the master, which would only risk
+// repeating the failure this function exists to avoid) would leave the
+// gateway datapath running with no ingress attachment at all.
+func ResolveTargets(ifaceName string) ([]string, error) {
+	iface, err := linkByNameFn(ifaceName)
+	if err != nil {
+		return nil, fmt.Errorf("edgeattach: find link %q: %w", ifaceName, err)
+	}
+	if !bond.IsMaster(iface) {
+		return []string{ifaceName}, nil
+	}
+
+	links, err := linkListFn()
+	if err != nil {
+		return nil, fmt.Errorf("edgeattach: enumerate slaves of bonding master %q: %w", ifaceName, err)
+	}
+	slaves := bond.SlaveNames(iface, links)
+	if len(slaves) == 0 {
+		return nil, fmt.Errorf(
+			"edgeattach: bonding master %q has no slave interfaces to attach the XDP program to", ifaceName)
+	}
+	return slaves, nil
+}
+
+// Attach attaches program (edgeprog.EdgedsrObjects.EdgeLb) to every
+// interface in ifaceNames' XDP hook in native (driver) mode, returning the
+// resulting link.Link for each -- in the same order as ifaceNames -- for
+// the caller to hold open and Close on shutdown. Callers resolve ifaceNames
+// via ResolveTargets first, so this is usually a single bond slave or
+// [ifaceName] itself, never the bond master (see ResolveTargets' own doc
+// comment for why); see doc.go for why native mode is required, not merely
+// preferred, and why no pinning or Watch-style re-attachment is needed
+// here.
+//
+// If attaching to one interface fails partway through, every link already
+// attached in this call is Closed before returning the error -- a caller
+// that gets an error here holds no partial attachment to clean up itself.
+func Attach(program *ebpf.Program, ifaceNames []string) ([]link.Link, error) {
 	if program == nil {
 		return nil, errors.New("edgeattach: program is nil")
 	}
+	if len(ifaceNames) == 0 {
+		return nil, errors.New("edgeattach: no interfaces to attach to")
+	}
 
+	links := make([]link.Link, 0, len(ifaceNames))
+	for _, ifaceName := range ifaceNames {
+		xdpLink, err := attachOne(program, ifaceName)
+		if err != nil {
+			for _, already := range links {
+				_ = already.Close()
+			}
+			return nil, err
+		}
+		links = append(links, xdpLink)
+	}
+	return links, nil
+}
+
+// attachOne attaches program to ifaceName's XDP hook in native (driver)
+// mode -- the single-interface mechanism Attach applies to every name in
+// ifaceNames.
+func attachOne(program *ebpf.Program, ifaceName string) (link.Link, error) {
 	iface, err := netlink.LinkByName(ifaceName)
 	if err != nil {
 		return nil, fmt.Errorf("edgeattach: find link %q: %w", ifaceName, err)

--- a/internal/plumbing/ebpf/edgeattach/attach_test.go
+++ b/internal/plumbing/ebpf/edgeattach/attach_test.go
@@ -9,11 +9,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 
+	"github.com/cilium/ebpf"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/plumbing/bond"
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
 )
 
@@ -54,10 +58,132 @@ func TestLoad_PreflightBlocksLoad(t *testing.T) {
 // TestAttach_NilProgramIsError covers Attach's defensive nil-program
 // guard directly, without needing root.
 func TestAttach_NilProgramIsError(t *testing.T) {
-	if _, err := Attach(nil, "eth0"); err == nil {
+	if _, err := Attach(nil, []string{"eth0"}); err == nil {
 		t.Error("Attach(nil program, ...) error = nil, want an error")
 	}
 }
+
+// TestAttach_NoInterfacesIsError covers Attach's defensive empty-slice
+// guard directly, without needing root or a real program.
+func TestAttach_NoInterfacesIsError(t *testing.T) {
+	if _, err := Attach(&ebpf.Program{}, nil); err == nil {
+		t.Error("Attach(program, nil) error = nil, want an error")
+	}
+}
+
+// fakeLink is a minimal netlink.Link implementation for tests -- mirrors
+// internal/plumbing/ebpf/attach's identical test fixture.
+type fakeLink struct {
+	attrs    netlink.LinkAttrs
+	linkType string
+}
+
+func (f *fakeLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
+func (f *fakeLink) Type() string {
+	if f.linkType == "" {
+		return "fake"
+	}
+	return f.linkType
+}
+
+// TestResolveTargets exercises ResolveTargets against a faked netlink view
+// (linkByNameFn/linkListFn), covering the reason it exists: unlike
+// internal/plumbing/ebpf/attach's expandBondSlaves, which includes a bond
+// master alongside its slaves, ResolveTargets must exclude the master
+// entirely -- native-mode XDP cannot attach to it at all.
+func TestResolveTargets(t *testing.T) {
+	origLinkByNameFn, origLinkListFn := linkByNameFn, linkListFn
+	t.Cleanup(func() { linkByNameFn, linkListFn = origLinkByNameFn, origLinkListFn })
+
+	const (
+		nonBondName = "eth0"
+		bondName    = "bond0"
+		bondIndex   = 10
+		slave1      = "enp3s0f1"
+		slave2      = "eno2"
+	)
+
+	links := map[string]netlink.Link{
+		nonBondName: &fakeLink{attrs: netlink.LinkAttrs{Name: nonBondName, Index: 2}},
+		bondName:    &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bond.LinkType},
+	}
+	allLinks := []netlink.Link{
+		links[nonBondName],
+		links[bondName],
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 11, MasterIndex: bondIndex}},
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave2, Index: 12, MasterIndex: bondIndex}},
+		// A link enslaved to some other, unrelated master must never leak in.
+		&fakeLink{attrs: netlink.LinkAttrs{Name: "unrelated-slave", Index: 13, MasterIndex: 999}},
+	}
+
+	linkByNameFn = func(name string) (netlink.Link, error) {
+		if l, ok := links[name]; ok {
+			return l, nil
+		}
+		return nil, errFixtureNotFound
+	}
+	linkListFn = func() ([]netlink.Link, error) { return allLinks, nil }
+
+	t.Run("NonBondPassthrough", func(t *testing.T) {
+		got, err := ResolveTargets(nonBondName)
+		if err != nil {
+			t.Fatalf("ResolveTargets() error = %v", err)
+		}
+		if len(got) != 1 || got[0] != nonBondName {
+			t.Errorf("ResolveTargets() = %v, want [%s]", got, nonBondName)
+		}
+	})
+
+	t.Run("BondExpandsToSlavesOnly", func(t *testing.T) {
+		got, err := ResolveTargets(bondName)
+		if err != nil {
+			t.Fatalf("ResolveTargets() error = %v", err)
+		}
+		want := []string{slave1, slave2}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("ResolveTargets() = %v, want %v (slaves only, master excluded)", got, want)
+		}
+		for _, name := range got {
+			if name == bondName {
+				t.Errorf("ResolveTargets() = %v, must never include the bond master itself", got)
+			}
+		}
+	})
+
+	t.Run("UnresolvableInterfaceIsError", func(t *testing.T) {
+		// Unlike internal/plumbing/ebpf/attach's expandBondSlaves (whose
+		// override path never requires its named interfaces to exist yet
+		// at config-generation time), the gateway's publicInterface is
+		// expected to be a real interface at process startup -- so an
+		// unresolvable name is fatal here, matching Attach's own
+		// pre-existing behavior for a nonexistent interface.
+		if _, err := ResolveTargets("does-not-exist"); err == nil {
+			t.Fatal("ResolveTargets() error = nil, want the underlying link-lookup error surfaced")
+		}
+	})
+
+	t.Run("BondWithNoSlavesIsError", func(t *testing.T) {
+		emptyBondName := "bond1"
+		links[emptyBondName] = &fakeLink{
+			attrs: netlink.LinkAttrs{Name: emptyBondName, Index: 20}, linkType: bond.LinkType,
+		}
+		if _, err := ResolveTargets(emptyBondName); err == nil {
+			t.Fatal("ResolveTargets() error = nil, want an error for a bond master with no slaves")
+		}
+	})
+
+	t.Run("LinkListErrorPropagated", func(t *testing.T) {
+		origLinkListFn := linkListFn
+		linkListFn = func() ([]netlink.Link, error) { return nil, errFixtureNotFound }
+		defer func() { linkListFn = origLinkListFn }()
+
+		if _, err := ResolveTargets(bondName); err == nil {
+			t.Fatal("ResolveTargets() error = nil, want the underlying link-list error surfaced")
+		}
+	})
+}
+
+var errFixtureNotFound = errors.New("edgeattach: fixture link not found")
 
 // TestLoadAttach_SurvivesRestartWithMapsIntact is the real, root-gated
 // exit criterion: program load/attach survives a simulated process
@@ -120,11 +246,14 @@ func TestLoadAttach_SurvivesRestartWithMapsIntact(t *testing.T) {
 		}
 		defer func() { _ = objs.Close() }()
 
-		l, err := Attach(objs.EdgeLb, ifaceName)
+		links, err := Attach(objs.EdgeLb, []string{ifaceName})
 		if err != nil {
 			return fmt.Errorf("attach: %w", err)
 		}
-		firstLink = l
+		if len(links) != 1 {
+			return fmt.Errorf("attach: got %d links, want 1", len(links))
+		}
+		firstLink = links[0]
 
 		if err := objs.VipTable.Put(vipKey, vipValue); err != nil {
 			return fmt.Errorf("populate vip_table: %w", err)
@@ -151,11 +280,11 @@ func TestLoadAttach_SurvivesRestartWithMapsIntact(t *testing.T) {
 		}
 		defer func() { _ = objs.Close() }()
 
-		l, err := Attach(objs.EdgeLb, ifaceName)
+		links, err := Attach(objs.EdgeLb, []string{ifaceName})
 		if err != nil {
 			return fmt.Errorf("re-attach after restart: %w", err)
 		}
-		defer func() { _ = l.Close() }()
+		defer func() { _ = links[0].Close() }()
 
 		var got edgeprog.EdgedsrVipValue
 		if err := objs.VipTable.Lookup(vipKey, &got); err != nil {
@@ -168,5 +297,205 @@ func TestLoadAttach_SurvivesRestartWithMapsIntact(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("post-restart verification: %v", err)
+	}
+}
+
+// TestAttach_MultipleInterfacesRollsBackOnPartialFailure exercises Attach's
+// multi-interface path end-to-end against real veth interfaces: attaching
+// to two interfaces returns two links, and if a later interface in the
+// list fails to attach, every link already attached earlier in that same
+// call is rolled back (Closed) rather than left dangling -- verified here
+// by re-attaching to the first interface afterward, which only succeeds if
+// its earlier attach was genuinely undone (a still-attached native XDP
+// program on that interface would make a second attach fail).
+func TestAttach_MultipleInterfacesRollsBackOnPartialFailure(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-edge-test-multi-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	const (
+		iface0Name = "edgetestb0"
+		peer0Name  = "edgetestb1"
+		iface1Name = "edgetestb2"
+		peer1Name  = "edgetestb3"
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		handle, err := netlink.NewHandle()
+		if err != nil {
+			return err
+		}
+		defer handle.Close() //nolint:errcheck // best-effort cleanup
+
+		for _, v := range []*netlink.Veth{
+			{LinkAttrs: netlink.LinkAttrs{Name: iface0Name}, PeerName: peer0Name},
+			{LinkAttrs: netlink.LinkAttrs{Name: iface1Name}, PeerName: peer1Name},
+		} {
+			if err := handle.LinkAdd(v); err != nil {
+				return fmt.Errorf("add veth pair %q/%q: %w", v.Name, v.PeerName, err)
+			}
+			link, err := handle.LinkByName(v.Name)
+			if err != nil {
+				return err
+			}
+			if err := handle.LinkSetUp(link); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("setup veth interfaces: %v", err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("load: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		// --- attach to both real interfaces: two links back. ---
+		links, err := Attach(objs.EdgeLb, []string{iface0Name, iface1Name})
+		if err != nil {
+			return fmt.Errorf("attach to both interfaces: %w", err)
+		}
+		if len(links) != 2 {
+			return fmt.Errorf("attach: got %d links, want 2", len(links))
+		}
+		for _, l := range links {
+			_ = l.Close()
+		}
+
+		// --- attach again, this time with a second name that can never
+		// attach (it doesn't exist): the first interface's attach must be
+		// rolled back, not left dangling. ---
+		if _, err := Attach(objs.EdgeLb, []string{iface0Name, "does-not-exist"}); err == nil {
+			return errors.New("Attach() with an unresolvable second interface error = nil, want an error")
+		}
+
+		// If the rollback above genuinely closed iface0Name's link, a
+		// fresh solo attach to it succeeds; if it leaked, this fails with
+		// the kernel refusing a second native XDP program on the same
+		// interface.
+		links, err = Attach(objs.EdgeLb, []string{iface0Name})
+		if err != nil {
+			return fmt.Errorf(
+				"re-attach to %q after a rolled-back partial failure: %w "+
+					"(the earlier partial attach was likely not rolled back)", iface0Name, err)
+		}
+		defer func() { _ = links[0].Close() }()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("multi-interface attach/rollback: %v", err)
+	}
+}
+
+// TestResolveTargetsAndAttach_RealBondDevice exercises ResolveTargets and
+// Attach against a genuine Linux bonding master (real netlink IFLA_MASTER
+// enslavement, not TestResolveTargets' faked netlink view), end to end:
+// resolving the bond to its slaves and attaching the real XDP program to
+// each one.
+//
+// Deliberately does not also assert that attaching directly to the bond
+// master fails: on this test's kernel, with veth slaves (which do support
+// native XDP themselves), it does not -- some kernels' bonding driver does
+// implement ndo_bpf by forwarding the attach to every slave, which only
+// fails if a slave's own driver lacks native XDP support (this is believed
+// to be the actual failure mode on proxima-evices: 802.3ad over an
+// igb/tg3 pair, and tg3 in particular is commonly cited as lacking native
+// XDP support; not independently confirmed against that node's kernel).
+// Whether master-attach fails outright or succeeds-but-silently-relies-on
+// slave support is kernel/driver dependent either way, so asserting one
+// direction here would make this test flaky across kernels rather than
+// meaningful -- resolving to (and attaching only to) the slaves directly
+// is correct regardless of which case a given kernel falls into.
+func TestResolveTargetsAndAttach_RealBondDevice(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-edge-test-bond-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	const (
+		bondName = "bond0"
+		slave0   = "edgebond0"
+		slave1   = "edgebond1"
+	)
+
+	nsObj, err := ns.TempNetNS()
+	if err != nil {
+		t.Fatalf("create test netns: %v", err)
+	}
+	defer func() { _ = nsObj.Close() }()
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		bondLink := netlink.NewLinkBond(netlink.LinkAttrs{Name: bondName})
+		if err := netlink.LinkAdd(bondLink); err != nil {
+			return fmt.Errorf("add bond master: %w", err)
+		}
+
+		for i, name := range []string{slave0, slave1} {
+			veth := &netlink.Veth{
+				LinkAttrs: netlink.LinkAttrs{Name: name},
+				PeerName:  fmt.Sprintf("%s-peer%d", bondName, i),
+			}
+			if err := netlink.LinkAdd(veth); err != nil {
+				return fmt.Errorf("add veth %q: %w", name, err)
+			}
+			slave, err := netlink.LinkByName(name)
+			if err != nil {
+				return err
+			}
+			if err := netlink.LinkSetMaster(slave, bondLink); err != nil {
+				return fmt.Errorf("enslave %q to %q: %w", name, bondName, err)
+			}
+			if err := netlink.LinkSetUp(slave); err != nil {
+				return err
+			}
+		}
+		return netlink.LinkSetUp(bondLink)
+	})
+	if err != nil {
+		t.Fatalf("setup bond0 with two real slaves: %v", err)
+	}
+
+	err = nsObj.Do(func(_ ns.NetNS) error {
+		got, err := ResolveTargets(bondName)
+		if err != nil {
+			return fmt.Errorf("ResolveTargets(%q): %w", bondName, err)
+		}
+		sort.Strings(got)
+		want := []string{slave0, slave1}
+		if !slices.Equal(got, want) {
+			return fmt.Errorf("ResolveTargets(%q) = %v, want %v", bondName, got, want)
+		}
+
+		objs, err := Load(pinDir)
+		if err != nil {
+			return fmt.Errorf("load: %w", err)
+		}
+		defer func() { _ = objs.Close() }()
+
+		// Attaching to the resolved slaves is exactly what this design
+		// exists to make work.
+		links, err := Attach(objs.EdgeLb, got)
+		if err != nil {
+			return fmt.Errorf("attach to bond slaves %v: %w", got, err)
+		}
+		for _, l := range links {
+			_ = l.Close()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("resolve/attach against a real bond device: %v", err)
 	}
 }

--- a/internal/plumbing/ebpf/edgeattach/doc.go
+++ b/internal/plumbing/ebpf/edgeattach/doc.go
@@ -3,24 +3,32 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package edgeattach loads internal/plumbing/ebpf/edgeprog's compiled XDP
-// program and attaches it to one interface -- the gateway node's single
-// public/underlay-facing uplink. Load mirrors
-// internal/plumbing/ebpf/attach.Load's mechanics (pinned maps, verifier-
-// error unwrapping, incompatible-map recreation on a schema change) almost
-// verbatim, since none of that is attach-mechanism-specific; Attach itself
-// is genuinely new, not a port of internal/plumbing/ebpf/gwattach's TC-BPF
-// clsact+filter mechanics (the earlier, rejected Geneve-based design) --
-// XDP attaches via a kernel bpf_link (github.com/cilium/ebpf/link.
-// AttachXDP), a different netlink/bpf-link surface than TC's
-// netlink.BpfFilter entirely.
+// program and attaches it to the gateway node's public/underlay-facing
+// uplink. Load mirrors internal/plumbing/ebpf/attach.Load's mechanics
+// (pinned maps, verifier-error unwrapping, incompatible-map recreation on a
+// schema change) almost verbatim, since none of that is
+// attach-mechanism-specific; Attach itself is genuinely new, not a port of
+// internal/plumbing/ebpf/gwattach's TC-BPF clsact+filter mechanics (the
+// earlier, rejected Geneve-based design) -- XDP attaches via a kernel
+// bpf_link (github.com/cilium/ebpf/link.AttachXDP), a different
+// netlink/bpf-link surface than TC's netlink.BpfFilter entirely.
 //
-// Like gwattach before it, there is no Watch-style netlink-driven
-// re-attachment here: this program has exactly one attach target (a
-// fixed, operator-configured interface name,
-// config.GatewayConfig.PublicInterface), attached once at process startup
-// -- there is no external network event (a Geneve device appearing, a NIC
-// renumbering) this package would ever need to notice on its own, unlike
-// internal/plumbing/ebpf/attach's SRv6 underlay-facing interface set.
+// The configured uplink (config.GatewayConfig.PublicInterface) is usually a
+// single physical interface, in which case ResolveTargets/Attach have
+// exactly one attach target, attached once at process startup. If it names
+// a Linux bonding master instead, ResolveTargets expands it to that bond's
+// slave interfaces and Attach attaches to every one of them -- native-mode
+// XDP against a bonding master is not reliable (see ResolveTargets' own
+// doc comment for the confirmed failure and why it's not simply "bonding
+// never implements ndo_bpf"), unlike internal/plumbing/ebpf/attach's
+// TC-BPF path, which attaches to both the master and its slaves. Either
+// way there is no
+// Watch-style netlink-driven re-attachment here: the attach target set is
+// resolved once at process startup and never revisited -- there is no
+// external network event (a Geneve device appearing, a NIC renumbering, a
+// bond's active slave changing) this package needs to notice on its own,
+// unlike internal/plumbing/ebpf/attach's SRv6 underlay-facing interface
+// set.
 //
 // Native XDP support is required, not merely preferred: Attach always
 // requests link.XDPDriverMode and returns an error rather than silently
@@ -35,11 +43,11 @@
 // Unlike a TC-BPF filter (which persists in the kernel's qdisc structure
 // independent of any process holding a reference), an unpinned bpf_link
 // detaches automatically when the last file descriptor referencing it is
-// closed. This package does not pin the returned link: the owning process
-// (galactic-gateway) is expected to hold it open for its own lifetime and
-// Close it on shutdown, the same "keep the fd, don't pin" simplification
-// gwattach's own AttachPublic used for its single fixed interface. A
-// process restart therefore has a genuinely clean slate -- no existing
-// attach to conflict with -- so there is no TC-FilterReplace-style
+// closed. This package does not pin the returned links: the owning process
+// (galactic-gateway) is expected to hold every one of them open for its own
+// lifetime and Close each on shutdown, the same "keep the fd, don't pin"
+// simplification gwattach's own AttachPublic used for its single fixed
+// interface. A process restart therefore has a genuinely clean slate -- no
+// existing attach to conflict with -- so there is no TC-FilterReplace-style
 // "replace what's already there" case to handle.
 package edgeattach


### PR DESCRIPTION
## Problem

`galactic-gateway-proxima-evices-7tjtt` crash-loops. It's the first
galactic-gateway edge node whose public uplink is a Linux bonding
master (`bond0`, 802.3ad over an `enp3s0f1`/igb + `eno2`/tg3 pair).
Native-mode XDP attach against that bond fails outright on this
node's kernel/driver combination:

```
Error: setup edge gateway eBPF datapath: attach edge gateway datapath to public interface "bond0": edgeattach: attach XDP program to "bond0" in native/driver mode: failed to attach link: create link: operation not supported
```

`edgeattach` (the gateway's XDP attach path) had no bonding
awareness — unlike the CNI's TC-BPF path
(`internal/plumbing/ebpf/attach`'s `expandBondSlaves`), which already
resolves bond slaves, though for a different reason (there it
attaches to *both* the master and slaves; here the master must never
be targeted at all).

Infra stopgap (`datum-cloud/infra#4495`) already points
`proxima-evices` at `enp3s0f1` directly. This is the proper fix.

## Fix

- New `internal/plumbing/bond` package: shared bond-master/slave
  detection, factored out of `internal/plumbing/ebpf/attach`'s
  previously-private `expandBondSlaves`/`bondSlaveNames` so both the
  CNI's TC-BPF path and the gateway's XDP path use one implementation.
- `edgeattach.ResolveTargets`: resolves the configured public
  interface to its bond slaves when it names a bonding master, never
  the master itself.
- `edgeattach.Attach`: now takes/returns `[]link.Link`, attaching to
  every resolved target and rolling back (closing) whatever it
  already attached if a later interface in the same call fails.
- `cmd/galactic-gateway/gateway.go`: resolves targets before
  attaching, applies `ConfigureFIBLookupUplinkSysctls` to every
  resolved target rather than just the configured interface
  (`edgedsr.c` looks up `ctx->ingress_ifindex`, the slave's own
  ifindex once attached there — not the bond master's), and
  holds/closes every returned link on shutdown.

## Testing

- `internal/plumbing/bond`: unit tests, 100% coverage.
- `internal/plumbing/ebpf/edgeattach`: faked-netlink `ResolveTargets`
  unit tests, plus two new root-gated tests —
  `TestResolveTargetsAndAttach_RealBondDevice` (a genuine Linux bond
  with real veth slaves) and
  `TestAttach_MultipleInterfacesRollsBackOnPartialFailure`.
- `task ci` (lint → build → test:unit → test:e2e) green, plus
  `task test:unit-root` for the root-gated packages.

## A finding worth flagging

Writing the real-bond test surfaced a nuance the original diagnosis
didn't have: attaching XDP directly to a bond master isn't reliably
rejected by every kernel. On the test kernel, with veth slaves (which
support native XDP themselves), attaching to the master **succeeds**
— some kernels' bonding driver forwards the attach through to
slaves that support it. The production failure is real, but
"bonding doesn't implement `ndo_bpf`" isn't the precise universal
mechanism; a slave's own driver lacking native XDP (tg3 is commonly
cited as one that does) is the more likely explanation on
`proxima-evices` specifically. Comments and
`ARCHITECTURE-GATEWAY.md`'s Known Constraints reflect this.

One open question this PR does not resolve: `Attach` is all-or-nothing
across every resolved slave. If `eno2`'s tg3 driver genuinely can't
accept a native XDP attach, the whole datapath fails to start with
`publicInterface: bond0` even after this ships, rather than running
degraded on just `enp3s0f1`. Worth confirming both slaves' native XDP
support on the real node before reverting the infra stopgap back to
`bond0` — if `eno2` can't do it, a follow-up may be needed to make
this best-effort (attach to whichever slaves succeed, warn on the
rest) instead of all-or-nothing.

No containerlab bonded-uplink scenario was added: containerlab's
gateway nodes use veth uplinks, and per the finding above, a veth
bond would not reproduce the real failure this exists for — only
give false coverage. The real-bond-device unit test covers the
generalizable resolve/attach mechanics instead.

## Follow-up

Once merged and released here, revert
`datum-cloud/infra#4495`'s stopgap back to `bond0` for
`proxima-evices` — tracked separately, contingent on confirming both
slaves' native XDP support first (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)