### PR TITLE
fix(installer): install a local route for this node's own uSID locator

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -653,6 +653,12 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 		}()
 	}
 
+	// This node's own uSID locator has to be locally resolvable before any
+	// same-node SRv6 egress route can be registered -- see
+	// ensureLocatorLocalRoute. Non-fatal, and retried on refreshTicker
+	// below, since the BGPRouter carrying the locator may not exist yet.
+	reconcileLocatorLocalRoute(ctx, ebpfState)
+
 	// Serve Prometheus metrics at the conventional /metrics scrape path.
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", m.Handler())
@@ -756,6 +762,11 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 			if logFileHostPath != "" {
 				rotateLogFile(logFileHostPath)
 			}
+
+			// Re-assert this node's uSID locator local route: picks up a
+			// BGPRouter created after startup, and restores the route if
+			// something flushed it.
+			reconcileLocatorLocalRoute(ctx, ebpfState)
 
 		case <-ebpfHealthTicker.C:
 			if ebpfState.objs == nil {

--- a/internal/installer/locatorroute.go
+++ b/internal/installer/locatorroute.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package installer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// ensureLocatorLocalRoute installs a local route for this node's own uSID
+// locator /64 -- the Block(48) + Node-ID(16) prefix from its BGPRouter --
+// into the kernel's local table, pointed at lo.
+//
+// This exists because a node has to be able to resolve a route to its *own*
+// SIDs. internal/plumbing/ebpf/egressroutemap's resolveLinkAndL2 calls
+// netlink.RouteGet(sid) once per registration to pick the egress interface
+// and next-hop MAC that usid_egress will then redirect to, and for a
+// same-node destination (an Envoy sidecar reaching a backend on its own
+// node) that SID belongs to this very node. Without a matching route,
+// RouteGet fails against the locator's own Null0 discard route with EINVAL,
+// registration fails, and same-node SRv6 encapsulation is never set up.
+//
+// A route, deliberately, and not an address on a dummy interface -- which is
+// how this was previously satisfied. A locally-assigned global address is
+// published as a node address by cluster discovery, which lands it in every
+// KubeSpan peer's allowedIPs; KubeSpan's nftables chains then steer traffic
+// to it into the WireGuard policy table, where this datapath is not attached
+// (attach.ResolveInterfaces skips wireguard links) and could not parse it
+// anyway, a WireGuard interface being link-type RAW with no Ethernet header
+// for usid_ingress's first parse step. That silently blackholed every
+// inter-node SRv6 packet. Cluster discovery publishes addresses, not routes,
+// so a local route restores resolution without re-creating that.
+//
+// Covering the whole /64 rather than individual SIDs is what makes this
+// self-maintaining: every SID this node can compute shares that prefix, so
+// no per-VPC or per-Argument bookkeeping is needed, and a VPC whose Argument
+// nobody thought to configure resolves the same as any other. It cannot
+// shadow decapsulation either, because usid_ingress claims packets at tc
+// ingress before any FIB lookup runs.
+//
+// Idempotent (RouteReplace), and safe to call repeatedly: Run invokes it at
+// startup and on its refresh ticker, so a BGPRouter that appears later, or a
+// route flushed out from under us, is picked up without a restart.
+func ensureLocatorLocalRoute(ctx context.Context, k8s client.Client, namespace, nodeName string) error {
+	if k8s == nil || nodeName == "" {
+		return nil // no node identity configured; nothing to resolve against
+	}
+
+	prefix, err := nodeLocatorPrefix(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return err
+	}
+	if !prefix.IsValid() {
+		return nil // this node's BGPRouter carries no SRv6 locator yet
+	}
+
+	lo, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("look up lo: %w", err)
+	}
+
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: prefix.Addr().AsSlice(), Mask: net.CIDRMask(prefix.Bits(), 128)},
+		LinkIndex: lo.Attrs().Index,
+		Table:     unix.RT_TABLE_LOCAL,
+		Type:      unix.RTN_LOCAL,
+		Scope:     netlink.SCOPE_HOST,
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("install local route %s dev lo table local: %w", prefix, err)
+	}
+	return nil
+}
+
+// nodeLocatorPrefix returns the Block(48)+Node-ID(16) /64 carved out of this
+// node's BGPRouter locator, or the zero Prefix when this node has no
+// BGPRouter or that router carries no SRv6 locator yet -- both ordinary
+// during bring-up, and neither an error.
+//
+// Matched on Spec.TargetRef.Name, the same way internal/cnibgp and
+// internal/ingresssidecar both find the router for a node.
+func nodeLocatorPrefix(
+	ctx context.Context, k8s client.Client, namespace, nodeName string,
+) (netip.Prefix, error) {
+	routers := &bgpv1alpha1.BGPRouterList{}
+	if err := k8s.List(ctx, routers, client.InNamespace(namespace)); err != nil {
+		return netip.Prefix{}, fmt.Errorf("list BGPRouters in namespace %s: %w", namespace, err)
+	}
+
+	for _, r := range routers.Items {
+		if r.Spec.TargetRef.Name != nodeName {
+			continue
+		}
+		if r.Spec.SRv6Locator == "" || r.Spec.NodeID == 0 {
+			return netip.Prefix{}, nil
+		}
+		locator, err := netip.ParsePrefix(r.Spec.SRv6Locator)
+		if err != nil {
+			return netip.Prefix{}, fmt.Errorf("parse SRv6 locator %q: %w", r.Spec.SRv6Locator, err)
+		}
+		if !locator.Addr().Is6() || locator.Bits() != uformat.BlockBits {
+			return netip.Prefix{}, fmt.Errorf(
+				"SRv6 locator %q must be an IPv6 /%d uSID Block", r.Spec.SRv6Locator, uformat.BlockBits)
+		}
+		if r.Spec.NodeID < uformat.NodeIDMin || r.Spec.NodeID > uformat.NodeIDMax {
+			return netip.Prefix{}, fmt.Errorf("BGPRouter %s: nodeID %d outside [%#x,%#x]",
+				r.Name, r.Spec.NodeID, uint16(uformat.NodeIDMin), uint16(uformat.NodeIDMax))
+		}
+
+		// Node-ID occupies bits 49-64, immediately after the 48-bit Block --
+		// the same layout uformat.Block/NodeID read back out of a SID.
+		b := locator.Addr().As16()
+		b[6] = byte(uint16(r.Spec.NodeID) >> 8)
+		b[7] = byte(uint16(r.Spec.NodeID))
+		return netip.PrefixFrom(netip.AddrFrom16(b), uformat.BlockBits+uformat.NodeIDBits), nil
+	}
+	return netip.Prefix{}, nil
+}
+
+// reconcileLocatorLocalRoute is Run's non-fatal wrapper: a missing or
+// not-yet-created BGPRouter, or a transient API error, must not stop the
+// installer daemon, and the refresh ticker retries on its own.
+func reconcileLocatorLocalRoute(ctx context.Context, st ebpfDatapathState) {
+	if err := ensureLocatorLocalRoute(ctx, st.k8sClient, st.namespace, st.nodeName); err != nil {
+		slog.Warn("Could not install this node's uSID locator local route; "+
+			"same-node SRv6 egress registration will fail until this succeeds", "err", err)
+	}
+}

--- a/internal/installer/locatorroute_test.go
+++ b/internal/installer/locatorroute_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package installer
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	testNamespace = "galactic-system"
+	testLocator   = "2607:ed40:8002::/48"
+)
+
+// newRouterClient builds a fake client holding routers, so the derivation can
+// be exercised without a kernel or an API server. nodeLocatorPrefix is the
+// half of ensureLocatorLocalRoute worth testing: the netlink call needs root
+// and a real lo, but getting the prefix wrong would install a local route for
+// address space this node does not own.
+func newRouterClient(t *testing.T, routers ...*bgpv1alpha1.BGPRouter) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := bgpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	b := fake.NewClientBuilder().WithScheme(scheme)
+	for _, r := range routers {
+		b = b.WithObjects(r)
+	}
+	return b.Build()
+}
+
+func router(target, locator string, nodeID int32) *bgpv1alpha1.BGPRouter {
+	return &bgpv1alpha1.BGPRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: testNamespace},
+		Spec: bgpv1alpha1.BGPRouterSpec{
+			TargetRef:   bgpv1alpha1.TargetRef{Name: target},
+			SRv6Locator: locator,
+			NodeID:      nodeID,
+		},
+	}
+}
+
+// TestNodeLocatorPrefix_DerivesBlockPlusNodeID pins the layout the whole fix
+// depends on: Node-ID sits at bits 49-64, immediately after the 48-bit Block,
+// and the result is the /64 covering every SID this node can compute.
+func TestNodeLocatorPrefix_DerivesBlockPlusNodeID(t *testing.T) {
+	for _, tc := range []struct {
+		name, locator string
+		nodeID        int32
+		want          string
+	}{
+		{"node 1", testLocator, 1, "2607:ed40:8002:1::/64"},
+		{"node 6", testLocator, 6, "2607:ed40:8002:6::/64"},
+		{"two-byte node id", testLocator, 0x0142, "2607:ed40:8002:142::/64"},
+		{"max node id", "2607:ed40:8001::/48", 0xDFFF, "2607:ed40:8001:dfff::/64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRouterClient(t, router("n1", tc.locator, tc.nodeID))
+			got, err := nodeLocatorPrefix(context.Background(), c, testNamespace, "n1")
+			if err != nil {
+				t.Fatalf("nodeLocatorPrefix() error = %v", err)
+			}
+			if got.String() != tc.want {
+				t.Errorf("nodeLocatorPrefix() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNodeLocatorPrefix_AbsentIsNotAnError covers the ordinary bring-up
+// states: this node has no BGPRouter yet, or one that carries no locator.
+// Both must read as "nothing to install", never as a failure, or the
+// installer daemon would report an error on every refresh on a node that
+// simply is not an SRv6 node.
+func TestNodeLocatorPrefix_AbsentIsNotAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		routers []*bgpv1alpha1.BGPRouter
+		node    string
+	}{
+		{"no routers at all", nil, "n1"},
+		{"router targets another node", []*bgpv1alpha1.BGPRouter{router("other", testLocator, 1)}, "n1"},
+		{"no locator configured", []*bgpv1alpha1.BGPRouter{router("n1", "", 1)}, "n1"},
+		{"no node id configured", []*bgpv1alpha1.BGPRouter{router("n1", testLocator, 0)}, "n1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRouterClient(t, tc.routers...)
+			got, err := nodeLocatorPrefix(context.Background(), c, testNamespace, tc.node)
+			if err != nil {
+				t.Fatalf("nodeLocatorPrefix() error = %v, want nil", err)
+			}
+			if got.IsValid() {
+				t.Errorf("nodeLocatorPrefix() = %s, want the zero Prefix", got)
+			}
+		})
+	}
+}
+
+// TestNodeLocatorPrefix_RejectsBadLocator guards the other direction: a
+// locator that is not a /48 uSID Block, or a Node-ID out of range, must fail
+// loudly rather than silently produce a prefix for space this node does not
+// own -- installing a local route for someone else's locator would blackhole
+// their SIDs on this node.
+func TestNodeLocatorPrefix_RejectsBadLocator(t *testing.T) {
+	for _, tc := range []struct {
+		name, locator string
+		nodeID        int32
+		wantSubstr    string
+	}{
+		{"not a /48", "2607:ed40:8002::/56", 1, "uSID Block"},
+		{"ipv4", "10.0.0.0/48", 1, ""},
+		{"unparseable", "not-a-prefix", 1, "parse SRv6 locator"},
+		{"node id too large", testLocator, 0x10000, "outside"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRouterClient(t, router("n1", tc.locator, tc.nodeID))
+			_, err := nodeLocatorPrefix(context.Background(), c, testNamespace, "n1")
+			if err == nil {
+				t.Fatalf("nodeLocatorPrefix() error = nil, want an error")
+			}
+			if tc.wantSubstr != "" && !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("nodeLocatorPrefix() error = %q, want it to mention %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestEnsureLocatorLocalRoute_NoIdentityIsNoop covers the guard that keeps
+// this inert on a node with no configured identity, before any netlink call
+// is attempted -- so it is safe on a node where the installer runs without a
+// name or client.
+func TestEnsureLocatorLocalRoute_NoIdentityIsNoop(t *testing.T) {
+	if err := ensureLocatorLocalRoute(context.Background(), nil, testNamespace, ""); err != nil {
+		t.Errorf("ensureLocatorLocalRoute(nil, \"\") error = %v, want nil", err)
+	}
+	c := newRouterClient(t)
+	if err := ensureLocatorLocalRoute(context.Background(), c, testNamespace, ""); err != nil {
+		t.Errorf("ensureLocatorLocalRoute(_, \"\") error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
A node has to resolve a route to its own SIDs. `egressroutemap`'s `resolveLinkAndL2` calls `netlink.RouteGet(sid)` once per registration to pick the egress interface and next-hop MAC that `usid_egress` then redirects to. For a same-node destination, an Envoy sidecar reaching a backend on its own node, that SID belongs to this very node.

Until now it resolved by accident, against a `/128` on a Talos `sid` dummy interface. Removing that interface in datum-cloud/infra#4544 left the locator's Null0 discard route as the only match:

```
$ ip -6 route get 2607:ed40:8002:1:e001::
RTNETLINK answers: Invalid argument

$ ip -6 route show 2607:ed40:8002:1::/64
blackhole 2607:ed40:8002:1::/64 dev lo proto 196
```

So `RouteGet` fails with EINVAL, registration fails, and same-node SRv6 encapsulation is never set up.

That interface had two jobs and only one was obvious. It fed `redistribute connected` so the SID reached BGP peers, which infra#4544 replaced with an explicit per-node `/64` network statement. It was also, unremarked, what made the node's own SIDs locally resolvable.

## Impact

Latent rather than an outage. `egress_route_table` is pinned, so entries already installed keep working. What fails is re-registration: a pod attaching on that node, a sidecar reconcile, or a map reload.

## Change

Install a local route, not an address.

A locally-assigned global address is published as a node address by cluster discovery, which lands it in every KubeSpan peer's `allowedIPs`. KubeSpan's nftables chains then steer traffic to it into the WireGuard policy table, where this datapath is not attached (`attach.ResolveInterfaces` skips wireguard links) and could not parse it anyway, a WireGuard interface being link-type RAW with no Ethernet header for `usid_ingress`'s first parse step. Cluster discovery publishes addresses, not routes, so a local route restores resolution without re-creating that.

Covering the whole Block+Node-ID `/64` rather than individual SIDs makes it self-maintaining. Every SID the node can compute shares that prefix, so a VPC whose Argument nobody configured resolves like any other. It cannot shadow decapsulation, since `usid_ingress` claims packets at tc ingress before any FIB lookup.

Runs from `installer.Run`, which already holds the node name, a client with `bgpv1alpha1` in scheme, and root netns. Called at startup and on the existing refresh ticker, so a `BGPRouter` created later, or a route flushed from under us, is picked up without a restart. Non-fatal throughout: a node with no `BGPRouter`, or one carrying no locator, installs nothing.

## Tests

`nodeLocatorPrefix` is the part with real logic, so it is covered directly: Node-ID placement at bits 49-64 including a two-byte value and the reserved maximum, the bring-up states that must read as "nothing to install" rather than errors, and the malformed inputs that must fail loudly rather than yield a prefix for space this node does not own.

`go build ./...`, the unit suite and `golangci-lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)