### PR TITLE
fix(attach): attach the uSID ingress hook to BGP-learned fabric interfaces

### DIFF
--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -7,6 +7,7 @@ package attach
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
 
@@ -57,11 +58,13 @@ var (
 // This is the explicit override for multi-homed nodes where auto-detection
 // is ambiguous.
 //
-// Otherwise, the interface(s) carrying the default IPv6 route are
-// auto-detected. Attaching to the wrong (or too few) interfaces fails as
-// silent blackholing of overlay traffic (design plan §4.1), so callers
-// that get an error here must not proceed with a partial or empty
-// interface set.
+// Otherwise the interfaces are auto-detected: those carrying the default
+// IPv6 route, followed by those carrying a BGP-learned route, which is
+// where a fabric peer's SRv6 traffic arrives when the locators travel over
+// a segment the default route does not use (see isFabricPeerRoute).
+// Attaching to the wrong (or too few) interfaces fails as silent
+// blackholing of overlay traffic (design plan §4.1), so callers that get
+// an error here must not proceed with a partial or empty interface set.
 //
 // Either way, the resolved set is then run through expandBondSlaves: any
 // interface that is itself a Linux bonding master is expanded to include
@@ -107,7 +110,8 @@ func parseInterfaceList(v string) []string {
 }
 
 // autoDetectInterfaces returns the deduplicated set of interface names
-// carrying an IPv6 default route (::/0), in the order netlink reports them
+// carrying an IPv6 default route (::/0) or a BGP-learned route, default
+// routes first, and within each group in the order netlink reports them
 // -- analogous to the existing GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
 // auto-detection-from-`lo` pattern (internal/plumbing/loaddr), but over
 // routes rather than addresses.
@@ -152,37 +156,96 @@ func autoDetectInterfaces() ([]string, error) {
 
 	var names []string
 	seen := make(map[string]bool)
-	for _, r := range routes {
-		if !isDefaultRoute(r) || r.LinkIndex <= 0 {
-			continue
+	collect := func(match func(netlink.Route) bool) {
+		for _, r := range routes {
+			if !match(r) || r.LinkIndex <= 0 {
+				continue
+			}
+			link, err := linkByIndexFn(r.LinkIndex)
+			if err != nil {
+				// A route pointing at an interface we can't resolve isn't
+				// actionable here; skip it rather than failing the whole
+				// detection over one stale/racing route.
+				continue
+			}
+			if link.Type() == excludedLinkType {
+				continue
+			}
+			if isVRFSlave(link) {
+				continue
+			}
+			if link.Attrs().Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			name := link.Attrs().Name
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
 		}
-		link, err := linkByIndexFn(r.LinkIndex)
-		if err != nil {
-			// A route pointing at an interface we can't resolve isn't
-			// actionable here; skip it rather than failing the whole
-			// detection over one stale/racing route.
-			continue
-		}
-		if link.Type() == excludedLinkType {
-			continue
-		}
-		if isVRFSlave(link) {
-			continue
-		}
-		name := link.Attrs().Name
-		if seen[name] {
-			continue
-		}
-		seen[name] = true
-		names = append(names, name)
 	}
+
+	// Default-route interfaces first, and the ordering is contractual, not
+	// cosmetic: ResolveNodeSourceAddress takes names[0] and uses that
+	// interface's global address as the outer source of every packet this
+	// node encapsulates. That has to stay the interface carrying the
+	// default route. A private fabric segment's address is reachable only
+	// from that segment, so promoting it here would give cross-site SRv6
+	// a source no intermediate network forwards on -- the same silent loss
+	// the wireguard exclusion above exists to prevent.
+	collect(isDefaultRoute)
+	collect(isFabricPeerRoute)
 
 	if len(names) == 0 {
 		return nil, fmt.Errorf(
-			"attach: no default IPv6 route found to auto-detect the SRv6/underlay-facing interface; "+
-				"set %s to override", config.EnvCNIEBPFInterfaces)
+			"attach: no default or BGP-learned IPv6 route found to auto-detect the "+
+				"SRv6/underlay-facing interface; set %s to override", config.EnvCNIEBPFInterfaces)
 	}
 	return names, nil
+}
+
+// isFabricPeerRoute reports whether r is a route this node's own routing
+// daemon learned over BGP, making r's interface one where a fabric peer --
+// and so SRv6-encapsulated traffic from it -- can arrive.
+//
+// Default-route detection alone is not enough, and the gap is not
+// theoretical. Encapsulated traffic arrives wherever a peer's route to
+// this node's locator points, which is not necessarily the default route's
+// interface: a fabric can carry its locators over a private segment shared
+// only by the nodes on it, reached by a specific route rather than the
+// default. Measured on such a pair -- iBGP and the locators over a VLAN on
+// a private bond, the default route still on the public NIC -- 10
+// correctly-formed SRv6 packets arrived on the VLAN, the ingress hook was
+// attached only to the public NIC, nothing was decapsulated, and the
+// kernel counted them as Ip6InHdrErrors because a local SID with no
+// seg6local action is all it saw. No error anywhere: the tenant datapath
+// was silently dead.
+//
+// BGP is the signal because a fabric peer is by definition one this node
+// exchanges routes with, so the interface reaching it carries a
+// BGP-learned route whatever addressing the segment uses. It holds for a
+// peer in this node's own uSID Block and for one in a different Block,
+// which a rule keyed on locator address space would not. The exclusions
+// applied to default routes apply here unchanged, and they matter more:
+// EVPN routes for tenant prefixes are BGP-learned too, and every one of
+// them points into a VRF, which isVRFSlave rejects.
+func isFabricPeerRoute(r netlink.Route) bool {
+	if r.Protocol != unix.RTPROT_BGP {
+		return false
+	}
+	// A discard is not a path to anything. FRR installs the locator and
+	// aggregate prefixes this node originates itself as blackholes, and
+	// reports them on lo, so without this every node with an originated
+	// aggregate would nominate lo as a fabric interface. Rejecting the
+	// known non-forwarding types rather than requiring RTN_UNICAST, because
+	// an ordinary unicast route is also reported as RTN_UNSPEC by some
+	// netlink paths and requiring unicast would then match nothing.
+	switch r.Type {
+	case unix.RTN_BLACKHOLE, unix.RTN_UNREACHABLE, unix.RTN_PROHIBIT:
+		return false
+	}
+	return true
 }
 
 // excludedLinkType is the vishvananda/netlink Link.Type() value

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -7,11 +7,13 @@ package attach
 import (
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/plumbing/bond"
@@ -580,4 +582,130 @@ func equalStringSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// TestAutoDetect_FabricPeerRoutes covers the gap that left a real tenant
+// datapath silently dead: SRv6 arrives wherever a peer's route to this
+// node's locator points, which is not always the default route's
+// interface. A fabric carrying its locators over a private segment reaches
+// them by a BGP-learned route, and the ingress hook has to be attached
+// there too.
+func TestAutoDetect_FabricPeerRoutes(t *testing.T) {
+	t.Setenv(config.EnvCNIEBPFInterfaces, "")
+	stubNonBondLinks(t)
+
+	origRouteListFn, origLinkByIndexFn := routeListFn, linkByIndexFn
+	t.Cleanup(func() { routeListFn, linkByIndexFn = origRouteListFn, origLinkByIndexFn })
+
+	links := map[int]netlink.Link{
+		2: &fakeLink{attrs: netlink.LinkAttrs{Index: 2, Name: testIfaceEth0}},
+		3: &fakeLink{attrs: netlink.LinkAttrs{Index: 3, Name: testIfaceEth1}},
+		4: &fakeLink{attrs: netlink.LinkAttrs{Index: 4, Name: "lo", Flags: net.FlagLoopback}},
+	}
+	linkByIndexFn = func(index int) (netlink.Link, error) {
+		if l, ok := links[index]; ok {
+			return l, nil
+		}
+		return nil, errFixtureNotFound
+	}
+	bgp := func(idx int) netlink.Route {
+		return netlink.Route{LinkIndex: idx, Dst: &net.IPNet{
+			IP: net.ParseIP("2607:ed40:8002:6::"), Mask: net.CIDRMask(64, 128),
+		}, Protocol: unix.RTPROT_BGP}
+	}
+
+	for _, tt := range []struct {
+		name   string
+		routes []netlink.Route
+		want   []string
+	}{
+		{
+			// The deployed topology: default route on the public NIC, the
+			// peer's locator reached over a private segment.
+			name:   "adds the interface a locator is learned over",
+			routes: []netlink.Route{{LinkIndex: 2, Dst: nil}, bgp(3)},
+			want:   []string{testIfaceEth0, testIfaceEth1},
+		},
+		{
+			// The ordering is contractual: ResolveNodeSourceAddress takes
+			// names[0] for the outer source address of every encapsulated
+			// packet, and a private segment's address is not reachable off
+			// that segment. The default-route interface must stay first
+			// even when netlink reports the BGP route before it.
+			name:   "default route stays first regardless of netlink order",
+			routes: []netlink.Route{bgp(3), {LinkIndex: 2, Dst: nil}},
+			want:   []string{testIfaceEth0, testIfaceEth1},
+		},
+		{
+			name:   "a BGP route alone is still a usable fabric interface",
+			routes: []netlink.Route{bgp(3)},
+			want:   []string{testIfaceEth1},
+		},
+		{
+			name:   "one interface carrying both is not duplicated",
+			routes: []netlink.Route{{LinkIndex: 2, Dst: nil}, bgp(2)},
+			want:   []string{testIfaceEth0},
+		},
+		{
+			// Measured on every node in the fabric: FRR reports the
+			// aggregate this node originates itself as
+			// "blackhole <prefix> dev lo". Without rejecting it, every such
+			// node nominates lo as a fabric interface.
+			name: "an originated aggregate's blackhole is not a peer path",
+			routes: []netlink.Route{{LinkIndex: 2, Dst: nil}, {LinkIndex: 4, Dst: &net.IPNet{
+				IP: net.ParseIP("2607:ed40:1fe::"), Mask: net.CIDRMask(48, 128),
+			}, Protocol: unix.RTPROT_BGP, Type: unix.RTN_BLACKHOLE}},
+			want: []string{testIfaceEth0},
+		},
+		{
+			// Belt and braces for the same case: even a unicast BGP route
+			// reported on loopback must not attach the ingress hook there.
+			name: "loopback is never a fabric interface",
+			routes: []netlink.Route{{LinkIndex: 2, Dst: nil}, {LinkIndex: 4, Dst: &net.IPNet{
+				IP: net.ParseIP("2607:ed40:8002:6::"), Mask: net.CIDRMask(64, 128),
+			}, Protocol: unix.RTPROT_BGP}},
+			want: []string{testIfaceEth0},
+		},
+		{
+			// Every EVPN route for a tenant prefix is BGP-learned and points
+			// into a VRF. Attaching to those would put the ingress hook on
+			// tenant plumbing.
+			name: "non-BGP protocols are not fabric signals",
+			routes: []netlink.Route{{LinkIndex: 2, Dst: nil}, {LinkIndex: 3, Dst: &net.IPNet{
+				IP: net.ParseIP("2607:ed40:8002:6::"), Mask: net.CIDRMask(64, 128),
+			}, Protocol: unix.RTPROT_KERNEL}},
+			want: []string{testIfaceEth0},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			routeListFn = func() ([]netlink.Route, error) { return tt.routes, nil }
+			got, err := ResolveInterfaces()
+			if err != nil {
+				t.Fatalf("ResolveInterfaces() error = %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ResolveInterfaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAutoDetect_NoUsableRouteStillErrors keeps the failure mode intact:
+// with neither a default nor a BGP-learned route there is nothing to attach
+// to, and callers must get an error rather than an empty set they would
+// treat as success and silently blackhole traffic behind.
+func TestAutoDetect_NoUsableRouteStillErrors(t *testing.T) {
+	t.Setenv(config.EnvCNIEBPFInterfaces, "")
+	stubNonBondLinks(t)
+
+	origRouteListFn := routeListFn
+	t.Cleanup(func() { routeListFn = origRouteListFn })
+	routeListFn = func() ([]netlink.Route, error) {
+		return []netlink.Route{{LinkIndex: 2, Dst: &net.IPNet{
+			IP: net.ParseIP("2607:ed40:8002:6::"), Mask: net.CIDRMask(64, 128),
+		}, Protocol: unix.RTPROT_STATIC}}, nil
+	}
+	if _, err := ResolveInterfaces(); err == nil {
+		t.Fatal("ResolveInterfaces() error = nil, want an error")
+	}
 }


### PR DESCRIPTION
## Problem

Auto-detection nominated only the interfaces carrying an IPv6 default route. Encapsulated traffic arrives wherever a peer's route to this node's locator points, which is not necessarily that interface. A fabric can carry its locators over a private segment shared only by the nodes on it, reached by a specific route.

Found by running the tenant datapath end to end against a real unikernel guest. iBGP and the locators travel over a VLAN on a private bond; the default route is still on the public NIC.

```
fd00:231:2010::2 > 2607:ed40:8002:1:e001:: RT6 (segleft=0, [0]2607:ed40:8002:1:e001::)
  IP6 fd00:231:2010::2 > fd20:0:2::3:0:0: ICMP6 echo request
```

Ten of those arrived on the VLAN. The hook was attached to the public NIC only, so nothing was decapsulated, zero packets reached the guest's tap, and the kernel counted them as `Ip6InHdrErrors`, a local SID with no `seg6local` action being all it saw. Nothing reported an error. The tenant datapath was silently dead.

## Why BGP is the signal

A fabric peer is by definition one this node exchanges routes with, so the interface reaching it carries a BGP-learned route whatever addressing the segment uses. That holds both for a peer in this node's own uSID Block and for one in a different Block, which a rule keyed on locator address space would not.

## Ordering is contractual

Default-route interfaces are still collected first. `ResolveNodeSourceAddress` takes `names[0]` and uses that interface's global address as the outer source of every packet this node encapsulates. A private segment's address is reachable only from that segment, so promoting it would give cross-site SRv6 a source no intermediate network forwards on, which is the silent loss the existing wireguard exclusion already prevents. A test pins this by feeding the BGP route to netlink first.

## Two exclusions, from what the fabric reports

Checking the rule against all three node types before trusting it turned up a case theory would have missed:

```
eris-giune      default: bond0   bgp: bond1.2010, lo
proxima-evices  default: bond0   bgp: bond1.2010, lo
worker-8b4e1647 default: eth0    bgp: lo
```

`lo` is FRR reporting the aggregate each node originates itself:

```
blackhole 2607:ed40:1fe::/48 dev lo metric 20
```

So discard routes are rejected, by their non-forwarding types rather than by requiring `RTN_UNICAST`, since an ordinary unicast route is reported as `RTN_UNSPEC` by some netlink paths. Loopback links are excluded too.

The existing wireguard and VRF-slave exclusions apply to the new signal unchanged, and matter more for it: EVPN routes for tenant prefixes are BGP-learned too, and every one points into a VRF.

## Verification

- `task lint`: 0 issues
- `task test:unit`: 57 packages ok
- With this rule, the two affected nodes resolve to `bond0` then `bond1.2010`, and the workers stay on `eth0` alone

The end-to-end test is not yet re-run: it needs this in a `galactic-cni` image on the nodes.