### PR TITLE
fix(runtime/gobgp): drop the unreachable vrf_table fallback; add returnpath-lab

### DIFF
--- a/docs/plans/855-return-path-ingress-decap.md
+++ b/docs/plans/855-return-path-ingress-decap.md
@@ -1,0 +1,405 @@
+# Implementation plan — #855 follow-up: return-path ingress decap on the gateway node
+
+- **Parent:** [datum-cloud/enhancements#796](https://github.com/datum-cloud/enhancements/issues/796) — HTTP Ingress for VPC Networks
+- **Sibling plans** (read both first):
+  - [docs/plans/855-ingress-sidecar-vpc-backend-connectivity.md](855-ingress-sidecar-vpc-backend-connectivity.md) — the accepted #855 design; §4 explicitly punts on the decap side ("already exists, not this issue's problem... verify compatibility... do not build a new decap path for this issue"). This plan is that unverified assumption, found false, and its fix.
+  - [docs/plans/855-return-path-gateway-advertisement.md](855-return-path-gateway-advertisement.md) — fixes the *sending* side of the return path. This plan picks up where that one stops: what happens once a correctly-encapsulated reply arrives at the node hosting the Envoy Gateway pod.
+- **Status:** proposed, design review complete. No code written for Pieces 1–3 yet. One related defect found during the review (`vrfTableID`'s dead `vrf_table` fallback) is already fixed in the working tree — see [Related fixes](#related-fixes).
+
+---
+
+## 1. Decision log
+
+The review that produced this revision settled the following. They are recorded here because several of them close questions that look open in the sibling plans, and because two of them reverse earlier decisions.
+
+| # | Decision | Consequence |
+| - | -------- | ----------- |
+| D-1 | **The netns crossing is irreducible.** Neither a different SID Function, nor delivery to the Envoy pod's own cluster IP, nor stateless address translation avoids it. | Root-netns state on the gateway node is mandatory. The only real question was who creates it. See [§4](#4-closed-questions). |
+| D-2 | **A root-netns component owns the root-netns half** — `galactic-router`, not the sidecar reaching out via `setns`. | Envoy's pod spec does not change. `hostPID` stays off the Envoy pod. Reverses this plan's earlier "all three pieces extend `internal/ingresssidecar`" shape. |
+| D-3 | **Stateful NAT remains excluded; stateless translation was evaluated and rejected on the merits**, not on the Non-Goal. | #796's "NAT or SNAT configuration for return traffic" Non-Goal stands as written. See [§4.3](#43-stateless-address-translation). |
+| D-4 | **One gateway pod per node — structurally, not by convention**, on the `edge` overlay: `infra/apps/network-services-operator/downstream/edge/patches/downstream-gateway.yaml:9` provisions Envoy via `envoyDaemonSet`. | Closes this plan's former Open Question 4 and the latent per-`(vpc, node)` gateway-address collision, which `DeriveGatewayAddress`'s per-`(vpc, nodeID)` keying depends on. **Not** guaranteed on the `base`/`staging` overlays, which use `envoyDeployment` (`.../downstream/base/downstream-gateway.yaml:72`, `.../staging/patches/downstream-gateway.yaml:19`) — see [§7.5](#75-deployment-shape-and-where-the-sidecar-actually-runs). |
+| D-5 | **Co-location with tenant attachments is expected, not excluded.** The Envoy DaemonSet's own node affinity admits `node=compute` nodes, so a gateway pod routinely shares a node with tenant pods. | Reverses an earlier revision of this decision, which assumed the opposite. D-6 is therefore load-bearing rather than tidy — it is the only thing keeping `vrf_table`'s key uncontended — and §7.4's Argument/`vrf_table` ceilings are live, not hypothetical. |
+| D-6 | **The return path gets its own `BGPVRFInstance` and Argument**, rather than sharing the tenant's `(vpc, node)` instance. | Makes `vrf_table`'s key uncontended. Reverses the sibling plan's deliberate share-the-instance decision — see [§6.3](#63-piece-3--the-root-netns-half-of-the-vrf). |
+| D-7 | **No root-netns VRF *device*** — a bare reserved routing table instead. | Keeps `galactic-router`, `internal/gc`, and `vrf.Add`'s host VRF-ID allocator entirely out of this. See [§5.2](#52-b3--a-root-netns-vrf-device-silently-rewires-galactic-router). |
+| D-8 | **`locator_table`/`function_table` seeding moves to `galactic-router`**, not the sidecar. | Matches the owner `usidmap`'s own package doc already names, and fixes the same hole on compute nodes after a map wipe. |
+
+---
+
+## 2. The framing: the VRF is split across two namespaces
+
+It is tempting to describe this work as *extending a VPC's VRF onto the nodes that host Envoy*. That is accurate at the BGP layer — such a node genuinely becomes another PE for that VPC's Route Target, importing and exporting the same RT over the same EVPN mesh — and it is what makes the sibling plan's `BGPAdvertisement` obviously necessary rather than a bolt-on.
+
+**A terminology warning, because this repo overloads the word.** "Gateway node" below means *a node hosting an Envoy Gateway pod*. It does **not** mean `galactic.datumapis.com/node=edge`, which is `galactic-gateway`'s XDP NAT+LB ingress boundary — a different component on a possibly disjoint node set (see [docs/node-labels.md](../node-labels.md) on that exact collision). Per D-5 a gateway node is frequently an ordinary `node=compute` node.
+
+It is misleading at the datapath layer, and every gap below lives in the gap between the two readings. On a gateway node the VPC's VRF is not extended, it is **split across two network namespaces, joined by a veth**:
+
+| | Tenant pod on any node | Envoy pod on a gateway node |
+| ------------------------ | --------------------------------------------- | ------------------------------------------------------ |
+| Where the VRF device is | host root netns, created by `galactic-cni` | Envoy's pod netns, created by the sidecar |
+| Visible to `galactic-router`/`internal/gc`? | yes | **no** |
+| The attachment's address | tenant IPAM, inside the VPC subnet | reserved `GATEWAY-BLOCK` pool, disjoint from tenant space |
+| Which VPCs are present | those with pods scheduled here (a subset) | every VPC on the platform with a pod (see [§7.4](#74-ceilings)) |
+| Who builds the veth | `galactic-cni`, root netns, netns handle from kubelet | nothing today — this plan |
+
+Both halves are mandatory and neither is optional:
+
+- The **pod-netns half must exist**, because #856 binds Envoy's upstream socket with `SO_BINDTODEVICE` to the VRF device name (`network-services-operator/internal/extensionserver/mutate/vpcpod.go:137` emits `G%09sV`, byte-identical to `intf.GenerateInterfaceNameVRF`'s `"G%09s%s"` + `"V"`). A socket can only name an ifindex in its own netns, and only a VRF device redirects a route lookup into a per-VPC table at all — `SO_BINDTODEVICE` sets the output interface, not the table.
+- The **root-netns half must exist**, because that is where the fabric terminates and where `usid_ingress` is attached.
+
+So the veth between them is not an implementation detail, it is the seam. Pieces 2 and 3 below are best read not as "add a second veth and two map writes" but as **building the root-netns half of a VRF that currently only has a pod-netns half** — for which a reference implementation already exists: `internal/hostgw.ConfigureHostGateway` does exactly this for a tenant pod.
+
+---
+
+## 2a. Phase 0 result: a blocker upstream of all three gaps
+
+**A live proof run on `us-central-1-staging-lab` (2026-09-02) found that
+inter-node SRv6 decap cannot work on that cluster at all, for reasons upstream
+of Gaps 1–3.** Pieces 1–3 remain necessary and their key derivations are
+confirmed correct, but implementing them changes nothing until this is settled.
+Full record and reproduction steps: [hack/returnpath-lab/README.md](../../hack/returnpath-lab/README.md).
+
+Two compounding causes:
+
+1. **`usid_ingress` is not attached to the interface carrying the traffic.**
+   `attach.ResolveInterfaces` skips WireGuard links
+   (`internal/plumbing/ebpf/attach/interfaces.go:166`) — a deliberate guard so
+   `srv6.ResolveNodeSourceAddress` cannot bake a mesh ULA in as the node's
+   source address. But these are Talos nodes with KubeSpan, and `kubespan` is
+   what actually carries every inter-node IPv6 packet, iBGP sessions included.
+   Attached sets were `[lo bond0 eno2 enp3s0f1]` (gateway node) and
+   `[lo bond0 ens2f1np1 ens1f1np1]` (backend node) — neither includes it.
+   Capture confirmed the return packet arriving correctly formed on `kubespan`
+   while `eno2`/`enp3s0f1`/`bond0`, filtered to the same destination, saw
+   nothing.
+2. **Attaching it there is not sufficient.** With the program attached to
+   `kubespan` through the production `attach.Attach` path and every map entry
+   verified, `vrf_table` `pkts` stayed 0. `kubespan` is `link-type RAW (Raw
+   IP)` — no Ethernet header — and step 1 unconditionally parses
+   `struct usid_ethhdr` and tests `h_proto == ETH_P_IPV6`, so on an L3
+   interface it reads the inner IPv6 header's own bytes as an ethertype,
+   mismatches, and exits `TC_ACT_UNSPEC` on the one deliberately uncounted
+   path.
+
+The datapath therefore assumes an Ethernet-framed fabric. The same applies to
+the forward direction: the backend node's `vrf_table` hits come from the Envoy
+pod *on that same node*, whose encapsulated traffic loops back via `lo`, which
+*is* attached. Cross-node #855 ingress has never worked on this cluster in
+either direction.
+
+**This has to be resolved before Pieces 1–3 are worth building**, and the
+choice belongs with whoever owns the underlay:
+
+- carry the SRv6 fabric over an Ethernet-framed underlay on these nodes rather
+  than over KubeSpan, or
+- teach `usid_ingress`/`usid_egress` to handle L3/RAW interfaces — detect the
+  absence of a MAC header instead of assuming `ETH_HLEN`, and give step 9 a
+  redirect path not dependent on resolved L2 addressing.
+
+Either is materially larger than Pieces 1–3. Note also that assumption 2 in
+[§9](#9-pre-merge-verification) is still untested, because no packet ever
+reached step 6.
+
+Three further live findings, none of which are this plan's scope but all of
+which are real today, are recorded in the harness README: a ~40% forward-path
+loss on tap-backed (unikernel) workloads from `hostgw` skipping the permanent
+neighbor entry for taps; `locator_table` seeding being unsafe on a node also
+running `galactic-gateway`; and the fabric carrying only `/128` routes for
+advertised SIDs, with the containing `/48` a `Null0` static.
+
+---
+
+## 3. What's broken
+
+With the sibling plan's fixes deployed, a full end-to-end curl through `envoy-datum-downstream-gateway` into a VPC-hosted backend still fails (`upstream_reset_before_response_started{connection_timeout}`). Packet capture confirmed the backend node now correctly re-encapsulates its reply toward the gateway node's own SID — the previous gap is closed — but the encapsulated packet's fate on arrival was never verified. Three independent gaps in `usid_ingress` (`internal/plumbing/ebpf/prog/usid.c`) each independently prevent delivery.
+
+`usid_ingress` is attached once per node on the bond slave interfaces and processes every SRv6-addressed packet arriving on the wire. Its relevant steps, with the line numbers of each lookup:
+
+| Step | What it does | Line |
+| ---- | ------------------------------------------------------------------------ | ---------- |
+| 2 | exact-match outer destination's top 64 bits (Block+NodeID) vs `locator_table`; miss → `TC_ACT_UNSPEC` | `usid.c:1098` |
+| 3–4 | exact-match (Block, Function nibble) vs `function_table` | `usid.c:1117` |
+| 5–6 | exact-match (Block, 12-bit Argument) vs `vrf_table` → `vrf_table_id`, `egress_kind` | `usid.c:1145` |
+| 7 | strip the outer header | `usid.c:1257` |
+| 8 | `bpf_fib_lookup()` with `BPF_FIB_LOOKUP_DIRECT \| BPF_FIB_LOOKUP_TBID`, `tbid = vrf_table_id` | `usid.c:1399` |
+| 9 | `bpf_redirect_peer()` for `EGRESS_KIND_VETH`, `bpf_redirect()` for `EGRESS_KIND_TAP` | `usid.c:1443` |
+
+Steps 8 and 9 always execute **in the netns `usid_ingress` itself runs in — the host root netns**, since that is where the bond slaves live.
+
+The return packet's outer destination is `uSID(gatewayNodeBlock, gatewayNodeID, 0xE, vrfID)`. That is not an assumption: `internal/reconcile.resolveSRv6SID` (`reconcile.go:373`) computes the SID from the *advertising* router's `Spec.SRv6Locator` and `Spec.NodeID` plus the advertisement's own `VRFID`/`Function`, and the sidecar's `PublishGateway` sets `Function = SRv6FunctionEndDT46`. So all three of the above lookups are keyed off the gateway node's own real locator.
+
+### Gap 1 — `locator_table`/`function_table` are empty on the gateway node
+
+```
+$ bpftool map dump pinned /sys/fs/bpf/galactic/locator_table   # on the gateway node
+[]
+$ bpftool map dump pinned /sys/fs/bpf/galactic/function_table
+[]
+```
+
+`usid_ingress` *is* loaded and attached there — `internal/installer/installer.go:207` calls `attach.StartWatching`, and `galactic-cni`'s DaemonSet keys off `galactic.datumapis.com/galactic: router`, which gateway nodes carry. The maps are pinned. But the only writers of these two are `internal/cnibgp/bgp.go:651,654`, inside `registerEBPFDatapath`, reachable only from a real CNI ADD. A gateway node with no tenant attachment of its own never runs it, so step 2 never matches *any* packet and the program falls through for all of them.
+
+### Gap 2 — `vrf_table` has no entry the real lookup could find
+
+`internal/ingresssidecar/ebpfdatapath.go:368` does write a `vrf_table` entry, but under `ingressSidecarBlock = uformat.BlockMax` with `argument = vrf.TableID(vpc)` — a synthetic key by explicit design, existing purely for `usid_egress`'s opposite-direction lookup via `ifindex_vrf_table`. Step 5–6 keys off the Block genuinely present in the packet's destination — the node's real, `BGPRouter`-derived locator Block. No entry keyed that way exists, so even with Gap 1 fixed the lookup misses.
+
+### Gap 3 — nothing to redirect into
+
+`EGRESS_KIND_VETH`'s `bpf_redirect_peer()` needs step 8's FIB lookup to resolve to a veth's **root-netns-side** ifindex; the helper then delivers across to that veth's peer wherever it lives. That is how a tenant attachment works — `galactic-cni` creates the pair with the host end in root netns.
+
+`ensureEgressVeth` (`ebpfdatapath.go:136`) creates its pair with **both ends inside Envoy's pod netns**, deliberately, so the pod's own `SO_BINDTODEVICE` resolves. There is no root-netns-visible interface belonging to this VPC on this node for step 8 to resolve to. Fixing Gaps 1–2 is necessary but not sufficient.
+
+---
+
+## 4. Closed questions
+
+These were evaluated during review and are closed. They are recorded so they are not re-opened.
+
+### 4.1 A different SID Function
+
+`End.DT46`'s entire semantic is "look the inner packet up in a VRF table," which is what forces the `vrf_table` → table-ID → FIB chain. But a hypothetical "decap and deliver locally" Function would still have to deliver into another netns, and `vrf_table` is keyed `(block, argument)` with neither Node-ID nor Function in the key (`usid.c:713`), so two SIDs differing only in Function collide there anyway. No help.
+
+### 4.2 Delivering to the Envoy pod's own cluster IP
+
+The one thing that already carries arbitrary traffic from the gateway node's root netns into the Envoy pod is Cilium's own veth for that pod's cluster IP. Using it would require the Envoy pod's cluster IP to be routable from an arbitrary backend node across the fabric — false in the multi-PoP topology (`deploy/containerlab` models three separate clusters). Worse, it would appear to work within one cluster and fail across PoPs.
+
+### 4.3 Stateless address translation
+
+This repo already ships two per-VRF translation mechanisms on this exact datapath, and #796's Non-Goal excludes *stateful* NAT specifically, so both were evaluated:
+
+- `apply_nptv6` (`usid.c:918`) — RFC 6296 checksum-neutral prefix translation, applied by `usid_ingress` after decap and by `usid_egress` in reverse. It rewrites **the tenant's own address**, between a ULA prefix and a public prefix.
+- `apply_vip_xlat` (`usid.c:969`) — genuine addr+port substitution keyed `(block, argument, proto, port, direction)`. Also the tenant's own service endpoint, at a VIP boundary.
+
+Neither translates a *remote peer's* address, so neither provides a way to make the gateway address reachable from inside a tenant VRF. Building one would be new datapath work, and it would not avoid D-1 regardless.
+
+### 4.4 The sidecar reaching out into root netns
+
+Rejected in favour of D-2. `/proc/1/ns/net` inside the pod is the *pod's* netns; it only becomes the host's with `hostPID: true`, which is **pod-scoped** and therefore lands on Envoy too — directly contradicting PR #851's stated privilege split ("the sidecar holds the capability to create and tear down network devices and routes; Envoy itself only ever needs the capability to bind a socket to a device that already exists"). The hostPath-of-nsfs variant is containable (volumes are pod-level, `volumeMounts` per-container) but requires a change to NSO's strategic-merge patch — a second repo, and the mechanism PR #851 itself flags as fragile — and hands the Envoy pod a handle on the host network namespace.
+
+Note also that the sidecar is not deployed from this repo at all, and what is currently committed on the NSO side is a placeholder: `network-services-operator/config/dev/downstream_resources/downstream-gateway.yaml:75` injects `name: vpc-vrf-sidecar, image: busybox:1.36, command: ["sleep", "infinity"]`. Any claim about the sidecar's mounts or capabilities is a cross-repo assumption of exactly the kind that produced Gaps 1–3.
+
+---
+
+## 5. Defects in the previous revision of this plan
+
+Recorded because each is a thing the earlier design would have got wrong, and the fix for each is now folded into §6.
+
+### 5.1 B1 — no neighbor entry means a guaranteed drop
+
+`internal/hostgw/hostgw.go:121-133` states the rule outright:
+
+> `bpf_fib_lookup()` does not itself trigger ARP/NDP resolution the way ordinary kernel packet forwarding does, so without a pre-existing neighbor table entry it fails with `BPF_FIB_LKUP_RET_NO_NEIGH` and the datapath drops the packet.
+
+The working tenant path therefore installs **three** things per delivery target — the gateway address on the host-side interface, a host route into the table, and a `NUD_PERMANENT` neigh entry keyed on the guest veth's known MAC. The previous revision proposed only the route. Fixed by reusing `hostgw` rather than re-deriving it (§6.3).
+
+### 5.2 B3 — a root-netns VRF device silently rewires `galactic-router`
+
+The previous revision proposed creating a root-netns VRF via `vrf.Add(vpc)`, which names it `intf.GenerateInterfaceNameVRF(vpc)`. Three separate components key off exactly that name in root netns:
+
+| Component | Effect of the new VRF appearing |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `internal/gc`'s `resolveVRFKernelState` (`gc.go:756`) | starts matching → GC's repair loop begins writing `(realBlock, VRFID)` into `vrf_table` itself, with its own table ID and an `egress_kind` inferred from whatever link is enslaved (`gc.go:747-795`) |
+| `internal/runtime/gobgp`'s `vrfTableID` | `vrfpkg.TableID(vpc)` starts succeeding → the router installs that VPC's whole imported EVPN route set into the table intended to hold one `/128` |
+| `internal/gc`'s `CollectOrphanedVRFs`/`RemoveOrphanedVRFs` (`gc.go:400,453`) | becomes the de-facto owner of its lifecycle, deleting it via `vrf.Delete` → `FlushTable` |
+
+Resolved by D-7. Step 8 passes `BPF_FIB_LOOKUP_TBID` with `fib_params.tbid` (`usid.c:1393-1400`) — a bare table-ID lookup. A VRF master device buys nothing on the root-netns side: nothing binds a socket to it and nothing needs ingress l3mdev redirection there.
+
+### 5.3 B4 — the flock dependency the sibling plan dismissed
+
+The sibling plan's §2 argued `/var/lib/cni/galactic-vrf`'s cross-process flock "doesn't apply here" because the sidecar is one long-running process. Allocating a *host* VRF ID would have reintroduced it — racing real CNI plugin processes for the same space — and that flock's writability from the sidecar's container is still one of the sibling plan's undone §7 pre-merge checks. D-7 removes the dependency instead of satisfying it.
+
+### 5.4 B2 — `vrf_table`'s key had three writers
+
+`vrf_table` is a node-global BPF hash keyed `block<<12 | argument`. The previous revision's Piece 3 wrote `(realBlock, vrfID)`, which is the same key two other components write, because `PublishGateway` deliberately reuses the tenant's instance:
+
+```go
+// gateway.go:240 — "Same (vpc, node)-keyed BGPVRFInstance a real CNI
+// attachment on this node would use ... rather than creating a competing entry"
+vrfName := crdnames.BGPVRFInstanceName(vpc, p.nodeName)
+```
+
+`argument` in the eBPF key *is* that `Spec.VRFID`, so the gateway and any tenant attachment of the same VPC on the same node shared one key by construction:
+
+| Writer | Value it wants |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `cnibgp/bgp.go:658` (CNI ADD) | tenant pod's root-netns VRF table, redirect → pod's host veth |
+| `gc/gc.go:689` (repair loop) | whatever `resolveVRFKernelState` reads off a root-netns VRF link |
+| previous Piece 3 | gateway's table, redirect → gateway's veth |
+
+One key cannot express two of those at once; last writer wins and the loser is misdelivered, including tenant traffic being redirected toward the Envoy pod. Today it is inert only because `resolveVRFKernelState` cannot see a pod-netns VRF and returns `ok=false`.
+
+The previous revision's Open Question 2 framed this as a *Linux VRF table ID* allocation collision. Those do not collide — `findNextAvailableVRFID` handles it. What collided is the eBPF map key, derived from the CRD's `VRFID`. Two different things both called "VRF ID."
+
+Resolved by D-6 (§6.3).
+
+---
+
+## 6. Design
+
+### 6.1 Piece 1 — seed `locator_table`/`function_table` from `galactic-router`
+
+Both maps are keyed by node facts alone — `(block, nodeID)` and `(block, function)` — derived entirely from this node's own `BGPRouter`. They have no per-VPC component. `usidmap`'s own package doc already names the intended owner:
+
+> Milestone 3.1's control daemon (`internal/plumbing/ebpf/attach`) is expected to call `LocatorTable.Register`/`FunctionTable.Register` at startup (and on `BGPRouter.Spec.SRv6Locator` change) to seed `locator_table`/`function_table` for this node's active uSID Block(s) — that wiring is not part of this milestone's scope either.
+
+Implement it in `galactic-router`'s `BGPRouter` reconcile path: it already watches that CRD, already holds `Spec.SRv6Locator` and `Spec.NodeID`, already runs in root netns with a pinned-map handle, and already runs on every node including edge ones (`galactic=router` covers both `compute` and `edge`). Derive `block` via `uformat.Block(netip.MustParsePrefix(locator).Addr())` — the same derivation `cnibgp/bgp.go:606-611` uses — then `Locator.Register(block, uint16(nodeID))` and `Function.Register(block, uformat.FunctionEndDT46)`. Both are idempotent map writes; redundant against `cnibgp`'s own registration on a node that has both, which is harmless (identical values) and is the precedent every additional CNI ADD already relies on.
+
+Putting this in the sidecar instead — the previous revision's proposal — would make a node-scoped fact contingent on a per-VPC reconcile inside a pod that may not exist, and would leave the same hole unrepaired on compute nodes after an `attach.Load` map wipe (the hole `gc.go`'s repair loop exists to plug for `vrf_table` and cannot plug for these two).
+
+No GC interaction: the sweep's scope is `vrf_table` only, and `LocatorTable`/`FunctionTable` deliberately expose no `Reconcile` (`usidmap/doc.go`).
+
+### 6.2 Piece 2 — the veth seam
+
+One veth per `(VPC, gateway node)`, created by `galactic-router`: **host end in root netns, pod end enslaved into the pod-netns VPC VRF.** Structurally identical to a tenant pod's attachment.
+
+Per-VPC, and enslaved, are both forced rather than chosen — see [§7.1](#71-why-the-pod-side-end-must-be-enslaved-per-vpc).
+
+**Two shapes, and a sequencing risk worth naming explicitly.**
+
+*Target shape (recommended).* This veth **replaces** `ensureEgressVeth`'s pod-internal pair and carries both directions:
+
+- Forward: Envoy (bound to the VRF) → route in the VRF table → pod end → host end in root netns → `usid_egress` on the host end's *ingress* hook → SRv6 encap → fabric.
+- Return: fabric → bond slave → `usid_ingress` → decap → FIB in the reserved table → `bpf_redirect_peer(host end)` → pod end → socket.
+
+This is exactly `cnibgp`'s own pattern (`attachUsidEgress` on the host-side veth), and it deletes the workaround `ensureEgressVeth` exists for — that "a Linux VRF master device's own TC egress hook never actually fires for traffic routed through it," which is why the sidecar had to invent a pod-internal pair to attach to at all (`ebpfdatapath.go:274-288`). It also moves every eBPF map write into root netns, so the sidecar would no longer need `CAP_BPF` or the bpffs mount for the egress path.
+
+*Conservative shape.* Keep `ensureEgressVeth`'s pair for the forward path and add this veth as return-only. The forward path then egresses `ivsN` while replies arrive on the new veth — asymmetric paths through two interfaces enslaved to the same VRF. That works (the socket is bound to the VRF master, and both links are enslaved to it) but it is unusual enough that someone will later "fix" it, so it needs a comment if chosen.
+
+**The risk:** the target shape modifies a forward path that currently works in the lab. The conservative shape does not. Recommendation is to implement the conservative shape first, prove the return path in isolation, then collapse to the target shape as a separate change — not to do both at once, which is the mistake that produced the compounding gaps this plan exists to fix.
+
+**Sequencing.** The VRF device is created by the sidecar in the pod netns; the veth is created by the router in root netns; the pod end has to be enslaved into that VRF. So there is a handshake either way, and its shape is the main remaining open question — see [§10](#10-open-questions).
+
+The host end needs a deterministic name so it is recoverable after either process restarts, mirroring `intf.GenerateInterfaceNameHost`'s convention.
+
+### 6.3 Piece 3 — the root-netns half of the VRF
+
+Three pieces of root-netns state, all created by `galactic-router` alongside Piece 2's veth, and all of which `internal/hostgw.ConfigureHostGateway` already implements for a tenant pod. Reuse it rather than re-deriving it; the role mapping is:
+
+| `hostgw` parameter | Value here |
+| ------------------------- | ---------------------------------------------------------- |
+| host-side interface | Piece 2's root-netns veth end |
+| the attachment's address | the gateway address (`DeriveGatewayAddress`) |
+| `guestHWAddr` | Piece 2's pod-side veth end's MAC (known to the router, which created the pair before moving one end) |
+| VRF table ID | the reserved root-netns table below, **not** `vrf.TableID(vpc)` |
+
+That yields the gateway address on the host end, a `/128` route for it into the reserved table, and the `NUD_PERMANENT` neigh entry §5.1 requires.
+
+**The reserved table.** A bare Linux routing table ID, not a VRF device (D-7). It must come from a range that cannot collide with `vrf.Add`'s allocator (`minVRFID = 1` upward, `vrf.go:24`) — pick a high, documented base. Because it is not a VRF device it is invisible to `vrf.ListVRFLinks`, `vrfpkg.TableID`, `resolveVRFKernelState`, and `CollectOrphanedVRFs`, which is the entire point.
+
+**The `vrf_table` entry.** `VRF.Register(realBlock, gwArgument, reservedTableID, usidmap.EgressKindVeth)`, where `gwArgument` comes from **the gateway's own `BGPVRFInstance`** (D-6), not the tenant's. Under a gateway-specific instance name, `resolveVRFKernelState` cannot match it either — it only matches `<vpcKey>-<nodeName>` against root-netns VRF link names — so GC's repair loop stays neutralised, and `cnibgp` can never land on the same key. The advertised SID then encodes `gwArgument`, which is also more honest: it means "deliver to the gateway," not "deliver to the tenant VRF."
+
+`EgressKindVeth` here is a real claim, not a don't-care. `ebpfdatapath.go:361-367`'s comment — *"a don't-care here ... `usid_ingress` is never attached anywhere in this pod's netns — this sidecar has no ingress/decap side at all"* — becomes false with this plan and must be updated.
+
+---
+
+## 7. Constraints that pin the design
+
+### 7.1 Why the pod-side end must be enslaved, per VPC
+
+#856's mutation binds Envoy's upstream socket to the VRF master via `SO_BINDTODEVICE`. A socket with `sk_bound_dev_if` set matches an incoming packet only when that ifindex appears as the packet's `dif` or `sdif`; a reply arriving on a *non*-VRF interface will never find the socket. `net.ipv4.tcp_l3mdev_accept` cannot rescue that case — its early-return fires only for *unbound* sockets — and nothing in this repo sets it anyway (`internal/plumbing/sysctl/sysctl.go:20-27` sets only `rp_filter`, `forwarding`, `proxy_arp`, `proxy_ndp`).
+
+So the tempting one-veth-per-pod simplification is closed off: the pod end must be enslaved into the VRF, which makes the veth per-VPC. **This is derived from kernel behaviour, not measured — it needs one live confirmation** (see §9).
+
+It also means the return path depends on #856's mutation continuing to apply. PR #851 flags upstream drift in Envoy Gateway's generated Deployment as a live risk; if that mutation silently stops applying, this return path breaks in a way that looks like a decap bug. State the dependency and check it (§9).
+
+### 7.2 Overlapping VPC address space
+
+None of Pieces 1–3 route on a tenant's own inner address: Piece 1 is keyed by node identity, and Piece 3's `vrf_table` entry is selected by the outer header's Argument before the inner packet's address is read. Two VPCs with identical backend CIDRs land in different tables regardless. Gateway addresses are drawn from a reserved, tenant-disjoint prefix and hashed per `(vpc, nodeID)`, so they cannot collide across VPCs either — and per D-4 there is at most one gateway pod per node under the DaemonSet shape, which is what makes that per-`(vpc, node)` keying sufficient — see [§7.5](#75-deployment-shape-and-where-the-sidecar-actually-runs) for where that does not hold.
+
+### 7.3 A pre-existing forward-path hazard, now reclassifiable
+
+`ensureRedirectRoute` (`ebpfdatapath.go:473`) installs each backend pod's `/128` into `unix.RT_TABLE_MAIN` — one table shared by every VPC the gateway pod serves. Two VPCs whose backend pods land on the identical address would have the second silently overwrite the first via `RouteReplace`.
+
+The review changes how this should be read. Since #856's `SO_BINDTODEVICE` mutation **is** implemented and verified to name the right device, the VRF-scoped forward path genuinely exists, and this main-table route is a redundant *second* path that can only cause the cross-VPC misroute, never prevent one. That makes it a candidate for **deletion** rather than a follow-up fix — unless it is load-bearing in deployments where the extension server isn't running, which needs confirming before removal. Out of scope here either way; worth its own change.
+
+### 7.4 Ceilings
+
+Both Argument allocators are scoped per node — `cnibgp/bgp.go:204` and `gateway.go:206` both filter on `inst.Spec.RouterRef.Name != routerName` — so the 12-bit Argument space (`uformat.go:88-89`, `0x001`–`0xFFF`, `0x000` reserved) is consumed per node, not globally. Under D-5 the gateway's extra Argument **does** coexist with a tenant's on any node hosting both, so budget two Arguments per VPC on those nodes.
+
+The number that does scale is different, and it is pre-existing. `publishEndpointSlice` fires on **every** CNI ADD with an IPv6 allocation (`ops_add.go:96`) — it is not gated on the pod being an ingress backend — and the sidecar's watch is cluster-wide by label. So a gateway node's sidecar materializes a VRF, and needs an Argument, for every VPC on the platform with at least one pod, not just those fronted by an `HTTPProxy`. Three ceilings follow:
+
+| Ceiling | Value | Source |
+| ------------------------------- | ----- | ---------------------- |
+| uSID Argument per node | 4095 | `uformat.go:89` |
+| Linux VRF table ID in the pod netns | 4095 | `argumentForTableID`, `ebpfdatapath.go:83` |
+| `vrf_table` entries per node | 8192 | `usid.c:742` |
+
+`vrf_table`'s own sizing comment says 8192 is "~2 uSID Blocks' worth of Argument space today." At 4095 VPCs with two entries each that is exactly at the wall — and per D-5 two entries per VPC is the co-located case, which is the normal one. So `vrf_table`'s sizing needs revisiting as part of this work, not after it. This is the sibling plan's Open Decision 9 confirmed in code; its active-VRF-count and active-route-count metrics are the instrument.
+
+### 7.5 Deployment shape and where the sidecar actually runs
+
+Envoy is provisioned through `EnvoyProxy.spec.provider.kubernetes`, and the overlays differ on which workload field they use:
+
+| Overlay | Field | One pod per node? |
+| ----------------------------------------------------------------- | ----------------- | ---------------------------- |
+| `infra/.../downstream/edge/patches/downstream-gateway.yaml:9` | `envoyDaemonSet` | yes, structurally |
+| `infra/.../downstream/base/downstream-gateway.yaml:72` | `envoyDeployment` | no — replicas, no anti-affinity |
+| `infra/.../downstream/staging/patches/downstream-gateway.yaml:19` | `envoyDeployment` | no |
+
+**The sidecar is deployed, correctly, in exactly one overlay: `edge-staging`.** `infra/.../downstream/edge-staging/patches/vpc-vrf-sidecar.yaml` JSON-patches it into `envoyDaemonSet` (line 29) with the real image (`ghcr.io/datum-cloud/galactic-vrf:v0.0.0-main`, line 43), `NET_ADMIN` + `BPF` (lines 84-85), the bpffs hostPath at `/sys/fs/bpf` (line 101), and — closing one of the sibling plan's undone §7 pre-merge checks — a writable mount at `/var/lib/cni/galactic-vrf` (line 96) for `internal/plumbing/vrf`'s flock. Both feature gates are set: `NODE_NAME` (line 68) and `GALACTIC_VRF_GATEWAY_PREFIX = fd30:e2e::/32` (line 73), so the gateway publisher *and* address provisioning are live there.
+
+Two consequences:
+
+1. **`edge-staging` is the environment to prove this in**, and it is ready — DaemonSet shape (so D-4 holds), real sidecar, both gates on, flock and bpffs mounted. Nothing about the deployment blocks bring-up; the return-path datapath is the only missing piece.
+2. **Productionization is a separate, later gap.** The production `edge` overlay has no `vpc-vrf-sidecar` patch at all, and `base`/`staging` use `envoyDeployment`, where D-4 does not hold: nothing stops two replicas per node, and `DeriveGatewayAddress`'s per-`(vpc, nodeID)` keying would then yield the same `/128` in two netns with one `vrf_table` entry between them. Either the DaemonSet shape becomes the contract for any environment running this feature, or the gateway address must be keyed per-pod — which also means a per-pod Argument, since one `vrf_table` key cannot serve two pods.
+
+---
+
+## 8. Teardown
+
+The previous revision left this as an open question. It needs writing explicitly, not piggybacking on the pod-netns veth's removal, and it now spans two components:
+
+| Resource | Owner | Trigger |
+| ------------------------------------- | ------------------ | ------------------------------------------------ |
+| gateway `BGPAdvertisement` | sidecar (`WithdrawGateway`) | VRF teardown, best-effort, already implemented |
+| gateway `BGPVRFInstance` (D-6) | `galactic-router` GC | orphan sweep, same as every other CRD this repo leaves for GC |
+| Piece 2 veth (both ends) | `galactic-router` | gateway `BGPVRFInstance` gone |
+| gateway address, `/128` route, neigh entry | `galactic-router` | with the veth (deleting the link removes all three) |
+| Piece 3 `vrf_table` entry | `galactic-router` | explicit `Unregister` before the veth goes |
+
+Follow the best-effort, `errors.Join`-all shape `removeEgressDatapath` already uses: attempt every step even if an earlier one failed. Order matters in one place — unregister the `vrf_table` entry *before* deleting the veth, so a decapped packet can never be redirected at a freed ifindex.
+
+---
+
+## 9. Pre-merge verification
+
+The sibling plan's three required-but-undone checks still stand. This plan adds four, each of which is a place where the design rests on derived rather than observed behaviour:
+
+1. **`BPF_FIB_LOOKUP_TBID` against a table with no VRF device.** D-7's entire premise. One route in a bare table plus one `bpf_fib_lookup` is enough to confirm.
+2. **`bpf_redirect_peer` into a VRF-enslaved pod-side end**, and that the socket actually receives it. This is §7.1's derivation; it is the single highest-risk assumption in the plan.
+3. **#856's `SO_BINDTODEVICE` mutation is actually applied** to the cluster in question — `nso_extension_vpcpod_socket_bind_total` (`extensionserver/metrics/metrics.go:183`) should be non-zero. Without it, §7.1's whole argument inverts.
+4. **The neigh entry is present and `NUD_PERMANENT`** after setup, and `DROP_REASON_FIB_NO_NEIGH` stays at zero under load.
+
+`drop_reasons` is the instrument for 1, 2 and 4: each has its own counter (`FIB_UNREACHABLE`, `REDIRECT_FAILED`, `FIB_NO_NEIGH`), so those failures are diagnosable without a packet capture.
+
+**One blind spot.** `BPF_FIB_LKUP_RET_FWD_DISABLED`/`NOT_FWDED` — the kernel refusing a forwarding lookup on an interface not configured as a router — has no drop reason of its own (`prog/dropreason.go:25-29` carries only `LookupFailed`, `NoNeigh`, `Unreachable`, `FragNeeded`), so it lands in the generic `fib_lookup_failed` bucket. `ConfigureFIBLookupUplinkSysctls`'s own doc comment records that this exact indistinguishability is what hid the containerlab XDP blocker, and that helper only runs on `galactic-gateway`/`galactic-nat66` nodes — which a gateway node need not be. Adding the counter is a small change and worth doing alongside Piece 3 rather than rediscovering it live.
+
+---
+
+## 10. Open questions
+
+1. **The Piece 2 handshake.** The VRF is created by the sidecar in the pod netns; the veth by the router in root netns; the pod end must be enslaved into that VRF. Who waits for whom, and how does each side recover idempotently after its own restart? Sub-question: how does the router learn the pod's netns — `hostPID` plus a `/proc/*/ns/net` inode scan against an inode the sidecar publishes, or a CRI lookup from the pod's identity? `hostPID` on `galactic-router` (already `hostNetwork`) is far less objectionable than on the Envoy pod, but it is still a new grant.
+2. **Where the gateway address lives.** `ensureGatewayAddress` currently assigns it to `ivsN` (`gatewayaddress.go:166`). Under §6.3 it belongs on Piece 2's veth. Under the conservative shape, does it move, or does it stay on `ivsN` with the new veth carrying only the route? Both are locally deliverable since both links are enslaved to the same VRF, but only one keeps `NetlinkGatewayAddressResolver` working unchanged.
+3. **`ensureRedirectRoute`'s fate** (§7.3) — delete, or keep for extension-server-less deployments?
+4. **`vrf_table` sizing.** Two entries per VPC per co-located node against `max_entries = 8192` puts the ceiling at ~4095 platform VPCs, and `usid.c:742`'s own comment already flags a third concurrent Block as an exhaustion case. Does this change raise it, or does the platform accept that ceiling explicitly?
+5. **Is the Envoy node affinity expressing what it means?** `.../edge/patches/downstream-gateway.yaml` requires `galactic.datumapis.com/node NotIn [control]`, but `node`'s documented values are `compute`/`edge` — `control` is a value of the *`galactic`* key (the route reflector). As written the term also requires the `node` label to be present at all. Possibly intended as `galactic NotIn [control]`. Either reading admits compute nodes, so it does not change D-5, but it is worth confirming rather than inheriting.
+
+---
+
+## References
+
+- [internal/plumbing/ebpf/prog/usid.c](../../internal/plumbing/ebpf/prog/usid.c) — `usid_ingress` steps 1–9, `usid_egress`, `enum egress_kind`, `apply_nptv6`, `apply_vip_xlat`.
+- [internal/cnibgp/bgp.go](../../internal/cnibgp/bgp.go) — `registerEBPFDatapath` (line 587), the working reference implementation for a tenant attachment.
+- [internal/hostgw/hostgw.go](../../internal/hostgw/hostgw.go) — `ConfigureHostGateway`, `installGatewayNeighbor`; the reference implementation Piece 3 reuses.
+- [internal/gc/gc.go](../../internal/gc/gc.go) — `SweepEBPFVRFTable`'s repair loop (line 663), `resolveVRFKernelState` (line 756), `CollectOrphanedVRFs` (line 400).
+- [internal/ingresssidecar/ebpfdatapath.go](../../internal/ingresssidecar/ebpfdatapath.go) — `ingressSidecarBlock`, `ensureEgressDatapath`, `ensureEgressVeth`, `ensureRedirectRoute`.
+- [internal/ingresssidecar/gateway.go](../../internal/ingresssidecar/gateway.go) — `k8sGatewayPublisher`, `lookupBGPRouter`, `allocateGatewayArgument`.
+- [internal/plumbing/ebpf/usidmap/doc.go](../../internal/plumbing/ebpf/usidmap/doc.go) — names Piece 1's intended owner; states that `locator_table`/`function_table` are unswept by design.
+- `network-services-operator/internal/extensionserver/mutate/vpcpod.go` — `ApplyVPCPodSocketBind`, `vrfDeviceName`; the `SO_BINDTODEVICE` dependency §7.1 rests on.
+
+---
+
+## Related fixes
+
+**`vrfTableID`'s `vrf_table` fallback (PR #500) — fixed, in the working tree.** The fallback added to recover a table ID for a VRF invisible in root netns could never hit any real row: it derived `block` from the *VPC identifier* (`intf.Base62ToHex(vpc)` parsed as hex) while every writer keys `block` off an SRv6 locator's top 48 bits (`uformat.Block`) or off the reserved `uformat.BlockMax`, and it looked up `BGPVRFInstance.Spec.VRFID` as the argument while the sidecar registers `vrf.TableID(vpc)` — two unrelated allocators. Its own doc comment asserted the opposite.
+
+Removed rather than re-keyed, for the reason §6.2's target shape makes clearer: on a node whose only consumer of that VPC is Envoy, the `egress_route_table` entries that table ID would have been used to install are already written per-EndpointSlice by the sidecar itself (`backend.go:107` → `srv6.RouteEgressAdd`), and Envoy only ever connects to backends those same EndpointSlices published. So there was nothing for `galactic-router` to add, and the honest handling is to skip quietly. `internal/plumbing/vrf` gained an `ErrNotFound` sentinel so `applyVRFs` can tell "absent from this netns" (ordinary, now debug-level) from a genuine netlink failure (still an error) — previously that condition logged `"this VRF's routes will not be installed"` on every reconcile, forever, for a VRF that was fine.

--- a/hack/returnpath-lab/README.md
+++ b/hack/returnpath-lab/README.md
@@ -1,0 +1,200 @@
+# returnpath-lab
+
+Phase 0 proof harness for
+[docs/plans/855-return-path-ingress-decap.md](../../docs/plans/855-return-path-ingress-decap.md).
+
+A lab tool, not a shipped binary. It performs by hand — and reverses — exactly
+what that plan's Pieces 1–3 would automate, so the plan's derived-but-unproven
+kernel assumptions can be tested before production code is written against
+them. It calls the same packages the real implementation will
+(`internal/plumbing/ebpf/usidmap`, `intf`, `uformat`, `egressroutemap`), so
+what it proves is proven about the real code paths.
+
+## Running it
+
+Needs the host root netns, `hostPID`, `privileged` (setns wants
+`CAP_SYS_ADMIN` on top of `NET_ADMIN`/`BPF`/`NET_RAW`), and the host's bpffs.
+`galactic-system` enforces `privileged` pod security, so a pod there works:
+
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/returnpath-lab ./hack/returnpath-lab
+kubectl -n galactic-system apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata: {name: returnpath-lab, namespace: galactic-system}
+spec:
+  nodeName: NODE            # the node hosting the Envoy Gateway pod
+  hostNetwork: true
+  hostPID: true             # pod-netns discovery walks /proc
+  restartPolicy: Never
+  containers:
+    - name: lab
+      image: busybox:1.36
+      command: ["sleep", "3600"]
+      securityContext: {privileged: true, runAsUser: 0}
+      volumeMounts: [{name: bpf-fs, mountPath: /sys/fs/bpf}]
+  volumes:
+    - name: bpf-fs
+      hostPath: {path: /sys/fs/bpf, type: Directory}
+EOF
+kubectl -n galactic-system cp /tmp/returnpath-lab returnpath-lab:/work/returnpath-lab
+```
+
+Invoke through `sh -c` — under a bare `kubectl exec ... -- binary sub -flags`
+the flags do not reach the process:
+
+```bash
+kubectl -n galactic-system exec returnpath-lab -- sh -c "/work/returnpath-lab status $FLAGS"
+```
+
+## The facts it needs
+
+| Flag | Where it comes from |
+| ----------- | ------------------------------------------------------------------------------- |
+| `-locator` | `kubectl -n galactic-system get bgprouter <node> -o jsonpath='{.spec.srv6Locator}'` |
+| `-node-id` | the same object's `.spec.nodeID` |
+| `-vpc` | the base62 VPC id — the first segment of an `EndpointSlice`'s `galactic.datum.net/tenant-id` |
+| `-argument` | `.spec.vrfID` of `BGPVRFInstance` `<vpcHex>-<node>` |
+| `-gw-addr` | the `/128` in the sidecar's own `BGPAdvertisement` (`<vpcHex>-<ingressHex>-<node>`) |
+
+Note that `-argument` (the CRD's `VRFID`) is **not** the pod-netns Linux VRF
+table id, and the two routinely differ. The advertised SID encodes the CRD
+value, so that is what `vrf_table` must be keyed on.
+
+## Subcommands
+
+| | |
+| -------------- | ---------------------------------------------------------------------------- |
+| `status` | read-only: every piece of state the return path needs, and whether it exists |
+| `up` | install it (needs `-yes`; without it, prints the plan only) |
+| `down` | remove it (`-purge-locator` also removes the locator/function entries) |
+| `probe` | open a VRF-bound TCP connection from inside the Envoy pod's netns, as #856 configures Envoy. **Refused counts as success** — a RST has to traverse the whole return path |
+| `inject` | send a real SRv6-encapsulated packet at a node's return SID, isolating decap from whether any tenant workload replies |
+| `egress-route` | look one `/128` up in `egress_route_table` — run on a *backend* node against the gateway address to see whether it imported the advertisement |
+| `filters` | list an interface's tc filter chain in evaluation order |
+| `verify-maps` | check that the bpffs-pinned maps are the same objects the attached program reads |
+
+Always run `probe` before `up` for a baseline. `-purge-locator` on teardown is
+not optional on a node that also runs `galactic-gateway` — see below.
+
+## What the first run established (2026-09-02, us-central-1-staging-lab)
+
+Confirmed:
+
+- **Gaps 1 and 2 are real.** `locator_table` and `function_table` were empty
+  on the gateway node; `vrf_table` held only the sidecar's five synthetic
+  `BlockMax` entries and nothing under the node's real locator.
+- **Pod-netns discovery works**, which answers the plan's Open Question 1:
+  walking `/proc/*/ns/net`, deduplicating by inode, and looking for
+  `intf.GenerateInterfaceNameVRF(vpc)` finds the Envoy pod's namespace
+  unambiguously. The VRF's name is the identifier — no annotation, CRI call
+  or published inode is needed.
+- **The sibling plan's advertisement path works end to end.** On the backend
+  node, `egress_route_table` resolved the gateway address to
+  `2607:ed40:8002:6:e001::`, decoding to exactly the expected block, Node-ID,
+  Function and Argument.
+- **Envoy's source-address selection is correct** — a VRF-bound socket in the
+  Envoy pod sourced from the derived gateway address.
+- **`up` installs cleanly**: veth across the netns boundary, enslavement into
+  the pod-netns VRF, a `/128` into a bare routing table with no VRF device,
+  a `NUD_PERMANENT` neighbor entry, and all three map entries.
+
+Found, and not previously known:
+
+- **The forward path drops packets on the backend node.** `vrf_table` for that
+  VPC showed `pkts=54 drops=21` against `fib_no_neigh=21` — ~40% loss. The
+  backend is a Kraftlet unikernel on a tap (`egress_kind=1`), and
+  `hostgw.ConfigureHostGateway` installs its permanent neighbor entry only
+  when `guestHWAddr != nil`, which its own doc comment says is "nil for tap
+  attachments". So tap-backed workloads depend on dynamic NDP and lose
+  traffic when it is not resolved. This is independent of the return path and
+  is live today.
+- **Seeding `locator_table` is not harmless on a `galactic-gateway` node.**
+  That component's `GALACTIC_GATEWAY_SRV6_ADDRESS` shares this node's Block
+  and Node-ID with Function `0x0`. `usid_ingress` step 2 matches on the top
+  64 bits alone, so once a locator entry exists the gateway's own address is
+  claimed and then dropped at step 4 as `UNKNOWN_FUNCTION` rather than passed
+  through. Measured zero collateral in a short window here, but it is
+  structural, and the plan's Piece 1 currently describes these writes as
+  harmless.
+- **`usid_egress` never sees host-originated traffic.** It attaches to the
+  *ingress* hook of a tenant's tap/veth, where a workload's own outbound
+  traffic arrives. A packet the host originates into a tenant VRF bypasses it
+  entirely and leaves via that VRF's NAT66 default route.
+- **The fabric carries only `/128` routes for advertised SIDs.** The
+  containing `/48` is a `Null0` static, so an arbitrary address in a node's
+  own locator space is unroutable — any design assuming locator-prefix
+  reachability is wrong.
+- **The Go drop-reason mirror is behind `usid.c`.** `prog.DropReasonCount` is
+  16 while the C enum defines 29, and `metrics/collector.go` iterates only to
+  the former, so the `TRACE_*` counters are never exported. Separately, a
+  node whose bpffs `drop_reasons` pin predates a newly-added reason has a map
+  too small to hold it and `count_drop` silently fails for that index, so two
+  nodes on the identical image can expose different counters.
+
+## Root cause, established (2026-09-02)
+
+Phase 0's gate is **not** cleared, and the reason is upstream of everything the
+plan describes. Inter-node SRv6 decap cannot work on this cluster at all:
+
+1. **`usid_ingress` is not attached to the interface that carries the
+   traffic.** `attach.ResolveInterfaces` picks the interfaces holding the IPv6
+   default route and then deliberately skips WireGuard links
+   (`attach/interfaces.go:166`, `excludedLinkType`) — a sensible guard, since a
+   WireGuard mesh can install a default-ish route and
+   `srv6.ResolveNodeSourceAddress` would otherwise bake its ULA in as the
+   node's source address. But this is Talos with KubeSpan enabled, and
+   `kubespan` is exactly what carries all inter-node IPv6 — the iBGP sessions
+   included. Attached sets were `[lo bond0 eno2 enp3s0f1]` on the gateway node
+   and `[lo bond0 ens2f1np1 ens1f1np1]` on the backend node; neither includes
+   `kubespan`.
+
+   Proven by capture: an injected return packet arrives correctly formed and on
+   the wrong interface —
+
+   ```
+   kubespan In IP6 2600:9c01:0:c::2 > 2607:ed40:8002:6:e001:::
+              IP6 fd20:0:2::3:0:0.44444 > fd30:e2e:3a5:...:9999: Flags [S]
+   ```
+
+   while `tcpdump` on `eno2`, `enp3s0f1` and `bond0`, filtered to that same
+   destination, captured nothing.
+
+2. **Attaching it there is not sufficient either.** `attach-iface` was used to
+   attach the running program (id 2828) to `kubespan` via the production
+   `attach.Attach` path, with Pieces 1–3 installed and every map entry
+   verified. `vrf_table` `pkts` stayed at 0. `kubespan` reports `link-type RAW
+   (Raw IP)` — there is no Ethernet header — and `usid_ingress` step 1
+   unconditionally parses `struct usid_ethhdr` and tests `h_proto ==
+   ETH_P_IPV6`. On an L3 interface it reads the inner IPv6 header's own bytes
+   as an ethertype, mismatches, and returns `TC_ACT_UNSPEC` — silently, on the
+   one path that is deliberately uncounted.
+
+So the datapath structurally assumes an Ethernet-framed fabric. Over a
+KubeSpan/WireGuard mesh it cannot decap, and the same applies to the forward
+direction: the backend node's `vrf_table` hits (`pkts=54`) come from the Envoy
+pod *on that same node*, whose encapsulated traffic loops back via `lo` — which
+*is* in the attached set. Cross-node #855 ingress has therefore never worked
+here, in either direction.
+
+### What this means for the plan
+
+Pieces 1–3 are still necessary and their key derivations are confirmed correct,
+but they are not sufficient and are not the top blocker. Before any of that
+work is worth doing, one of the following has to be settled:
+
+- run the SRv6 fabric over an Ethernet-framed underlay on these nodes (i.e. do
+  not carry it over KubeSpan), or
+- teach `usid_ingress`/`usid_egress` to handle L3/RAW interfaces — detect the
+  absence of a MAC header rather than assuming `ETH_HLEN`, and give step 9 a
+  redirect path that does not depend on resolved L2 addressing.
+
+Either is a materially larger change than this plan's Pieces 1–3, and the
+choice belongs with whoever owns the underlay.
+
+### Still unverified
+
+The plan's assumption 2 — `bpf_redirect_peer` from root netns into a
+VRF-enslaved pod-side veth delivering to a `SO_BINDTODEVICE`-bound socket —
+remains untested, because no packet ever reached step 6. It needs an
+environment where inter-node decap works at all.

--- a/hack/returnpath-lab/main.go
+++ b/hack/returnpath-lab/main.go
@@ -1,0 +1,1436 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Command returnpath-lab is the Phase 0 proof harness for
+// docs/plans/855-return-path-ingress-decap.md. It is a lab tool, not a
+// shipped binary: it performs, by hand and reversibly, exactly what that
+// plan's Pieces 1-3 would automate, so the plan's three derived-but-
+// unproven kernel assumptions can be tested before any production code is
+// written against them.
+//
+// The assumptions under test, and how a successful `up` + end-to-end
+// request proves each:
+//
+//  1. bpf_fib_lookup with BPF_FIB_LOOKUP_TBID resolves against a bare
+//     Linux routing table that has no VRF device attached (plan D-7). `up`
+//     installs the return route into exactly such a table.
+//  2. bpf_redirect_peer from the host root netns into a VRF-enslaved
+//     pod-side veth end delivers to a socket that is SO_BINDTODEVICE-bound
+//     to that VRF master (plan §7.1). `up` builds precisely that topology.
+//  3. A packet arriving on one VRF-enslaved link is locally delivered for
+//     an address configured on a *different* link enslaved to the same VRF
+//     (plan §7.1 point 3) -- the gateway address lives on the sidecar's own
+//     ivsN veth, not on the link this tool creates.
+//
+// It deliberately reuses the production packages (internal/plumbing/ebpf/
+// usidmap, internal/plumbing/intf, internal/plumbing/ebpf/uformat) rather
+// than hand-marshalling map keys with bpftool, both to avoid layout bugs
+// and so that whatever `up` proves is proven about the real code paths that
+// Phase 2 will move into galactic-router.
+//
+// Must run in the host's root network namespace with CAP_NET_ADMIN, CAP_BPF
+// and hostPID (the pod-netns discovery below walks /proc), with the host's
+// bpffs mounted. See hack/returnpath-lab/README.md.
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	"go.datum.net/galactic/internal/plumbing/intf"
+	"go.datum.net/galactic/internal/plumbing/srv6"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+type config struct {
+	locator     string
+	nodeID      uint
+	vpc         string
+	argument    uint
+	gwAddr      string
+	tableID     uint
+	pinDir      string
+	ifPrefix    string
+	yes         bool
+	backend     string
+	ports       string
+	timeout     time.Duration
+	purge       bool
+	egressTable uint
+	addr        string
+	netnsPath   string
+	innerSrc    string
+	innerSport  uint
+	innerDport  uint
+	count       int
+	sidOverride string
+	iface       string
+	progID      uint
+}
+
+func main() {
+	var cfg config
+	flag.StringVar(&cfg.locator, "locator", "",
+		"this node's BGPRouter spec.srv6Locator, e.g. 2607:ed40:8002::/48 (required)")
+	flag.UintVar(&cfg.nodeID, "node-id", 0, "this node's BGPRouter spec.nodeID (required)")
+	flag.StringVar(&cfg.vpc, "vpc", "", "base62 VPC id, e.g. 2 (required)")
+	flag.UintVar(&cfg.argument, "argument", 0, "this VPC's BGPVRFInstance spec.vrfID on this node (required)")
+	flag.StringVar(&cfg.gwAddr, "gw-addr", "",
+		"the return-path gateway address the sidecar advertised (required for up/down)")
+	flag.UintVar(&cfg.tableID, "table", 900,
+		"reserved root-netns routing table id for the return route (plan D-7: a bare table, not a VRF)")
+	flag.StringVar(&cfg.pinDir, "pin-dir", "/sys/fs/bpf/galactic", "bpffs directory holding the usid_ingress pinned maps")
+	flag.StringVar(&cfg.ifPrefix, "if-prefix", "gwr",
+		"root-side veth name prefix; the pair is <prefix><argument> / <prefix><argument>p")
+	flag.BoolVar(&cfg.yes, "yes", false, "for up/down: actually apply, instead of only printing the plan")
+	flag.StringVar(&cfg.backend, "backend", "", "for probe: a VPC backend address to connect to, e.g. fd20:0:2::3:0:0")
+	flag.StringVar(&cfg.ports, "ports", "80,8080,443", "for probe: comma-separated TCP ports to try")
+	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Second, "for probe: per-port connect timeout")
+	flag.UintVar(&cfg.egressTable, "egress-table", 0, "for egress-route: the Linux VRF table id to look the prefix up in")
+	flag.StringVar(&cfg.addr, "addr", "", "for egress-route: the /128 address to look up")
+	flag.StringVar(&cfg.innerSrc, "inner-src", "",
+		"for inject: the VPC backend address the inner packet claims to come from")
+	flag.UintVar(&cfg.innerSport, "inner-sport", 44444, "for inject: inner TCP source port")
+	flag.UintVar(&cfg.innerDport, "inner-dport", 9999, "for inject: inner TCP destination port")
+	flag.IntVar(&cfg.count, "count", 3, "for inject: how many packets to send")
+	flag.UintVar(&cfg.progID, "prog-id", 0, "for verify-maps: the attached program id, from the filters output")
+	flag.StringVar(&cfg.iface, "iface", "",
+		"for filters/attach-iface/detach-iface: the interface to act on")
+	flag.StringVar(&cfg.sidOverride, "sid", "",
+		"for inject: send to this outer destination instead of the derived return SID. Use it to probe which "+
+			"usid_ingress step a packet reaches: a SID sharing this node's Block+Node-ID but carrying an "+
+			"unregistered Function must be counted as unknown_function if the program runs at all, so a zero "+
+			"there means usid_ingress never executed on the packet (it never arrived, or an earlier tc filter "+
+			"claimed it with a final verdict).")
+	flag.StringVar(&cfg.netnsPath, "netns", "",
+		"for probe: use this netns instead of discovering one. Needed where more than one namespace holds a VRF "+
+			"for the same VPC -- e.g. a compute node has the tenant VRF in root netns AND its own Envoy pod's VRF "+
+			"in that pod's netns. Pass /proc/1/ns/net to probe from the tenant side.")
+	flag.BoolVar(&cfg.purge, "purge-locator", false,
+		"for down: also remove the locator_table/function_table entries. Needed on a node that also runs "+
+			"galactic-gateway, whose own SRv6 address shares this locator+Node-ID with Function 0x0: while a "+
+			"locator_table entry exists, usid_ingress claims that address at step 2 and then drops it at step 4 "+
+			"as UNKNOWN_FUNCTION instead of passing it through to the XDP/stack path that handles it.")
+	flag.Usage = usage
+
+	// The action is the first argument, consumed before flag.Parse: Go's
+	// flag package stops parsing at the first non-flag argument, so a
+	// trailing subcommand would silently swallow every flag after it.
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	action := os.Args[1]
+	switch action {
+	case "status", "up", "down", "probe", "egress-route", "inject", "filters",
+		"verify-maps", "attach-iface", "detach-iface":
+	default:
+		usage()
+		os.Exit(2)
+	}
+	if err := flag.CommandLine.Parse(os.Args[2:]); err != nil {
+		os.Exit(2)
+	}
+
+	if err := run(action, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "\nreturnpath-lab: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `returnpath-lab <status|up|down> [flags]
+
+  status  read-only: report every piece of state the return path needs, and
+          whether it is present. Safe, changes nothing.
+  up      install the missing state (needs -yes to apply).
+  down    remove what up installed (needs -yes to apply). Leaves
+          locator_table/function_table alone: those are per-node facts the
+          plan's Piece 1 wants permanently, and they are harmless.
+  egress-route
+          look one /128 up in egress_route_table for a given VRF table id --
+          i.e. ask "would usid_egress SRv6-encapsulate a packet this VRF
+          sends to that address, and toward which SID?". Run it on a BACKEND
+          node against the gateway address to see whether that node has
+          imported the sidecar's return-path advertisement at all.
+  attach-iface / detach-iface
+          attach the already-loaded usid_ingress to an extra interface, or
+          remove it. For testing the WireGuard/KubeSpan exclusion.
+  filters list an interface's tc filter chain in evaluation order -- who runs
+          before usid_ingress, and whether usid_ingress is attached at all.
+  inject  send one real SRv6-encapsulated packet at a gateway node's return
+          SID, carrying an inner TCP SYN from a backend address to the
+          gateway address. Isolates the decap path from whether any tenant
+          workload actually replies. Run from any node on the fabric.
+  probe   open a VRF-bound TCP connection from inside the Envoy pod's own
+          netns to -backend, exactly as an Envoy upstream socket would, and
+          classify what comes back. Run it before "up" for a baseline and
+          after "up" to see whether the return path now works. Changes no
+          state. NOTE: connection *refused* counts as success -- a RST has
+          to traverse the whole return path to reach us.
+
+`)
+	flag.PrintDefaults()
+}
+
+// derived holds the values every action computes from the flags, so the
+// key arithmetic lives in exactly one place and `status` prints the same
+// numbers `up` would write.
+type derived struct {
+	block       uint64
+	nodeID      uint16
+	argument    uint16
+	locatorKey  uint64
+	functionKey uint64
+	vrfKey      uint64
+	returnSID   netip.Addr
+	vrfName     string
+	hostIf      string
+	peerIf      string
+	gwAddr      net.IP
+}
+
+func derive(cfg config) (derived, error) {
+	var d derived
+
+	if cfg.locator == "" || cfg.vpc == "" || cfg.nodeID == 0 || cfg.argument == 0 {
+		return d, errors.New("-locator, -node-id, -vpc and -argument are all required")
+	}
+	prefix, err := netip.ParsePrefix(cfg.locator)
+	if err != nil {
+		return d, fmt.Errorf("parse -locator %q: %w", cfg.locator, err)
+	}
+	if d.block, err = uformat.Block(prefix.Addr()); err != nil {
+		return d, fmt.Errorf("derive uSID Block from -locator %q: %w", cfg.locator, err)
+	}
+	if cfg.nodeID > uint(uformat.NodeIDMax) {
+		return d, fmt.Errorf("-node-id %d exceeds NodeIDMax %#x", cfg.nodeID, uint16(uformat.NodeIDMax))
+	}
+	if cfg.argument < uint(uformat.ArgumentMin) || cfg.argument > uint(uformat.ArgumentMax) {
+		return d, fmt.Errorf("-argument %d outside [%#x,%#x]",
+			cfg.argument, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax))
+	}
+	d.nodeID = uint16(cfg.nodeID)
+	d.argument = uint16(cfg.argument)
+
+	// The three keys usid_ingress steps 2, 4 and 6 look up, composed
+	// exactly as usid.c's own header comment specifies.
+	d.locatorKey = d.block<<16 | uint64(d.nodeID)
+	d.functionKey = d.block<<4 | uint64(uformat.FunctionEndDT46)
+	d.vrfKey = d.block<<12 | uint64(d.argument)
+
+	// The outer destination a backend node will address the reply to, so
+	// status can print it for comparison against a packet capture.
+	if d.returnSID, err = srv6.ComputeSID(cfg.locator, int32(cfg.nodeID), int32(cfg.argument),
+		bgpv1alpha1.SRv6FunctionEndDT46); err != nil {
+		return d, fmt.Errorf("compose return SID: %w", err)
+	}
+
+	d.vrfName = intf.GenerateInterfaceNameVRF(cfg.vpc)
+	d.hostIf = fmt.Sprintf("%s%d", cfg.ifPrefix, d.argument)
+	d.peerIf = d.hostIf + "p"
+
+	if cfg.gwAddr != "" {
+		if d.gwAddr = net.ParseIP(cfg.gwAddr); d.gwAddr == nil {
+			return d, fmt.Errorf("parse -gw-addr %q", cfg.gwAddr)
+		}
+	}
+	return d, nil
+}
+
+func run(action string, cfg config) error {
+	d, err := derive(cfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("=== derived ===\n")
+	fmt.Printf("  uSID Block          %#x\n", d.block)
+	fmt.Printf("  Node-ID             %d\n", d.nodeID)
+	fmt.Printf("  Argument (VRFID)    %d\n", d.argument)
+	fmt.Printf("  locator_key         %#x\n", d.locatorKey)
+	fmt.Printf("  function_key        %#x  (Function %#x = End.DT46)\n", d.functionKey, uint8(uformat.FunctionEndDT46))
+	fmt.Printf("  vrf_key             %#x\n", d.vrfKey)
+	fmt.Printf("  expected return SID %s   <-- outer dst a backend node addresses replies to\n", d.returnSID)
+	fmt.Printf("  pod-netns VRF       %s\n", d.vrfName)
+	fmt.Printf("  veth pair           %s (root netns) <-> %s (pod netns, enslaved into %s)\n",
+		d.hostIf, d.peerIf, d.vrfName)
+	if d.gwAddr != nil {
+		fmt.Printf("  gateway address     %s/128 -> table %d via %s\n", d.gwAddr, cfg.tableID, d.hostIf)
+	}
+	fmt.Println()
+
+	switch action {
+	case "status":
+		return status(cfg, d)
+	case "up":
+		return up(cfg, d)
+	case "down":
+		return down(cfg, d)
+	case "probe":
+		return probe(cfg, d)
+	case "egress-route":
+		return egressRoute(cfg, d)
+	case "inject":
+		return inject(cfg, d)
+	case "filters":
+		return filters(cfg, d)
+	case "verify-maps":
+		return verifyMaps(cfg, d)
+	case "attach-iface":
+		return attachIface(cfg, d)
+	case "detach-iface":
+		return detachIface(cfg, d)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// pod netns discovery
+// ---------------------------------------------------------------------
+
+type podNetns struct {
+	path  string
+	pid   string
+	inode string
+}
+
+// findPodNetns locates the network namespace holding vrfName by walking
+// /proc, deduplicating by netns inode, and entering each distinct namespace
+// to look for that interface.
+//
+// This is deliberately the same mechanism the plan's Open Question 1 needs
+// an answer for: identifying which pod's netns holds a given VPC's VRF, from
+// a root-netns process, with no CNI ADD ever having happened for that pod.
+// Proving it here is part of Phase 0's job. The VRF's name is fully
+// determined by the VPC id (intf.GenerateInterfaceNameVRF), so the interface
+// itself is the identifier -- no annotation, CRI call or published inode is
+// needed.
+func findPodNetns(vrfName string) ([]podNetns, error) {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("read /proc (is hostPID set?): %w", err)
+	}
+
+	seen := make(map[string]string) // netns inode -> first pid seen
+	var pids []string
+	for _, e := range entries {
+		if !e.IsDir() || strings.IndexFunc(e.Name(), func(r rune) bool { return r < '0' || r > '9' }) >= 0 {
+			continue
+		}
+		link, lerr := os.Readlink(filepath.Join("/proc", e.Name(), "ns", "net"))
+		if lerr != nil {
+			continue // process exited, or not visible to us
+		}
+		if _, dup := seen[link]; dup {
+			continue
+		}
+		seen[link] = e.Name()
+		pids = append(pids, e.Name())
+	}
+	sort.Strings(pids)
+
+	var found []podNetns
+	for _, pid := range pids {
+		path := filepath.Join("/proc", pid, "ns", "net")
+		var hit bool
+		err := ns.WithNetNSPath(path, func(ns.NetNS) error {
+			if _, lerr := netlink.LinkByName(vrfName); lerr == nil {
+				hit = true
+			}
+			return nil
+		})
+		if err != nil {
+			continue // namespace vanished mid-walk, or cannot be entered
+		}
+		if hit {
+			inode := ""
+			if l, lerr := os.Readlink(path); lerr == nil {
+				inode = l
+			}
+			found = append(found, podNetns{path: path, pid: pid, inode: inode})
+		}
+	}
+	return found, nil
+}
+
+// ---------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------
+
+func status(cfg config, d derived) error {
+	fmt.Printf("=== eBPF maps (%s) ===\n", cfg.pinDir)
+	registry, closer, err := usidmap.OpenPinnedRegistry(cfg.pinDir)
+	if err != nil {
+		fmt.Printf("  !! cannot open pinned registry: %v\n", err)
+	} else {
+		defer func() { _ = closer.Close() }()
+
+		locs, lerr := registry.Locator.List()
+		fmt.Printf("  locator_table  %s\n", countOrErr(len(locs), lerr))
+		for _, l := range locs {
+			mark := " "
+			if l.Block == d.block && l.NodeID == d.nodeID {
+				mark = "*"
+			}
+			fmt.Printf("   %s block=%#x node-id=%d\n", mark, l.Block, l.NodeID)
+		}
+
+		fns, ferr := registry.Function.List()
+		fmt.Printf("  function_table %s\n", countOrErr(len(fns), ferr))
+		for _, f := range fns {
+			mark := " "
+			if f.Block == d.block && f.Function == uint8(uformat.FunctionEndDT46) {
+				mark = "*"
+			}
+			fmt.Printf("   %s block=%#x function=%#x behavior=%d\n", mark, f.Block, f.Function, f.Behavior)
+		}
+
+		vrfs, verr := registry.VRF.List()
+		fmt.Printf("  vrf_table      %s\n", countOrErr(len(vrfs), verr))
+		for _, v := range vrfs {
+			mark := " "
+			if v.Block == d.block && v.Argument == d.argument {
+				mark = "*"
+			}
+			note := ""
+			if v.Block == uformat.BlockMax {
+				note = "  (ingresssidecar's synthetic BlockMax entry, usid_egress only)"
+			}
+			fmt.Printf("   %s block=%#x arg=%d -> table=%d egress_kind=%d pkts=%d drops=%d%s\n",
+				mark, v.Block, v.Argument, v.VRFTableID, v.EgressKind, v.Packets, v.DroppedPackets, note)
+		}
+		fmt.Printf("  (* = the entry this return path needs)\n")
+	}
+
+	fmt.Printf("\n=== root netns ===\n")
+	reportLink(d.hostIf)
+	reportRoute(d, cfg.tableID)
+	reportNeigh(d)
+	reportForwarding(d.hostIf)
+
+	fmt.Printf("\n=== pod netns discovery (looking for %s) ===\n", d.vrfName)
+	found, err := findPodNetns(d.vrfName)
+	if err != nil {
+		fmt.Printf("  !! %v\n", err)
+	} else if len(found) == 0 {
+		fmt.Printf("  !! no network namespace on this node holds %s\n", d.vrfName)
+		fmt.Printf("     the sidecar has not created this VPC's VRF here; nothing to attach to yet\n")
+	} else {
+		for _, p := range found {
+			fmt.Printf("  netns %s (pid %s, %s)\n", p.path, p.pid, p.inode)
+			if derr := describePodNetns(p.path, d); derr != nil {
+				fmt.Printf("    !! %v\n", derr)
+			}
+		}
+	}
+
+	fmt.Printf("\n=== drop_reasons (non-zero) ===\n")
+	if err := reportDropReasons(cfg.pinDir); err != nil {
+		fmt.Printf("  !! %v\n", err)
+	}
+	return nil
+}
+
+func countOrErr(n int, err error) string {
+	if err != nil {
+		return fmt.Sprintf("ERROR: %v", err)
+	}
+	if n == 0 {
+		return "EMPTY"
+	}
+	return fmt.Sprintf("%d entr%s", n, plural(n))
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+func reportLink(name string) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		fmt.Printf("  link %-10s ABSENT\n", name)
+		return
+	}
+	a := link.Attrs()
+	fmt.Printf("  link %-10s present ifindex=%d mac=%s oper=%s\n", name, a.Index, a.HardwareAddr, a.OperState)
+}
+
+func reportRoute(d derived, tableID uint) {
+	if d.gwAddr == nil {
+		fmt.Printf("  route             (skipped, no -gw-addr)\n")
+		return
+	}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
+		&netlink.Route{Table: int(tableID)}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		fmt.Printf("  route             ERROR: %v\n", err)
+		return
+	}
+	if len(routes) == 0 {
+		fmt.Printf("  table %-4d        EMPTY (no route for %s)\n", tableID, d.gwAddr)
+		return
+	}
+	for _, r := range routes {
+		dst := "default"
+		if r.Dst != nil {
+			dst = r.Dst.String()
+		}
+		name := strconv.Itoa(r.LinkIndex)
+		if l, lerr := netlink.LinkByIndex(r.LinkIndex); lerr == nil {
+			name = l.Attrs().Name
+		}
+		fmt.Printf("  table %-4d        %s dev %s\n", tableID, dst, name)
+	}
+}
+
+func reportNeigh(d derived) {
+	if d.gwAddr == nil {
+		fmt.Printf("  neigh             (skipped, no -gw-addr)\n")
+		return
+	}
+	link, err := netlink.LinkByName(d.hostIf)
+	if err != nil {
+		fmt.Printf("  neigh             (skipped, %s absent)\n", d.hostIf)
+		return
+	}
+	neighs, err := netlink.NeighList(link.Attrs().Index, netlink.FAMILY_V6)
+	if err != nil {
+		fmt.Printf("  neigh             ERROR: %v\n", err)
+		return
+	}
+	for _, n := range neighs {
+		if n.IP.Equal(d.gwAddr) {
+			perm := ""
+			if n.State&netlink.NUD_PERMANENT != 0 {
+				perm = " NUD_PERMANENT"
+			}
+			fmt.Printf("  neigh             %s lladdr %s dev %s%s\n", n.IP, n.HardwareAddr, d.hostIf, perm)
+			return
+		}
+	}
+	fmt.Printf("  neigh             ABSENT for %s on %s  <-- bpf_fib_lookup would return NO_NEIGH\n", d.gwAddr, d.hostIf)
+}
+
+func reportForwarding(hostIf string) {
+	for _, k := range []string{"all", hostIf} {
+		p := filepath.Join("/proc/sys/net/ipv6/conf", k, "forwarding")
+		b, err := os.ReadFile(p) //nolint:gosec // fixed, non-user-controlled proc path
+		if err != nil {
+			fmt.Printf("  fwd %-13s (unreadable: %v)\n", k, err)
+			continue
+		}
+		v := strings.TrimSpace(string(b))
+		note := ""
+		if v == "0" {
+			note = "  <-- bpf_fib_lookup can return FWD_DISABLED, which usid.c counts as generic fib_lookup_failed"
+		}
+		fmt.Printf("  fwd %-13s %s%s\n", k, v, note)
+	}
+}
+
+// describePodNetns reports, from inside the pod's own namespace, the three
+// things the return path depends on there: the VRF and its table, which
+// links are enslaved to it, and which of those links actually carries the
+// gateway address (plan §7.1 point 3 -- delivery is cross-interface within
+// one VRF, so this is expected NOT to be the link this tool creates).
+func describePodNetns(path string, d derived) error {
+	return ns.WithNetNSPath(path, func(ns.NetNS) error {
+		vrfLink, err := netlink.LinkByName(d.vrfName)
+		if err != nil {
+			return fmt.Errorf("look up %s: %w", d.vrfName, err)
+		}
+		vrfDev, ok := vrfLink.(*netlink.Vrf)
+		if !ok {
+			return fmt.Errorf("%s is a %s, not a VRF", d.vrfName, vrfLink.Type())
+		}
+		fmt.Printf("    %s ifindex=%d table=%d oper=%s\n",
+			d.vrfName, vrfDev.Attrs().Index, vrfDev.Table, vrfDev.Attrs().OperState)
+
+		links, err := netlink.LinkList()
+		if err != nil {
+			return fmt.Errorf("list links: %w", err)
+		}
+		for _, l := range links {
+			a := l.Attrs()
+			if a.MasterIndex != vrfDev.Attrs().Index {
+				continue
+			}
+			addrs, _ := netlink.AddrList(l, netlink.FAMILY_V6) //nolint:errcheck // reported as empty below
+			var strs []string
+			for _, ad := range addrs {
+				mark := ""
+				if d.gwAddr != nil && ad.IP.Equal(d.gwAddr) {
+					mark = " <-- gateway address"
+				}
+				strs = append(strs, ad.IPNet.String()+mark)
+			}
+			fmt.Printf("      enslaved: %-12s (%s) mac=%s oper=%s addrs=%s\n",
+				a.Name, l.Type(), a.HardwareAddr, a.OperState, strings.Join(strs, ", "))
+		}
+		if _, err := netlink.LinkByName(d.peerIf); err == nil {
+			fmt.Printf("      %s present in this netns\n", d.peerIf)
+		} else {
+			fmt.Printf("      %s ABSENT from this netns\n", d.peerIf)
+		}
+		return nil
+	})
+}
+
+func reportDropReasons(pinDir string) error {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, "drop_reasons"), nil)
+	if err != nil {
+		return fmt.Errorf("open pinned drop_reasons: %w", err)
+	}
+	defer func() { _ = m.Close() }()
+
+	// max_entries matters: attach.Load reuses an already-pinned map as-is,
+	// so a node whose bpffs pin predates a newly-added drop reason has a
+	// map too small to hold it, and count_drop for that index silently
+	// fails. Two nodes running the identical image can therefore expose
+	// different counters -- report the size so that is visible rather than
+	// looking like a genuine zero.
+	fmt.Printf("  (map max_entries=%d; usid.c currently defines 29)\n", m.MaxEntries())
+
+	any := false
+	for idx := range m.MaxEntries() {
+		var perCPU []uint64
+		if err := m.Lookup(&idx, &perCPU); err != nil {
+			fmt.Printf("  !! lookup index %d failed: %v\n", idx, err)
+			break
+		}
+		var total uint64
+		for _, v := range perCPU {
+			total += v
+		}
+		if total == 0 {
+			continue
+		}
+		any = true
+		name, ok := prog.DropReasonNames[idx]
+		if !ok {
+			// usid.c carries diagnostic TRACE_* counters above the Go
+			// mirror's DropReasonCount (16); prog.DropReasonNames stops
+			// there, and metrics/collector.go deliberately does not export
+			// them. They are the most useful signal for this harness, so
+			// name them locally rather than widening the production mirror
+			// for a set usid.c documents as temporary.
+			if n, tok := traceReasonNames[idx]; tok {
+				name = n
+			} else {
+				name = fmt.Sprintf("unknown(%d)", idx)
+			}
+		}
+		fmt.Printf("  %-28s %d\n", name, total)
+	}
+	if !any {
+		fmt.Printf("  (all zero)\n")
+	}
+	return nil
+}
+
+// traceReasonNames mirrors usid.c's DROP_REASON_TRACE_* diagnostic
+// checkpoints, which sit above prog.DropReasonCount and so have no entry in
+// prog.DropReasonNames. Read together they say how far usid_egress got:
+// ENTRY -> IFINDEX_HIT -> ADJUST_ROOM_OK -> REACHED_REDIRECT -> REDIRECT_OK
+// is a fully successful encapsulation.
+var traceReasonNames = map[uint32]string{
+	16: "trace_multicast_ll_bail",
+	17: "trace_miss_vrf",
+	18: "trace_miss_route",
+	19: "trace_passthrough_entry",
+	20: "trace_adjust_room_ok",
+	21: "trace_reached_redirect",
+	22: "trace_redirect_ok",
+	23: "trace_ifindex_miss",
+	24: "trace_entry",
+	25: "trace_pull_data_failed",
+	26: "trace_eth_bounds_failed",
+	27: "trace_ethertype_mismatch",
+	28: "trace_ifindex_hit",
+}
+
+// ---------------------------------------------------------------------
+// up
+// ---------------------------------------------------------------------
+
+func up(cfg config, d derived) error {
+	if d.gwAddr == nil {
+		return errors.New("-gw-addr is required for up")
+	}
+
+	found, err := findPodNetns(d.vrfName)
+	if err != nil {
+		return fmt.Errorf("discover pod netns: %w", err)
+	}
+	switch len(found) {
+	case 0:
+		return fmt.Errorf(
+			"no network namespace on this node holds %s -- the sidecar has not created this VPC's VRF here", d.vrfName)
+	case 1:
+	default:
+		return fmt.Errorf("ambiguous: %d namespaces hold %s; refusing to guess", len(found), d.vrfName)
+	}
+	target := found[0]
+	fmt.Printf("=== plan ===\n")
+	fmt.Printf("  1. create veth %s <-> %s in root netns\n", d.hostIf, d.peerIf)
+	fmt.Printf("  2. move %s into %s (pid %s), enslave into %s, set up\n", d.peerIf, target.path, target.pid, d.vrfName)
+	fmt.Printf("  3. root netns: ip -6 route replace %s/128 dev %s table %d\n", d.gwAddr, d.hostIf, cfg.tableID)
+	fmt.Printf("  4. root netns: ip -6 neigh replace %s lladdr <%s mac> dev %s nud permanent\n",
+		d.gwAddr, d.peerIf, d.hostIf)
+	fmt.Printf("  5. locator_table.Register(block=%#x, node-id=%d)\n", d.block, d.nodeID)
+	fmt.Printf("  6. function_table.Register(block=%#x, function=%#x)\n", d.block, uint8(uformat.FunctionEndDT46))
+	fmt.Printf("  7. vrf_table.Register(block=%#x, arg=%d, table=%d, egress_kind=veth)\n",
+		d.block, d.argument, cfg.tableID)
+	fmt.Println()
+
+	if !cfg.yes {
+		fmt.Printf("dry run: pass -yes to apply\n")
+		return nil
+	}
+
+	// 1 + 2: the veth. Both ends are created in this (root) netns, then the
+	// peer is moved -- the same order galactic-cni uses for a tenant pod,
+	// and the reason the router can know the peer's MAC (needed by step 4)
+	// without ever entering the pod's namespace.
+	peerMAC, err := ensureVeth(d)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  [1,2] veth ready, %s mac=%s\n", d.peerIf, peerMAC)
+
+	if err := moveAndEnslave(target.path, d); err != nil {
+		return err
+	}
+	fmt.Printf("  [2]   %s moved into %s and enslaved into %s\n", d.peerIf, target.path, d.vrfName)
+
+	hostLink, err := netlink.LinkByName(d.hostIf)
+	if err != nil {
+		return fmt.Errorf("look up %s after setup: %w", d.hostIf, err)
+	}
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		return fmt.Errorf("set %s up: %w", d.hostIf, err)
+	}
+
+	// 3: the return route, into a bare table with no VRF device (plan D-7).
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: d.gwAddr, Mask: net.CIDRMask(128, 128)},
+		LinkIndex: hostLink.Attrs().Index,
+		Table:     int(cfg.tableID),
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("install %s/128 dev %s table %d: %w", d.gwAddr, d.hostIf, cfg.tableID, err)
+	}
+	fmt.Printf("  [3]   route %s/128 dev %s table %d\n", d.gwAddr, d.hostIf, cfg.tableID)
+
+	// 4: the permanent neighbor entry. Without this, bpf_fib_lookup returns
+	// BPF_FIB_LKUP_RET_NO_NEIGH and usid_ingress drops the packet -- see
+	// internal/hostgw.installGatewayNeighbor's doc comment.
+	if err := netlink.NeighSet(&netlink.Neigh{
+		LinkIndex:    hostLink.Attrs().Index,
+		Family:       netlink.FAMILY_V6,
+		State:        netlink.NUD_PERMANENT,
+		IP:           d.gwAddr,
+		HardwareAddr: peerMAC,
+	}); err != nil {
+		return fmt.Errorf("install permanent neighbor %s -> %s on %s: %w", d.gwAddr, peerMAC, d.hostIf, err)
+	}
+	fmt.Printf("  [4]   neigh %s lladdr %s dev %s NUD_PERMANENT\n", d.gwAddr, peerMAC, d.hostIf)
+
+	// 5-7: the three map entries.
+	registry, closer, err := usidmap.OpenPinnedRegistry(cfg.pinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned registry: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	if err := registry.Locator.Register(d.block, d.nodeID); err != nil {
+		return fmt.Errorf("register locator_table: %w", err)
+	}
+	fmt.Printf("  [5]   locator_table  block=%#x node-id=%d\n", d.block, d.nodeID)
+
+	if err := registry.Function.Register(d.block, uint8(uformat.FunctionEndDT46)); err != nil {
+		return fmt.Errorf("register function_table: %w", err)
+	}
+	fmt.Printf("  [6]   function_table block=%#x function=%#x\n", d.block, uint8(uformat.FunctionEndDT46))
+
+	if err := registry.VRF.Register(d.block, d.argument, uint32(cfg.tableID), usidmap.EgressKindVeth); err != nil {
+		return fmt.Errorf("register vrf_table: %w", err)
+	}
+	fmt.Printf("  [7]   vrf_table      block=%#x arg=%d -> table=%d egress_kind=veth\n", d.block, d.argument, cfg.tableID)
+
+	fmt.Printf("\nup complete. Now send a real request through Envoy for this VPC's backend.\n")
+	fmt.Printf("Re-run `status` afterwards: vrf_table's pkts/drops for arg=%d and drop_reasons\n", d.argument)
+	fmt.Printf("tell you exactly which step a failure landed on.\n")
+	return nil
+}
+
+// ensureVeth creates the pair if absent and returns the peer end's MAC,
+// read while both ends are still in this namespace. Idempotent.
+func ensureVeth(d derived) (net.HardwareAddr, error) {
+	if _, err := netlink.LinkByName(d.hostIf); err != nil {
+		var notFound netlink.LinkNotFoundError
+		if !errors.As(err, &notFound) {
+			return nil, fmt.Errorf("look up %s: %w", d.hostIf, err)
+		}
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: d.hostIf},
+			PeerName:  d.peerIf,
+		}
+		if err := netlink.LinkAdd(veth); err != nil {
+			return nil, fmt.Errorf("add veth %s/%s: %w", d.hostIf, d.peerIf, err)
+		}
+	}
+
+	// The peer may be here (freshly created) or already moved by a prior
+	// run; look in both places.
+	if peer, err := netlink.LinkByName(d.peerIf); err == nil {
+		return peer.Attrs().HardwareAddr, nil
+	}
+	found, err := findPodNetns(d.vrfName)
+	if err != nil || len(found) != 1 {
+		return nil, fmt.Errorf("%s is neither in root netns nor locatable in a pod netns", d.peerIf)
+	}
+	var mac net.HardwareAddr
+	if err := ns.WithNetNSPath(found[0].path, func(ns.NetNS) error {
+		peer, lerr := netlink.LinkByName(d.peerIf)
+		if lerr != nil {
+			return lerr
+		}
+		mac = peer.Attrs().HardwareAddr
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("read %s mac in pod netns: %w", d.peerIf, err)
+	}
+	return mac, nil
+}
+
+// moveAndEnslave moves the peer end into the pod's namespace (a no-op if a
+// prior run already did) and enslaves it into that VPC's VRF there.
+func moveAndEnslave(netnsPath string, d derived) error {
+	if peer, err := netlink.LinkByName(d.peerIf); err == nil {
+		handle, oerr := ns.GetNS(netnsPath)
+		if oerr != nil {
+			return fmt.Errorf("open %s: %w", netnsPath, oerr)
+		}
+		defer func() { _ = handle.Close() }()
+		if err := netlink.LinkSetNsFd(peer, int(handle.Fd())); err != nil {
+			return fmt.Errorf("move %s into %s: %w", d.peerIf, netnsPath, err)
+		}
+	}
+
+	return ns.WithNetNSPath(netnsPath, func(ns.NetNS) error {
+		peer, err := netlink.LinkByName(d.peerIf)
+		if err != nil {
+			return fmt.Errorf("look up %s inside pod netns: %w", d.peerIf, err)
+		}
+		vrfLink, err := netlink.LinkByName(d.vrfName)
+		if err != nil {
+			return fmt.Errorf("look up %s inside pod netns: %w", d.vrfName, err)
+		}
+		if err := netlink.LinkSetMaster(peer, vrfLink); err != nil {
+			return fmt.Errorf("enslave %s into %s: %w", d.peerIf, d.vrfName, err)
+		}
+		if err := netlink.LinkSetUp(peer); err != nil {
+			return fmt.Errorf("set %s up: %w", d.peerIf, err)
+		}
+		return nil
+	})
+}
+
+// ---------------------------------------------------------------------
+// down
+// ---------------------------------------------------------------------
+
+func down(cfg config, d derived) error {
+	fmt.Printf("=== plan ===\n")
+	fmt.Printf("  1. vrf_table.Unregister(block=%#x, arg=%d)\n", d.block, d.argument)
+	if d.gwAddr != nil {
+		fmt.Printf("  2. remove neigh %s on %s, and route %s/128 from table %d\n", d.gwAddr, d.hostIf, d.gwAddr, cfg.tableID)
+	}
+	fmt.Printf("  3. delete veth %s (takes %s with it)\n", d.hostIf, d.peerIf)
+	if cfg.purge {
+		fmt.Printf("  4. remove locator_table(block=%#x, node-id=%d) and function_table(block=%#x, function=%#x)\n",
+			d.block, d.nodeID, d.block, uint8(uformat.FunctionEndDT46))
+	} else {
+		fmt.Printf("  locator_table/function_table left in place; pass -purge-locator to remove them too\n")
+	}
+	fmt.Println()
+
+	if !cfg.yes {
+		fmt.Printf("dry run: pass -yes to apply\n")
+		return nil
+	}
+
+	var errs []error
+
+	// Unregister the map entry before the veth goes, so a decapped packet
+	// can never be redirected at a freed ifindex (plan §8's one ordering
+	// requirement).
+	if registry, closer, err := usidmap.OpenPinnedRegistry(cfg.pinDir); err != nil {
+		errs = append(errs, fmt.Errorf("open pinned registry: %w", err))
+	} else {
+		if err := registry.VRF.Unregister(d.block, d.argument); err != nil {
+			errs = append(errs, fmt.Errorf("unregister vrf_table: %w", err))
+		} else {
+			fmt.Printf("  [1]   vrf_table entry removed\n")
+		}
+		_ = closer.Close()
+	}
+
+	if d.gwAddr != nil {
+		if hostLink, err := netlink.LinkByName(d.hostIf); err == nil {
+			if err := netlink.NeighDel(&netlink.Neigh{
+				LinkIndex: hostLink.Attrs().Index,
+				Family:    netlink.FAMILY_V6,
+				IP:        d.gwAddr,
+			}); err != nil && !errors.Is(err, syscall.ENOENT) {
+				errs = append(errs, fmt.Errorf("delete neighbor: %w", err))
+			}
+		}
+		if err := netlink.RouteDel(&netlink.Route{
+			Dst:   &net.IPNet{IP: d.gwAddr, Mask: net.CIDRMask(128, 128)},
+			Table: int(cfg.tableID),
+		}); err != nil && !errors.Is(err, syscall.ESRCH) && !errors.Is(err, syscall.ENOENT) {
+			errs = append(errs, fmt.Errorf("delete route: %w", err))
+		}
+		fmt.Printf("  [2]   neigh/route removed (absent is not an error)\n")
+	}
+
+	if hostLink, err := netlink.LinkByName(d.hostIf); err == nil {
+		if err := netlink.LinkDel(hostLink); err != nil {
+			errs = append(errs, fmt.Errorf("delete veth %s: %w", d.hostIf, err))
+		} else {
+			fmt.Printf("  [3]   veth %s deleted\n", d.hostIf)
+		}
+	} else {
+		fmt.Printf("  [3]   veth %s already absent\n", d.hostIf)
+	}
+
+	if cfg.purge {
+		if registry, closer, err := usidmap.OpenPinnedRegistry(cfg.pinDir); err != nil {
+			errs = append(errs, fmt.Errorf("open pinned registry for purge: %w", err))
+		} else {
+			if err := registry.Locator.Unregister(d.block, d.nodeID); err != nil {
+				errs = append(errs, fmt.Errorf("unregister locator_table: %w", err))
+			}
+			if err := registry.Function.Unregister(d.block, uint8(uformat.FunctionEndDT46)); err != nil {
+				errs = append(errs, fmt.Errorf("unregister function_table: %w", err))
+			}
+			_ = closer.Close()
+			fmt.Printf("  [4]   locator_table/function_table entries removed\n")
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// ---------------------------------------------------------------------
+// probe
+// ---------------------------------------------------------------------
+
+// probe opens a TCP connection from inside the Envoy pod's own network
+// namespace, bound to that VPC's VRF device with SO_BINDTODEVICE -- the
+// exact socket shape #856's extension server configures on Envoy's upstream
+// clusters (network-services-operator's mutate.ApplyVPCPodSocketBind). What
+// comes back classifies the return path:
+//
+//   - connected, or refused (RST): the return path WORKS. Both outcomes
+//     require a packet to have travelled backend -> VRF -> SRv6 encap ->
+//     fabric -> this node -> usid_ingress decap -> veth -> this socket.
+//     A RST is as good a proof as a SYN-ACK.
+//   - timeout: nothing came back. Either the forward path did not reach the
+//     backend, or the reply was lost on the return path. `status`'s
+//     vrf_table counters and drop_reasons disambiguate which.
+//
+// Raw syscalls rather than net.Dialer: the socket must be created on the
+// same OS thread that is currently attached to the pod's netns, and Go's
+// netpoll offers no guarantee about which thread performs the underlying
+// socket(2). SO_SNDTIMEO bounds the blocking connect(2).
+func probe(cfg config, d derived) error {
+	if cfg.backend == "" {
+		return errors.New("-backend is required for probe")
+	}
+	backend := net.ParseIP(cfg.backend)
+	if backend == nil || backend.To4() != nil {
+		return fmt.Errorf("-backend %q is not an IPv6 address", cfg.backend)
+	}
+
+	var ports []int
+	for _, p := range strings.Split(cfg.ports, ",") {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			return fmt.Errorf("parse -ports %q: %w", cfg.ports, err)
+		}
+		ports = append(ports, n)
+	}
+
+	netnsPath := cfg.netnsPath
+	if netnsPath == "" {
+		found, err := findPodNetns(d.vrfName)
+		if err != nil {
+			return fmt.Errorf("discover pod netns: %w", err)
+		}
+		if len(found) != 1 {
+			return fmt.Errorf("%d namespaces hold %s; pass -netns to pick one", len(found), d.vrfName)
+		}
+		netnsPath = found[0].path
+	}
+
+	fmt.Printf("=== probe ===\n")
+	fmt.Printf("  from netns  %s\n", netnsPath)
+	fmt.Printf("  bound to    %s (SO_BINDTODEVICE, as #856 configures Envoy)\n", d.vrfName)
+	fmt.Printf("  to          %s ports %v, %s timeout each\n\n", backend, ports, cfg.timeout)
+
+	return ns.WithNetNSPath(netnsPath, func(ns.NetNS) error {
+		for _, port := range ports {
+			verdict, src, err := connectOnce(d.vrfName, backend, port, cfg.timeout)
+			line := fmt.Sprintf("  port %-5d %s", port, verdict)
+			if src != "" {
+				line += fmt.Sprintf("  (source %s)", src)
+			}
+			if err != nil {
+				line += fmt.Sprintf("  [%v]", err)
+			}
+			fmt.Println(line)
+		}
+		return nil
+	})
+}
+
+// connectOnce performs one VRF-bound connect and classifies the result.
+func connectOnce(vrfName string, backend net.IP, port int, timeout time.Duration) (verdict, src string, err error) {
+	fd, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM, syscall.IPPROTO_TCP)
+	if err != nil {
+		return "SOCKET FAILED", "", err
+	}
+	defer func() { _ = syscall.Close(fd) }()
+
+	// SO_BINDTODEVICE against the VRF master is what sends this socket's
+	// route lookup into that VPC's own table, and what makes a reply
+	// arriving on a VRF-enslaved link match this socket at all (plan §7.1).
+	if err := syscall.SetsockoptString(fd, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, vrfName); err != nil {
+		return "SO_BINDTODEVICE FAILED", "", err
+	}
+	tv := syscall.NsecToTimeval(timeout.Nanoseconds())
+	if err := syscall.SetsockoptTimeval(fd, syscall.SOL_SOCKET, syscall.SO_SNDTIMEO, &tv); err != nil {
+		return "SO_SNDTIMEO FAILED", "", err
+	}
+
+	sa := &syscall.SockaddrInet6{Port: port}
+	copy(sa.Addr[:], backend.To16())
+
+	cerr := syscall.Connect(fd, sa)
+	if name, gerr := syscall.Getsockname(fd); gerr == nil {
+		if in6, ok := name.(*syscall.SockaddrInet6); ok {
+			ip := net.IP(in6.Addr[:])
+			if !ip.IsUnspecified() {
+				src = ip.String()
+			}
+		}
+	}
+
+	switch {
+	case cerr == nil:
+		return "CONNECTED       -> return path WORKS", src, nil
+	case errors.Is(cerr, syscall.ECONNREFUSED):
+		return "REFUSED (RST)   -> return path WORKS (a RST traversed it)", src, nil
+	case errors.Is(cerr, syscall.ECONNRESET):
+		return "RESET           -> return path WORKS (a RST traversed it)", src, nil
+	case errors.Is(cerr, syscall.EINPROGRESS), errors.Is(cerr, syscall.EAGAIN), errors.Is(cerr, syscall.ETIMEDOUT):
+		return "TIMEOUT         -> nothing came back", src, nil
+	case errors.Is(cerr, syscall.ENETUNREACH), errors.Is(cerr, syscall.EHOSTUNREACH):
+		return "UNREACHABLE     -> forward path broken, not the return path", src, cerr
+	default:
+		return "ERROR", src, cerr
+	}
+}
+
+// ---------------------------------------------------------------------
+// egress-route
+// ---------------------------------------------------------------------
+
+// egressRoute answers the one question that separates "the backend never
+// replied" from "the backend replied but its node had nowhere to send the
+// reply": does egress_route_table hold an entry for this address in this
+// VRF's table, and if so toward which SID?
+//
+// Run on a backend node with the *gateway* address and that node's own
+// tenant VRF table id. A hit means galactic-router imported the sidecar's
+// BGPAdvertisement and usid_egress will encapsulate replies toward the
+// gateway node. A miss means the reply leaves unencapsulated (or not at
+// all), and no amount of decap state on the gateway node can help.
+func egressRoute(cfg config, _ derived) error {
+	if cfg.addr == "" || cfg.egressTable == 0 {
+		return errors.New("-addr and -egress-table are both required for egress-route")
+	}
+	ip := net.ParseIP(cfg.addr)
+	if ip == nil {
+		return fmt.Errorf("parse -addr %q", cfg.addr)
+	}
+	prefix := &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+
+	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(cfg.pinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned egress_route_table: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	fmt.Printf("=== egress_route_table lookup ===\n")
+	fmt.Printf("  table %d, prefix %s\n", cfg.egressTable, prefix)
+
+	sid, ok, err := table.Lookup(uint32(cfg.egressTable), prefix)
+	if err != nil {
+		return fmt.Errorf("lookup: %w", err)
+	}
+	if !ok {
+		fmt.Printf("  MISS -- this VRF has no egress route for %s.\n", ip)
+		fmt.Printf("  A reply to that address is NOT SRv6-encapsulated from this node.\n")
+		return nil
+	}
+	if sid == nil || sid.IsUnspecified() {
+		fmt.Printf("  HIT, local pass-through (no SID): not encapsulated.\n")
+		return nil
+	}
+	fmt.Printf("  HIT -> SID %s\n", sid)
+	if f, derr := uformat.Decode(mustAddr(sid)); derr == nil {
+		fmt.Printf("  decoded: block=%#x node-id=%d function=%#x argument=%d\n",
+			f.Block, f.NodeID, f.Function, f.Argument)
+	}
+	return nil
+}
+
+func mustAddr(ip net.IP) netip.Addr {
+	a, _ := netip.AddrFromSlice(ip.To16())
+	return a
+}
+
+// ---------------------------------------------------------------------
+// inject
+// ---------------------------------------------------------------------
+
+// inject sends one genuine SRv6/IPv6-in-IPv6 encapsulated packet at a
+// gateway node's uplink, addressed to that node's return SID, carrying an
+// inner TCP SYN from a VPC backend address to the gateway address.
+//
+// This is what finally isolates the decap path. Every other way of
+// generating the reply depends on a tenant workload actually replying:
+//
+//   - probing the backend from Envoy needs the backend to answer, and this
+//     lab's VPC-2 backends are Kraftlet unikernels behind a tap that do not
+//     (see the fib_no_neigh drops on their own node).
+//   - probing the gateway address from the backend node's own root-netns
+//     VRF does not work either, and the reason is instructive: usid_egress
+//     attaches to the *ingress* hook of a tenant's tap/veth -- where a
+//     tenant's own outbound traffic arrives from the workload -- so a packet
+//     the host itself originates into that VRF never traverses it, and
+//     leaves via the VRF's NAT66 default route instead.
+//
+// So the encapsulation is done here, by the kernel, on our behalf: an
+// AF_INET6 SOCK_RAW socket with protocol 41 (IPv6-in-IPv6) makes the kernel
+// build the outer header -- next-header 41, source address chosen from the
+// host's own routing, which is what keeps it past BCP38 filtering -- with
+// our inner packet as its payload. Byte-for-byte what a backend node's
+// usid_egress would have produced.
+func inject(cfg config, d derived) error {
+	innerSrc := net.ParseIP(cfg.innerSrc)
+	if innerSrc == nil {
+		return fmt.Errorf("-inner-src %q is not an IP", cfg.innerSrc)
+	}
+	if d.gwAddr == nil {
+		return errors.New("-gw-addr is required for inject (it is the inner destination)")
+	}
+
+	inner := buildInnerSYN(innerSrc, d.gwAddr, uint16(cfg.innerSport), uint16(cfg.innerDport))
+
+	fd, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_RAW, 41) // 41 = IPv6-in-IPv6
+	if err != nil {
+		return fmt.Errorf("open raw socket (need CAP_NET_RAW): %w", err)
+	}
+	defer func() { _ = syscall.Close(fd) }()
+
+	outer := d.returnSID
+	label := "this node's derived return SID"
+	if cfg.sidOverride != "" {
+		a, perr := netip.ParseAddr(cfg.sidOverride)
+		if perr != nil {
+			return fmt.Errorf("parse -sid %q: %w", cfg.sidOverride, perr)
+		}
+		outer, label = a, "override"
+	}
+	var sa syscall.SockaddrInet6
+	copy(sa.Addr[:], outer.AsSlice())
+
+	fmt.Printf("=== inject ===\n")
+	fmt.Printf("  outer dst  %s   (%s)\n", outer, label)
+	fmt.Printf("  outer nh   41 (IPv6-in-IPv6), outer src chosen by the kernel\n")
+	fmt.Printf("  inner      [%s]:%d -> [%s]:%d  TCP SYN, %d bytes\n",
+		innerSrc, cfg.innerSport, d.gwAddr, cfg.innerDport, len(inner))
+	fmt.Printf("  count      %d\n\n", cfg.count)
+
+	for range cfg.count {
+		if err := syscall.Sendto(fd, inner, 0, &sa); err != nil {
+			return fmt.Errorf("sendto %s: %w", outer, err)
+		}
+	}
+	fmt.Printf("  sent %d packet(s).\n", cfg.count)
+	fmt.Printf("  Now check the GATEWAY node's vrf_table entry for arg=%d:\n", d.argument)
+	fmt.Printf("    pkts up, drops 0  -> decap + redirect succeeded; the return path WORKS\n")
+	fmt.Printf("    pkts up, drops up -> claimed then dropped; drop_reasons names which step\n")
+	fmt.Printf("    pkts unchanged    -> never reached step 6 (locator/function miss, or never arrived)\n")
+	return nil
+}
+
+// buildInnerSYN builds a 60-byte inner packet: a 40-byte IPv6 header plus a
+// 20-byte TCP SYN, with the TCP checksum computed over the RFC 2460
+// pseudo-header. usid_ingress requires the inner packet's own version nibble
+// to be 4 or 6 and reads its addresses for the step 8 FIB lookup, so this
+// has to be genuinely well-formed, not a stub payload.
+func buildInnerSYN(src, dst net.IP, sport, dport uint16) []byte {
+	const tcpLen = 20
+	pkt := make([]byte, 40+tcpLen)
+
+	pkt[0] = 0x60 // version 6
+	binary.BigEndian.PutUint16(pkt[4:6], tcpLen)
+	pkt[6] = 6  // next header: TCP
+	pkt[7] = 64 // hop limit
+	copy(pkt[8:24], src.To16())
+	copy(pkt[24:40], dst.To16())
+
+	tcp := pkt[40:]
+	binary.BigEndian.PutUint16(tcp[0:2], sport)
+	binary.BigEndian.PutUint16(tcp[2:4], dport)
+	binary.BigEndian.PutUint32(tcp[4:8], 0x13572468) // seq
+	tcp[12] = 5 << 4                                 // data offset 5 words
+	tcp[13] = 0x02                                   // SYN
+	binary.BigEndian.PutUint16(tcp[14:16], 64240)    // window
+
+	// RFC 2460 pseudo-header: src, dst, upper-layer length, next header.
+	ph := make([]byte, 40, 40+len(tcp))
+	copy(ph[0:16], src.To16())
+	copy(ph[16:32], dst.To16())
+	binary.BigEndian.PutUint32(ph[32:36], tcpLen)
+	ph[39] = 6
+	binary.BigEndian.PutUint16(tcp[16:18], checksum(append(ph, tcp...)))
+	return pkt
+}
+
+// checksum is the standard 16-bit one's-complement sum.
+func checksum(b []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(b); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(b[i : i+2]))
+	}
+	if len(b)%2 == 1 {
+		sum += uint32(b[len(b)-1]) << 8
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return ^uint16(sum)
+}
+
+// ---------------------------------------------------------------------
+// filters
+// ---------------------------------------------------------------------
+
+// filters lists the clsact ingress filter chain on an interface, in the
+// order the kernel evaluates it (ascending priority).
+//
+// This exists because a correct usid_ingress with correct maps still does
+// nothing if it never runs. usid.c attaches direct-action at a fixed
+// priority (attach.go's defaultFilterPriority) to the same native-device
+// ingress hook Cilium uses, and returns TC_ACT_UNSPEC on every fail-open
+// path specifically so a Cilium filter at a *later* priority still sees the
+// packet. That reasoning only holds while galactic actually sits earlier in
+// the chain and is still present: in direct-action mode an earlier filter
+// returning TC_ACT_OK is a final verdict that ends the chain, and a filter
+// installed at the same priority by another agent replaces rather than
+// stacks.
+func filters(cfg config, _ derived) error {
+	if cfg.iface == "" {
+		return errors.New("-iface is required for filters")
+	}
+	link, err := netlink.LinkByName(cfg.iface)
+	if err != nil {
+		return fmt.Errorf("look up %s: %w", cfg.iface, err)
+	}
+
+	for _, hook := range []struct {
+		name   string
+		handle uint32
+	}{
+		{"ingress", netlink.HANDLE_MIN_INGRESS},
+		{"egress", netlink.HANDLE_MIN_EGRESS},
+	} {
+		fl, ferr := netlink.FilterList(link, hook.handle)
+		fmt.Printf("=== %s %s filters ===\n", cfg.iface, hook.name)
+		if ferr != nil {
+			fmt.Printf("  ERROR: %v\n", ferr)
+			continue
+		}
+		if len(fl) == 0 {
+			fmt.Printf("  (none)\n")
+			continue
+		}
+		sort.SliceStable(fl, func(i, j int) bool {
+			return fl[i].Attrs().Priority < fl[j].Attrs().Priority
+		})
+		for _, f := range fl {
+			a := f.Attrs()
+			desc := f.Type()
+			if bf, ok := f.(*netlink.BpfFilter); ok {
+				da := ""
+				if bf.DirectAction {
+					da = " direct-action"
+				}
+				desc = fmt.Sprintf("bpf%s name=%q id=%d", da, bf.Name, bf.Id)
+			}
+			fmt.Printf("  pref/prio %-6d handle %#x  %s\n", a.Priority, a.Handle, desc)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// verify-maps
+// ---------------------------------------------------------------------
+
+// verifyMaps checks the assumption every other action here silently rests
+// on: that the maps reachable through bpffs pins are the same kernel objects
+// the *attached* program actually reads.
+//
+// They can diverge. attach.Load pins each map under pinDir and reuses an
+// existing pin as-is, but a schema-incompatible reload replaces the
+// program's maps; anything still holding, or newly opening, the old pin then
+// reads and writes an orphaned map that no attached program consults. The
+// symptom is exactly what it looks like from outside: registrations that
+// appear to succeed, a program that is demonstrably attached and receiving
+// packets, and counters that never move.
+func verifyMaps(cfg config, _ derived) error {
+	if cfg.progID == 0 {
+		return errors.New("-prog-id is required (take it from the filters output)")
+	}
+	attached, err := ebpf.NewProgramFromID(ebpf.ProgramID(cfg.progID))
+	if err != nil {
+		return fmt.Errorf("open program id %d: %w", cfg.progID, err)
+	}
+	defer func() { _ = attached.Close() }()
+
+	info, err := attached.Info()
+	if err != nil {
+		return fmt.Errorf("program info: %w", err)
+	}
+	progMaps, ok := info.MapIDs()
+	if !ok {
+		return errors.New("kernel did not report this program's map ids")
+	}
+	inUse := make(map[ebpf.MapID]bool, len(progMaps))
+	for _, id := range progMaps {
+		inUse[id] = true
+	}
+
+	name, _ := info.Name, info.Type
+	fmt.Printf("=== attached program ===\n")
+	fmt.Printf("  id=%d name=%q maps=%v\n\n", cfg.progID, name, progMaps)
+
+	fmt.Printf("=== pinned maps under %s ===\n", cfg.pinDir)
+	mismatch := false
+	for _, mapName := range []string{"locator_table", "function_table", "vrf_table", "drop_reasons"} {
+		m, merr := ebpf.LoadPinnedMap(filepath.Join(cfg.pinDir, mapName), nil)
+		if merr != nil {
+			fmt.Printf("  %-15s ERROR: %v\n", mapName, merr)
+			continue
+		}
+		mi, ierr := m.Info()
+		if ierr != nil {
+			fmt.Printf("  %-15s ERROR: %v\n", mapName, ierr)
+			_ = m.Close()
+			continue
+		}
+		id, _ := mi.ID()
+		verdict := "ORPHANED -- the attached program does not use this map"
+		if inUse[id] {
+			verdict = "in use by the attached program"
+		} else {
+			mismatch = true
+		}
+		fmt.Printf("  %-15s id=%-5d %s\n", mapName, id, verdict)
+		_ = m.Close()
+	}
+	if mismatch {
+		fmt.Printf("\n  At least one pinned map is not the one the program reads: every\n")
+		fmt.Printf("  registration written through that pin is invisible to the datapath.\n")
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// attach-iface / detach-iface
+// ---------------------------------------------------------------------
+
+// attachIface attaches an already-loaded usid_ingress (by program id, from
+// the filters output) to an additional interface, via the same
+// attach.Attach path production uses.
+//
+// It exists to test one specific failure: attach.ResolveInterfaces picks the
+// interfaces carrying the IPv6 default route and then deliberately skips
+// WireGuard links (attach/interfaces.go's excludedLinkType), because a
+// WireGuard mesh can install a default-ish route of its own and
+// srv6.ResolveNodeSourceAddress would then bake its ULA in as this node's
+// source address. On a Talos cluster with KubeSpan enabled, that same
+// WireGuard interface is what actually carries inter-node traffic --
+// including the iBGP sessions and every SRv6-encapsulated packet -- so the
+// skip removes the only interface the datapath needed.
+func attachIface(cfg config, _ derived) error {
+	if cfg.progID == 0 || cfg.iface == "" {
+		return errors.New("-prog-id and -iface are both required")
+	}
+	attached, err := ebpf.NewProgramFromID(ebpf.ProgramID(cfg.progID))
+	if err != nil {
+		return fmt.Errorf("open program id %d: %w", cfg.progID, err)
+	}
+	defer func() { _ = attached.Close() }()
+
+	if err := attach.Attach(attached, []string{cfg.iface}); err != nil {
+		return fmt.Errorf("attach program %d to %s: %w", cfg.progID, cfg.iface, err)
+	}
+	fmt.Printf("attached program %d to %s ingress\n", cfg.progID, cfg.iface)
+	return nil
+}
+
+// detachIface removes what attachIface added.
+func detachIface(cfg config, _ derived) error {
+	if cfg.iface == "" {
+		return errors.New("-iface is required")
+	}
+	if err := attach.Detach([]string{cfg.iface}); err != nil {
+		return fmt.Errorf("detach %s: %w", cfg.iface, err)
+	}
+	fmt.Printf("detached from %s\n", cfg.iface)
+	return nil
+}

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -24,6 +24,16 @@ import (
 const minVRFID = uint32(1)
 const maxVRFID = uint32(math.MaxUint32 - 1)
 
+// ErrNotFound is returned (wrapped) by TableID when no VRF interface for
+// that VPC exists in *this process's own* network namespace. Callers need
+// this distinguishable from a genuine netlink failure because "absent" is
+// an ordinary, expected condition for some callers rather than an error:
+// galactic-router runs in the host's root netns and legitimately cannot
+// see a VRF #855's ingress sidecar created inside Envoy's own pod netns
+// (see internal/runtime/gobgp's vrfTableID), while a failed
+// netlink.LinkList is a real problem worth surfacing either way.
+var ErrNotFound = errors.New("vrf: no VRF interface for this VPC in this network namespace")
+
 // vrfMu serializes VRF creation/deletion within a single process (e.g.
 // concurrent goroutines in galactic-router's GC). It does not, by itself,
 // protect against two separate CNI ADD/DEL invocations racing on the same
@@ -121,7 +131,10 @@ func Delete(vpc string) error {
 }
 
 // TableID returns the Linux routing table ID for the VRF associated with the
-// given base62-encoded VPC.
+// given base62-encoded VPC. The returned error wraps ErrNotFound when no
+// such interface exists in this process's own network namespace — see that
+// variable's doc comment for why callers may need to treat that case as
+// ordinary rather than as a failure.
 func TableID(vpc string) (uint32, error) {
 	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc))
 }
@@ -221,5 +234,5 @@ func getVRFIDForInterface(name string) (uint32, error) {
 	if vrf, ok := vrfByName[name]; ok {
 		return vrf.Table, nil
 	}
-	return 0, fmt.Errorf("could not find VRF ID for interface: %s", name)
+	return 0, fmt.Errorf("could not find VRF ID for interface %s: %w", name, ErrNotFound)
 }

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -6,12 +6,11 @@ package gobgp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
 	"net/netip"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +21,6 @@ import (
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
-	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/intf"
 	"go.datum.net/galactic/internal/plumbing/srv6"
 	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
@@ -33,6 +31,14 @@ import (
 // internal/plumbing/srv6's own pinDir var provides, so this package's tests
 // don't depend on a real bpffs mount or root privileges either.
 var pinDir = attach.PinDir
+
+// errVRFNotInThisNetns marks the one vrfTableID failure that is an ordinary
+// operating condition rather than a fault: the VRF exists, just not in this
+// process's own network namespace. applyVRFs skips such a VRF at debug
+// level instead of reporting that its routes will not be installed --
+// see vrfTableID's own History note for why there is nothing for this
+// process to install in that case anyway.
+var errVRFNotInThisNetns = errors.New("kernel VRF interface is not in this process's network namespace")
 
 // startRIBMonitor starts the shared EVPN best-path watcher goroutine once per
 // GoBGPRuntime lifetime, regardless of how many VRFs exist. It installs and
@@ -246,34 +252,47 @@ func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeIn
 // that don't cleanly hex-encode), which is correct here too: that form was
 // never recoverable to a real interface name in the first place.
 //
-// argument is the same value as the owning BGPVRFInstance's own
-// Spec.VRFID — used only by the vrf_table fallback below, not by the
-// primary netlink lookup.
+// A VRF absent from this process's own netns is reported by wrapping
+// errVRFNotInThisNetns, so applyVRFs can treat it as an ordinary skip
+// rather than a failure -- see that variable's own doc comment.
 //
 // vrfpkg.TableID's own netlink.LinkList() call is scoped to this
-// process's own network namespace — galactic-router runs
+// process's own network namespace -- galactic-router runs
 // hostNetwork: true, so that's the host's root netns, correct for a VRF
 // galactic-cni created there directly for a real tenant pod's own CNI
 // attachment. It is structurally blind to a VRF #855's ingress sidecar
 // creates instead, which lives entirely inside Envoy's own pod netns by
 // design (so its own SO_BINDTODEVICE calls resolve there). Confirmed
 // live on us-central-1-staging-lab: a node running only the ingress
-// sidecar for a given VPC — no real tenant CNI attachment for it at all
-// — never has that VRF's interface visible in its own root netns, so the
-// primary lookup fails on every single reconcile, forever; not a race,
-// not something a restart or a longer wait fixes.
+// sidecar for a given VPC -- no real tenant CNI attachment for it at all
+// -- never has that VRF's interface visible in its own root netns, so
+// this lookup fails on every single reconcile, forever; not a race, not
+// something a restart or a longer wait fixes.
 //
-// The fallback below reads vrf_table directly instead of reaching into
-// that other netns: internal/ingresssidecar's own ensureEgressDatapath
-// already writes this exact (block, argument) -> kernel table ID mapping
-// there the moment it creates its own VRF, so usid_ingress's own decap
-// path can find it — the same bpffs-pinned map this process already
-// opens a second handle onto for vip_xlat_table
-// (cmd/galactic-router/root.go). Reading it here needs no new privilege,
-// no cross-namespace setns, and no change to the network repo's own CRD
-// schema: it's the same value, already published by whoever actually
-// created the VRF, through a channel this process already has open.
-func vrfTableID(vrfName string, argument int32) (uint32, error) {
+// History: that condition was previously handled by falling back to
+// reading the pinned vrf_table for the VPC's own (block, argument) row,
+// on the stated premise that "internal/ingresssidecar's own
+// ensureEgressDatapath already writes this exact (block, argument) ->
+// kernel table ID mapping there". It does not, on either half of the
+// key: that fallback derived block from the *VPC identifier*
+// (intf.Base62ToHex(vpc) parsed as hex) while every writer of that map
+// keys block off an SRv6 locator's own top 48 bits (uformat.Block, e.g.
+// internal/cnibgp's registerEBPFDatapath) or off the reserved
+// uformat.BlockMax the sidecar itself uses; and it looked up
+// BGPVRFInstance.Spec.VRFID as the argument while the sidecar registers
+// vrf.TableID(vpc) -- two unrelated allocators. The lookup therefore
+// could never hit any real row, and its "no vrf_table entry exists
+// either" error was reported for every sidecar-owned VRF regardless of
+// what the map actually held. Removed rather than re-keyed: on a node
+// whose only consumer of that VPC is Envoy, the egress_route_table
+// entries this table id would have been used to install are already
+// written per-EndpointSlice by the sidecar itself
+// (internal/ingresssidecar's kernelBackend.EnsureRoute ->
+// srv6.RouteEgressAdd), and Envoy only ever connects to backends those
+// same EndpointSlices published -- so there is nothing for this process
+// to add there, and the honest handling is to skip quietly rather than
+// to recover a table id for redundant work.
+func vrfTableID(vrfName string) (uint32, error) {
 	parts := strings.SplitN(vrfName, "-", 2)
 	if len(parts) != 2 {
 		return 0, fmt.Errorf("VRF name %q does not contain '-'", vrfName)
@@ -283,59 +302,14 @@ func vrfTableID(vrfName string, argument int32) (uint32, error) {
 		return 0, fmt.Errorf("VRF name %q: could not decode VPC segment %q back to base62: %w", vrfName, parts[0], err)
 	}
 
-	tableID, localErr := vrfpkg.TableID(vpc)
-	if localErr == nil {
-		return tableID, nil
-	}
-
-	fallbackID, ok, fallbackErr := vrfTableIDFromRegistry(vpc, argument)
-	if fallbackErr != nil {
-		return 0, fmt.Errorf("VRF %q: local netlink lookup failed (%w), and vrf_table fallback also failed: %w",
-			vrfName, localErr, fallbackErr)
-	}
-	if !ok {
-		return 0, fmt.Errorf(
-			"VRF %q: local netlink lookup failed (%w), and no vrf_table entry exists either (vpc=%s argument=%d) "+
-				"— this VRF may not exist on this node yet", vrfName, localErr, vpc, argument)
-	}
-	return fallbackID, nil
-}
-
-// vrfTableIDFromRegistry looks up the kernel VRF table ID (vpc, argument)
-// maps to in vrf_table — see vrfTableID's own doc comment for why this
-// fallback exists. Opens a fresh handle each call via pinDir, the same
-// on-demand-open idiom probeEgressRouteWrite (below) already uses for
-// egress_route_table, rather than keeping a long-lived handle: this only
-// runs on the local-netlink-miss path (once per affected VRF per
-// reconcile that needs it), not a per-packet or per-reconcile hot path
-// for every VRF.
-func vrfTableIDFromRegistry(vpc string, argument int32) (uint32, bool, error) {
-	if argument < 0 || argument > math.MaxUint16 {
-		return 0, false, fmt.Errorf("argument %d out of range for a uint16 uSID Argument", argument)
-	}
-	vpcHex, err := intf.Base62ToHex(vpc)
+	tableID, err := vrfpkg.TableID(vpc)
 	if err != nil {
-		return 0, false, fmt.Errorf("convert vpc %q to hex: %w", vpc, err)
+		if errors.Is(err, vrfpkg.ErrNotFound) {
+			return 0, fmt.Errorf("VRF %q: %w: %w", vrfName, errVRFNotInThisNetns, err)
+		}
+		return 0, fmt.Errorf("VRF %q: %w", vrfName, err)
 	}
-	block, err := strconv.ParseUint(vpcHex, 16, 64)
-	if err != nil {
-		return 0, false, fmt.Errorf("parse vpc hex %q: %w", vpcHex, err)
-	}
-
-	registry, closer, err := usidmap.OpenPinnedRegistry(pinDir)
-	if err != nil {
-		return 0, false, fmt.Errorf("open pinned vrf_table (missing bpffs mount, BPF capability, or root?): %w", err)
-	}
-	defer closer.Close() //nolint:errcheck // best-effort close of our own fd, immediately after use
-
-	entry, ok, err := registry.VRF.Get(block, uint16(argument))
-	if err != nil {
-		return 0, false, fmt.Errorf("vrf_table: get vpc=%s (block=%#x) argument=%#x: %w", vpc, block, argument, err)
-	}
-	if !ok {
-		return 0, false, nil
-	}
-	return entry.VRFTableID, true, nil
+	return tableID, nil
 }
 
 // evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path

--- a/internal/runtime/gobgp/monitor_test.go
+++ b/internal/runtime/gobgp/monitor_test.go
@@ -5,11 +5,13 @@
 package gobgp
 
 import (
-	"math"
+	"errors"
 	"strings"
 	"testing"
 
 	bgp "github.com/osrg/gobgp/v4/pkg/packet/bgp"
+
+	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
 )
 
 // extCommAttr builds a PathAttributeExtendedCommunities attribute from
@@ -110,7 +112,7 @@ func TestMatchTableID_NoExtendedCommunitiesAttributeAtAll(t *testing.T) {
 // asserts on the interface name vrfpkg.TableID reports missing rather than
 // on a successful lookup.
 func TestVRFTableID_DecodesHexSegmentBackToBase62(t *testing.T) {
-	_, err := vrfTableID("3e-dfw-worker", 1)
+	_, err := vrfTableID("3e-dfw-worker")
 	if err == nil {
 		t.Fatalf("vrfTableID() error = nil, want a 'VRF ID not found' error (no such kernel VRF in test env)")
 	}
@@ -128,7 +130,7 @@ func TestVRFTableID_DecodesHexSegmentBackToBase62(t *testing.T) {
 // interface name, so vrfTableID must fail fast on the decode rather than
 // attempt a kernel lookup with a garbage name.
 func TestVRFTableID_HashFallbackSegmentErrors(t *testing.T) {
-	_, err := vrfTableID("x0123456789ab-dfw-worker", 1)
+	_, err := vrfTableID("x0123456789ab-dfw-worker")
 	if err == nil {
 		t.Fatalf("vrfTableID() error = nil, want a base62-decode error for a hash-fallback segment")
 	}
@@ -138,65 +140,42 @@ func TestVRFTableID_HashFallbackSegmentErrors(t *testing.T) {
 // a VRF name with no '-' at all can't be split into a VPC segment and a
 // node name.
 func TestVRFTableID_NoDashErrors(t *testing.T) {
-	_, err := vrfTableID("nodash", 1)
+	_, err := vrfTableID("nodash")
 	if err == nil {
 		t.Fatalf("vrfTableID(\"nodash\") error = nil, want a \"does not contain '-'\" error")
 	}
 }
 
-// TestVRFTableID_FallbackErrorMentionsBothAttempts covers the case this
-// fallback exists for: a VRF whose interface genuinely does not exist in
-// this process's own root netns (galactic-router's normal case for a VRF
-// #855's ingress sidecar created instead, inside Envoy's own pod netns —
-// see vrfTableID's own doc comment). With no bpffs mount in this test
-// environment either, both attempts fail, and the combined error must
-// still surface the original local-netlink failure (mentioning the
-// base62-decoded interface name), not just the fallback's own error, so
-// an operator reading the log doesn't lose the first, usually more
-// familiar signal.
-func TestVRFTableID_FallbackErrorMentionsBothAttempts(t *testing.T) {
-	_, err := vrfTableID("3e-dfw-worker", 7)
+// TestVRFTableID_MissingVRFIsClassifiedAsNotInThisNetns pins the
+// classification applyVRFs depends on: a VRF with no kernel interface in
+// this process's own netns must be reported as errVRFNotInThisNetns, so it
+// is skipped at debug level rather than logged as "this VRF's routes will
+// not be installed" on every reconcile. There is no VRF interface for this
+// name in the test sandbox, which is exactly the condition being asserted.
+func TestVRFTableID_MissingVRFIsClassifiedAsNotInThisNetns(t *testing.T) {
+	_, err := vrfTableID("3e-dfw-worker")
 	if err == nil {
-		t.Fatal("vrfTableID() error = nil, want an error (no kernel VRF and no pinned vrf_table in the test env)")
+		t.Fatal("vrfTableID() error = nil, want an error (no such kernel VRF in the test env)")
 	}
-	if !strings.Contains(err.Error(), "G000000010V") {
-		t.Errorf("vrfTableID() error = %q, want it to still mention the local netlink failure", err)
+	if !errors.Is(err, errVRFNotInThisNetns) {
+		t.Errorf("vrfTableID() error = %q, want it to wrap errVRFNotInThisNetns", err)
 	}
-	if !strings.Contains(err.Error(), "vrf_table") {
-		t.Errorf("vrfTableID() error = %q, want it to also mention the vrf_table fallback attempt", err)
+	if !errors.Is(err, vrfpkg.ErrNotFound) {
+		t.Errorf("vrfTableID() error = %q, want it to preserve vrf.ErrNotFound underneath", err)
 	}
 }
 
-// TestVRFTableIDFromRegistry_RejectsOutOfRangeArgument covers the bounds
-// check on argument: model.DesiredVRFInstance.VRFID is an int32 (RFC 4364
-// route-distinguisher assignment compatibility), but a uSID Argument is
-// only ever 16 bits (uformat.ValidateArgument) — this must reject a value
-// that can't round-trip through uint16 before ever touching a pinned map,
-// rather than silently truncating it into a lookup for the wrong key.
-func TestVRFTableIDFromRegistry_RejectsOutOfRangeArgument(t *testing.T) {
-	for _, argument := range []int32{-1, math.MaxUint16 + 1} {
-		if _, _, err := vrfTableIDFromRegistry("2", argument); err == nil {
-			t.Errorf("vrfTableIDFromRegistry(%d) error = nil, want an out-of-range error", argument)
+// TestVRFTableID_MalformedNameIsNotASkip guards the other half of that
+// classification: a genuinely malformed VRF name is a real fault and must
+// NOT be swallowed as a not-in-this-netns skip.
+func TestVRFTableID_MalformedNameIsNotASkip(t *testing.T) {
+	for _, name := range []string{"nodash", "x0123456789ab-dfw-worker"} {
+		_, err := vrfTableID(name)
+		if err == nil {
+			t.Fatalf("vrfTableID(%q) error = nil, want an error", name)
 		}
-	}
-}
-
-// TestVRFTableIDFromRegistry_MissingPinReturnsError covers the "eBPF uSID
-// datapath not loaded on this node" case (a route-reflector/control-role
-// node, or simply not yet attached) — pinDir points at this test's own
-// temp directory instead of a real bpffs mount, so OpenPinnedRegistry's
-// own open() calls fail exactly as they would against a genuinely absent
-// pin, with no real bpffs mount or root privilege needed to exercise it.
-func TestVRFTableIDFromRegistry_MissingPinReturnsError(t *testing.T) {
-	old := pinDir
-	pinDir = t.TempDir()
-	t.Cleanup(func() { pinDir = old })
-
-	_, _, err := vrfTableIDFromRegistry("2", 1)
-	if err == nil {
-		t.Fatal("vrfTableIDFromRegistry() error = nil, want an error opening a non-existent pinned map")
-	}
-	if !strings.Contains(err.Error(), "vrf_table") {
-		t.Errorf("vrfTableIDFromRegistry() error = %q, want it to name vrf_table", err)
+		if errors.Is(err, errVRFNotInThisNetns) {
+			t.Errorf("vrfTableID(%q) error = %q, must not be classified as a netns skip", name, err)
+		}
 	}
 }

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -6,6 +6,7 @@ package gobgp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -350,8 +351,19 @@ func (r *GoBGPRuntime) applyVRFs(
 		tableID, ok := r.appliedVRFs[v.Name]
 		if !ok {
 			var err error
-			tableID, err = vrfTableID(v.Name, v.VRFID)
+			tableID, err = vrfTableID(v.Name)
 			if err != nil {
+				// A VRF whose interface simply isn't in this process's own
+				// netns is the ordinary case for a VPC served only by #855's
+				// ingress sidecar on this node, not a fault -- and there is
+				// nothing for this process to install for it either way (see
+				// vrfTableID's own History note). Skip it quietly rather than
+				// reporting a failure on every reconcile, forever.
+				if errors.Is(err, errVRFNotInThisNetns) {
+					slog.Debug("applyVRFs: skipping VRF whose kernel interface is not in this netns",
+						"vrf", v.Name, "err", err)
+					continue
+				}
 				slog.Error("applyVRFs: failed to resolve kernel VRF table; this VRF's routes will not be installed",
 					"vrf", v.Name, "err", err)
 				continue


### PR DESCRIPTION
Three commits, reviewable in order.

## 1. Drop the vrf_table fallback that could never match

The fallback for a VRF invisible in this process's own netns cannot hit any real row, on either half of its key.

It derives block from the VPC identifier (`intf.Base62ToHex` parsed as hex). Every writer keys block off an SRv6 locator's top 48 bits (`uformat.Block`) or off the reserved `uformat.BlockMax` the #855 sidecar uses. It then looks up `BGPVRFInstance.Spec.VRFID` as the argument, while the sidecar registers `vrf.TableID(vpc)` there. Two unrelated allocators. On staging one VPC's CRD VRFID was 1 and its pod-netns table id was 3.

Its doc comment claims `ensureEgressDatapath` "already writes this exact (block, argument) -> kernel table ID mapping". It does not.

Removed rather than re-keyed. On a node whose only consumer of that VPC is Envoy, the `egress_route_table` entries this table id would have fed are already written per-EndpointSlice by the sidecar (`kernelBackend.EnsureRoute` -> `srv6.RouteEgressAdd`), and Envoy only connects to backends those EndpointSlices published.

`internal/plumbing/vrf` gains an `ErrNotFound` sentinel so `applyVRFs` can tell "absent from this netns" (ordinary, now debug level) from a real netlink failure (still an error). That condition used to log "this VRF's routes will not be installed" on every reconcile, forever, for a healthy VRF.

## 2. Add returnpath-lab

A lab harness that installs and reverses, by hand, what the #855 return-path plan's Pieces 1-3 would automate. It calls the real packages, so what it proves holds for the code paths that work would move into `galactic-router`.

Its first run found why inter-node SRv6 decap cannot work on `us-central-1-staging-lab`, upstream of everything that plan describes. The traffic rides Talos KubeSpan, a WireGuard link `attach.ResolveInterfaces` skips and whose link-type RAW frames `usid_ingress`'s Ethernet parse cannot read. Fixed in datum-cloud/infra#4544, not here.

It also surfaced three live issues in this repo, none in that plan's scope, each worth its own issue:

1. Tap-backed unikernel and VM workloads lose forward-path traffic to `BPF_FIB_LKUP_RET_NO_NEIGH`. `hostgw.ConfigureHostGateway` installs its permanent neighbor entry only when `guestHWAddr != nil`, which its own doc comment says is nil for tap attachments.
2. Seeding `locator_table` is unsafe on a node also running `galactic-gateway`. That component's SRv6 address shares the node's Block and Node-ID with Function `0x0`, so step 2 claims it and step 4 drops it as `UNKNOWN_FUNCTION`.
3. `prog.DropReasonCount` is 16 while `usid.c` defines 29, and `metrics/collector.go` iterates only to the former, so the `TRACE_*` counters never reach Prometheus. A node whose bpffs `drop_reasons` pin predates a newer reason also has a map too small to hold it, and `count_drop` fails silently for that index.

## 3. Add the plan

Records the design review of the decap side, confirms the three gaps and their key derivations against the code, and leads with the Phase 0 result above.

## Verification

`go build ./...`, `go vet`, unit tests and `golangci-lint run ./...` are clean. `task test:e2e` needs a Kind cluster and was not run.

No production behavior changes beyond commit 1's logging and the removed dead path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)