### PR TITLE
fix(installer): remove locator local routes for a locator the node no longer owns

### DIFF
--- a/internal/installer/locatorroute.go
+++ b/internal/installer/locatorroute.go
@@ -6,6 +6,7 @@ package installer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -53,6 +54,13 @@ import (
 // Idempotent (RouteReplace), and safe to call repeatedly: Run invokes it at
 // startup and on its refresh ticker, so a BGPRouter that appears later, or a
 // route flushed out from under us, is picked up without a restart.
+//
+// It also removes the routes it installed for a locator this node no longer
+// owns. RouteReplace alone cannot: a changed Block or Node-ID is a different
+// prefix, so the old route is left behind claiming address space this node
+// has given up, and nothing would ever retract it. Observed after moving a
+// node back to its cluster Block, which left both the new and the old /64
+// local on lo.
 func ensureLocatorLocalRoute(ctx context.Context, k8s client.Client, namespace, nodeName string) error {
 	if k8s == nil || nodeName == "" {
 		return nil // no node identity configured; nothing to resolve against
@@ -81,7 +89,75 @@ func ensureLocatorLocalRoute(ctx context.Context, k8s client.Client, namespace, 
 	if err := netlink.RouteReplace(route); err != nil {
 		return fmt.Errorf("install local route %s dev lo table local: %w", prefix, err)
 	}
+
+	// Deliberately only after a successful install, and only with a valid
+	// desired prefix in hand -- pruning against the zero Prefix would strip
+	// this node's working route every time the BGPRouter is briefly
+	// unreadable during bring-up. A prune failure is not the install
+	// failing: same-node resolution already works, a leftover only
+	// over-claims space, and the refresh ticker retries.
+	if err := pruneStaleLocatorLocalRoutes(lo.Attrs().Index, prefix); err != nil {
+		slog.Warn("Could not remove stale uSID locator local routes; this node still "+
+			"claims a locator prefix it no longer owns", "keep", prefix.String(), "err", err)
+	}
 	return nil
+}
+
+// pruneStaleLocatorLocalRoutes removes every locator local route on lo except
+// keep. See staleLocatorLocalRoute for what it will and will not touch.
+func pruneStaleLocatorLocalRoutes(loIndex int, keep netip.Prefix) error {
+	routes, err := netlink.RouteListFiltered(unix.AF_INET6,
+		&netlink.Route{Table: unix.RT_TABLE_LOCAL, LinkIndex: loIndex},
+		netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
+	if err != nil {
+		return fmt.Errorf("list local table routes on lo: %w", err)
+	}
+
+	var errs []error
+	for i := range routes {
+		if !staleLocatorLocalRoute(routes[i], loIndex, keep) {
+			continue
+		}
+		if err := netlink.RouteDel(&routes[i]); err != nil {
+			errs = append(errs, fmt.Errorf("delete %s: %w", routes[i].Dst, err))
+			continue
+		}
+		slog.Info("Removed stale uSID locator local route",
+			"prefix", routes[i].Dst.String(), "keep", keep.String())
+	}
+	return errors.Join(errs...)
+}
+
+// staleLocatorLocalRoute reports whether r is one of ensureLocatorLocalRoute's
+// own routes for a prefix other than keep.
+//
+// The filtering is the whole safety argument, because the local table is
+// mostly the kernel's and deleting from it wrongly would black-hole one of
+// this node's own addresses. Every entry the kernel derives from an assigned
+// address carries RTPROT_KERNEL and is a /128 host route; what this component
+// installs carries neither. So a candidate must be RTN_LOCAL on lo, not
+// RTPROT_KERNEL, and exactly a Block+Node-ID /64 -- the one length
+// ensureLocatorLocalRoute ever writes. A node's own loopback /128, ::1, and
+// anything on another link all fail that.
+func staleLocatorLocalRoute(r netlink.Route, loIndex int, keep netip.Prefix) bool {
+	if r.LinkIndex != loIndex || r.Table != unix.RT_TABLE_LOCAL {
+		return false
+	}
+	if r.Type != unix.RTN_LOCAL || r.Protocol == unix.RTPROT_KERNEL {
+		return false
+	}
+	if r.Dst == nil || r.Dst.IP.To4() != nil {
+		return false
+	}
+	ones, bits := r.Dst.Mask.Size()
+	if bits != 128 || ones != uformat.BlockBits+uformat.NodeIDBits {
+		return false
+	}
+	got, ok := netip.AddrFromSlice(r.Dst.IP)
+	if !ok {
+		return false
+	}
+	return netip.PrefixFrom(got.Unmap(), ones) != keep
 }
 
 // nodeLocatorPrefix returns the Block(48)+Node-ID(16) /64 carved out of this

--- a/internal/installer/locatorroute_test.go
+++ b/internal/installer/locatorroute_test.go
@@ -6,9 +6,13 @@ package installer
 
 import (
 	"context"
+	"net"
+	"net/netip"
 	"strings"
 	"testing"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -147,5 +151,88 @@ func TestEnsureLocatorLocalRoute_NoIdentityIsNoop(t *testing.T) {
 	c := newRouterClient(t)
 	if err := ensureLocatorLocalRoute(context.Background(), c, testNamespace, ""); err != nil {
 		t.Errorf("ensureLocatorLocalRoute(_, \"\") error = %v, want nil", err)
+	}
+}
+
+// localRoute builds a local-table route the way the kernel reports one, so
+// the cases below differ only in the field under test.
+func localRoute(dst string, loIndex int, opts ...func(*netlink.Route)) netlink.Route {
+	_, n, err := net.ParseCIDR(dst)
+	if err != nil {
+		panic(err)
+	}
+	r := netlink.Route{
+		Dst:       n,
+		LinkIndex: loIndex,
+		Table:     unix.RT_TABLE_LOCAL,
+		Type:      unix.RTN_LOCAL,
+	}
+	for _, o := range opts {
+		o(&r)
+	}
+	return r
+}
+
+// TestStaleLocatorLocalRoute is the safety argument for pruning, written as
+// the cases that must NOT be deleted. This predicate deletes from the local
+// table, which is mostly the kernel's; matching one of the node's own address
+// routes would black-hole that address. Every "want false" below is a route
+// that has to survive.
+func TestStaleLocatorLocalRoute(t *testing.T) {
+	const lo = 1
+	keep := netip.MustParsePrefix("2607:ed40:8002:6::/64")
+	kernel := func(r *netlink.Route) { r.Protocol = unix.RTPROT_KERNEL }
+
+	for _, tc := range []struct {
+		name  string
+		route netlink.Route
+		want  bool
+	}{
+		// The bug this fixes: a node moved to a different Block leaves the
+		// old /64 local on lo, claiming space it no longer owns.
+		{"our route for a locator we no longer own", localRoute("2607:ed40:8006:6::/64", lo), true},
+		{"a different Node-ID in the same Block", localRoute("2607:ed40:8002:1::/64", lo), true},
+
+		{"the prefix we want to keep", localRoute("2607:ed40:8002:6::/64", lo), false},
+
+		// Kernel-derived entries: one per assigned address. Deleting the
+		// loopback's would take this node's router-id address away.
+		{"kernel loopback host route", localRoute("2607:ed40:1fe::4/128", lo, kernel), false},
+		{"kernel ::1", localRoute("::1/128", lo, kernel), false},
+		// A /64 that the kernel derived, which we must still not touch even
+		// though its length matches ours.
+		{"kernel-derived /64", localRoute("2607:ed40:8006:6::/64", lo, kernel), false},
+
+		{"another link's route", localRoute("2607:ed40:8006:6::/64", lo+1), false},
+		{"another table", localRoute("2607:ed40:8006:6::/64", lo,
+			func(r *netlink.Route) { r.Table = unix.RT_TABLE_MAIN }), false},
+		{"not a local route", localRoute("2607:ed40:8006:6::/64", lo,
+			func(r *netlink.Route) { r.Type = unix.RTN_UNICAST }), false},
+
+		// Only the /64 this component writes qualifies. A /48 Block discard
+		// or a /128 SID is somebody else's business.
+		{"the /48 Block, not a node locator", localRoute("2607:ed40:8006::/48", lo), false},
+		{"a single SID", localRoute("2607:ed40:8006:6::1/128", lo), false},
+
+		{"no destination", netlink.Route{LinkIndex: lo, Table: unix.RT_TABLE_LOCAL, Type: unix.RTN_LOCAL}, false},
+		{"ipv4", localRoute("10.0.0.0/24", lo), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := staleLocatorLocalRoute(tc.route, lo, keep); got != tc.want {
+				t.Errorf("staleLocatorLocalRoute(%v) = %v, want %v", tc.route.Dst, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPruneStaleLocatorLocalRoutes_UnknownLinkIsQuiet records the kernel
+// behaviour this relies on to stay inert on a host with no matching routes:
+// a filtered list against an ifindex that does not exist comes back empty
+// rather than failing, so pruning finds nothing to do and reports no error.
+// Pinned so this does not start warning on every refresh tick.
+func TestPruneStaleLocatorLocalRoutes_UnknownLinkIsQuiet(t *testing.T) {
+	err := pruneStaleLocatorLocalRoutes(0x7fffffff, netip.MustParsePrefix("2607:ed40:8002:6::/64"))
+	if err != nil {
+		t.Errorf("pruneStaleLocatorLocalRoutes() on a nonexistent link error = %v, want nil", err)
 	}
 }


### PR DESCRIPTION
## Problem

`ensureLocatorLocalRoute` installs this node's Block+Node-ID /64 into the local table with `RouteReplace`, which cannot retract anything. A changed Block or Node-ID is a different prefix, so the old route stays behind and nothing removes it. The node keeps claiming address space it gave up, and still accepts traffic for it.

Seen on a node moved back to its cluster Block, which left both:

```
local 2607:ed40:8002:6::/64 dev lo    <- the locator it now owns
local 2607:ed40:8006:6::/64 dev lo    <- the one it used to
```

## Fix

Prune the others after installing.

The filtering is the whole safety argument, because this deletes from the local table, which is mostly the kernel's. Matching one of the node's own address routes would black-hole that address.

Every entry the kernel derives from an assigned address carries `RTPROT_KERNEL` and is a /128 host route. What this component writes carries neither. So a candidate must be `RTN_LOCAL` on lo, in the local table, not `RTPROT_KERNEL`, and exactly a Block+Node-ID /64, the one length this ever writes.

On the affected node that separates the two cleanly:

```
local ::1 proto kernel                      <- survives
local 2607:ed40:1fe::4 proto kernel         <- survives
local 2607:ed40:8002:6::/64                 <- kept, it is the current locator
local 2607:ed40:8006:6::/64                 <- deleted
```

`staleLocatorLocalRoute` is split out as a pure predicate so those cases are tested without root. The table is written as the routes that must survive, including a `/48` Block discard, a single SID, another link's route, and a kernel-derived /64.

## Two deliberate limits

Pruning runs only after a successful install, and only with a valid desired prefix. Pruning against the zero Prefix would strip the node's working route every time its BGPRouter is briefly unreadable during bring-up.

A prune failure is warned, not returned. The install already succeeded, same-node resolution works, and a leftover only over-claims space until the refresh ticker retries. Returning it would have surfaced under the caller's existing warning, which says same-node egress registration will fail, and that would be wrong.

## Verification

- `task lint`: 0 issues
- `task test:unit`: 57 packages ok