### PR TITLE
feat(attach): report unhealthy when another tc program runs ahead of us

### DIFF
--- a/internal/plumbing/ebpf/attach/health.go
+++ b/internal/plumbing/ebpf/attach/health.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
@@ -51,6 +52,7 @@ func Health(objs *prog.UsidObjects, ifaces []string) error {
 		checkProgramReachable(objs.UsidIngress),
 		checkMapsReachable(objs),
 		checkAttached(ifaces),
+		checkNotPreempted(ifaces),
 	)
 }
 
@@ -123,12 +125,12 @@ func checkAttached(ifaces []string) error {
 // process-local and not meaningfully comparable against a value returned
 // from a netlink query).
 func checkAttachedOne(name string) error {
-	link, err := linkByNameFn(name)
+	iface, err := linkByNameFn(name)
 	if err != nil {
 		return fmt.Errorf("find link: %w", err)
 	}
 
-	filters, err := filterListFn(link, netlink.HANDLE_MIN_INGRESS)
+	filters, err := filterListFn(iface, netlink.HANDLE_MIN_INGRESS)
 	if err != nil {
 		return fmt.Errorf("list filters: %w", err)
 	}
@@ -211,4 +213,101 @@ func (h *Handle) Healthy() error {
 			"(dead watcher can't self-heal drift)"))
 	}
 	return healthErr
+}
+
+// tcxQueryFn is a package-level override point, matching linkByNameFn and
+// filterListFn above, so checkNotPreempted's tests need neither root nor a
+// live interface with a foreign program on it.
+var tcxQueryFn = func(ifindex int) ([]ebpf.ProgramID, error) {
+	res, err := link.QueryPrograms(link.QueryOptions{
+		Target: ifindex,
+		Attach: ebpf.AttachTCXIngress,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]ebpf.ProgramID, 0, len(res.Programs))
+	for _, p := range res.Programs {
+		ids = append(ids, p.ID)
+	}
+	return ids, nil
+}
+
+// programNameFn resolves a program id to its kernel program name. Also an
+// override point, for the same reason as tcxQueryFn.
+var programNameFn = func(id ebpf.ProgramID) (string, error) {
+	p, err := ebpf.NewProgramFromID(id)
+	if err != nil {
+		return "", err
+	}
+	defer p.Close() //nolint:errcheck // read-only query, nothing to react to
+	info, err := p.Info()
+	if err != nil {
+		return "", err
+	}
+	return info.Name, nil
+}
+
+// checkNotPreempted confirms nothing runs ahead of this datapath on the
+// interfaces it owns.
+//
+// Being attached is not the same as being reached. This package attaches
+// via clsact, and the kernel runs every tcx program on a hook before any
+// clsact filter on it, so another CNI that attaches tcx to an interface
+// this datapath owns sits permanently in front of it. If that program
+// consumes or drops the packet, usid_ingress is never invoked, and every
+// counter in this datapath reads a clean zero -- there is no drop to see,
+// because from this side nothing arrived.
+//
+// That is worth a health check rather than a comment because the failure
+// is invisible from every vantage point this codebase has. Diagnosing one
+// instance took kernel kfree_skb tracing to find the drop, bpftool to see
+// a tcx link that `tc filter show` cannot display at all, and the other
+// CNI's own drop monitor to name the reason. A health check states it in
+// one line instead.
+//
+// Written to survive this package moving to tcx itself: what it asserts is
+// that either no tcx program is present (so clsact is first by default) or
+// the first tcx program is this datapath's own. Both readings are correct
+// now and after such a move.
+func checkNotPreempted(ifaces []string) error {
+	var errs []error
+	for _, name := range ifaces {
+		if err := checkNotPreemptedOne(name); err != nil {
+			errs = append(errs, fmt.Errorf("attach: health: interface %q: %w", name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func checkNotPreemptedOne(name string) error {
+	iface, err := linkByNameFn(name)
+	if err != nil {
+		return fmt.Errorf("find link: %w", err)
+	}
+
+	ids, err := tcxQueryFn(iface.Attrs().Index)
+	if err != nil {
+		// A kernel without BPF_PROG_QUERY for tcx cannot have a tcx
+		// program to be preempted by either, so this is not a datapath
+		// fault. Reporting it as one would make every such node
+		// permanently unhealthy over a condition it cannot have.
+		return nil
+	}
+	if len(ids) == 0 {
+		return nil // nothing in front of clsact
+	}
+
+	first, err := programNameFn(ids[0])
+	if err != nil {
+		// The program is attached but its name is unreadable. Do not
+		// claim preemption on that basis: a false unhealthy here would
+		// point an operator at the wrong thing entirely.
+		return nil
+	}
+	if first == prog.UsidProgUsidIngress || first == prog.UsidProgUsidEgress {
+		return nil
+	}
+	return fmt.Errorf("tc program %q runs ahead of this datapath (tcx precedes clsact), "+
+		"so traffic it consumes never reaches usid_ingress", first)
 }

--- a/internal/plumbing/ebpf/attach/health_test.go
+++ b/internal/plumbing/ebpf/attach/health_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cilium/ebpf"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 
@@ -320,4 +321,91 @@ func TestHealth_RealDatapath_FlipsAfterAttachIsKilled(t *testing.T) {
 		t.Errorf("Health() after objs.Close(): error = %v, want it to mention the program/maps are not reachable", err)
 	}
 	t.Logf("Health() correctly flipped to unhealthy after objs.Close(): %v", err)
+}
+
+// TestCheckNotPreempted covers the condition that makes this datapath
+// silently invisible: another CNI attaching tcx to an interface this one
+// owns. tcx runs ahead of clsact, so such a program decides the packet's
+// fate before usid_ingress is invoked, and this side sees a clean zero
+// rather than a drop.
+//
+// Every case here is about which of those readings is worth calling
+// unhealthy. Reporting one wrongly points an operator at the datapath when
+// the fault is elsewhere, or worse, marks a healthy node down.
+func TestCheckNotPreempted(t *testing.T) {
+	origLinkByName := linkByNameFn
+	origTCXQuery := tcxQueryFn
+	origProgramName := programNameFn
+	t.Cleanup(func() {
+		linkByNameFn = origLinkByName
+		tcxQueryFn = origTCXQuery
+		programNameFn = origProgramName
+	})
+
+	dummyLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: testIfaceEth0, Index: 7}}
+	linkByNameFn = func(string) (netlink.Link, error) { return dummyLink, nil }
+
+	t.Run("no tcx program means clsact is first", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return nil, nil }
+		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil with no tcx program attached", err)
+		}
+	})
+
+	t.Run("a foreign tcx program in front is unhealthy", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{101}, nil }
+		programNameFn = func(ebpf.ProgramID) (string, error) { return "cil_from_netdev", nil }
+		err := checkNotPreempted([]string{testIfaceEth0})
+		if err == nil {
+			t.Fatal("checkNotPreempted() error = nil, want an error for a foreign tcx program")
+		}
+		// The offender's name is the whole diagnostic value: without it an
+		// operator learns only that something is wrong.
+		if !strings.Contains(err.Error(), "cil_from_netdev") {
+			t.Errorf("checkNotPreempted() error = %q, want it to name the preempting program", err)
+		}
+		if !strings.Contains(err.Error(), testIfaceEth0) {
+			t.Errorf("checkNotPreempted() error = %q, want it to name the interface", err)
+		}
+	})
+
+	// Keeps this correct if this package moves to tcx itself: its own
+	// program running first is the desired end state, not a fault.
+	t.Run("this datapath first in the tcx chain is healthy", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{202, 203}, nil }
+		programNameFn = func(id ebpf.ProgramID) (string, error) {
+			if id == 202 {
+				return prog.UsidProgUsidIngress, nil
+			}
+			return "cil_from_netdev", nil
+		}
+		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil when this datapath is first", err)
+		}
+	})
+
+	// A kernel with no tcx query support cannot have a tcx program to be
+	// preempted by. Reporting that as a datapath fault would hold such a
+	// node permanently unhealthy over a condition it cannot have.
+	t.Run("query unsupported is not a datapath fault", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) {
+			return nil, errors.New("simulated: BPF_PROG_QUERY unsupported")
+		}
+		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil when the query is unsupported", err)
+		}
+	})
+
+	// An attached program whose name cannot be read is not evidence of
+	// preemption by anything in particular, and a guess here would send an
+	// operator after the wrong component.
+	t.Run("unreadable program name does not claim preemption", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{404}, nil }
+		programNameFn = func(ebpf.ProgramID) (string, error) {
+			return "", errors.New("simulated: program vanished")
+		}
+		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil when the name is unreadable", err)
+		}
+	})
 }


### PR DESCRIPTION
Being attached is not the same as being reached. This package attaches via clsact, and the kernel runs every tcx program on a hook before any clsact filter on it. Another CNI that attaches tcx to an interface this datapath owns therefore sits permanently in front of it, and if it consumes or drops the packet, `usid_ingress` is never invoked.

Nothing in this codebase could see that. Every counter reads a clean zero, because from this side the packet never arrived.

Diagnosing one instance on us-central-1-staging-lab took three tools this repo does not use:

1. Kernel `kfree_skb` tracing, to find where the packet died.
2. `bpftool net show`, to see a tcx link that `tc filter show` cannot display at all.
3. The other CNI's own drop monitor, to name the reason.

The health check now states it on the tick it happens, naming the interface and the program in front:

```
tc program "cil_from_netdev" runs ahead of this datapath (tcx precedes clsact),
so traffic it consumes never reaches usid_ingress
```

## What it asserts

Either no tcx program is present, so clsact is first by default, or the first tcx program is this datapath's own. Both readings are correct now and if this package moves to tcx itself, which is the intended direction.

## What it deliberately does not report

Three cases return healthy, because a false unhealthy is worse than silence here: it moves the search away from the real cause.

A kernel without `BPF_PROG_QUERY` for tcx cannot have a tcx program to be preempted by, so holding such a node unhealthy would be over a condition it cannot have. An attached program whose name cannot be read is not evidence of preemption by anything in particular, and guessing would send an operator after the wrong component.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. The tcx query and program-name lookup are behind package-level override points, matching `linkByNameFn`/`filterListFn` alongside them, so the cases above are covered without root or a live interface carrying a foreign program.
