### PR TITLE
fix(hostgw): only solicit real tap guests, and off the installer's loop

### DIFF
--- a/internal/hostgw/tapneigh.go
+++ b/internal/hostgw/tapneigh.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -112,6 +113,24 @@ func EnsureTapGuestNeighbors() (resolved, pending int) {
 // back from the pod-subnet routes installPodSubnetRoute installed in the
 // VPC VRF's own table. Both families, since the same NO_NEIGH drop applies
 // to each; only the IPv6 side has been observed in the wild.
+//
+// The filtering is the whole job. A VPC VRF's table carries several routes
+// per tap and only one of them names a guest, so an unfiltered sweep spends
+// its time soliciting addresses that can never answer. Measured on
+// us-central-1-staging-lab with three real guests, it found 32 candidates
+// and blocked for 32 seconds a pass. What the table actually holds:
+//
+//	local fd20:0:2::1 dev <tap> proto kernel metric 0     <- host's own gateway addr
+//	fd20:0:2::1 dev <tap> proto kernel metric 256         <- its connected route
+//	fd20:0:2::3:0:0/96 dev <tap> metric 1024              <- the guest, what we want
+//	anycast fe80:: dev <tap> proto kernel metric 0
+//	fe80::/64 dev <tap> proto kernel metric 256
+//
+// So: only unicast routes this component installed itself. RTPROT_KERNEL
+// excludes everything the kernel derived from an address assignment, which
+// is the gateway address and the link-local pair; RTN_UNICAST excludes the
+// local and anycast entries; and link-local or multicast destinations are
+// skipped outright, since a guest is never addressed by one here.
 func guestAddrsForTap(tableID, tapIndex int) []net.IP {
 	var out []net.IP
 	for _, family := range []int{netlink.FAMILY_V6, netlink.FAMILY_V4} {
@@ -121,10 +140,17 @@ func guestAddrsForTap(tableID, tapIndex int) []net.IP {
 			continue
 		}
 		for _, r := range routes {
-			if r.LinkIndex != tapIndex || r.Dst == nil || r.Dst.IP.IsUnspecified() {
+			if r.LinkIndex != tapIndex || r.Dst == nil {
 				continue
 			}
-			out = append(out, r.Dst.IP)
+			if r.Protocol == unix.RTPROT_KERNEL || r.Type != unix.RTN_UNICAST {
+				continue
+			}
+			ip := r.Dst.IP
+			if ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+				continue
+			}
+			out = append(out, ip)
 		}
 	}
 	return out

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -63,6 +63,13 @@ var ebpfGCSweepInterval = 5 * time.Minute
 // at all -- a guest's own boot time dwarfs a couple of seconds either way.
 var radvReconcileInterval = 2 * time.Second
 
+// tapNeighReconcileInterval paces hostgw.EnsureTapGuestNeighbors. Far slower
+// than radv's own ticker: a resolved neighbor is refreshed by the kernel from
+// the guest's own advertisements, so this only has to notice one that has
+// aged out of the cache or a guest that has newly booted, and each pass costs
+// a solicit per unresolved guest.
+var tapNeighReconcileInterval = 30 * time.Second
+
 // ebpfHealthServiceName is the gRPC health service name (see
 // grpc_health_v1.HealthServer) reporting the live status of the eBPF uSID
 // datapath specifically, separate from the overall (""), always-serving
@@ -497,6 +504,27 @@ func cleanupOldBinaryWrapper() {
 	}
 }
 
+// startTapNeighborSweep runs one hostgw.EnsureTapGuestNeighbors pass off
+// Run's own goroutine, dropping the tick when a previous pass is still in
+// flight. Split out of Run's select for the same reason startEBPFDatapath
+// was: to keep Run inside golangci-lint's gocyclo budget.
+//
+// sem is a size-1 semaphore, so a slow pass delays nothing and never queues
+// a backlog of ticks behind itself.
+func startTapNeighborSweep(sem chan struct{}) {
+	select {
+	case sem <- struct{}{}:
+		go func() {
+			defer func() { <-sem }()
+			if resolved, pending := hostgw.EnsureTapGuestNeighbors(); pending > 0 {
+				slog.Info("Tap guest neighbor resolution incomplete; will retry",
+					"resolved", resolved, "pending", pending)
+			}
+		}()
+	default:
+	}
+}
+
 // radvActorSet tracks the currently running radv.RunActor goroutines, keyed
 // by host interface name (radv.Record.HostInterface) -- Run's own local
 // state, reconciled against radv.ListAttachments on every
@@ -742,6 +770,12 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	radvReconcileTicker := time.NewTicker(radvReconcileInterval)
 	defer radvReconcileTicker.Stop()
 
+	tapNeighTicker := time.NewTicker(tapNeighReconcileInterval)
+	defer tapNeighTicker.Stop()
+	// Size-1 semaphore, so at most one sweep runs at a time and a tick
+	// arriving during one is dropped instead of piling up behind it.
+	tapNeighSem := make(chan struct{}, 1)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -811,17 +845,24 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 		case <-radvReconcileTicker.C:
 			reconcileRadvActors(ctx, radvActors)
 
+		case <-tapNeighTicker.C:
 			// Resolve each tap guest's neighbor entry, without which
 			// usid_ingress's own FIB lookup drops every decapsulated packet
-			// bound for it -- see hostgw.EnsureTapGuestNeighbors. On this
-			// ticker, and not once at CNI ADD, for the same reason the radv
-			// actors above run here: a VM guest's boot almost always outlives
-			// the short-lived plugin process that attached it, so there is
+			// bound for it -- see hostgw.EnsureTapGuestNeighbors. Periodic,
+			// and not once at CNI ADD, for the same reason the radv actors
+			// above run here: a VM guest's boot almost always outlives the
+			// short-lived plugin process that attached it, so there is
 			// nothing to solicit yet at ADD time.
-			if resolved, pending := hostgw.EnsureTapGuestNeighbors(); pending > 0 {
-				slog.Info("Tap guest neighbor resolution incomplete; will retry",
-					"resolved", resolved, "pending", pending)
-			}
+			//
+			// Off this loop's goroutine, and on a ticker of its own rather
+			// than radv's 2s one. Each unresolved guest costs a solicit plus
+			// up to neighResolveTimeout of polling, so a node whose guests
+			// are down would otherwise hold the select loop long past the
+			// next tick and starve the credential refresh, GC sweeps and
+			// eBPF health check with it -- measured at 32s a pass before the
+			// route filter was tightened. The semaphore drops a tick rather
+			// than queueing it when the previous pass is still running.
+			startTapNeighborSweep(tapNeighSem)
 
 		case iface := <-radvActors.failed:
 			radvActorFailed(radvActors, iface)


### PR DESCRIPTION
Two defects in the sweep added in #503, both visible the moment it ran on a node with real tap attachments:

```
INFO Tap guest neighbor resolution incomplete resolved=3 pending=32
INFO Tap guest neighbor resolution incomplete resolved=3 pending=32
     (32 seconds apart, on a 2 second ticker)
```

## The route filter was too loose

Three real guests, 32 candidates. A VPC VRF's table carries several routes per tap and only one names a guest, but the filter took any route pointing at the tap:

```
local fd20:0:2::1 dev <tap> proto kernel metric 0     <- host's own gateway addr
fd20:0:2::1 dev <tap> proto kernel metric 256         <- its connected route
fd20:0:2::3:0:0/96 dev <tap> metric 1024              <- the guest, the only one wanted
anycast fe80:: dev <tap> proto kernel metric 0
fe80::/64 dev <tap> proto kernel metric 256
```

So it solicited the host's own gateway address, the link-local pair and the anycast entries, none of which can answer.

It now takes only unicast routes this component installed. `RTPROT_KERNEL` excludes everything the kernel derived from an address assignment, `RTN_UNICAST` excludes the local and anycast entries, and link-local or multicast destinations are skipped outright.

## It was blocking the installer's main loop

Each unresolved candidate costs a solicit plus up to `neighResolveTimeout` of polling, and the sweep ran inline on `Run`'s select loop. Those 32 candidates held the loop for 32 seconds a pass, starving the credential refresh, the radv actors, the GC sweeps and the eBPF health check, none of which have anything to do with tap neighbours.

It now has its own 30s ticker and runs on its own goroutine, with a size-1 semaphore that drops a tick rather than queueing it while a pass is in flight. 30s rather than radv's 2s because the kernel refreshes a resolved entry from the guest's own advertisements, so this only has to notice one that has aged out or a guest that has newly booted.

The body is split into `startTapNeighborSweep` for the same reason `startEBPFDatapath` was: keeping `Run` inside golangci-lint's gocyclo budget.

## Note

#503's own verification stands. The resolution mechanism worked and the injection went from 20 dropped to 20 delivered. What was wrong is what it swept and where it ran, not how it resolves.

`go build ./...`, `go vet`, the unit suite and `golangci-lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)