### PR TITLE
fix(usid): clear the outer transit VLAN off a decapsulated packet

### DIFF
--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -148,6 +148,13 @@ static long (*bpf_skb_pull_data)(struct __sk_buff *skb, __u32 len) = (void *) BP
 static long (*bpf_skb_adjust_room)(struct __sk_buff *skb, __s32 len_diff, __u32 mode,
 				    __u64 flags) = (void *) BPF_FUNC_skb_adjust_room;
 
+// Clears the outer transit VLAN off a decapsulated packet -- see its call
+// site (step 7) for why the inner packet must not inherit it, and why a
+// helper is needed rather than zeroing a field: skb->vlan_tci is not
+// writable from BPF, and the tag lives there rather than in packet data
+// whenever the NIC strips it on receive.
+static long (*bpf_skb_vlan_pop)(struct __sk_buff *skb) = (void *) BPF_FUNC_skb_vlan_pop;
+
 // Only used on the IPv4-inner decap path, to retag skb->protocol -- see
 // the long comment at its call site (step 7) for why a helper is needed
 // here at all instead of a plain assignment.
@@ -1341,9 +1348,46 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	// bpf_skb_change_proto/bpf_skb_adjust_room can both change the
-	// underlying packet buffer: all previously derived data/data_end
-	// pointers are invalidated and must be re-read.
+	// Drop the outer transit VLAN, which the decapsulated inner packet
+	// must not inherit.
+	//
+	// When the uSID packet arrives on a VLAN whose tag the NIC strips
+	// into skb metadata (hardware VLAN offload, the ordinary case), the
+	// tag lives in skb->vlan_tci rather than in packet data, so the
+	// ethertype check at the top of this function sees IPv6 and the
+	// carve above never touches the tag. Stripping the outer IPv6
+	// header therefore leaves the tag attached to a packet it has
+	// nothing to do with: the tag describes the segment the *outer*
+	// packet crossed to reach this node, while the inner packet is
+	// addressed inside a tenant VRF and never belonged to that segment.
+	//
+	// Carrying it forward breaks the redirect in step 9 two ways. A tap
+	// re-inserts a metadata tag into the frame on transmit, so the guest
+	// would receive a tagged frame it has no VLAN interface to accept;
+	// and any other egress program on the resolved interface that
+	// filters by VLAN id sees a tag from a segment that interface is not
+	// on, and is entitled to drop the packet before it is ever
+	// transmitted -- a discard that happens after this program has
+	// already returned TC_ACT_REDIRECT, so no counter here can see it.
+	//
+	// Unconditional and idempotent: with no tag present this is a no-op
+	// returning success, so it needs no guard of its own. It is placed
+	// here, immediately after the carve, so the existing pointer re-read
+	// below covers this helper's invalidation too.
+	//
+	// A failure counts as DROP_REASON_STRIP_FAILED rather than earning a
+	// reason of its own: removing the tag is part of the same carve step
+	// as removing the outer header, and the only way this helper fails
+	// is the allocation the carve above can equally fail on, so the two
+	// share a cause as well as a step.
+	if (bpf_skb_vlan_pop(skb)) {
+		count_claimed_drop(DROP_REASON_STRIP_FAILED, vrf);
+		return TC_ACT_SHOT;
+	}
+
+	// bpf_skb_change_proto/bpf_skb_adjust_room/bpf_skb_vlan_pop can all
+	// change the underlying packet buffer: all previously derived
+	// data/data_end pointers are invalidated and must be re-read.
 	data = (void *) (long) skb->data;
 	data_end = (void *) (long) skb->data_end;
 


### PR DESCRIPTION
`usid_ingress` decapsulated a uSID packet, resolved the right egress interface, redirected to it, and the packet was destroyed before it was ever transmitted. Every counter in the program read success.

#508's instrumentation is what made this findable, and it took one run:

```
vrf_table arg=1              pkts +5   drops +0
trace_ing_reached_redirect        +5
trace_ing_redirect_ok             +5
trace_ing_last_ifindex            149   <-- the target tap
tap 149 rx / tx / tx_dropped   unmoved
```

An in-VRF ping of the same count to the same tap moves its tx by +5, so the tap's counters are faithful. The packet reaches `bpf_redirect`, gets `TC_ACT_REDIRECT` for the correct ifindex, and dies after the program returns.

## What was happening

The kernel's `kfree_skb` tracepoint puts the drop inside `__dev_queue_xmit`, reason `TC_EGRESS`, reached via `__bpf_redirect` from our own TC ingress hook:

```
__dev_queue_xmit
__bpf_redirect
__netif_receive_skb_core
bnxt_poll
```

A uSID packet arriving on a VLAN whose tag the NIC strips on receive carries that tag in `skb->vlan_tci`, not in packet data. The ethertype check at the top of the program therefore sees IPv6, and the carve that removes the outer header never touches the tag. What comes out is an inner packet, addressed inside a tenant VRF, still tagged for the segment the outer packet crossed to get here.

Two things then go wrong on the way out, both after `TC_ACT_REDIRECT` has been returned, which is why nothing in this file could see either:

1. A tap re-inserts a metadata tag into the frame on transmit, so a guest receives a tagged frame it has no VLAN interface to accept.
2. An egress program on the resolved interface that filters by VLAN id sees a tag from a segment that interface is not on, and drops the packet.

The second is what fired here. That drop is correct behaviour. The tag really is wrong.

## The fix

Pop the tag, immediately after the carve and for the same reason. The outer encapsulation includes it, so removing the outer header without it leaves the packet half-decapsulated.

The helper is a no-op when no tag is present, so it needs no guard, and placing it next to the carve lets the existing pointer re-read cover its invalidation too. A failure counts as `DROP_REASON_STRIP_FAILED` rather than earning a reason of its own: it is the same step, and the only way it fails is the allocation the carve can equally fail on.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. The behaviour needs a real `net_device` and a tagged receive, so it is a live-cluster concern, same as the FIB-lookup and redirect paths around it -- verification is the end-to-end run above, repeated after this deploys.

