### PR TITLE
diag(usid): make usid_ingress observable end to end, and drop an unusable ifindex

### DIFF
--- a/hack/returnpath-lab/main.go
+++ b/hack/returnpath-lab/main.go
@@ -681,6 +681,12 @@ var traceReasonNames = map[uint32]string{
 	30: "trace_ing_redirect_ok",
 	31: "trace_ing_last_ifindex (VALUE, not a count)",
 	32: "fib_no_ifindex",
+	33: "trace_ing_entry",
+	34: "trace_ing_pull_data_failed",
+	35: "trace_ing_eth_bounds_failed",
+	36: "trace_ing_ethertype_mismatch",
+	37: "trace_ing_ip6_bounds_failed",
+	38: "trace_ing_locator_miss",
 }
 
 // ---------------------------------------------------------------------

--- a/hack/returnpath-lab/main.go
+++ b/hack/returnpath-lab/main.go
@@ -658,6 +658,11 @@ func reportDropReasons(pinDir string) error {
 // prog.DropReasonNames. Read together they say how far usid_egress got:
 // ENTRY -> IFINDEX_HIT -> ADJUST_ROOM_OK -> REACHED_REDIRECT -> REDIRECT_OK
 // is a fully successful encapsulation.
+//
+// Slots 29-32 are the same idea for usid_ingress, which had no success
+// counter at all: ING_REACHED_REDIRECT -> ING_REDIRECT_OK brackets its own
+// step 9. ing_last_ifindex is a value, not a count -- the ifindex
+// bpf_fib_lookup resolved, printed as-is. fib_no_ifindex is a real drop.
 var traceReasonNames = map[uint32]string{
 	16: "trace_multicast_ll_bail",
 	17: "trace_miss_vrf",
@@ -672,6 +677,10 @@ var traceReasonNames = map[uint32]string{
 	26: "trace_eth_bounds_failed",
 	27: "trace_ethertype_mismatch",
 	28: "trace_ifindex_hit",
+	29: "trace_ing_reached_redirect",
+	30: "trace_ing_redirect_ok",
+	31: "trace_ing_last_ifindex (VALUE, not a count)",
+	32: "fib_no_ifindex",
 }
 
 // ---------------------------------------------------------------------

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -722,6 +722,31 @@ enum drop_reason {
 	// into the real block when the temporary slots around it are
 	// removed.
 	DROP_REASON_FIB_NO_IFINDEX = 32,
+	// TEMPORARY, and the ingress mirror of DROP_REASON_TRACE_ENTRY
+	// through DROP_REASON_TRACE_IFINDEX_HIT above, added for the same
+	// reason those were: usid_ingress's own entry sequence has five
+	// exits with no counter at all, so "nothing incremented" cannot
+	// currently distinguish "never invoked" from "always took an
+	// uninstrumented path".
+	//
+	// Two of the five are live hypotheses rather than completeness for
+	// its own sake. ETHERTYPE_MISMATCH is where a VLAN tag left in the
+	// packet data by a NIC that does not strip it would land, silently.
+	// LOCATOR_MISS is where a Block or Node-ID that does not match this
+	// node's own registration would land, equally silently, and it is
+	// the one miss in the lookup chain with no counter (function_table
+	// and vrf_table misses are already DROP_REASON_UNKNOWN_FUNCTION and
+	// DROP_REASON_UNKNOWN_ARGUMENT).
+	//
+	// drop_reasons is a PERCPU_ARRAY, so the unconditional entry counter
+	// is a per-CPU increment with no cross-CPU contention, on a program
+	// that already runs for every packet arriving on the fabric NICs.
+	DROP_REASON_TRACE_ING_ENTRY = 33,
+	DROP_REASON_TRACE_ING_PULL_DATA_FAILED = 34,
+	DROP_REASON_TRACE_ING_ETH_BOUNDS_FAILED = 35,
+	DROP_REASON_TRACE_ING_ETHERTYPE_MISMATCH = 36,
+	DROP_REASON_TRACE_ING_IP6_BOUNDS_FAILED = 37,
+	DROP_REASON_TRACE_ING_LOCATOR_MISS = 38,
 	__DROP_REASON_MAX,
 };
 
@@ -1094,8 +1119,12 @@ int usid_ingress(struct __sk_buff *skb)
 	// filter on this device unmodified (TC_ACT_UNSPEC, not TC_ACT_OK: see
 	// the note below step 2) rather than drop traffic this program hasn't
 	// even determined is a uSID packet yet.
-	if (bpf_skb_pull_data(skb, 0))
+	count_drop(DROP_REASON_TRACE_ING_ENTRY); // TEMPORARY
+
+	if (bpf_skb_pull_data(skb, 0)) {
+		count_drop(DROP_REASON_TRACE_ING_PULL_DATA_FAILED); // TEMPORARY
 		return TC_ACT_UNSPEC;
+	}
 
 	void *data = (void *) (long) skb->data;
 	void *data_end = (void *) (long) skb->data_end;
@@ -1105,16 +1134,22 @@ int usid_ingress(struct __sk_buff *skb)
 	// (R6; see the note below step 2).
 	struct usid_ethhdr *eth = data;
 
-	if ((void *) (eth + 1) > data_end)
+	if ((void *) (eth + 1) > data_end) {
+		count_drop(DROP_REASON_TRACE_ING_ETH_BOUNDS_FAILED); // TEMPORARY
 		return TC_ACT_UNSPEC;
+	}
 
-	if (eth->h_proto != __builtin_bswap16(USID_ETH_P_IPV6))
+	if (eth->h_proto != __builtin_bswap16(USID_ETH_P_IPV6)) {
+		count_drop(DROP_REASON_TRACE_ING_ETHERTYPE_MISMATCH); // TEMPORARY
 		return TC_ACT_UNSPEC;
+	}
 
 	struct usid_ip6hdr *ip6 = (void *) (eth + 1);
 
-	if ((void *) (ip6 + 1) > data_end)
+	if ((void *) (ip6 + 1) > data_end) {
+		count_drop(DROP_REASON_TRACE_ING_IP6_BOUNDS_FAILED); // TEMPORARY
 		return TC_ACT_UNSPEC;
+	}
 
 	// Step 2: exact-match the destination address's top 64 bits
 	// (Block(48) + Node-ID(16), read with no shift) against
@@ -1142,8 +1177,10 @@ int usid_ingress(struct __sk_buff *skb)
 
 	struct locator_value *loc = bpf_map_lookup_elem(&locator_table, &locator_key);
 
-	if (!loc)
+	if (!loc) {
+		count_drop(DROP_REASON_TRACE_ING_LOCATOR_MISS); // TEMPORARY
 		return TC_ACT_UNSPEC;
+	}
 
 	__u64 block = locator_key >> 16;
 

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -691,6 +691,37 @@ enum drop_reason {
 	DROP_REASON_TRACE_ETH_BOUNDS_FAILED = 26,
 	DROP_REASON_TRACE_ETHERTYPE_MISMATCH = 27,
 	DROP_REASON_TRACE_IFINDEX_HIT = 28,
+	// TEMPORARY diagnostic checkpoints for usid_ingress's step 8/9, the
+	// mirror of DROP_REASON_TRACE_* above for usid_egress. Remove once
+	// resolved.
+	//
+	// The ingress path has no success counter at all, so a packet that
+	// is claimed at step 6 and then lost has the same signature as one
+	// delivered: the per-vrf_table packets counter moves, no drop
+	// counter moves, and nothing distinguishes the two. Measured on a
+	// live tap attachment: packets=+5 per 5 sent, dropped_packets flat,
+	// and the target tap's own tx_packets flat, so the packet is neither
+	// dropped by this program nor delivered.
+	//
+	// Everything between step 6 and the redirect is already counted, so
+	// what is left is the redirect itself and what the kernel does with
+	// it after this program returns. skb_do_redirect runs post-return
+	// and can discard the packet with nothing here to observe it, which
+	// a zero or otherwise unusable fib_params.ifindex would cause.
+	DROP_REASON_TRACE_ING_REACHED_REDIRECT = 29,
+	DROP_REASON_TRACE_ING_REDIRECT_OK = 30,
+	// Not a counter: SET to the ifindex bpf_fib_lookup resolved, so the
+	// redirect target itself is observable rather than inferred. Read it
+	// as a value, never as a count.
+	DROP_REASON_TRACE_ING_LAST_IFINDEX = 31,
+	// A real drop, not a trace: bpf_fib_lookup returned SUCCESS with an
+	// ifindex that cannot be redirected to. Sitting in the temporary
+	// block rather than with the other FIB reasons at 0-15 only to avoid
+	// renumbering slots 16-30, which the Go mirror's DropReasonCount and
+	// hack/returnpath-lab's name table both key off. It should graduate
+	// into the real block when the temporary slots around it are
+	// removed.
+	DROP_REASON_FIB_NO_IFINDEX = 32,
 	__DROP_REASON_MAX,
 };
 
@@ -882,6 +913,20 @@ static USID_ALWAYS_INLINE void count_drop(__u32 reason)
 
 	if (count)
 		__sync_fetch_and_add(count, 1);
+}
+
+// record_value overwrites a drop_reasons slot instead of incrementing it,
+// for the TEMPORARY diagnostic slots documented as values rather than
+// counts (DROP_REASON_TRACE_ING_LAST_IFINDEX). A counter cannot carry an
+// ifindex, and the alternative -- a second map -- would need its own
+// pinning and control-plane wiring for a slot that exists only until this
+// investigation closes.
+static USID_ALWAYS_INLINE void record_value(__u32 slot, __u64 value)
+{
+	__u64 *cell = bpf_map_lookup_elem(&drop_reasons, &slot);
+
+	if (cell)
+		*cell = value;
 }
 
 // count_claimed_drop is count_drop plus the per-vrf_table-entry
@@ -1415,6 +1460,17 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
+	// TEMPORARY (see DROP_REASON_TRACE_ING_REACHED_REDIRECT): record the
+	// resolved redirect target before using it. A lookup that returns
+	// SUCCESS is not required to hand back a usable ifindex, and
+	// redirecting to a zero one is a silent post-return discard.
+	record_value(DROP_REASON_TRACE_ING_LAST_IFINDEX, (__u64) fib_params.ifindex);
+
+	if (fib_params.ifindex <= 0) {
+		count_claimed_drop(DROP_REASON_FIB_NO_IFINDEX, vrf);
+		return TC_ACT_SHOT;
+	}
+
 	__builtin_memcpy(new_eth->h_dest, fib_params.dmac, sizeof(new_eth->h_dest));
 	__builtin_memcpy(new_eth->h_source, fib_params.smac, sizeof(new_eth->h_source));
 
@@ -1440,6 +1496,8 @@ int usid_ingress(struct __sk_buff *skb)
 	// this file's other FIB-lookup tests already document.
 	long redirect_rc;
 
+	count_drop(DROP_REASON_TRACE_ING_REACHED_REDIRECT); // TEMPORARY
+
 	if (vrf->egress_kind == EGRESS_KIND_TAP)
 		redirect_rc = bpf_redirect(fib_params.ifindex, 0);
 	else
@@ -1449,6 +1507,8 @@ int usid_ingress(struct __sk_buff *skb)
 		count_claimed_drop(DROP_REASON_REDIRECT_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}
+
+	count_drop(DROP_REASON_TRACE_ING_REDIRECT_OK); // TEMPORARY
 
 	return redirect_rc;
 }


### PR DESCRIPTION
## Problem

`usid_ingress` has no success counter and five uncounted exits. A packet claimed at step 6 and then lost looks exactly like one delivered: the per-`vrf_table` `packets` counter moves, no drop counter moves, and nothing tells the two apart.

Measured on a live tap attachment, with the hook correctly attached (#506, #507) and the maps correctly populated:

```
vrf_table arg=1 -> table=1   packets 150 -> 155   dropped_packets 77 -> 77
tap G0000000028s5H           tx=168 rx=48  -> unchanged
VRF master G000000002V       tx=762 rx=846 -> unchanged
```

Neither dropped by this program nor delivered.

## Step 9

Everything between step 6 and the redirect is already counted: `MALFORMED_INNER`, `UNKNOWN_INNER_VERSION`, `STRIP_FAILED`, and all four `bpf_fib_lookup` return classes. `egress_kind=1` is `EGRESS_KIND_TAP`, so the tap takes `bpf_redirect`, and a failed redirect would count `REDIRECT_FAILED`.

What is left is the redirect and what the kernel does after this program returns. `skb_do_redirect` runs post-return and can discard the packet with nothing here to observe it, which an unusable `fib_params.ifindex` would cause.

So bracket step 9 the way `usid_egress` already is, with `trace_ing_reached_redirect` and `trace_ing_redirect_ok`, and record the resolved ifindex as `trace_ing_last_ifindex` rather than inferring it. `record_value` writes a slot instead of incrementing it; a counter cannot carry an ifindex, and a second map would need its own pinning and control-plane wiring for something that exists only until this closes.

`DROP_REASON_FIB_NO_IFINDEX` is a real drop, not a trace. A lookup returning SUCCESS is not obliged to hand back a usable ifindex, and redirecting to a zero one is a guaranteed silent discard. It sits in the temporary block only to avoid renumbering slots 16-30, which the Go mirror's `DropReasonCount` and the lab's name table both key off, and should graduate into the real block when the temporary slots around it go.

## The entry sequence

An audit of every exit found five that count nothing, all in the entry sequence: `bpf_skb_pull_data` failure, the Ethernet bounds check, the ethertype check, the IPv6 bounds check, and the `locator_table` miss. There is also no entry counter. That is the same ambiguity `DROP_REASON_TRACE_ENTRY` through `DROP_REASON_TRACE_IFINDEX_HIT` already closed for `usid_egress`.

Two are live hypotheses rather than completeness for its own sake:

- `ETHERTYPE_MISMATCH` is where a VLAN tag left in the packet data by a NIC that does not strip it would land. These NICs do strip it, checked on the wire, but that is a property of the hardware rather than of the code.
- `LOCATOR_MISS` is where a Block or Node-ID not matching this node's registration would land. It is the one miss in the lookup chain with no counter, since `function_table` and `vrf_table` misses are already `UNKNOWN_FUNCTION` and `UNKNOWN_ARGUMENT`.

`usid_ingress` now has no uncounted exit.

## Cost

`drop_reasons` is a `PERCPU_ARRAY`, so the unconditional entry counter is a per-CPU increment with no cross-CPU contention, on a program that already runs for every packet arriving on the fabric NICs.

## What the next run says

One pass now distinguishes every case rather than only the three step-9 ones:

1. `trace_ing_entry` flat: the program is not being invoked at all.
2. `trace_ing_ethertype_mismatch` or `trace_ing_locator_miss` moving: the packet is rejected before the lookup chain completes, and which one says why.
3. `fib_no_ifindex` moving: the lookup returned an unusable target.
4. `trace_ing_redirect_ok` moving while the tap stays flat: `skb_do_redirect` is discarding post-return, and `trace_ing_last_ifindex` names the target to compare against the tap's real index.

## Verification

- `go generate ./internal/plumbing/ebpf/prog/`: the object rebuilds clean, so the C compiles
- `task lint`: 0 issues
- `task test:unit`: 57 packages ok
- An exit audit of `usid_ingress` reports 0 uncounted exits

The existing `usid_test.go` FIB tests cannot cover the step-9 path: a real lookup-then-redirect needs a live route and `net_device` that `BPF_PROG_TEST_RUN` cannot fabricate, which that file already documents.