### PR TITLE
feat(installer): give the ingress sidecar's return path a host side

### DIFF
--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -135,6 +135,28 @@ func VPCSegment(vpc string) string {
 	return nameSegment(vpc)
 }
 
+// IngressAttachment is the synthetic vpcAttachment segment the ingress
+// sidecar publishes its own per-VPC gateway address under. A sidecar has no
+// real VPCAttachment -- it is not a tenant workload and no CNI ADD ever runs
+// for it -- but BGPAdvertisementName needs a middle segment, and one fixed
+// value keeps the name deterministic and one-per-(VPC, node).
+//
+// Defined here, in the package that owns every CRD name, rather than in
+// internal/ingresssidecar which writes these advertisements: the host side
+// (internal/installer's sidecar return path) has to *recognize* them, and
+// two independently-maintained copies of the same literal is exactly how
+// that recognition silently stops matching.
+const IngressAttachment = "ingress"
+
+// IngressAdvertisementSegment is the middle name segment of every
+// BGPAdvertisement the ingress sidecar publishes, i.e. what
+// BGPAdvertisementName renders IngressAttachment as. Exported so a reader
+// can identify a sidecar's own gateway advertisement among the ones this
+// node originates, without re-deriving the encoding.
+func IngressAdvertisementSegment() string {
+	return nameSegment(IngressAttachment)
+}
+
 // BGPVRFInstanceName returns the deterministic name for a BGPVRFInstance.
 // This is keyed by (vpc, node): the underlying kernel VRF is shared by every
 // attachment (pod or VM) on this VPC on this node (see internal/plumbing/vrf

--- a/internal/ingresssidecar/gateway.go
+++ b/internal/ingresssidecar/gateway.go
@@ -33,7 +33,12 @@ import (
 // CNI-derived attachment's own advertisement for the same (vpc, node),
 // which always shares this sidecar's own BGPVRFInstance (see
 // PublishGateway) but never its BGPAdvertisement.
-const ingressVPCAttachment = "ingress"
+//
+// Aliased to crdnames' own constant rather than repeating the literal: the
+// host side has to recognize the advertisements this writes (see
+// internal/installer's sidecar return path), so both ends must read the
+// same value or the recognition quietly stops matching.
+const ingressVPCAttachment = crdnames.IngressAttachment
 
 // ErrGatewayAddressNotProvisioned is returned by a GatewayAddressResolver
 // when this VPC has no local gateway address to advertise yet. Callers

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -70,6 +70,15 @@ var radvReconcileInterval = 2 * time.Second
 // a solicit per unresolved guest.
 var tapNeighReconcileInterval = 30 * time.Second
 
+// sidecarReturnReconcileInterval paces ensureSidecarReturnPath. Matched to
+// tapNeighReconcileInterval rather than the credential-refresh ticker
+// because what it installs points at a pod: an Envoy pod restart changes
+// the host-side veth and MAC the return route and neighbor name, and its
+// sidecar creates the VRF holding the gateway address some time after the
+// pod is scheduled. Each pass walks this node's network namespaces, so it
+// is not free enough for radv's cadence.
+var sidecarReturnReconcileInterval = 30 * time.Second
+
 // ebpfHealthServiceName is the gRPC health service name (see
 // grpc_health_v1.HealthServer) reporting the live status of the eBPF uSID
 // datapath specifically, separate from the overall (""), always-serving
@@ -525,6 +534,24 @@ func startTapNeighborSweep(sem chan struct{}) {
 	}
 }
 
+// startSidecarReturnSweep runs one ensureSidecarReturnPath pass off Run's
+// own goroutine, for the same reason startTapNeighborSweep does: a pass
+// enters every network namespace on this node, and a node running a large
+// Envoy fleet must not hold the select loop long enough to starve the
+// credential refresh, GC sweeps and eBPF health check. The semaphore drops
+// a tick rather than queueing it when the previous pass is still running,
+// so a slow pass costs freshness rather than piling up goroutines.
+func startSidecarReturnSweep(ctx context.Context, sem chan struct{}, st ebpfDatapathState) {
+	select {
+	case sem <- struct{}{}:
+		go func() {
+			defer func() { <-sem }()
+			reconcileSidecarReturnPath(ctx, st)
+		}()
+	default:
+	}
+}
+
 // radvActorSet tracks the currently running radv.RunActor goroutines, keyed
 // by host interface name (radv.Record.HostInterface) -- Run's own local
 // state, reconciled against radv.ListAttachments on every
@@ -772,9 +799,13 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 
 	tapNeighTicker := time.NewTicker(tapNeighReconcileInterval)
 	defer tapNeighTicker.Stop()
+
+	sidecarReturnTicker := time.NewTicker(sidecarReturnReconcileInterval)
+	defer sidecarReturnTicker.Stop()
 	// Size-1 semaphore, so at most one sweep runs at a time and a tick
 	// arriving during one is dropped instead of piling up behind it.
 	tapNeighSem := make(chan struct{}, 1)
+	sidecarReturnSem := make(chan struct{}, 1)
 
 	for {
 		select {
@@ -863,6 +894,15 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 			// route filter was tightened. The semaphore drops a tick rather
 			// than queueing it when the previous pass is still running.
 			startTapNeighborSweep(tapNeighSem)
+
+		case <-sidecarReturnTicker.C:
+			// Install (and re-assert) the host side of the ingress
+			// sidecar's return path -- the routes, neighbors and uSID map
+			// entries a reply encapsulated toward this node's own SID needs
+			// in order to reach an Envoy pod's per-VPC sidecar VRF. See
+			// sidecarreturn.go's own file comment for why this cannot live
+			// in the sidecar itself.
+			startSidecarReturnSweep(ctx, sidecarReturnSem, ebpfState)
 
 		case iface := <-radvActors.failed:
 			radvActorFailed(radvActors, iface)

--- a/internal/installer/sidecarreturn.go
+++ b/internal/installer/sidecarreturn.go
@@ -1,0 +1,602 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package installer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+// The ingress sidecar's return path, host side.
+//
+// internal/ingresssidecar gives an Envoy pod one Linux VRF per tenant VPC
+// inside its *own* netns, and advertises a per-VPC gateway address into
+// EVPN so a backend's reply -- addressed back to that gateway address --
+// has an SRv6 route to follow (GatewayPublisher's doc comment). A remote
+// node duly encapsulates that reply toward this node's own SID for the
+// advertised Argument.
+//
+// Nothing on this node could take delivery of it. The sidecar registers
+// only what usid_egress reads, under a synthetic Block that usid_ingress
+// deliberately never matches (ingressSidecarBlock's doc comment), and it
+// cannot register the ingress side itself for two reasons that both come
+// down to which netns it is in: usid_ingress runs in the *host* netns,
+// while the sidecar's VRFs, their routing tables, and both ends of their
+// veth pairs are in the pod's, and a container in that pod cannot install
+// host-netns routes. So the receiving half has to live here, in the host
+// daemon, and this file is it.
+//
+// What a decapsulated reply needs, and what this installs per advertised
+// sidecar gateway address:
+//
+//  1. locator_table + function_table entries for this node's own Block and
+//     Node-ID, so usid_ingress claims the packet at all rather than passing
+//     it to a stack that has no tunnel device to hand it to. A node hosting
+//     only sidecars has no CNI attachment, so nothing else ever writes
+//     these -- internal/cnibgp's registerEBPFDatapath, their only other
+//     writer, runs at CNI ADD.
+//  2. A vrf_table entry under this node's *real* Block, keyed on the
+//     Argument the advertisement was published with, pointing at a routing
+//     table this file owns, with EgressKindVeth so step 9 uses
+//     bpf_redirect_peer and crosses into the pod's netns.
+//  3. In that table, a route for the gateway address out the *host* side of
+//     the pod's netns-crossing veth, so step 8's bpf_fib_lookup resolves to
+//     an interface bpf_redirect_peer can cross.
+//  4. A permanent neighbor for that address on the same interface. As
+//     internal/hostgw's installGatewayNeighbor records, bpf_fib_lookup does
+//     not trigger NDP the way ordinary forwarding does, so an unresolved
+//     neighbor is BPF_FIB_LKUP_RET_NO_NEIGH and a silent drop.
+//
+// The Argument is the one subtlety worth stating plainly, because getting
+// it wrong is invisible. The sidecar's own vrf_table registrations key on
+// argumentForTableID -- its pod-netns table id -- while the advertisement,
+// and therefore the SID a remote node encapsulates toward, carries the
+// BGPVRFInstance VRFID. Those are different numbers for the same VPC. This
+// file keys on the advertised VRFID, since that is what actually arrives on
+// the wire.
+
+const (
+	// sidecarReturnTableBase is the first Linux routing table id this file
+	// allocates from, and sidecarReturnTableMax the last. A dedicated,
+	// documented range matters twice over: internal/plumbing/vrf's own
+	// allocator hands out table ids from 1 upward for real tenant VRFs, so
+	// anything low would eventually collide with one, and pruning below
+	// deletes whole tables, which must never be able to reach a table this
+	// file did not create.
+	//
+	// The range is sized to hold one table per Argument
+	// ([ArgumentMin,ArgumentMax], 12 bits), which is the most sidecar VRFs
+	// a single node can ever have.
+	sidecarReturnTableBase = 0xF000
+	sidecarReturnTableMax  = sidecarReturnTableBase + uformat.ArgumentMax
+)
+
+// sidecarReturnTableID maps an advertised Argument to the routing table
+// this file keeps that VPC's return route in. One table per Argument rather
+// than one shared table so pruning a single withdrawn VPC cannot disturb
+// another's route.
+func sidecarReturnTableID(vrfID uint16) (uint32, error) {
+	if vrfID < uformat.ArgumentMin || vrfID > uformat.ArgumentMax {
+		return 0, fmt.Errorf("sidecar return path: VRFID %d outside the valid Argument range [%#x,%#x]",
+			vrfID, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax))
+	}
+	return uint32(sidecarReturnTableBase) + uint32(vrfID), nil
+}
+
+// sidecarEndpoint is one gateway address this node's sidecar has advertised,
+// and the Argument a remote node will have encoded into the SID it
+// encapsulates replies toward.
+type sidecarEndpoint struct {
+	advName string
+	addr    netip.Addr
+	vrfID   uint16
+}
+
+// podNetNS is one network namespace on this node other than our own, with
+// the two things a return path needs from it: which host-side interface
+// crosses into it, and every address reachable inside it.
+type podNetNS struct {
+	path string
+	// hostIfindex is the ifindex, in *this* (host) netns, of the peer of
+	// the netns-crossing veth found inside. That is the interface
+	// bpf_redirect_peer has to target to enter this namespace.
+	hostIfindex int
+	// mac is the pod-side end's hardware address, which is what a frame
+	// entering the namespace is addressed to.
+	mac net.HardwareAddr
+	// addrs is every unicast address assigned on any link inside, across
+	// every VRF -- a sidecar's gateway address sits on a veth inside one of
+	// the pod's own VRFs, not on its primary interface, so matching has to
+	// consider all of them.
+	addrs map[netip.Addr]struct{}
+}
+
+// reconcileSidecarReturnPath is Run's non-fatal wrapper, matching
+// reconcileLocatorLocalRoute's contract: a node with no sidecar on it, a
+// not-yet-created BGPRouter, or a transient API error must never stop the
+// installer daemon, and the caller's ticker retries on its own.
+func reconcileSidecarReturnPath(ctx context.Context, st ebpfDatapathState) {
+	if st.k8sClient == nil || st.nodeName == "" {
+		return
+	}
+	if err := ensureSidecarReturnPath(ctx, st.k8sClient, st.namespace, st.nodeName); err != nil {
+		slog.Warn("Could not install the ingress sidecar's return path; "+
+			"replies to this node's sidecar gateway addresses will be dropped until this succeeds", "err", err)
+	}
+}
+
+// ensureSidecarReturnPath brings the host side of every advertised sidecar
+// gateway address on this node up to date, and prunes what no longer
+// belongs. Idempotent, and safe on a node with no sidecar at all: with no
+// matching advertisement it installs nothing and only prunes.
+func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, nodeName string) error {
+	endpoints, err := sidecarGatewayEndpoints(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return err
+	}
+
+	// Prune first, and unconditionally: a withdrawn advertisement has to
+	// stop being routed here even on a node whose identity has since gone
+	// away, and pruning is the only step that is correct with an empty
+	// endpoint set.
+	live := make(map[uint32]netip.Addr, len(endpoints))
+	for _, e := range endpoints {
+		if table, terr := sidecarReturnTableID(e.vrfID); terr == nil {
+			live[table] = e.addr
+		}
+	}
+	if perr := pruneSidecarReturnRoutes(live); perr != nil {
+		slog.Warn("Could not prune stale sidecar return routes", "err", perr)
+	}
+
+	if len(endpoints) == 0 {
+		return nil
+	}
+
+	block, nodeID, ok, err := nodeLocatorIdentity(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		// No SRv6 identity configured for this node yet. The sidecar's
+		// advertisements exist but nothing can be keyed off a Block we do
+		// not have; the ticker retries.
+		return nil
+	}
+
+	namespaces, err := discoverPodNetNS()
+	if err != nil {
+		return err
+	}
+
+	registry, closer, err := usidmap.OpenPinnedRegistry(attach.PinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned uSID maps for the sidecar return path: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	// Per-node, not per-endpoint, and the reason a sidecar-only node needs
+	// this file at all: without them usid_ingress rejects every arriving
+	// uSID packet before it reaches any Argument-specific decision.
+	if err := registry.Locator.Register(block, nodeID); err != nil {
+		return fmt.Errorf("register locator_table entry for the sidecar return path: %w", err)
+	}
+	if err := registry.Function.Register(block, uformat.FunctionEndDT46); err != nil {
+		return fmt.Errorf("register function_table entry for the sidecar return path: %w", err)
+	}
+
+	var errs []error
+	for _, e := range endpoints {
+		if err := installSidecarReturn(registry, namespaces, block, e); err != nil {
+			// Per-endpoint, and never fatal to the sweep: one Envoy pod
+			// still starting up must not stop another VPC's return path
+			// being installed.
+			errs = append(errs, fmt.Errorf("advertisement %s: %w", e.advName, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("sidecar return path: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+// installSidecarReturn wires up one endpoint: locate the netns holding its
+// gateway address, then install the route, the neighbor, and the vrf_table
+// entry that point at it.
+func installSidecarReturn(
+	registry *usidmap.Registry, namespaces []podNetNS, block uint64, e sidecarEndpoint,
+) error {
+	target := findNetNSForAddr(namespaces, e.addr)
+	if target == nil {
+		// The ordinary not-yet case, and the reason this is a warn-and-retry
+		// reconcile rather than a one-shot: the advertisement outlives any
+		// single Envoy pod, so between a pod restart and its sidecar
+		// re-creating the VRF there is a window where the address it names
+		// exists nowhere on this node.
+		return fmt.Errorf("no network namespace on this node holds gateway address %s yet", e.addr)
+	}
+
+	table, err := sidecarReturnTableID(e.vrfID)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureSidecarReturnRoute(table, e.addr, target.hostIfindex); err != nil {
+		return err
+	}
+	if err := ensureSidecarReturnNeighbor(e.addr, target.hostIfindex, target.mac); err != nil {
+		return err
+	}
+
+	// EgressKindVeth is a real claim here, not a don't-care: the interface
+	// the route above resolves to is one end of a veth pair whose peer is
+	// in the pod's netns, so step 9 must use bpf_redirect_peer to cross
+	// into it. Plain bpf_redirect would hand the packet to that interface's
+	// own egress in this netns and never reach the sidecar.
+	if err := registry.VRF.Register(block, e.vrfID, table, usidmap.EgressKindVeth); err != nil {
+		return fmt.Errorf("register vrf_table entry (block %#x, argument %d): %w", block, e.vrfID, err)
+	}
+	return nil
+}
+
+// ensureSidecarReturnRoute installs the /128 device route step 8's
+// bpf_fib_lookup resolves against, in this file's own table for that
+// Argument. RouteReplace so a pod that came back on a different host-side
+// veth is followed rather than duplicated.
+func ensureSidecarReturnRoute(table uint32, addr netip.Addr, hostIfindex int) error {
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: addr.AsSlice(), Mask: net.CIDRMask(addr.BitLen(), addr.BitLen())},
+		LinkIndex: hostIfindex,
+		Table:     int(table),
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("install return route %s dev %d table %d: %w", addr, hostIfindex, table, err)
+	}
+	return nil
+}
+
+// ensureSidecarReturnNeighbor primes the neighbor entry bpf_fib_lookup needs
+// but will not resolve for itself. Permanent, unlike internal/hostgw's tap
+// sweep and for the opposite reason: the pod-side MAC here is read
+// authoritatively from the kernel rather than solicited, so a stale entry
+// is not a risk -- and if the pod is replaced, the next tick reads the new
+// MAC and RouteReplace/NeighSet overwrite this one.
+func ensureSidecarReturnNeighbor(addr netip.Addr, hostIfindex int, mac net.HardwareAddr) error {
+	neigh := &netlink.Neigh{
+		LinkIndex:    hostIfindex,
+		Family:       netlink.FAMILY_V6,
+		State:        netlink.NUD_PERMANENT,
+		IP:           addr.AsSlice(),
+		HardwareAddr: mac,
+	}
+	if err := netlink.NeighSet(neigh); err != nil {
+		return fmt.Errorf("add permanent neighbor %s -> %s on ifindex %d: %w", addr, mac, hostIfindex, err)
+	}
+	return nil
+}
+
+// pruneSidecarReturnRoutes removes every route in this file's own table
+// range that live does not account for, so a withdrawn VPC stops being
+// routed into a pod that may since have been replaced by an unrelated one.
+//
+// One listing across all tables, filtered down to the reserved range here,
+// rather than a listing per table: the range spans every possible Argument,
+// so per-table would be 4096 netlink round trips on every tick to find the
+// handful of routes that exist.
+//
+// staleSidecarReturnRoute is the whole safety argument, and it is a pure
+// predicate so the cases it must not match can be enumerated in a test --
+// this deletes routes, and a range check that drifted from the constants
+// would delete somebody else's.
+func pruneSidecarReturnRoutes(live map[uint32]netip.Addr) error {
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
+		&netlink.Route{Table: unix.RT_TABLE_UNSPEC}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("list routes to prune the sidecar return path: %w", err)
+	}
+
+	var errs []error
+	for i := range routes {
+		r := routes[i]
+		if !staleSidecarReturnRoute(r, live) {
+			continue
+		}
+		if err := netlink.RouteDel(&r); err != nil {
+			errs = append(errs, fmt.Errorf("delete stale return route %v from table %d: %w",
+				r.Dst, r.Table, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// staleSidecarReturnRoute reports whether r is a route this file installed
+// for an endpoint that live no longer accounts for.
+//
+// Every condition here is a guard against deleting something else. The
+// table range is what confines this to tables this file allocates from; a
+// route with no destination, or one whose table holds the address live still
+// wants, is left alone.
+func staleSidecarReturnRoute(r netlink.Route, live map[uint32]netip.Addr) bool {
+	if r.Table < sidecarReturnTableBase || r.Table > sidecarReturnTableMax {
+		return false
+	}
+	if r.Dst == nil {
+		return false
+	}
+	keep, wanted := live[uint32(r.Table)]
+	if !wanted {
+		return true // no live endpoint maps to this table at all
+	}
+	got, ok := netip.AddrFromSlice(r.Dst.IP)
+	if !ok {
+		return false
+	}
+	return got.Unmap() != keep
+}
+
+// sidecarGatewayEndpoints returns every gateway advertisement the ingress
+// sidecar on *this* node has published.
+//
+// Identified by name rather than by shape. A sidecar's advertisement is a
+// single /128 with an Argument and End.DT46, which is also exactly what a
+// real CNI attachment publishes for a pod address -- and those must not be
+// touched here, since internal/cnibgp already registers a vrf_table entry
+// pointing at the pod's real host-netns VRF. The name is the only
+// discriminator that cannot confuse the two, which is why
+// crdnames.IngressAdvertisementSegment is exported for it.
+func sidecarGatewayEndpoints(
+	ctx context.Context, k8s client.Client, namespace, nodeName string,
+) ([]sidecarEndpoint, error) {
+	advs := &bgpv1alpha1.BGPAdvertisementList{}
+	if err := k8s.List(ctx, advs, client.InNamespace(namespace)); err != nil {
+		return nil, fmt.Errorf("list BGPAdvertisements in namespace %s: %w", namespace, err)
+	}
+
+	segment := crdnames.IngressAdvertisementSegment()
+	var out []sidecarEndpoint
+	for i := range advs.Items {
+		a := &advs.Items[i]
+		if a.Spec.RouterRef.Name != nodeName {
+			continue
+		}
+		if !isIngressAdvertisementName(a.Name, nodeName, segment) {
+			continue
+		}
+		if a.Spec.VRFID == nil {
+			continue
+		}
+		for _, p := range a.Spec.Prefixes {
+			pref, err := netip.ParsePrefix(string(p))
+			if err != nil || !pref.Addr().Is6() || pref.Bits() != pref.Addr().BitLen() {
+				// A gateway address is always a single host route. Anything
+				// else is not something this return path knows how to point
+				// at a namespace.
+				continue
+			}
+			out = append(out, sidecarEndpoint{
+				advName: a.Name,
+				addr:    pref.Addr().Unmap(),
+				vrfID:   uint16(*a.Spec.VRFID),
+			})
+		}
+	}
+	return out, nil
+}
+
+// isIngressAdvertisementName reports whether name is what
+// crdnames.BGPAdvertisementName renders for the ingress attachment on
+// nodeName. Matched from the end because a node name may itself contain the
+// separator, while the two leading segments never can.
+func isIngressAdvertisementName(name, nodeName, segment string) bool {
+	rest, ok := strings.CutSuffix(name, "-"+nodeName)
+	if !ok {
+		return false
+	}
+	idx := strings.LastIndex(rest, "-")
+	if idx < 0 {
+		return false
+	}
+	return rest[idx+1:] == segment
+}
+
+// nodeLocatorIdentity returns the Block and Node-ID this node's own SIDs are
+// built from. ok is false, with a nil error, when this node has no SRv6
+// identity configured yet -- the same "nothing to do" case
+// nodeLocatorPrefix returns its zero Prefix for.
+func nodeLocatorIdentity(
+	ctx context.Context, k8s client.Client, namespace, nodeName string,
+) (block uint64, nodeID uint16, ok bool, err error) {
+	prefix, err := nodeLocatorPrefix(ctx, k8s, namespace, nodeName)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	if !prefix.IsValid() {
+		return 0, 0, false, nil
+	}
+	// Derived from the prefix nodeLocatorPrefix already assembled rather
+	// than re-read from the BGPRouter, so the two can never disagree about
+	// which locator this node owns.
+	block, err = uformat.Block(prefix.Addr())
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("derive uSID Block from node locator %s: %w", prefix, err)
+	}
+	nodeID, err = uformat.NodeID(prefix.Addr())
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("derive uSID Node-ID from node locator %s: %w", prefix, err)
+	}
+	return block, nodeID, true, nil
+}
+
+// discoverPodNetNS enumerates every network namespace on this node other
+// than our own.
+//
+// By enumeration rather than by asking. The sidecar cannot tell us where it
+// is: a netns is only addressable as /proc/<pid>/ns/net, and a pid is not
+// something a container can meaningfully publish about itself for another
+// process to reuse later. The gateway address is the identity that matters
+// anyway, and matching on it is self-validating -- if the address is in a
+// namespace, that is the namespace replies to it belong in.
+//
+// Errors on individual namespaces are skipped rather than returned: a
+// process exiting mid-walk is entirely ordinary, and one unreadable
+// namespace must not hide every other.
+func discoverPodNetNS() ([]podNetNS, error) {
+	self, err := os.Readlink("/proc/self/ns/net")
+	if err != nil {
+		return nil, fmt.Errorf("read own network namespace: %w", err)
+	}
+
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("enumerate /proc: %w", err)
+	}
+
+	seen := make(map[string]struct{})
+	var out []podNetNS
+	for _, entry := range entries {
+		if _, cerr := strconv.Atoi(entry.Name()); cerr != nil {
+			continue // not a pid
+		}
+		path := "/proc/" + entry.Name() + "/ns/net"
+		target, rerr := os.Readlink(path)
+		if rerr != nil {
+			continue
+		}
+		if target == self {
+			continue // our own namespace: usid_ingress already runs here
+		}
+		if _, dup := seen[target]; dup {
+			continue // another process in a namespace already inspected
+		}
+		seen[target] = struct{}{}
+
+		inspected, ierr := inspectPodNetNS(path)
+		if ierr != nil {
+			slog.Debug("Could not inspect network namespace for the sidecar return path",
+				"path", path, "err", ierr)
+			continue
+		}
+		out = append(out, *inspected)
+	}
+	return out, nil
+}
+
+// inspectPodNetNS reads the one namespace at path: every address inside,
+// and the host-side ifindex plus pod-side MAC of the veth that crosses into
+// it.
+func inspectPodNetNS(path string) (*podNetNS, error) {
+	handle, err := ns.GetNS(path)
+	if err != nil {
+		return nil, fmt.Errorf("open network namespace %s: %w", path, err)
+	}
+	defer handle.Close() //nolint:errcheck // netns close on teardown
+
+	result := &podNetNS{path: path, addrs: make(map[netip.Addr]struct{})}
+	err = handle.Do(func(_ ns.NetNS) error {
+		links, lerr := netlink.LinkList()
+		if lerr != nil {
+			return fmt.Errorf("list links: %w", lerr)
+		}
+		byIndex := make(map[int]netlink.Link, len(links))
+		for _, l := range links {
+			byIndex[l.Attrs().Index] = l
+		}
+		for _, l := range links {
+			attrs := l.Attrs()
+			// Prefer the primary interface when there is one, so a pod with
+			// more than one way in (a Multus secondary, say) resolves to the
+			// same interface on every pass rather than to whichever the
+			// kernel happened to list first.
+			better := result.hostIfindex == 0 || attrs.Name == primaryPodInterface
+			if better && crossingVeth(l, byIndex) {
+				result.hostIfindex = attrs.ParentIndex
+				result.mac = append(net.HardwareAddr(nil), attrs.HardwareAddr...)
+			}
+			addrs, aerr := netlink.AddrList(l, netlink.FAMILY_V6)
+			if aerr != nil {
+				continue
+			}
+			for _, a := range addrs {
+				if got, ok := netip.AddrFromSlice(a.IP); ok {
+					got = got.Unmap()
+					if got.IsGlobalUnicast() {
+						result.addrs[got] = struct{}{}
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.hostIfindex == 0 {
+		return nil, fmt.Errorf("no netns-crossing veth found in %s", path)
+	}
+	return result, nil
+}
+
+// primaryPodInterface is the name Kubernetes gives a pod's own interface,
+// and so the netns-crossing veth to prefer when a pod has more than one.
+const primaryPodInterface = "eth0"
+
+// crossingVeth reports whether link is a veth whose peer is outside this
+// namespace, i.e. the one interface a packet can be redirected in through.
+// byIndex is every link in this same namespace, keyed by ifindex.
+//
+// A pod netns holds two kinds of veth: its primary interface, whose peer is
+// the host-side end, and (for an Envoy pod running the ingress sidecar) a
+// pair per tenant VPC with *both* ends inside this same namespace. Only the
+// first is a way in, and the second must never be mistaken for one.
+//
+// Distinguished by reciprocity, not by whether the peer ifindex resolves
+// here. Ifindices are per-namespace and collide freely across them, so a
+// pod whose primary interface happens to peer with host ifindex 12 while
+// this namespace also has some link 12 would look internal and be skipped,
+// leaving that pod unreachable with nothing to indicate why. A genuine
+// same-namespace pair points back: the peer's own ParentIndex is this
+// link's index. A coincidental collision does not.
+func crossingVeth(link netlink.Link, byIndex map[int]netlink.Link) bool {
+	if _, isVeth := link.(*netlink.Veth); !isVeth {
+		return false
+	}
+	attrs := link.Attrs()
+	peerIndex := attrs.ParentIndex
+	if peerIndex <= 0 {
+		return false
+	}
+	if peer, ok := byIndex[peerIndex]; ok && peer.Attrs().ParentIndex == attrs.Index {
+		return false // a real pair with both ends here: an internal veth
+	}
+	return true
+}
+
+// findNetNSForAddr returns the namespace holding addr, or nil.
+func findNetNSForAddr(namespaces []podNetNS, addr netip.Addr) *podNetNS {
+	for i := range namespaces {
+		if _, ok := namespaces[i].addrs[addr]; ok {
+			return &namespaces[i]
+		}
+	}
+	return nil
+}

--- a/internal/installer/sidecarreturn_test.go
+++ b/internal/installer/sidecarreturn_test.go
@@ -1,0 +1,482 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package installer
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"go.datum.net/galactic/internal/crdnames"
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
+)
+
+const (
+	testSidecarNode = "worker-8b4e1647-dfw"
+	testSidecarAddr = "fd30:e2e:3a5:6094:7c95:22a:4aec:a4a9"
+)
+
+// newAdvClient builds a fake client holding advertisements, so endpoint
+// selection can be exercised without an API server. The counterpart to
+// locatorroute_test.go's newRouterClient, which holds BGPRouters.
+func newAdvClient(t *testing.T, advs ...*bgpv1alpha1.BGPAdvertisement) client.Client {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := bgpv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	b := fake.NewClientBuilder().WithScheme(s)
+	for _, a := range advs {
+		b = b.WithObjects(a)
+	}
+	return b.Build()
+}
+
+// gatewayAdv builds a BGPAdvertisement shaped like one the ingress sidecar
+// publishes, named exactly the way crdnames does it so the recognition
+// under test is exercised against the real encoder rather than a literal.
+func gatewayAdv(vpc, node, prefix string, vrfID int32) *bgpv1alpha1.BGPAdvertisement {
+	fn := bgpv1alpha1.SRv6FunctionEndDT46
+	return &bgpv1alpha1.BGPAdvertisement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crdnames.BGPAdvertisementName(vpc, crdnames.IngressAttachment, node),
+			Namespace: testNamespace,
+		},
+		Spec: bgpv1alpha1.BGPAdvertisementSpec{
+			RouterRef: bgpv1alpha1.RouterRef{Name: node},
+			Prefixes:  []bgpv1alpha1.Prefix{bgpv1alpha1.Prefix(prefix)},
+			VRFID:     &vrfID,
+			Function:  &fn,
+		},
+	}
+}
+
+// podAdv builds the advertisement a *real* CNI attachment publishes for a
+// pod address: same shape (one /128, an Argument, End.DT46), different
+// middle name segment. These must never be picked up here -- see
+// TestSidecarGatewayEndpoints_IgnoresPodAdvertisements.
+func podAdv(vpc, attachment, node, prefix string, vrfID int32) *bgpv1alpha1.BGPAdvertisement {
+	adv := gatewayAdv(vpc, node, prefix, vrfID)
+	adv.Name = crdnames.BGPAdvertisementName(vpc, attachment, node)
+	return adv
+}
+
+// TestIngressAdvertisementSegment_MatchesTheEncoder pins the one value both
+// ends of this feature depend on. internal/ingresssidecar names its
+// advertisements through BGPAdvertisementName and the host side recognizes
+// them by this segment; if the encoding of "ingress" ever changed, the
+// sidecar would keep publishing and the host would silently stop installing
+// return paths, with nothing failing anywhere.
+func TestIngressAdvertisementSegment_MatchesTheEncoder(t *testing.T) {
+	got := crdnames.IngressAdvertisementSegment()
+	// The middle segment of a real advertisement name, extracted the same
+	// way isIngressAdvertisementName does.
+	name := crdnames.BGPAdvertisementName("2", crdnames.IngressAttachment, testSidecarNode)
+	if !isIngressAdvertisementName(name, testSidecarNode, got) {
+		t.Fatalf("IngressAdvertisementSegment() = %q does not match name %q it must recognize", got, name)
+	}
+}
+
+// TestIsIngressAdvertisementName covers the matching that decides whether a
+// return path gets installed at all. The node-name cases are the ones worth
+// having: a node name contains the same separator the name segments are
+// joined with, so matching from the left would mis-split every real node
+// name in this fleet.
+func TestIsIngressAdvertisementName(t *testing.T) {
+	seg := crdnames.IngressAdvertisementSegment()
+	for _, tc := range []struct {
+		name, advName, node string
+		want                bool
+	}{
+		{
+			name:    "sidecar advertisement on a hyphenated node",
+			advName: crdnames.BGPAdvertisementName("2", crdnames.IngressAttachment, testSidecarNode),
+			node:    testSidecarNode, want: true,
+		},
+		{
+			name:    "sidecar advertisement on a single-word node",
+			advName: crdnames.BGPAdvertisementName("2", crdnames.IngressAttachment, "eris-giune"),
+			node:    "eris-giune", want: true,
+		},
+		// A pod's own advertisement: identical shape, different segment.
+		{
+			name:    "pod attachment advertisement",
+			advName: crdnames.BGPAdvertisementName("2", "0mg", testSidecarNode),
+			node:    testSidecarNode, want: false,
+		},
+		// The same sidecar advertisement, but originated by another node.
+		{
+			name:    "another node's sidecar advertisement",
+			advName: crdnames.BGPAdvertisementName("2", crdnames.IngressAttachment, "eris-giune"),
+			node:    testSidecarNode, want: false,
+		},
+		{name: "empty", advName: "", node: testSidecarNode, want: false},
+		{name: "node name only", advName: testSidecarNode, node: testSidecarNode, want: false},
+		{
+			name:    "segment present but not in the middle position",
+			advName: seg + "-" + testSidecarNode,
+			node:    testSidecarNode, want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isIngressAdvertisementName(tc.advName, tc.node, seg); got != tc.want {
+				t.Errorf("isIngressAdvertisementName(%q, %q) = %v, want %v",
+					tc.advName, tc.node, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSidecarReturnTableID_StaysInTheReservedRange pins the mapping the
+// prune predicate's safety depends on: every table this file can allocate
+// has to land inside the range staleSidecarReturnRoute will consider, and
+// nothing else may.
+func TestSidecarReturnTableID_StaysInTheReservedRange(t *testing.T) {
+	for _, vrfID := range []uint16{uformat.ArgumentMin, 1, 6, 2048, uformat.ArgumentMax} {
+		got, err := sidecarReturnTableID(vrfID)
+		if err != nil {
+			t.Fatalf("sidecarReturnTableID(%d) error = %v", vrfID, err)
+		}
+		if got < sidecarReturnTableBase || got > sidecarReturnTableMax {
+			t.Errorf("sidecarReturnTableID(%d) = %d, outside the reserved range [%d,%d]",
+				vrfID, got, sidecarReturnTableBase, sidecarReturnTableMax)
+		}
+	}
+}
+
+// TestSidecarReturnTableID_RejectsOutOfRange guards the other direction. A
+// zero Argument is the reserved value uformat excludes, and anything past
+// ArgumentMax cannot have arrived in a SID at all -- either would compute a
+// table id outside the reserved range and put pruning in reach of somebody
+// else's routes.
+func TestSidecarReturnTableID_RejectsOutOfRange(t *testing.T) {
+	for _, vrfID := range []uint16{0, uformat.ArgumentMax + 1, 0xFFFF} {
+		if _, err := sidecarReturnTableID(vrfID); err == nil {
+			t.Errorf("sidecarReturnTableID(%d) error = nil, want an error", vrfID)
+		}
+	}
+}
+
+// returnRoute builds a route the way the kernel reports one from this file's
+// own table range, so the cases below differ only in the field under test.
+func returnRoute(dst string, table int) netlink.Route {
+	_, n, err := net.ParseCIDR(dst)
+	if err != nil {
+		panic(err)
+	}
+	return netlink.Route{Dst: n, Table: table}
+}
+
+// TestStaleSidecarReturnRoute is the safety argument for pruning, written
+// as the cases that must NOT be deleted. This predicate deletes routes, so
+// every "want false" is a route that has to survive -- most importantly
+// anything outside the reserved table range, which is every route the
+// kernel and every other component on the node own.
+func TestStaleSidecarReturnRoute(t *testing.T) {
+	const vrfID = 1
+	table, err := sidecarReturnTableID(vrfID)
+	if err != nil {
+		t.Fatalf("sidecarReturnTableID: %v", err)
+	}
+	keep := netip.MustParseAddr(testSidecarAddr)
+	live := map[uint32]netip.Addr{table: keep}
+
+	for _, tc := range []struct {
+		name  string
+		route netlink.Route
+		want  bool
+	}{
+		{"the route we want to keep", returnRoute(testSidecarAddr+"/128", int(table)), false},
+
+		// The bug this prunes: the advertisement moved to a different
+		// address, or was withdrawn and another took its table.
+		{"a different address in a live table", returnRoute("fd30:e2e:1::1/128", int(table)), true},
+		{"a table no live endpoint maps to", returnRoute(testSidecarAddr+"/128", sidecarReturnTableBase+9), true},
+
+		// Everything outside the range belongs to somebody else.
+		{"the main table", returnRoute(testSidecarAddr+"/128", 254), false},
+		{"a tenant VRF table", returnRoute(testSidecarAddr+"/128", 1), false},
+		{"just below the range", returnRoute(testSidecarAddr+"/128", sidecarReturnTableBase-1), false},
+		{"just above the range", returnRoute(testSidecarAddr+"/128", sidecarReturnTableMax+1), false},
+
+		{"no destination", netlink.Route{Table: int(table)}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := staleSidecarReturnRoute(tc.route, live); got != tc.want {
+				t.Errorf("staleSidecarReturnRoute(%v, table %d) = %v, want %v",
+					tc.route.Dst, tc.route.Table, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSidecarGatewayEndpoints_ReadsAdvertisedArgument is the point of the
+// whole file: the Argument used here must be the one the advertisement
+// carries, because that is what a remote node encodes into the SID it sends.
+// The sidecar's own vrf_table registrations use a different number for the
+// same VPC (its pod-netns table id), so reading the wrong one would install
+// a return path keyed on an Argument nothing ever arrives with.
+func TestSidecarGatewayEndpoints_ReadsAdvertisedArgument(t *testing.T) {
+	c := newAdvClient(t,
+		gatewayAdv("2", testSidecarNode, testSidecarAddr+"/128", 1),
+		gatewayAdv("4", testSidecarNode, "fd30:e2e:55d2::1/128", 6),
+	)
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("sidecarGatewayEndpoints() returned %d endpoints, want 2: %+v", len(got), got)
+	}
+	byAddr := map[string]uint16{}
+	for _, e := range got {
+		byAddr[e.addr.String()] = e.vrfID
+	}
+	if byAddr[testSidecarAddr] != 1 {
+		t.Errorf("endpoint %s vrfID = %d, want the advertised 1", testSidecarAddr, byAddr[testSidecarAddr])
+	}
+	if byAddr["fd30:e2e:55d2::1"] != 6 {
+		t.Errorf("endpoint fd30:e2e:55d2::1 vrfID = %d, want the advertised 6", byAddr["fd30:e2e:55d2::1"])
+	}
+}
+
+// TestSidecarGatewayEndpoints_IgnoresPodAdvertisements is the isolation this
+// feature needs most. A pod's own advertisement is the same shape as a
+// sidecar's, and internal/cnibgp has already registered a vrf_table entry
+// for it pointing at that pod's real host-netns VRF. Picking one up here
+// would overwrite that entry with a table this file owns and break a
+// working tenant attachment.
+func TestSidecarGatewayEndpoints_IgnoresPodAdvertisements(t *testing.T) {
+	c := newAdvClient(t,
+		podAdv("2", "0mg", testSidecarNode, "fd20:0:2::3:0:0/128", 1),
+		podAdv("2", "eFz", testSidecarNode, "fd20:0:2::2:0:0/128", 1),
+	)
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("sidecarGatewayEndpoints() = %+v, want none: pod attachments are not this file's business", got)
+	}
+}
+
+// TestSidecarGatewayEndpoints_IgnoresOtherNodes covers the fleet case: every
+// Envoy node publishes a gateway advertisement for the same VPCs, and all of
+// them are visible in this namespace. Installing another node's would point
+// this node's return path at an address that lives somewhere else.
+func TestSidecarGatewayEndpoints_IgnoresOtherNodes(t *testing.T) {
+	c := newAdvClient(t,
+		gatewayAdv("2", "eris-giune", "fd30:e2e:af7::1/128", 1),
+		gatewayAdv("2", testSidecarNode, testSidecarAddr+"/128", 1),
+	)
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v", err)
+	}
+	if len(got) != 1 || got[0].addr.String() != testSidecarAddr {
+		t.Errorf("sidecarGatewayEndpoints() = %+v, want only this node's %s", got, testSidecarAddr)
+	}
+}
+
+// TestSidecarGatewayEndpoints_SkipsUnusable covers the advertisements that
+// exist but cannot be acted on. An advertisement with no VRFID has no
+// Argument to key a vrf_table entry on, and a prefix that is not a single
+// host route is not something a return path can point at one namespace --
+// both must be skipped quietly rather than erroring the whole sweep, since
+// the sweep also serves other VPCs.
+func TestSidecarGatewayEndpoints_SkipsUnusable(t *testing.T) {
+	noVRFID := gatewayAdv("2", testSidecarNode, testSidecarAddr+"/128", 1)
+	noVRFID.Spec.VRFID = nil
+
+	subnet := gatewayAdv("4", testSidecarNode, "fd30:e2e:55d2::/64", 6)
+	unparseable := gatewayAdv("5", testSidecarNode, "not-a-prefix", 7)
+
+	c := newAdvClient(t, noVRFID, subnet, unparseable)
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("sidecarGatewayEndpoints() = %+v, want none", got)
+	}
+}
+
+// TestNodeLocatorIdentity_DecodesBlockAndNodeID pins that the Block and
+// Node-ID this file keys locator_table/function_table on come out of the
+// same prefix ensureLocatorLocalRoute installs, so the two can never
+// disagree about which locator this node owns.
+func TestNodeLocatorIdentity_DecodesBlockAndNodeID(t *testing.T) {
+	c := newRouterClient(t, router(testSidecarNode, testLocator, 6))
+	block, nodeID, ok, err := nodeLocatorIdentity(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("nodeLocatorIdentity() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("nodeLocatorIdentity() ok = false, want a configured identity")
+	}
+	if block != 0x2607ed408002 {
+		t.Errorf("block = %#x, want 0x2607ed408002", block)
+	}
+	if nodeID != 6 {
+		t.Errorf("nodeID = %d, want 6", nodeID)
+	}
+}
+
+// TestNodeLocatorIdentity_AbsentIsNotAnError covers the ordinary bring-up
+// state on a node whose BGPRouter has no SRv6 identity yet: it must read as
+// "nothing to install", not as a failure, or the installer would warn on
+// every tick on a node that simply is not an SRv6 node.
+func TestNodeLocatorIdentity_AbsentIsNotAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		routers []*bgpv1alpha1.BGPRouter
+	}{
+		{"no routers at all", nil},
+		{"no locator configured", []*bgpv1alpha1.BGPRouter{router(testSidecarNode, "", 6)}},
+		{"no node id configured", []*bgpv1alpha1.BGPRouter{router(testSidecarNode, testLocator, 0)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newRouterClient(t, tc.routers...)
+			_, _, ok, err := nodeLocatorIdentity(context.Background(), c, testNamespace, testSidecarNode)
+			if err != nil {
+				t.Fatalf("nodeLocatorIdentity() error = %v, want nil", err)
+			}
+			if ok {
+				t.Error("nodeLocatorIdentity() ok = true, want false with no identity configured")
+			}
+		})
+	}
+}
+
+// veth builds a veth link the way the kernel reports one, with peer as its
+// ParentIndex.
+func veth(name string, index, peer int) netlink.Link {
+	return &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name, Index: index, ParentIndex: peer}}
+}
+
+// TestCrossingVeth separates a pod's way in from the ingress sidecar's own
+// internal pairs. Getting this wrong in either direction is silent: treat an
+// internal pair as the way in and every reply is redirected to an interface
+// inside the pod that leads nowhere; treat the real one as internal and the
+// pod looks like it has no entry point at all.
+//
+// The ifindex-collision case is the one worth writing down. Ifindices are
+// per-namespace, so a pod's primary interface can peer with a host ifindex
+// that also exists inside the pod, and a naive "does the peer index resolve
+// here" test would call that internal.
+func TestCrossingVeth(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		links []netlink.Link
+		// target is the index into links of the link under test.
+		target int
+		want   bool
+	}{
+		{
+			// The pod's own interface: peer 24 lives in the host netns and
+			// is absent here.
+			name:   "primary interface peering into the host",
+			links:  []netlink.Link{veth(primaryPodInterface, 23, 24)},
+			target: 0, want: true,
+		},
+		{
+			// A sidecar pair: both ends here, each naming the other.
+			name:   "internal sidecar pair",
+			links:  []netlink.Link{veth("ivp2", 9, 10), veth("ivs2", 10, 9)},
+			target: 0, want: false,
+		},
+		{
+			// The collision: this namespace has a link 12, but link 12 is
+			// not our peer -- it names something else entirely.
+			name: "peer ifindex collides with an unrelated local link",
+			links: []netlink.Link{
+				veth(primaryPodInterface, 23, 12),
+				veth("ivs3", 12, 13),
+				veth("ivp3", 13, 12),
+			},
+			target: 0, want: true,
+		},
+		{
+			name:   "no peer recorded",
+			links:  []netlink.Link{veth(primaryPodInterface, 23, 0)},
+			target: 0, want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			byIndex := make(map[int]netlink.Link, len(tc.links))
+			for _, l := range tc.links {
+				byIndex[l.Attrs().Index] = l
+			}
+			if got := crossingVeth(tc.links[tc.target], byIndex); got != tc.want {
+				t.Errorf("crossingVeth(%s) = %v, want %v",
+					tc.links[tc.target].Attrs().Name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCrossingVeth_NonVethIsNeverAWayIn covers the rest of a pod netns. A
+// VRF master and a tap both carry attributes that could look peer-like, and
+// neither is something bpf_redirect_peer can cross.
+func TestCrossingVeth_NonVethIsNeverAWayIn(t *testing.T) {
+	for _, l := range []netlink.Link{
+		&netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: "G000000002V", Index: 8, ParentIndex: 99}},
+		&netlink.Tuntap{LinkAttrs: netlink.LinkAttrs{Name: "G00000000hH", Index: 9, ParentIndex: 99}},
+		&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo", Index: 1}},
+	} {
+		t.Run(l.Attrs().Name, func(t *testing.T) {
+			if crossingVeth(l, map[int]netlink.Link{}) {
+				t.Errorf("crossingVeth(%s, type %T) = true, want false", l.Attrs().Name, l)
+			}
+		})
+	}
+}
+
+// TestFindNetNSForAddr covers the lookup that decides which namespace a
+// reply belongs in. The miss case is the one that matters operationally:
+// between an Envoy pod restarting and its sidecar re-creating the VRF, the
+// advertised address exists in no namespace on this node, and that has to
+// be a retry rather than a wrong answer.
+func TestFindNetNSForAddr(t *testing.T) {
+	want := netip.MustParseAddr(testSidecarAddr)
+	other := netip.MustParseAddr("fd30:e2e:af7::1")
+	namespaces := []podNetNS{
+		{path: "/proc/1/ns/net", hostIfindex: 11, addrs: map[netip.Addr]struct{}{other: {}}},
+		{path: "/proc/2/ns/net", hostIfindex: 22, addrs: map[netip.Addr]struct{}{want: {}}},
+	}
+
+	got := findNetNSForAddr(namespaces, want)
+	if got == nil {
+		t.Fatalf("findNetNSForAddr(%s) = nil, want the namespace holding it", want)
+	}
+	if got.hostIfindex != 22 {
+		t.Errorf("findNetNSForAddr(%s) hostIfindex = %d, want 22", want, got.hostIfindex)
+	}
+
+	if got := findNetNSForAddr(namespaces, netip.MustParseAddr("fd30:e2e:dead::1")); got != nil {
+		t.Errorf("findNetNSForAddr(absent) = %+v, want nil", got)
+	}
+}
+
+// TestEnsureSidecarReturnPath_NoAdvertisementsIsQuiet covers the common case
+// on every node that is not running an Envoy pod: with nothing advertised
+// the sweep must install nothing and report no error, so it does not warn
+// on every tick across the fleet. It still prunes, which on a host with no
+// routes in the reserved range finds nothing to do.
+func TestEnsureSidecarReturnPath_NoAdvertisementsIsQuiet(t *testing.T) {
+	c := newAdvClient(t)
+	if err := ensureSidecarReturnPath(
+		context.Background(), c, testNamespace, testSidecarNode); err != nil {
+		t.Errorf("ensureSidecarReturnPath() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
`internal/ingresssidecar` advertises a per-VPC gateway address into EVPN so a backend's reply has an SRv6 route to follow, and remote nodes duly encapsulate replies toward this node's own SID. Nothing here could take delivery of one.

Measured on us-central-1-staging-lab before this change. The reply leaves the backend's node correctly encapsulated:

```
trace_entry            39 -> 44   (+5)
trace_adjust_room_ok    0 ->  5   (+5)
trace_redirect_ok       0 ->  5   (+5)
```

and dies on arrival at the sidecar's own node, where:

```
locator_table   EMPTY
function_table  EMPTY
vrf_table       5 entries, all block=0xffffffffffff
```

Every arriving uSID packet counted `trace_ing_locator_miss`.

## Why it has to be here

The sidecar registers only what `usid_egress` reads, under a synthetic Block `usid_ingress` never matches, and it cannot register the ingress side itself. Both reasons come down to which namespace it is in: `usid_ingress` runs in the host's, while the sidecar's VRFs, their routing tables and both ends of their veth pairs are in the pod's, and a container in that pod cannot install host-netns routes.

## What it installs

Per advertised gateway address, the four things a decapsulated reply needs:

1. `locator_table` and `function_table` entries for this node's own Block and Node-ID. Their only other writer is `registerEBPFDatapath`, which runs at CNI ADD, so on a node hosting only sidecars nothing writes them at all.
2. A `vrf_table` entry under the real Block with `EgressKindVeth`, so step 9 uses `bpf_redirect_peer` and crosses into the pod.
3. A route in a table this file owns, out the host side of the pod's netns-crossing veth, for step 8's FIB lookup to resolve against.
4. A permanent neighbor, which that lookup needs but will not resolve for itself, per `internal/hostgw`'s own note.

On its own 30s ticker, matching `tapNeighReconcileInterval`, because what it points at is a pod: an Envoy pod restart changes the host-side veth and MAC, and the sidecar creates the VRF holding the address some time after the pod is scheduled. Off the select loop behind a semaphore, the same way the tap neighbor sweep is, since a pass enters every namespace on the node.

## Two things that are silent when wrong

Both are pinned by tests.

The Argument is the advertised `VRFID`, not the sidecar's own `argumentForTableID`. Those are different numbers for the same VPC, and only the first is what arrives on the wire.

A pod's entry point is told from the sidecar's internal veth pairs by reciprocity, not by whether the peer ifindex resolves locally. Ifindices collide across namespaces, and a collision would leave a pod looking like it has no entry point.

Advertisements are matched by name, which is why `crdnames` now exports the ingress segment. A pod's own advertisement is the same shape (one `/128`, an Argument, End.DT46), and picking one up would overwrite the `vrf_table` entry `internal/cnibgp` already made for a working tenant attachment.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. Pruning deletes routes, so `staleSidecarReturnRoute` is a pure predicate tested as the cases that must survive, following `staleLocatorLocalRoute`'s pattern.

The netns walk and the netlink writes need a real multi-namespace host, so those are a live-cluster concern, same as the FIB-lookup paths around them. Verification is re-running the end-to-end test this was measured against.

## Not in this change

Two other things block that end-to-end test, both independent of this:

1. Cilium claims galactic's interfaces (`devices` unset, `enable-tcx=true`), and tcx runs before clsact, so it consumes tenant traffic on galactic's taps before `usid_egress` sees it. Confirmed by detaching it on one tap, which is what let the encapsulation above be measured at all.
2. eris has no route to `2607:ed40:8002:{3,4,5}::/64`, so EVPN installs naming those SIDs fail `no route to sid`.
