### PR TITLE
fix(installer): publish the sidecar's entry point instead of going to look

### DIFF
--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -41,6 +41,29 @@ const AnnotationAllocatedSubnetIPv4 = "galactic.datum.net/allocated-subnet-ipv4"
 // full key appends a truncated container ID; see NetNSKey.
 const AnnotationNetNS = "galactic.datum.net/netns"
 
+// AnnotationIngressHostIfindex and AnnotationIngressHostMAC are the
+// BGPAdvertisement annotations the ingress sidecar records the two facts
+// about its own pod that the host side of its return path needs, and that
+// only the sidecar can read.
+//
+// A reply for a sidecar gateway address has to be redirected into the pod
+// that holds it, which means the host needs the ifindex of the host-side
+// end of that pod's netns-crossing veth, and the pod-side MAC to address
+// the frame to. Both are trivially readable from inside the pod (the
+// primary interface's peer index and its own hardware address) and not
+// readable from outside it without entering the namespace, which needs
+// CAP_SYS_ADMIN -- a privilege the node agent deliberately does not carry
+// (its container drops ALL and adds only BPF, NET_ADMIN and NET_RAW).
+//
+// So the side that can see them publishes them, rather than the side that
+// cannot being given the privilege to go and look. Recorded on the
+// advertisement the sidecar already creates for this address, keyed the
+// same way, so there is one object describing one return path.
+const (
+	AnnotationIngressHostIfindex = "galactic.datum.net/ingress-host-ifindex"
+	AnnotationIngressHostMAC     = "galactic.datum.net/ingress-host-mac"
+)
+
 // AnnotationNoAddressing marks a BGPAdvertisement whose spec.prefixes is
 // empty by design — the attachment's config carries no "ipam" block, so no
 // address was ever requested for it (a VM managing its own addressing is a

--- a/internal/ingresssidecar/gateway.go
+++ b/internal/ingresssidecar/gateway.go
@@ -225,6 +225,48 @@ func allocateGatewayArgument(
 		routerName, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax))
 }
 
+// primaryPodInterface is the name Kubernetes gives a pod its own interface
+// under, and so the veth whose peer is this pod's way in from the host.
+const primaryPodInterface = "eth0"
+
+// podEntryPoint returns the ifindex, in the *host's* namespace, of the peer
+// of this pod's primary interface, plus that interface's own hardware
+// address.
+//
+// Read here, and published on the advertisement, because this is the only
+// side that can see it. For a veth the kernel reports the peer's index even
+// when the peer is in another namespace, so both values come out of one
+// ordinary link query with no extra privilege. Reading them from the host
+// instead would mean entering this namespace, which needs CAP_SYS_ADMIN --
+// see crdnames.AnnotationIngressHostIfindex.
+//
+// A missing primary interface is a real error rather than a skip: a pod
+// without one has no way in at all, so publishing a gateway address for it
+// would advertise a return path that cannot be completed.
+// podEntryPointFn is podEntryPoint, indirected so tests can supply a pod
+// that does not exist -- the same override pattern
+// internal/installer's newK8sClientFn and addrListFn use. There is no
+// primary interface in a unit test's own namespace, and the value this
+// reads is a plain kernel attribute rather than logic worth faking a
+// netlink server for.
+var podEntryPointFn = podEntryPoint
+
+func podEntryPoint() (hostIfindex int, mac net.HardwareAddr, err error) {
+	link, err := netlink.LinkByName(primaryPodInterface)
+	if err != nil {
+		return 0, nil, fmt.Errorf("look up this pod's %q interface: %w", primaryPodInterface, err)
+	}
+	attrs := link.Attrs()
+	if attrs.ParentIndex <= 0 {
+		return 0, nil, fmt.Errorf("interface %q reports no peer index, so this pod has no host-side entry point",
+			primaryPodInterface)
+	}
+	if len(attrs.HardwareAddr) == 0 {
+		return 0, nil, fmt.Errorf("interface %q has no hardware address", primaryPodInterface)
+	}
+	return attrs.ParentIndex, attrs.HardwareAddr, nil
+}
+
 // PublishGateway implements GatewayPublisher.
 func (p *k8sGatewayPublisher) PublishGateway(ctx context.Context, vpc string, addr net.IP) error {
 	if addr == nil || addr.IsUnspecified() {
@@ -267,12 +309,28 @@ func (p *k8sGatewayPublisher) PublishGateway(ctx context.Context, vpc string, ad
 		return fmt.Errorf("apply BGPVRFInstance %s: %w", vrfName, err)
 	}
 
+	// The two facts the host side of this return path needs and cannot read
+	// for itself -- see podEntryPoint. Resolved before the advertisement is
+	// written so an advertisement never exists without them: the host keys
+	// its route and neighbor off these, and one published without them
+	// would look like a return path that should work while nothing could
+	// complete it.
+	hostIfindex, mac, err := podEntryPointFn()
+	if err != nil {
+		return fmt.Errorf("resolve this pod's host-side entry point for vpc %s: %w", vpc, err)
+	}
+
 	function := bgpv1alpha1.SRv6FunctionEndDT46
 	advName := crdnames.BGPAdvertisementName(vpc, ingressVPCAttachment, p.nodeName)
 	adv := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{Name: advName, Namespace: p.namespace},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, p.client, adv, func() error {
+		if adv.Annotations == nil {
+			adv.Annotations = make(map[string]string)
+		}
+		adv.Annotations[crdnames.AnnotationIngressHostIfindex] = strconv.Itoa(hostIfindex)
+		adv.Annotations[crdnames.AnnotationIngressHostMAC] = mac.String()
 		adv.Spec = bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef:     bgpv1alpha1.RouterRef{Name: bgp.routerName},
 			AddressFamily: bgpv1alpha1.AddressFamily{AFI: bgpv1alpha1.AFIL2VPN, SAFI: bgpv1alpha1.SAFIEVPN},

--- a/internal/ingresssidecar/gateway_test.go
+++ b/internal/ingresssidecar/gateway_test.go
@@ -6,6 +6,7 @@ package ingresssidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -53,7 +54,22 @@ func newGatewayTestRouter() *bgpv1alpha1.BGPRouter {
 	}
 }
 
+// stubPodEntryPoint makes podEntryPointFn return a fixed pod entry point
+// for the duration of one test. A unit test's own namespace has no primary
+// interface, so PublishGateway's real read of one cannot succeed here --
+// and what it reads is a plain kernel attribute, not behaviour these tests
+// are about.
+func stubPodEntryPoint(t *testing.T) {
+	t.Helper()
+	prev := podEntryPointFn
+	podEntryPointFn = func() (int, net.HardwareAddr, error) {
+		return 24, net.HardwareAddr{0x9a, 0x91, 0xc0, 0x8d, 0x83, 0xf1}, nil
+	}
+	t.Cleanup(func() { podEntryPointFn = prev })
+}
+
 func TestPublishGateway_CreatesVRFInstanceAndAdvertisement(t *testing.T) {
+	stubPodEntryPoint(t)
 	ctx := context.Background()
 	scheme := gatewayTestScheme(t)
 	router := newGatewayTestRouter()
@@ -100,6 +116,7 @@ func TestPublishGateway_CreatesVRFInstanceAndAdvertisement(t *testing.T) {
 }
 
 func TestPublishGateway_ReusesExistingVRFID(t *testing.T) {
+	stubPodEntryPoint(t)
 	ctx := context.Background()
 	scheme := gatewayTestScheme(t)
 	router := newGatewayTestRouter()
@@ -133,6 +150,7 @@ func TestPublishGateway_ReusesExistingVRFID(t *testing.T) {
 }
 
 func TestPublishGateway_AvoidsCollisionWithOtherVPCOnSameNode(t *testing.T) {
+	stubPodEntryPoint(t)
 	ctx := context.Background()
 	scheme := gatewayTestScheme(t)
 	router := newGatewayTestRouter()
@@ -189,6 +207,7 @@ func TestPublishGateway_RejectsUnspecifiedAddress(t *testing.T) {
 }
 
 func TestWithdrawGateway_DeletesAdvertisementOnlyNotVRFInstance(t *testing.T) {
+	stubPodEntryPoint(t)
 	ctx := context.Background()
 	scheme := gatewayTestScheme(t)
 	router := newGatewayTestRouter()
@@ -295,4 +314,67 @@ func (f *fakeGatewayResolver) ResolveGatewayAddress(vpc string) (net.IP, error) 
 		return addr, nil
 	}
 	return nil, fmt.Errorf("vpc %s: %w", vpc, ErrGatewayAddressNotProvisioned)
+}
+
+// TestPublishGateway_RecordsPodEntryPoint pins the half of this return path
+// that only this side can supply. internal/installer keys its route and
+// permanent neighbor off these two annotations and has no other source for
+// them: reading them itself would mean entering this pod's namespace, which
+// needs a privilege the node agent does not carry. An advertisement without
+// them is one the host silently skips.
+func TestPublishGateway_RecordsPodEntryPoint(t *testing.T) {
+	stubPodEntryPoint(t)
+
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router).Build()
+	p := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+
+	if err := p.PublishGateway(ctx, "2", net.ParseIP("fd30:e2e:3a5::1")); err != nil {
+		t.Fatalf("PublishGateway: %v", err)
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	name := crdnames.BGPAdvertisementName("2", ingressVPCAttachment, gatewayTestNode)
+	if err := fakeClient.Get(ctx,
+		types.NamespacedName{Name: name, Namespace: gatewayTestNamespace}, adv); err != nil {
+		t.Fatalf("get BGPAdvertisement %s: %v", name, err)
+	}
+
+	if got := adv.Annotations[crdnames.AnnotationIngressHostIfindex]; got != "24" {
+		t.Errorf("%s = %q, want %q", crdnames.AnnotationIngressHostIfindex, got, "24")
+	}
+	if got := adv.Annotations[crdnames.AnnotationIngressHostMAC]; got != "9a:91:c0:8d:83:f1" {
+		t.Errorf("%s = %q, want %q", crdnames.AnnotationIngressHostMAC, got, "9a:91:c0:8d:83:f1")
+	}
+}
+
+// TestPublishGateway_RefusesWithoutAnEntryPoint covers a pod with no way in.
+// Publishing anyway would advertise a return path into EVPN that no node
+// could complete, and remote nodes would encapsulate replies toward a SID
+// that blackholes them -- worse than not advertising at all.
+func TestPublishGateway_RefusesWithoutAnEntryPoint(t *testing.T) {
+	prev := podEntryPointFn
+	podEntryPointFn = func() (int, net.HardwareAddr, error) {
+		return 0, nil, errors.New("no primary interface")
+	}
+	t.Cleanup(func() { podEntryPointFn = prev })
+
+	ctx := context.Background()
+	scheme := gatewayTestScheme(t)
+	router := newGatewayTestRouter()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(router).Build()
+	p := NewK8sGatewayPublisher(fakeClient, gatewayTestNode, gatewayTestNamespace)
+
+	if err := p.PublishGateway(ctx, "2", net.ParseIP("fd30:e2e:3a5::1")); err == nil {
+		t.Fatal("PublishGateway() error = nil, want an error when the pod has no entry point")
+	}
+
+	adv := &bgpv1alpha1.BGPAdvertisement{}
+	name := crdnames.BGPAdvertisementName("2", ingressVPCAttachment, gatewayTestNode)
+	err := fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: gatewayTestNamespace}, adv)
+	if err == nil {
+		t.Error("an advertisement was created despite the pod having no entry point")
+	}
 }

--- a/internal/installer/sidecarreturn.go
+++ b/internal/installer/sidecarreturn.go
@@ -11,11 +11,9 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
-	"os"
 	"strconv"
 	"strings"
 
-	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +43,15 @@ import (
 // veth pairs are in the pod's, and a container in that pod cannot install
 // host-netns routes. So the receiving half has to live here, in the host
 // daemon, and this file is it.
+//
+// The split runs the other way too, which is why this reads annotations
+// rather than going to look. Pointing a reply at the right pod needs that
+// pod's host-side veth and MAC, and reading those from here means entering
+// its namespace: setns wants CAP_SYS_ADMIN, and this container drops ALL
+// and adds only BPF, NET_ADMIN and NET_RAW. The sidecar can read both from
+// inside with no privilege at all, so it publishes them on the
+// advertisement it already writes and this side consumes them. Each half
+// does the part it has the rights for.
 //
 // What a decapsulated reply needs, and what this installs per advertised
 // sidecar gateway address:
@@ -103,32 +110,24 @@ func sidecarReturnTableID(vrfID uint16) (uint32, error) {
 	return uint32(sidecarReturnTableBase) + uint32(vrfID), nil
 }
 
-// sidecarEndpoint is one gateway address this node's sidecar has advertised,
-// and the Argument a remote node will have encoded into the SID it
-// encapsulates replies toward.
+// sidecarEndpoint is one gateway address this node's sidecar has advertised:
+// the Argument a remote node will have encoded into the SID it encapsulates
+// replies toward, plus where on this node that pod can be reached.
 type sidecarEndpoint struct {
 	advName string
 	addr    netip.Addr
 	vrfID   uint16
-}
-
-// podNetNS is one network namespace on this node other than our own, with
-// the two things a return path needs from it: which host-side interface
-// crosses into it, and every address reachable inside it.
-type podNetNS struct {
-	path string
-	// hostIfindex is the ifindex, in *this* (host) netns, of the peer of
-	// the netns-crossing veth found inside. That is the interface
-	// bpf_redirect_peer has to target to enter this namespace.
+	// hostIfindex is the ifindex, in this (host) namespace, of the peer of
+	// the pod's primary interface -- what bpf_redirect_peer has to target
+	// to enter that pod. hostMAC is the pod-side end's hardware address.
+	//
+	// Both come from the advertisement's own annotations rather than being
+	// discovered here, because only the sidecar can see them: reading them
+	// from this side means entering the pod's namespace, and setns needs
+	// CAP_SYS_ADMIN, which this container deliberately does not carry. See
+	// crdnames.AnnotationIngressHostIfindex.
 	hostIfindex int
-	// mac is the pod-side end's hardware address, which is what a frame
-	// entering the namespace is addressed to.
-	mac net.HardwareAddr
-	// addrs is every unicast address assigned on any link inside, across
-	// every VRF -- a sidecar's gateway address sits on a veth inside one of
-	// the pod's own VRFs, not on its primary interface, so matching has to
-	// consider all of them.
-	addrs map[netip.Addr]struct{}
+	hostMAC     net.HardwareAddr
 }
 
 // reconcileSidecarReturnPath is Run's non-fatal wrapper, matching
@@ -184,11 +183,6 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 		return nil
 	}
 
-	namespaces, err := discoverPodNetNS()
-	if err != nil {
-		return err
-	}
-
 	registry, closer, err := usidmap.OpenPinnedRegistry(attach.PinDir)
 	if err != nil {
 		return fmt.Errorf("open pinned uSID maps for the sidecar return path: %w", err)
@@ -207,7 +201,7 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 
 	var errs []error
 	for _, e := range endpoints {
-		if err := installSidecarReturn(registry, namespaces, block, e); err != nil {
+		if err := installSidecarReturn(registry, block, e); err != nil {
 			// Per-endpoint, and never fatal to the sweep: one Envoy pod
 			// still starting up must not stop another VPC's return path
 			// being installed.
@@ -220,20 +214,19 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 	return nil
 }
 
-// installSidecarReturn wires up one endpoint: locate the netns holding its
-// gateway address, then install the route, the neighbor, and the vrf_table
-// entry that point at it.
-func installSidecarReturn(
-	registry *usidmap.Registry, namespaces []podNetNS, block uint64, e sidecarEndpoint,
-) error {
-	target := findNetNSForAddr(namespaces, e.addr)
-	if target == nil {
-		// The ordinary not-yet case, and the reason this is a warn-and-retry
-		// reconcile rather than a one-shot: the advertisement outlives any
-		// single Envoy pod, so between a pod restart and its sidecar
-		// re-creating the VRF there is a window where the address it names
-		// exists nowhere on this node.
-		return fmt.Errorf("no network namespace on this node holds gateway address %s yet", e.addr)
+// installSidecarReturn wires up one endpoint: the route, the neighbor, and
+// the vrf_table entry that together point a decapsulated reply at the pod
+// holding that gateway address.
+func installSidecarReturn(registry *usidmap.Registry, block uint64, e sidecarEndpoint) error {
+	// The interface the annotation names has to still exist here. It may
+	// not: the advertisement outlives any single Envoy pod, so between a
+	// pod being replaced and its sidecar re-publishing, this names the veth
+	// of a pod that is gone. Installing against a stale ifindex would put a
+	// route to a tenant address on whatever now holds that index, so this
+	// is checked rather than assumed.
+	if _, err := netlink.LinkByIndex(e.hostIfindex); err != nil {
+		return fmt.Errorf("host-side interface %d for gateway address %s is not present: %w",
+			e.hostIfindex, e.addr, err)
 	}
 
 	table, err := sidecarReturnTableID(e.vrfID)
@@ -241,10 +234,10 @@ func installSidecarReturn(
 		return err
 	}
 
-	if err := ensureSidecarReturnRoute(table, e.addr, target.hostIfindex); err != nil {
+	if err := ensureSidecarReturnRoute(table, e.addr, e.hostIfindex); err != nil {
 		return err
 	}
-	if err := ensureSidecarReturnNeighbor(e.addr, target.hostIfindex, target.mac); err != nil {
+	if err := ensureSidecarReturnNeighbor(e.addr, e.hostIfindex, e.hostMAC); err != nil {
 		return err
 	}
 
@@ -385,18 +378,30 @@ func sidecarGatewayEndpoints(
 		if a.Spec.VRFID == nil {
 			continue
 		}
+		hostIfindex, hostMAC, ok := ingressEntryPointAnnotations(a.Annotations)
+		if !ok {
+			// An advertisement from a sidecar that has not recorded its own
+			// entry point. Skipped rather than errored, and quietly: this is
+			// what an advertisement written by an older sidecar looks like,
+			// and it resolves itself the next time that sidecar republishes.
+			slog.Debug("Sidecar gateway advertisement carries no host-side entry point yet",
+				"advertisement", a.Name)
+			continue
+		}
 		for _, p := range a.Spec.Prefixes {
 			pref, err := netip.ParsePrefix(string(p))
 			if err != nil || !pref.Addr().Is6() || pref.Bits() != pref.Addr().BitLen() {
 				// A gateway address is always a single host route. Anything
 				// else is not something this return path knows how to point
-				// at a namespace.
+				// at a pod.
 				continue
 			}
 			out = append(out, sidecarEndpoint{
-				advName: a.Name,
-				addr:    pref.Addr().Unmap(),
-				vrfID:   uint16(*a.Spec.VRFID),
+				advName:     a.Name,
+				addr:        pref.Addr().Unmap(),
+				vrfID:       uint16(*a.Spec.VRFID),
+				hostIfindex: hostIfindex,
+				hostMAC:     hostMAC,
 			})
 		}
 	}
@@ -447,156 +452,34 @@ func nodeLocatorIdentity(
 	return block, nodeID, true, nil
 }
 
-// discoverPodNetNS enumerates every network namespace on this node other
-// than our own.
+// ingressEntryPointAnnotations reads the host-side ifindex and MAC the
+// sidecar recorded on its own advertisement. ok is false when either is
+// absent or unusable, which the caller treats as "not published yet"
+// rather than as a failure.
 //
-// By enumeration rather than by asking. The sidecar cannot tell us where it
-// is: a netns is only addressable as /proc/<pid>/ns/net, and a pid is not
-// something a container can meaningfully publish about itself for another
-// process to reuse later. The gateway address is the identity that matters
-// anyway, and matching on it is self-validating -- if the address is in a
-// namespace, that is the namespace replies to it belong in.
-//
-// Errors on individual namespaces are skipped rather than returned: a
-// process exiting mid-walk is entirely ordinary, and one unreadable
-// namespace must not hide every other.
-func discoverPodNetNS() ([]podNetNS, error) {
-	self, err := os.Readlink("/proc/self/ns/net")
+// Both are validated rather than trusted. They come from another component
+// via the API server, and they are about to become a route and a permanent
+// neighbor for a tenant address: a zero or negative ifindex, or a malformed
+// hardware address, must not reach netlink.
+func ingressEntryPointAnnotations(annotations map[string]string) (int, net.HardwareAddr, bool) {
+	if annotations == nil {
+		return 0, nil, false
+	}
+	raw, ok := annotations[crdnames.AnnotationIngressHostIfindex]
+	if !ok {
+		return 0, nil, false
+	}
+	ifindex, err := strconv.Atoi(raw)
+	if err != nil || ifindex <= 0 {
+		return 0, nil, false
+	}
+	rawMAC, ok := annotations[crdnames.AnnotationIngressHostMAC]
+	if !ok {
+		return 0, nil, false
+	}
+	mac, err := net.ParseMAC(rawMAC)
 	if err != nil {
-		return nil, fmt.Errorf("read own network namespace: %w", err)
+		return 0, nil, false
 	}
-
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return nil, fmt.Errorf("enumerate /proc: %w", err)
-	}
-
-	seen := make(map[string]struct{})
-	var out []podNetNS
-	for _, entry := range entries {
-		if _, cerr := strconv.Atoi(entry.Name()); cerr != nil {
-			continue // not a pid
-		}
-		path := "/proc/" + entry.Name() + "/ns/net"
-		target, rerr := os.Readlink(path)
-		if rerr != nil {
-			continue
-		}
-		if target == self {
-			continue // our own namespace: usid_ingress already runs here
-		}
-		if _, dup := seen[target]; dup {
-			continue // another process in a namespace already inspected
-		}
-		seen[target] = struct{}{}
-
-		inspected, ierr := inspectPodNetNS(path)
-		if ierr != nil {
-			slog.Debug("Could not inspect network namespace for the sidecar return path",
-				"path", path, "err", ierr)
-			continue
-		}
-		out = append(out, *inspected)
-	}
-	return out, nil
-}
-
-// inspectPodNetNS reads the one namespace at path: every address inside,
-// and the host-side ifindex plus pod-side MAC of the veth that crosses into
-// it.
-func inspectPodNetNS(path string) (*podNetNS, error) {
-	handle, err := ns.GetNS(path)
-	if err != nil {
-		return nil, fmt.Errorf("open network namespace %s: %w", path, err)
-	}
-	defer handle.Close() //nolint:errcheck // netns close on teardown
-
-	result := &podNetNS{path: path, addrs: make(map[netip.Addr]struct{})}
-	err = handle.Do(func(_ ns.NetNS) error {
-		links, lerr := netlink.LinkList()
-		if lerr != nil {
-			return fmt.Errorf("list links: %w", lerr)
-		}
-		byIndex := make(map[int]netlink.Link, len(links))
-		for _, l := range links {
-			byIndex[l.Attrs().Index] = l
-		}
-		for _, l := range links {
-			attrs := l.Attrs()
-			// Prefer the primary interface when there is one, so a pod with
-			// more than one way in (a Multus secondary, say) resolves to the
-			// same interface on every pass rather than to whichever the
-			// kernel happened to list first.
-			better := result.hostIfindex == 0 || attrs.Name == primaryPodInterface
-			if better && crossingVeth(l, byIndex) {
-				result.hostIfindex = attrs.ParentIndex
-				result.mac = append(net.HardwareAddr(nil), attrs.HardwareAddr...)
-			}
-			addrs, aerr := netlink.AddrList(l, netlink.FAMILY_V6)
-			if aerr != nil {
-				continue
-			}
-			for _, a := range addrs {
-				if got, ok := netip.AddrFromSlice(a.IP); ok {
-					got = got.Unmap()
-					if got.IsGlobalUnicast() {
-						result.addrs[got] = struct{}{}
-					}
-				}
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	if result.hostIfindex == 0 {
-		return nil, fmt.Errorf("no netns-crossing veth found in %s", path)
-	}
-	return result, nil
-}
-
-// primaryPodInterface is the name Kubernetes gives a pod's own interface,
-// and so the netns-crossing veth to prefer when a pod has more than one.
-const primaryPodInterface = "eth0"
-
-// crossingVeth reports whether link is a veth whose peer is outside this
-// namespace, i.e. the one interface a packet can be redirected in through.
-// byIndex is every link in this same namespace, keyed by ifindex.
-//
-// A pod netns holds two kinds of veth: its primary interface, whose peer is
-// the host-side end, and (for an Envoy pod running the ingress sidecar) a
-// pair per tenant VPC with *both* ends inside this same namespace. Only the
-// first is a way in, and the second must never be mistaken for one.
-//
-// Distinguished by reciprocity, not by whether the peer ifindex resolves
-// here. Ifindices are per-namespace and collide freely across them, so a
-// pod whose primary interface happens to peer with host ifindex 12 while
-// this namespace also has some link 12 would look internal and be skipped,
-// leaving that pod unreachable with nothing to indicate why. A genuine
-// same-namespace pair points back: the peer's own ParentIndex is this
-// link's index. A coincidental collision does not.
-func crossingVeth(link netlink.Link, byIndex map[int]netlink.Link) bool {
-	if _, isVeth := link.(*netlink.Veth); !isVeth {
-		return false
-	}
-	attrs := link.Attrs()
-	peerIndex := attrs.ParentIndex
-	if peerIndex <= 0 {
-		return false
-	}
-	if peer, ok := byIndex[peerIndex]; ok && peer.Attrs().ParentIndex == attrs.Index {
-		return false // a real pair with both ends here: an internal veth
-	}
-	return true
-}
-
-// findNetNSForAddr returns the namespace holding addr, or nil.
-func findNetNSForAddr(namespaces []podNetNS, addr netip.Addr) *podNetNS {
-	for i := range namespaces {
-		if _, ok := namespaces[i].addrs[addr]; ok {
-			return &namespaces[i]
-		}
-	}
-	return nil
+	return ifindex, mac, true
 }

--- a/internal/installer/sidecarreturn_test.go
+++ b/internal/installer/sidecarreturn_test.go
@@ -51,6 +51,10 @@ func gatewayAdv(vpc, node, prefix string, vrfID int32) *bgpv1alpha1.BGPAdvertise
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      crdnames.BGPAdvertisementName(vpc, crdnames.IngressAttachment, node),
 			Namespace: testNamespace,
+			Annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "24",
+				crdnames.AnnotationIngressHostMAC:     "9a:91:c0:8d:83:f1",
+			},
 		},
 		Spec: bgpv1alpha1.BGPAdvertisementSpec{
 			RouterRef: bgpv1alpha1.RouterRef{Name: node},
@@ -358,113 +362,127 @@ func TestNodeLocatorIdentity_AbsentIsNotAnError(t *testing.T) {
 	}
 }
 
-// veth builds a veth link the way the kernel reports one, with peer as its
-// ParentIndex.
-func veth(name string, index, peer int) netlink.Link {
-	return &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: name, Index: index, ParentIndex: peer}}
-}
-
-// TestCrossingVeth separates a pod's way in from the ingress sidecar's own
-// internal pairs. Getting this wrong in either direction is silent: treat an
-// internal pair as the way in and every reply is redirected to an interface
-// inside the pod that leads nowhere; treat the real one as internal and the
-// pod looks like it has no entry point at all.
-//
-// The ifindex-collision case is the one worth writing down. Ifindices are
-// per-namespace, so a pod's primary interface can peer with a host ifindex
-// that also exists inside the pod, and a naive "does the peer index resolve
-// here" test would call that internal.
-func TestCrossingVeth(t *testing.T) {
+// TestIngressEntryPointAnnotations covers the values that become a route
+// and a permanent neighbor for a tenant address. They arrive from another
+// component through the API server, so every rejection here is a value that
+// must not reach netlink -- a zero or negative ifindex would name no
+// interface, and a malformed MAC would be written into the neighbor table.
+func TestIngressEntryPointAnnotations(t *testing.T) {
+	const mac = "9a:91:c0:8d:83:f1"
 	for _, tc := range []struct {
-		name  string
-		links []netlink.Link
-		// target is the index into links of the link under test.
-		target int
-		want   bool
+		name        string
+		annotations map[string]string
+		wantOK      bool
+		wantIfindex int
 	}{
 		{
-			// The pod's own interface: peer 24 lives in the host netns and
-			// is absent here.
-			name:   "primary interface peering into the host",
-			links:  []netlink.Link{veth(primaryPodInterface, 23, 24)},
-			target: 0, want: true,
-		},
-		{
-			// A sidecar pair: both ends here, each naming the other.
-			name:   "internal sidecar pair",
-			links:  []netlink.Link{veth("ivp2", 9, 10), veth("ivs2", 10, 9)},
-			target: 0, want: false,
-		},
-		{
-			// The collision: this namespace has a link 12, but link 12 is
-			// not our peer -- it names something else entirely.
-			name: "peer ifindex collides with an unrelated local link",
-			links: []netlink.Link{
-				veth(primaryPodInterface, 23, 12),
-				veth("ivs3", 12, 13),
-				veth("ivp3", 13, 12),
+			name: "both present",
+			annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "24",
+				crdnames.AnnotationIngressHostMAC:     mac,
 			},
-			target: 0, want: true,
+			wantOK: true, wantIfindex: 24,
+		},
+		// What an advertisement from a sidecar that predates this feature
+		// looks like. Must read as "not published yet", not as a failure.
+		{name: "nil annotations", annotations: nil, wantOK: false},
+		{name: "empty annotations", annotations: map[string]string{}, wantOK: false},
+		{
+			name:        "ifindex only",
+			annotations: map[string]string{crdnames.AnnotationIngressHostIfindex: "24"},
+			wantOK:      false,
 		},
 		{
-			name:   "no peer recorded",
-			links:  []netlink.Link{veth(primaryPodInterface, 23, 0)},
-			target: 0, want: false,
+			name:        "mac only",
+			annotations: map[string]string{crdnames.AnnotationIngressHostMAC: mac},
+			wantOK:      false,
+		},
+		{
+			name: "zero ifindex names no interface",
+			annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "0",
+				crdnames.AnnotationIngressHostMAC:     mac,
+			},
+			wantOK: false,
+		},
+		{
+			name: "negative ifindex",
+			annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "-1",
+				crdnames.AnnotationIngressHostMAC:     mac,
+			},
+			wantOK: false,
+		},
+		{
+			name: "unparseable ifindex",
+			annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "not-a-number",
+				crdnames.AnnotationIngressHostMAC:     mac,
+			},
+			wantOK: false,
+		},
+		{
+			name: "malformed mac",
+			annotations: map[string]string{
+				crdnames.AnnotationIngressHostIfindex: "24",
+				crdnames.AnnotationIngressHostMAC:     "not-a-mac",
+			},
+			wantOK: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			byIndex := make(map[int]netlink.Link, len(tc.links))
-			for _, l := range tc.links {
-				byIndex[l.Attrs().Index] = l
+			ifindex, mac, ok := ingressEntryPointAnnotations(tc.annotations)
+			if ok != tc.wantOK {
+				t.Fatalf("ingressEntryPointAnnotations() ok = %v, want %v", ok, tc.wantOK)
 			}
-			if got := crossingVeth(tc.links[tc.target], byIndex); got != tc.want {
-				t.Errorf("crossingVeth(%s) = %v, want %v",
-					tc.links[tc.target].Attrs().Name, got, tc.want)
+			if !ok {
+				return
 			}
-		})
-	}
-}
-
-// TestCrossingVeth_NonVethIsNeverAWayIn covers the rest of a pod netns. A
-// VRF master and a tap both carry attributes that could look peer-like, and
-// neither is something bpf_redirect_peer can cross.
-func TestCrossingVeth_NonVethIsNeverAWayIn(t *testing.T) {
-	for _, l := range []netlink.Link{
-		&netlink.Vrf{LinkAttrs: netlink.LinkAttrs{Name: "G000000002V", Index: 8, ParentIndex: 99}},
-		&netlink.Tuntap{LinkAttrs: netlink.LinkAttrs{Name: "G00000000hH", Index: 9, ParentIndex: 99}},
-		&netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "lo", Index: 1}},
-	} {
-		t.Run(l.Attrs().Name, func(t *testing.T) {
-			if crossingVeth(l, map[int]netlink.Link{}) {
-				t.Errorf("crossingVeth(%s, type %T) = true, want false", l.Attrs().Name, l)
+			if ifindex != tc.wantIfindex {
+				t.Errorf("ifindex = %d, want %d", ifindex, tc.wantIfindex)
+			}
+			if len(mac) != 6 {
+				t.Errorf("mac = %v, want a 6-byte hardware address", mac)
 			}
 		})
 	}
 }
 
-// TestFindNetNSForAddr covers the lookup that decides which namespace a
-// reply belongs in. The miss case is the one that matters operationally:
-// between an Envoy pod restarting and its sidecar re-creating the VRF, the
-// advertised address exists in no namespace on this node, and that has to
-// be a retry rather than a wrong answer.
-func TestFindNetNSForAddr(t *testing.T) {
-	want := netip.MustParseAddr(testSidecarAddr)
-	other := netip.MustParseAddr("fd30:e2e:af7::1")
-	namespaces := []podNetNS{
-		{path: "/proc/1/ns/net", hostIfindex: 11, addrs: map[netip.Addr]struct{}{other: {}}},
-		{path: "/proc/2/ns/net", hostIfindex: 22, addrs: map[netip.Addr]struct{}{want: {}}},
-	}
+// TestSidecarGatewayEndpoints_SkipsUnannotated covers the rollout window.
+// A sidecar that has not yet republished leaves an advertisement with no
+// entry point on it; picking it up would mean guessing an interface, so it
+// has to be skipped and retried instead.
+func TestSidecarGatewayEndpoints_SkipsUnannotated(t *testing.T) {
+	adv := gatewayAdv("2", testSidecarNode, testSidecarAddr+"/128", 1)
+	adv.Annotations = nil
 
-	got := findNetNSForAddr(namespaces, want)
-	if got == nil {
-		t.Fatalf("findNetNSForAddr(%s) = nil, want the namespace holding it", want)
+	c := newAdvClient(t, adv)
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v, want nil", err)
 	}
-	if got.hostIfindex != 22 {
-		t.Errorf("findNetNSForAddr(%s) hostIfindex = %d, want 22", want, got.hostIfindex)
+	if len(got) != 0 {
+		t.Errorf("sidecarGatewayEndpoints() = %+v, want none until the entry point is published", got)
 	}
+}
 
-	if got := findNetNSForAddr(namespaces, netip.MustParseAddr("fd30:e2e:dead::1")); got != nil {
-		t.Errorf("findNetNSForAddr(absent) = %+v, want nil", got)
+// TestSidecarGatewayEndpoints_CarriesEntryPoint pins that the endpoint the
+// install step acts on is the one the sidecar published, since that is the
+// only source for it.
+func TestSidecarGatewayEndpoints_CarriesEntryPoint(t *testing.T) {
+	c := newAdvClient(t, gatewayAdv("2", testSidecarNode, testSidecarAddr+"/128", 1))
+	got, err := sidecarGatewayEndpoints(context.Background(), c, testNamespace, testSidecarNode)
+	if err != nil {
+		t.Fatalf("sidecarGatewayEndpoints() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("sidecarGatewayEndpoints() returned %d endpoints, want 1", len(got))
+	}
+	if got[0].hostIfindex != 24 {
+		t.Errorf("hostIfindex = %d, want the annotated 24", got[0].hostIfindex)
+	}
+	if got[0].hostMAC.String() != "9a:91:c0:8d:83:f1" {
+		t.Errorf("hostMAC = %s, want the annotated 9a:91:c0:8d:83:f1", got[0].hostMAC)
 	}
 }
 


### PR DESCRIPTION
The return path #510 added could never have worked, and rolling it out proved it. On proxima, every 30 seconds:

```
WARN Could not install the ingress sidecar's return path
  err="advertisement 2-f30273f7e4-proxima-evices:
       no network namespace on this node holds gateway address
       fd30:e2e:3a5:6094:7c95:22a:4aec:a4a9 yet" (and 4 more)
```

It located the pod holding a gateway address by walking `/proc` and entering each network namespace. The node agent can do neither:

```
hostPID: <unset>                     -> the container sees 4 pids, its own
capabilities: drop ALL, add [BPF, NET_ADMIN, NET_RAW]   -> no SYS_ADMIN, so no setns
```

Granting `CAP_SYS_ADMIN` to fix it would be a poor trade. It is close to root-equivalent, and it would buy one kernel attribute the other side of this boundary can already read.

## The fix

Invert the direction. The sidecar runs in the pod's namespace, where the host-side ifindex of its primary interface and that interface's MAC are one ordinary link query away with no privilege at all. It records both on the advertisement it already writes, and the installer consumes them.

That is the same split that put the receiving side in the host daemon to begin with: each half does the part it holds the rights for.

## Safety

Both values arrive from another component through the API server and become a route and a permanent neighbor for a tenant address, so neither is trusted. A non-positive ifindex or a malformed MAC is rejected, and the named interface is confirmed present before use, since an advertisement outlives any single Envoy pod and a stale ifindex would put a tenant route on whatever now holds that index.

An advertisement with no entry point recorded is skipped and retried, because that is what one written by an older sidecar looks like. `PublishGateway` refuses to publish when the pod has no way in, so no advertisement ever claims a return path nothing could complete.

## Also

Drops the `/proc` walk and the per-tick namespace entry, so the reconcile no longer costs anything proportional to the pod count on the node.

`task lint` 0 issues, `task test:unit` 57 packages.
