### PR TITLE
fix(ingresssidecar): route the gateway address into its own VRF

### DIFF
--- a/internal/ingresssidecar/gatewayaddress.go
+++ b/internal/ingresssidecar/gatewayaddress.go
@@ -166,5 +166,48 @@ func ensureGatewayAddress(vpc, inner string) error {
 	if err := netlink.AddrReplace(link, nladdr); err != nil {
 		return fmt.Errorf("assign gateway address %s to %q: %w", addr, inner, err)
 	}
+
+	return ensureGatewayVRFRoute(vpc, addr)
+}
+
+// ensureGatewayVRFRoute pulls traffic for this VPC's gateway address into
+// that VPC's VRF, by routing it at the VRF device in this namespace's main
+// table.
+//
+// Assigning the address above is not enough to receive on it. It lands on a
+// veth enslaved to the VPC's VRF, so it is local only within that VRF's own
+// table -- while a reply arriving from outside, redirected in by
+// usid_ingress on the host, lands on this pod's primary interface, which is
+// in no VRF at all. The input lookup then runs in the main table, finds
+// nothing local for the address, and the packet is dropped without being
+// counted anywhere: Ip6InReceives advances, Ip6InDelivers does not, and
+// neither Ip6InNoRoutes nor Ip6InAddrErrors moves. Measured exactly that
+// way before this existed.
+//
+// A route at the VRF device is the standard way across that boundary: the
+// VRF driver redirects the lookup into its own table, where the address is
+// local, and delivery proceeds. It is the same idiom the pod-subnet routes
+// this sidecar already installs use to reach a VPC at all, applied to the
+// one address the sidecar owns itself rather than to a remote prefix.
+//
+// In the main table deliberately, not the VRF's: a lookup that has already
+// entered the VRF's table finds the address local there and never needs
+// this, so putting it inside would be inert. The main table is where the
+// lookup that currently fails happens.
+func ensureGatewayVRFRoute(vpc string, addr net.IP) error {
+	vrfName := intf.GenerateInterfaceNameVRF(vpc)
+	vrfLink, err := netlink.LinkByName(vrfName)
+	if err != nil {
+		return fmt.Errorf("look up VRF interface %q to route gateway address %s into it: %w",
+			vrfName, addr, err)
+	}
+
+	route := &netlink.Route{
+		Dst:       &net.IPNet{IP: addr, Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8)},
+		LinkIndex: vrfLink.Attrs().Index,
+	}
+	if err := netlink.RouteReplace(route); err != nil {
+		return fmt.Errorf("route gateway address %s into VRF %q: %w", addr, vrfName, err)
+	}
 	return nil
 }

--- a/internal/ingresssidecar/gatewayaddress_test.go
+++ b/internal/ingresssidecar/gatewayaddress_test.go
@@ -151,3 +151,16 @@ func TestEnsureGatewayAddress_NoopWhenDisabled(t *testing.T) {
 		t.Errorf("ensureGatewayAddress with assignment disabled: %v, want nil (no-op)", err)
 	}
 }
+
+// TestEnsureGatewayVRFRoute_AbsentVRFIsAnError pins that this reports a
+// missing VRF rather than silently skipping. The route is what makes the
+// gateway address receivable from outside the VRF, so a caller that treated
+// its absence as success would leave an address assigned, advertised into
+// EVPN, and undeliverable -- the exact failure this route exists to fix,
+// but harder to find because nothing would say so.
+func TestEnsureGatewayVRFRoute_AbsentVRFIsAnError(t *testing.T) {
+	// A VPC with no VRF interface in this test's namespace.
+	if err := ensureGatewayVRFRoute("zzzzz", net.ParseIP("fd30:e2e:3a5::1")); err == nil {
+		t.Error("ensureGatewayVRFRoute() error = nil, want an error when the VPC has no VRF")
+	}
+}


### PR DESCRIPTION
Assigning the gateway address is not enough to receive on it. It lands on a veth enslaved to the VPC's VRF, so it is local only within that VRF's table. A reply redirected in by `usid_ingress` on the host arrives on the pod's primary interface, which is in no VRF, so the input lookup runs in the main table, finds nothing local for the address, and the packet is dropped.

Nothing counts that drop, which is what made it hard to find. Measured on the live path for 5 pings:

```
Ip6InReceives   +5      the replies arrive
Ip6InDelivers    0      none delivered
Ip6InNoRoutes    0
Ip6InAddrErrors  0
Ip6InHdrErrors   0
Ip6InDiscards    0
```

Every counter on either side of the pod said the reply had arrived and been handled.

## The fix

Route the address at the VRF device in the main table. The VRF driver redirects the lookup into its own table, where the address is local, and delivery proceeds. This is the same idiom the pod-subnet routes this sidecar already installs use to reach a VPC, applied to the one address the sidecar owns itself.

In the main table rather than the VRF's: a lookup that has already entered the VRF's table finds the address local and never needs this, so putting it there would be inert. The main table is where the failing lookup happens.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. The route itself needs a real VRF, so it is verified by the live run above; the unit test covers the absent-VRF case, which must report rather than skip, since a silent skip would leave an address assigned and advertised but undeliverable.

