### PR TITLE
fix(runtime/gobgp): fall back to vrf_table when a VRF's interface isn't in this process's own netns

### DIFF
--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"net"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
@@ -242,7 +245,35 @@ func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeIn
 // SHA-256 hash fallback form (crdnames.nameSegment's "x..." prefix, for VPCs
 // that don't cleanly hex-encode), which is correct here too: that form was
 // never recoverable to a real interface name in the first place.
-func vrfTableID(vrfName string) (uint32, error) {
+//
+// argument is the same value as the owning BGPVRFInstance's own
+// Spec.VRFID — used only by the vrf_table fallback below, not by the
+// primary netlink lookup.
+//
+// vrfpkg.TableID's own netlink.LinkList() call is scoped to this
+// process's own network namespace — galactic-router runs
+// hostNetwork: true, so that's the host's root netns, correct for a VRF
+// galactic-cni created there directly for a real tenant pod's own CNI
+// attachment. It is structurally blind to a VRF #855's ingress sidecar
+// creates instead, which lives entirely inside Envoy's own pod netns by
+// design (so its own SO_BINDTODEVICE calls resolve there). Confirmed
+// live on us-central-1-staging-lab: a node running only the ingress
+// sidecar for a given VPC — no real tenant CNI attachment for it at all
+// — never has that VRF's interface visible in its own root netns, so the
+// primary lookup fails on every single reconcile, forever; not a race,
+// not something a restart or a longer wait fixes.
+//
+// The fallback below reads vrf_table directly instead of reaching into
+// that other netns: internal/ingresssidecar's own ensureEgressDatapath
+// already writes this exact (block, argument) -> kernel table ID mapping
+// there the moment it creates its own VRF, so usid_ingress's own decap
+// path can find it — the same bpffs-pinned map this process already
+// opens a second handle onto for vip_xlat_table
+// (cmd/galactic-router/root.go). Reading it here needs no new privilege,
+// no cross-namespace setns, and no change to the network repo's own CRD
+// schema: it's the same value, already published by whoever actually
+// created the VRF, through a channel this process already has open.
+func vrfTableID(vrfName string, argument int32) (uint32, error) {
 	parts := strings.SplitN(vrfName, "-", 2)
 	if len(parts) != 2 {
 		return 0, fmt.Errorf("VRF name %q does not contain '-'", vrfName)
@@ -251,7 +282,60 @@ func vrfTableID(vrfName string) (uint32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("VRF name %q: could not decode VPC segment %q back to base62: %w", vrfName, parts[0], err)
 	}
-	return vrfpkg.TableID(vpc)
+
+	tableID, localErr := vrfpkg.TableID(vpc)
+	if localErr == nil {
+		return tableID, nil
+	}
+
+	fallbackID, ok, fallbackErr := vrfTableIDFromRegistry(vpc, argument)
+	if fallbackErr != nil {
+		return 0, fmt.Errorf("VRF %q: local netlink lookup failed (%w), and vrf_table fallback also failed: %w",
+			vrfName, localErr, fallbackErr)
+	}
+	if !ok {
+		return 0, fmt.Errorf(
+			"VRF %q: local netlink lookup failed (%w), and no vrf_table entry exists either (vpc=%s argument=%d) "+
+				"— this VRF may not exist on this node yet", vrfName, localErr, vpc, argument)
+	}
+	return fallbackID, nil
+}
+
+// vrfTableIDFromRegistry looks up the kernel VRF table ID (vpc, argument)
+// maps to in vrf_table — see vrfTableID's own doc comment for why this
+// fallback exists. Opens a fresh handle each call via pinDir, the same
+// on-demand-open idiom probeEgressRouteWrite (below) already uses for
+// egress_route_table, rather than keeping a long-lived handle: this only
+// runs on the local-netlink-miss path (once per affected VRF per
+// reconcile that needs it), not a per-packet or per-reconcile hot path
+// for every VRF.
+func vrfTableIDFromRegistry(vpc string, argument int32) (uint32, bool, error) {
+	if argument < 0 || argument > math.MaxUint16 {
+		return 0, false, fmt.Errorf("argument %d out of range for a uint16 uSID Argument", argument)
+	}
+	vpcHex, err := intf.Base62ToHex(vpc)
+	if err != nil {
+		return 0, false, fmt.Errorf("convert vpc %q to hex: %w", vpc, err)
+	}
+	block, err := strconv.ParseUint(vpcHex, 16, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse vpc hex %q: %w", vpcHex, err)
+	}
+
+	registry, closer, err := usidmap.OpenPinnedRegistry(pinDir)
+	if err != nil {
+		return 0, false, fmt.Errorf("open pinned vrf_table (missing bpffs mount, BPF capability, or root?): %w", err)
+	}
+	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
+
+	entry, ok, err := registry.VRF.Get(block, uint16(argument))
+	if err != nil {
+		return 0, false, fmt.Errorf("vrf_table: get vpc=%s (block=%#x) argument=%#x: %w", vpc, block, argument, err)
+	}
+	if !ok {
+		return 0, false, nil
+	}
+	return entry.VRFTableID, true, nil
 }
 
 // evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path

--- a/internal/runtime/gobgp/monitor_test.go
+++ b/internal/runtime/gobgp/monitor_test.go
@@ -5,6 +5,7 @@
 package gobgp
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -109,7 +110,7 @@ func TestMatchTableID_NoExtendedCommunitiesAttributeAtAll(t *testing.T) {
 // asserts on the interface name vrfpkg.TableID reports missing rather than
 // on a successful lookup.
 func TestVRFTableID_DecodesHexSegmentBackToBase62(t *testing.T) {
-	_, err := vrfTableID("3e-dfw-worker")
+	_, err := vrfTableID("3e-dfw-worker", 1)
 	if err == nil {
 		t.Fatalf("vrfTableID() error = nil, want a 'VRF ID not found' error (no such kernel VRF in test env)")
 	}
@@ -127,7 +128,7 @@ func TestVRFTableID_DecodesHexSegmentBackToBase62(t *testing.T) {
 // interface name, so vrfTableID must fail fast on the decode rather than
 // attempt a kernel lookup with a garbage name.
 func TestVRFTableID_HashFallbackSegmentErrors(t *testing.T) {
-	_, err := vrfTableID("x0123456789ab-dfw-worker")
+	_, err := vrfTableID("x0123456789ab-dfw-worker", 1)
 	if err == nil {
 		t.Fatalf("vrfTableID() error = nil, want a base62-decode error for a hash-fallback segment")
 	}
@@ -137,8 +138,65 @@ func TestVRFTableID_HashFallbackSegmentErrors(t *testing.T) {
 // a VRF name with no '-' at all can't be split into a VPC segment and a
 // node name.
 func TestVRFTableID_NoDashErrors(t *testing.T) {
-	_, err := vrfTableID("nodash")
+	_, err := vrfTableID("nodash", 1)
 	if err == nil {
 		t.Fatalf("vrfTableID(\"nodash\") error = nil, want a \"does not contain '-'\" error")
+	}
+}
+
+// TestVRFTableID_FallbackErrorMentionsBothAttempts covers the case this
+// fallback exists for: a VRF whose interface genuinely does not exist in
+// this process's own root netns (galactic-router's normal case for a VRF
+// #855's ingress sidecar created instead, inside Envoy's own pod netns —
+// see vrfTableID's own doc comment). With no bpffs mount in this test
+// environment either, both attempts fail, and the combined error must
+// still surface the original local-netlink failure (mentioning the
+// base62-decoded interface name), not just the fallback's own error, so
+// an operator reading the log doesn't lose the first, usually more
+// familiar signal.
+func TestVRFTableID_FallbackErrorMentionsBothAttempts(t *testing.T) {
+	_, err := vrfTableID("3e-dfw-worker", 7)
+	if err == nil {
+		t.Fatal("vrfTableID() error = nil, want an error (no kernel VRF and no pinned vrf_table in the test env)")
+	}
+	if !strings.Contains(err.Error(), "G000000010V") {
+		t.Errorf("vrfTableID() error = %q, want it to still mention the local netlink failure", err)
+	}
+	if !strings.Contains(err.Error(), "vrf_table") {
+		t.Errorf("vrfTableID() error = %q, want it to also mention the vrf_table fallback attempt", err)
+	}
+}
+
+// TestVRFTableIDFromRegistry_RejectsOutOfRangeArgument covers the bounds
+// check on argument: model.DesiredVRFInstance.VRFID is an int32 (RFC 4364
+// route-distinguisher assignment compatibility), but a uSID Argument is
+// only ever 16 bits (uformat.ValidateArgument) — this must reject a value
+// that can't round-trip through uint16 before ever touching a pinned map,
+// rather than silently truncating it into a lookup for the wrong key.
+func TestVRFTableIDFromRegistry_RejectsOutOfRangeArgument(t *testing.T) {
+	for _, argument := range []int32{-1, math.MaxUint16 + 1} {
+		if _, _, err := vrfTableIDFromRegistry("2", argument); err == nil {
+			t.Errorf("vrfTableIDFromRegistry(%d) error = nil, want an out-of-range error", argument)
+		}
+	}
+}
+
+// TestVRFTableIDFromRegistry_MissingPinReturnsError covers the "eBPF uSID
+// datapath not loaded on this node" case (a route-reflector/control-role
+// node, or simply not yet attached) — pinDir points at this test's own
+// temp directory instead of a real bpffs mount, so OpenPinnedRegistry's
+// own open() calls fail exactly as they would against a genuinely absent
+// pin, with no real bpffs mount or root privilege needed to exercise it.
+func TestVRFTableIDFromRegistry_MissingPinReturnsError(t *testing.T) {
+	old := pinDir
+	pinDir = t.TempDir()
+	t.Cleanup(func() { pinDir = old })
+
+	_, _, err := vrfTableIDFromRegistry("2", 1)
+	if err == nil {
+		t.Fatal("vrfTableIDFromRegistry() error = nil, want an error opening a non-existent pinned map")
+	}
+	if !strings.Contains(err.Error(), "vrf_table") {
+		t.Errorf("vrfTableIDFromRegistry() error = %q, want it to name vrf_table", err)
 	}
 }

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -350,7 +350,7 @@ func (r *GoBGPRuntime) applyVRFs(
 		tableID, ok := r.appliedVRFs[v.Name]
 		if !ok {
 			var err error
-			tableID, err = vrfTableID(v.Name)
+			tableID, err = vrfTableID(v.Name, v.VRFID)
 			if err != nil {
 				slog.Error("applyVRFs: failed to resolve kernel VRF table; this VRF's routes will not be installed",
 					"vrf", v.Name, "err", err)


### PR DESCRIPTION
fix(runtime/gobgp): fall back to vrf_table when a VRF's interface isn't in this process's own netns

## Summary

`applyVRFs`'s own kernel-VRF-table resolution (`vrfTableID`) only ever
tries a plain `netlink.LinkList()` in galactic-router's own network
namespace (hostNetwork: true, so the host's root netns). That's correct
for a VRF `galactic-cni` creates directly for a real tenant pod's own
CNI attachment -- it genuinely lives there. It is structurally blind to
a VRF #855's ingress sidecar creates instead, which lives entirely
inside Envoy's own pod netns by design, so its own `SO_BINDTODEVICE`
calls resolve there.

Confirmed live on `us-central-1-staging-lab`: a node running only the
ingress sidecar for a given VPC -- no real tenant CNI attachment for it
at all -- logs, on every single reconcile, forever:

```
applyVRFs: failed to resolve kernel VRF table; this VRF's routes will
not be installed vrf=2-proxima-evices
err="could not find VRF ID for interface: G000000002V"
```

Reproduced identically across three consecutive `galactic-router` pod
restarts -- not a race, not something a restart or a longer wait fixes.
Because this failure happens before any table ID exists for that VPC,
no egress route for any gateway address on that VPC can ever be
installed on that node: confirmed by dumping the pinned
`egress_route_table` eBPF map and finding the specific route absent
there, while present and correctly installed on a node that happens to
also host a real tenant pod for the same VPC.

## Fix

`internal/ingresssidecar`'s own `ensureEgressDatapath` already writes
this exact `(block, argument) -> kernel table ID` mapping into
`vrf_table` the moment it creates its own VRF, so `usid_ingress`'s own
decap path can find it -- the same bpffs-pinned map `galactic-router`
already opens a second handle onto for `vip_xlat_table`
(`cmd/galactic-router/root.go`). `vrfTableID` now falls back to reading
that existing entry (via `usidmap.VRFTable.Get`) when the local netlink
lookup fails, using the VRF's own `argument` (`BGPVRFInstance.Spec.VRFID`,
already known to `applyVRFs`) to build the lookup key.

This needs no new RBAC, no new host privileges (no hostPID, no
cross-namespace `setns`), and no change to the `network` repo's own CRD
schema -- it reads a value the party that actually created the VRF
already publishes, through a channel this process already has open.

## Validation

`task ci` (lint, build, unit tests with race detection) all pass. Added
tests cover: the combined error still surfaces the original local-netlink
failure when both attempts fail (so an operator doesn't lose the more
familiar signal); the argument bounds check rejects a value that can't
round-trip through the uSID Argument's own 16 bits; and the missing-pin
case (route-reflector/control-role node, or simply not yet attached)
returns a clear error without needing a real bpffs mount or root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)