### PR TITLE
fix(attach): expand a VLAN over a bond to the parent bond's slaves

### DIFF
--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -283,7 +283,9 @@ func isVRFSlave(link netlink.Link) bool {
 }
 
 // expandBondSlaves expands any bonding-master interface in names to also
-// include its slave interfaces, leaving every non-bond interface unchanged.
+// include its slave interfaces, and does the same for a VLAN interface
+// sitting on top of a bond (vlanBondMaster), leaving every other interface
+// unchanged.
 //
 // On a Linux bonding master, RX ingress tc/eBPF classification happens on
 // the slave devices, not the bond master itself -- a well-known kernel
@@ -331,20 +333,80 @@ func expandBondSlaves(names []string) ([]string, error) {
 				"leaving it as-is", "interface", name, "err", err)
 			continue
 		}
-		if !bond.IsMaster(link) {
-			continue
+
+		master := link
+		if !bond.IsMaster(master) {
+			// Not a bond itself. It may still sit on top of one: a VLAN
+			// over a bond has the same problem as the bond master, one
+			// level further up. See vlanBondMaster.
+			master = vlanBondMaster(link)
+			if master == nil {
+				continue
+			}
 		}
 
 		links, err := linkListFn()
 		if err != nil {
-			return nil, fmt.Errorf("attach: enumerate slaves of bonding master %q: %w", name, err)
+			return nil, fmt.Errorf("attach: enumerate slaves of bonding master %q: %w",
+				master.Attrs().Name, err)
 		}
-		for _, slave := range bond.SlaveNames(link, links) {
+		for _, slave := range bond.SlaveNames(master, links) {
 			add(slave)
 		}
 	}
 	return out, nil
 }
+
+// vlanBondMaster returns the bonding master a VLAN interface sits on top of,
+// or nil when link is not a VLAN or its parent is not a bond.
+//
+// A VLAN over a bond inherits the bond master's ingress problem rather than
+// escaping it. RX classification still happens on the physical slaves, so a
+// filter on the VLAN device never runs for traffic that arrives while
+// bonded, exactly as a filter on the bond master never does.
+//
+// Measured on a fabric carrying its locators over a VLAN on a private bond,
+// with the ingress hook attached to the VLAN device: SRv6 packets arrived
+// (pcap on the VLAN device showed them, since the packet tap runs where tc
+// classification does not), the datapath's own counters did not move at all,
+// and nothing was decapsulated. Attaching to the parent bond's slaves moved
+// the per-VRF packet counter by exactly the number of packets sent, and
+// detaching them stopped it again.
+//
+// The parent's own slaves are what gets added, not the parent: attaching to
+// a bond master is inert for the same reason, so naming it would achieve
+// nothing.
+//
+// The tag is not a problem here. These NICs strip it in hardware, so the
+// frame reaching tc on the slave carries ethertype IPv6 with the VLAN id in
+// skb metadata, which is what usid_ingress's Ethernet parse already
+// expects. A deployment whose NICs leave the tag in the packet data would
+// additionally need 802.1Q parsing in the datapath, which it does not have.
+func vlanBondMaster(link netlink.Link) netlink.Link {
+	if link.Type() != vlanLinkType {
+		return nil
+	}
+	idx := link.Attrs().ParentIndex
+	if idx <= 0 {
+		return nil
+	}
+	parent, err := linkByIndexFn(idx)
+	if err != nil {
+		// Unresolvable parent isn't actionable; don't guess, matching this
+		// package's stance on an unresolvable route target and master.
+		slog.Warn("attach: could not resolve a VLAN interface's parent to check whether it's a "+
+			"bonding master", "interface", link.Attrs().Name, "parentIndex", idx, "err", err)
+		return nil
+	}
+	if !bond.IsMaster(parent) {
+		return nil
+	}
+	return parent
+}
+
+// vlanLinkType is the vishvananda/netlink Link.Type() value identifying a
+// VLAN interface, whose parent vlanBondMaster checks for bonding.
+const vlanLinkType = "vlan"
 
 // isDefaultRoute reports whether r is an IPv6 default route (::/0).
 func isDefaultRoute(r netlink.Route) bool {

--- a/internal/plumbing/ebpf/attach/interfaces_test.go
+++ b/internal/plumbing/ebpf/attach/interfaces_test.go
@@ -709,3 +709,126 @@ func TestAutoDetect_NoUsableRouteStillErrors(t *testing.T) {
 		t.Fatal("ResolveInterfaces() error = nil, want an error")
 	}
 }
+
+// TestResolveInterfaces_VLANOverBondExpansion covers the topology that left
+// a real tenant datapath dead: the fabric carries its locators over a VLAN
+// on a private bond. RX classification happens on the physical slaves, so a
+// filter on the VLAN device never runs for traffic arriving while bonded,
+// exactly as a filter on a bond master never does.
+//
+// Measured on that fabric: with the hook on the VLAN device alone, SRv6
+// packets arrived and not one datapath counter moved. Attaching the parent
+// bond's slaves moved the per-VRF packet counter by exactly the number sent,
+// and detaching them stopped it.
+func TestResolveInterfaces_VLANOverBondExpansion(t *testing.T) {
+	const (
+		vlanName  = "bond1.2010"
+		vlanIndex = 20
+		bondName  = "bond1"
+		bondIndex = 8
+		slave1    = "ens2f0np0"
+		slave2    = "ens1f0np0"
+		nicName   = "eth9"
+		nicVLAN   = "eth9.7"
+	)
+
+	bondLink := &fakeLink{attrs: netlink.LinkAttrs{Name: bondName, Index: bondIndex}, linkType: bond.LinkType}
+	vlanLink := &fakeLink{
+		attrs:    netlink.LinkAttrs{Name: vlanName, Index: vlanIndex, ParentIndex: bondIndex},
+		linkType: vlanLinkType,
+	}
+	// A VLAN on a plain NIC, to prove only a bonded parent expands.
+	plainNIC := &fakeLink{attrs: netlink.LinkAttrs{Name: nicName, Index: 30}}
+	vlanOnNIC := &fakeLink{
+		attrs:    netlink.LinkAttrs{Name: nicVLAN, Index: 31, ParentIndex: 30},
+		linkType: vlanLinkType,
+	}
+	allLinks := []netlink.Link{
+		bondLink, vlanLink, plainNIC, vlanOnNIC,
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave1, Index: 9, MasterIndex: bondIndex}},
+		&fakeLink{attrs: netlink.LinkAttrs{Name: slave2, Index: 10, MasterIndex: bondIndex}},
+	}
+	byName := map[string]netlink.Link{}
+	byIndex := map[int]netlink.Link{}
+	for _, l := range allLinks {
+		byName[l.Attrs().Name] = l
+		byIndex[l.Attrs().Index] = l
+	}
+
+	for _, tt := range []struct {
+		name  string
+		iface string
+		want  []string
+	}{
+		{
+			// The deployed case. The parent's slaves are added, not the
+			// parent: attaching to a bond master is inert for the same
+			// reason, so naming it would achieve nothing.
+			name:  "a VLAN over a bond expands to the parent's slaves",
+			iface: vlanName,
+			want:  []string{vlanName, slave1, slave2},
+		},
+		{
+			name:  "a VLAN over a plain NIC expands to nothing",
+			iface: nicVLAN,
+			want:  []string{nicVLAN},
+		},
+		{
+			name:  "a bond master still expands to its own slaves",
+			iface: bondName,
+			want:  []string{bondName, slave1, slave2},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(config.EnvCNIEBPFInterfaces, tt.iface)
+
+			origByName, origList, origByIndex := linkByNameFn, linkListFn, linkByIndexFn
+			t.Cleanup(func() { linkByNameFn, linkListFn, linkByIndexFn = origByName, origList, origByIndex })
+			linkByNameFn = func(name string) (netlink.Link, error) {
+				if l, ok := byName[name]; ok {
+					return l, nil
+				}
+				return nil, errFixtureNotFound
+			}
+			linkByIndexFn = func(index int) (netlink.Link, error) {
+				if l, ok := byIndex[index]; ok {
+					return l, nil
+				}
+				return nil, errFixtureNotFound
+			}
+			linkListFn = func() ([]netlink.Link, error) { return allLinks, nil }
+
+			got, err := ResolveInterfaces()
+			if err != nil {
+				t.Fatalf("ResolveInterfaces() error = %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ResolveInterfaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVLANBondMaster_UnresolvableParentIsNotFatal keeps a VLAN whose parent
+// cannot be resolved from failing the whole detection, matching how this
+// package already treats an unresolvable route target or bond master: warn
+// and leave the interface as-is rather than guess.
+func TestVLANBondMaster_UnresolvableParentIsNotFatal(t *testing.T) {
+	origByIndex := linkByIndexFn
+	t.Cleanup(func() { linkByIndexFn = origByIndex })
+	linkByIndexFn = func(int) (netlink.Link, error) { return nil, errFixtureNotFound }
+
+	vlan := &fakeLink{
+		attrs:    netlink.LinkAttrs{Name: "bond1.2010", Index: 20, ParentIndex: 8},
+		linkType: vlanLinkType,
+	}
+	if got := vlanBondMaster(vlan); got != nil {
+		t.Errorf("vlanBondMaster() = %v, want nil", got.Attrs().Name)
+	}
+	// A VLAN with no parent index at all, which netlink reports for a link
+	// whose IFLA_LINK is absent.
+	noParent := &fakeLink{attrs: netlink.LinkAttrs{Name: "vlan0", Index: 21}, linkType: vlanLinkType}
+	if got := vlanBondMaster(noParent); got != nil {
+		t.Errorf("vlanBondMaster(no parent) = %v, want nil", got.Attrs().Name)
+	}
+}


### PR DESCRIPTION
## Problem

A VLAN over a bond inherits the bond master's ingress problem rather than escaping it. RX classification happens on the physical slaves, so a filter on the VLAN device never runs for traffic arriving while bonded, exactly as a filter on the bond master never does.

`expandBondSlaves` only expanded an interface that was itself a bond, so a VLAN's parent was never consulted and its slaves were never attached. #506 put the VLAN device in the resolved set, which was necessary and not sufficient.

## Evidence

Measured on a fabric carrying its locators over a VLAN on a private bond, hook on the VLAN device:

```
bond1's slaves attached:  vrf pkts 145 -> 150   (+5 per 5 pings)
bond1's slaves detached:  vrf pkts 150 -> 150   (+0)
```

Before attaching the slaves, SRv6 packets arrived and not one datapath counter moved. `pcap` on the VLAN device showed them, because the packet tap runs where tc classification does not, which is what made this look like a working interface.

## The tag

Not a problem on this hardware. The NICs strip it, so the frame reaching tc on the slave carries ethertype IPv6 with the VLAN id in skb metadata, which is what `usid_ingress`'s Ethernet parse already expects. On the wire:

```
ens2f0np0: ethertype IPv6 (0x86dd) ... 2607:ed40:8002:1:e001::
tagged frames seen: 0
```

A deployment whose NICs leave the tag in the packet data would additionally need 802.1Q parsing in the datapath, which it does not have.

## Details

The parent's slaves are added, not the parent. Attaching to a bond master is inert for the same reason, so naming it would achieve nothing.

An unresolvable parent warns and leaves the interface as-is rather than failing detection, matching how this package already treats an unresolvable route target or bond master.

## Not fixed by this

The datapath still does not deliver. With the slaves attached the packets are claimed and not dropped, and never reach the tap, with the tap's own tx/rx counters flat. That is a separate failure in steps 8-9, still to be diagnosed.

## Verification

- `task lint`: 0 issues
- `task test:unit`: 57 packages ok
- Tests cover the deployed topology, a VLAN on a plain NIC expanding to nothing, a bond master still expanding to its own slaves, and an unresolvable or absent parent