### PR TITLE
fix(attach): scope the preemption check to owned interfaces, and let it fail loudly

### DIFF
--- a/internal/plumbing/ebpf/attach/health.go
+++ b/internal/plumbing/ebpf/attach/health.go
@@ -7,6 +7,7 @@ package attach
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
@@ -52,7 +53,7 @@ func Health(objs *prog.UsidObjects, ifaces []string) error {
 		checkProgramReachable(objs.UsidIngress),
 		checkMapsReachable(objs),
 		checkAttached(ifaces),
-		checkNotPreempted(ifaces),
+		checkNotPreempted(),
 	)
 }
 
@@ -249,49 +250,89 @@ var programNameFn = func(id ebpf.ProgramID) (string, error) {
 }
 
 // checkNotPreempted confirms nothing runs ahead of this datapath on the
-// interfaces it owns.
+// interfaces it owns exclusively.
 //
 // Being attached is not the same as being reached. This package attaches
 // via clsact, and the kernel runs every tcx program on a hook before any
-// clsact filter on it, so another CNI that attaches tcx to an interface
-// this datapath owns sits permanently in front of it. If that program
-// consumes or drops the packet, usid_ingress is never invoked, and every
-// counter in this datapath reads a clean zero -- there is no drop to see,
-// because from this side nothing arrived.
+// clsact filter on it, so another CNI's tcx program on the same interface
+// decides a packet's fate first. If it consumes or drops the packet,
+// usid_egress is never invoked and every counter here reads a clean zero,
+// because from this side nothing arrived. That is worth a check because it
+// is invisible from every vantage point this codebase otherwise has:
+// diagnosing one instance took kernel kfree_skb tracing, then bpftool to
+// see a tcx link `tc filter show` cannot display, then the other CNI's own
+// drop monitor to name the reason.
 //
-// That is worth a health check rather than a comment because the failure
-// is invisible from every vantage point this codebase has. Diagnosing one
-// instance took kernel kfree_skb tracing to find the drop, bpftool to see
-// a tcx link that `tc filter show` cannot display at all, and the other
-// CNI's own drop monitor to name the reason. A health check states it in
-// one line instead.
+// Scoped to this datapath's own per-attachment interfaces -- the taps and
+// veths carrying usid_egress -- and deliberately not to the shared uplinks
+// usid_ingress attaches to. On an uplink another CNI is expected: it is
+// that CNI's interface too, and this datapath's own receive classification
+// happens on a bond's slaves rather than on the master a cluster CNI
+// attaches to, so a tcx program there is not in the way of anything.
+// Checking uplinks would report every node in a fleet unhealthy over the
+// ordinary arrangement.
 //
-// Written to survive this package moving to tcx itself: what it asserts is
-// that either no tcx program is present (so clsact is first by default) or
-// the first tcx program is this datapath's own. Both readings are correct
-// now and after such a move.
-func checkNotPreempted(ifaces []string) error {
+// Enumerating by filter rather than taking a caller-supplied list: an
+// interface carrying this package's own usid_egress filter is by definition
+// one this datapath owns, so the set defines itself and cannot drift out of
+// step with what is actually attached.
+func checkNotPreempted() error {
+	links, err := linkListFn()
+	if err != nil {
+		return fmt.Errorf("attach: health: list links to check for preemption: %w", err)
+	}
+
 	var errs []error
-	for _, name := range ifaces {
-		if err := checkNotPreemptedOne(name); err != nil {
-			errs = append(errs, fmt.Errorf("attach: health: interface %q: %w", name, err))
+	for _, l := range links {
+		if !hasEgressFilter(l) {
+			continue
+		}
+		if err := checkNotPreemptedOne(l); err != nil {
+			errs = append(errs, fmt.Errorf("attach: health: interface %q: %w", l.Attrs().Name, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func checkNotPreemptedOne(name string) error {
-	iface, err := linkByNameFn(name)
+// hasEgressFilter reports whether l carries this package's own usid_egress
+// filter, which is what marks an interface as one this datapath owns.
+func hasEgressFilter(l netlink.Link) bool {
+	filters, err := filterListFn(l, netlink.HANDLE_MIN_INGRESS)
 	if err != nil {
-		return fmt.Errorf("find link: %w", err)
+		return false
 	}
+	for _, f := range filters {
+		if bpfFilter, ok := f.(*netlink.BpfFilter); ok && bpfFilter.Name == egressFilterName {
+			return true
+		}
+	}
+	return false
+}
 
-	ids, err := tcxQueryFn(iface.Attrs().Index)
+// checkNotPreemptedOne reports whether anything precedes this datapath on
+// one owned interface.
+//
+// A failure to look is logged rather than returned. This check is a
+// diagnostic, and its own inability to run says nothing about whether the
+// datapath is carrying traffic, so failing health on it would report the
+// wrong thing. Logged, though, and not swallowed: an earlier version of
+// this returned nil on every error path, which made it impossible to tell
+// a passing check from one that never ran -- it sat inert in production
+// against an interface that genuinely was preempted, and looked identical
+// to healthy.
+func checkNotPreemptedOne(l netlink.Link) error {
+	name := l.Attrs().Name
+
+	ids, err := tcxQueryFn(l.Attrs().Index)
 	if err != nil {
-		// A kernel without BPF_PROG_QUERY for tcx cannot have a tcx
-		// program to be preempted by either, so this is not a datapath
-		// fault. Reporting it as one would make every such node
-		// permanently unhealthy over a condition it cannot have.
+		if errors.Is(err, ebpf.ErrNotSupported) {
+			// A kernel with no tcx cannot have a tcx program to be
+			// preempted by, so there is nothing to report and nothing
+			// to warn about either.
+			return nil
+		}
+		slog.Warn("attach: health: could not check whether another tc program precedes this datapath",
+			"interface", name, "err", err)
 		return nil
 	}
 	if len(ids) == 0 {
@@ -300,14 +341,13 @@ func checkNotPreemptedOne(name string) error {
 
 	first, err := programNameFn(ids[0])
 	if err != nil {
-		// The program is attached but its name is unreadable. Do not
-		// claim preemption on that basis: a false unhealthy here would
-		// point an operator at the wrong thing entirely.
+		slog.Warn("attach: health: a tc program precedes this datapath but could not be identified",
+			"interface", name, "err", err)
 		return nil
 	}
 	if first == prog.UsidProgUsidIngress || first == prog.UsidProgUsidEgress {
 		return nil
 	}
 	return fmt.Errorf("tc program %q runs ahead of this datapath (tcx precedes clsact), "+
-		"so traffic it consumes never reaches usid_ingress", first)
+		"so traffic it consumes never reaches usid_egress", first)
 }

--- a/internal/plumbing/ebpf/attach/health_test.go
+++ b/internal/plumbing/ebpf/attach/health_test.go
@@ -323,89 +323,179 @@ func TestHealth_RealDatapath_FlipsAfterAttachIsKilled(t *testing.T) {
 	t.Logf("Health() correctly flipped to unhealthy after objs.Close(): %v", err)
 }
 
+// testForeignProgram is a stand-in for another CNI's tc program, named as
+// one really is so the assertions read like the log line an operator sees.
+const testForeignProgram = "cil_from_netdev"
+
+// preemptTestLink is one owned interface: it carries the usid_egress
+// filter, which is what marks it as this datapath's own.
+func preemptTestLink(name string, index int) netlink.Link {
+	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name, Index: index}}
+}
+
 // TestCheckNotPreempted covers the condition that makes this datapath
-// silently invisible: another CNI attaching tcx to an interface this one
-// owns. tcx runs ahead of clsact, so such a program decides the packet's
-// fate before usid_ingress is invoked, and this side sees a clean zero
-// rather than a drop.
-//
-// Every case here is about which of those readings is worth calling
-// unhealthy. Reporting one wrongly points an operator at the datapath when
-// the fault is elsewhere, or worse, marks a healthy node down.
+// silently invisible: another CNI's tcx program on an interface this one
+// owns. tcx runs ahead of clsact, so it decides the packet's fate before
+// usid_egress is invoked, and this side sees a clean zero rather than a
+// drop.
 func TestCheckNotPreempted(t *testing.T) {
-	origLinkByName := linkByNameFn
+	origLinkList := linkListFn
+	origFilterList := filterListFn
 	origTCXQuery := tcxQueryFn
 	origProgramName := programNameFn
 	t.Cleanup(func() {
-		linkByNameFn = origLinkByName
+		linkListFn = origLinkList
+		filterListFn = origFilterList
 		tcxQueryFn = origTCXQuery
 		programNameFn = origProgramName
 	})
 
-	dummyLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: testIfaceEth0, Index: 7}}
-	linkByNameFn = func(string) (netlink.Link, error) { return dummyLink, nil }
+	owned := preemptTestLink("G000000002abcH", 7)
+	linkListFn = func() ([]netlink.Link, error) { return []netlink.Link{owned}, nil }
+	filterListFn = func(netlink.Link, uint32) ([]netlink.Filter, error) {
+		return []netlink.Filter{&netlink.BpfFilter{Name: egressFilterName}}, nil
+	}
 
 	t.Run("no tcx program means clsact is first", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return nil, nil }
-		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+		if err := checkNotPreempted(); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil with no tcx program attached", err)
 		}
 	})
 
 	t.Run("a foreign tcx program in front is unhealthy", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{101}, nil }
-		programNameFn = func(ebpf.ProgramID) (string, error) { return "cil_from_netdev", nil }
-		err := checkNotPreempted([]string{testIfaceEth0})
+		programNameFn = func(ebpf.ProgramID) (string, error) { return testForeignProgram, nil }
+		err := checkNotPreempted()
 		if err == nil {
 			t.Fatal("checkNotPreempted() error = nil, want an error for a foreign tcx program")
 		}
-		// The offender's name is the whole diagnostic value: without it an
-		// operator learns only that something is wrong.
-		if !strings.Contains(err.Error(), "cil_from_netdev") {
+		// The offender's name and the interface are the whole diagnostic
+		// value: without them an operator learns only that something is
+		// wrong somewhere.
+		if !strings.Contains(err.Error(), testForeignProgram) {
 			t.Errorf("checkNotPreempted() error = %q, want it to name the preempting program", err)
 		}
-		if !strings.Contains(err.Error(), testIfaceEth0) {
+		if !strings.Contains(err.Error(), "G000000002abcH") {
 			t.Errorf("checkNotPreempted() error = %q, want it to name the interface", err)
 		}
 	})
 
-	// Keeps this correct if this package moves to tcx itself: its own
-	// program running first is the desired end state, not a fault.
+	// Keeps this correct if this package moves to tcx itself, which is the
+	// intended direction: its own program running first is the end state,
+	// not a fault.
 	t.Run("this datapath first in the tcx chain is healthy", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{202, 203}, nil }
 		programNameFn = func(id ebpf.ProgramID) (string, error) {
 			if id == 202 {
-				return prog.UsidProgUsidIngress, nil
+				return prog.UsidProgUsidEgress, nil
 			}
-			return "cil_from_netdev", nil
+			return testForeignProgram, nil
 		}
-		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+		if err := checkNotPreempted(); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil when this datapath is first", err)
 		}
 	})
+}
 
-	// A kernel with no tcx query support cannot have a tcx program to be
-	// preempted by. Reporting that as a datapath fault would hold such a
-	// node permanently unhealthy over a condition it cannot have.
-	t.Run("query unsupported is not a datapath fault", func(t *testing.T) {
-		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) {
-			return nil, errors.New("simulated: BPF_PROG_QUERY unsupported")
-		}
-		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
-			t.Errorf("checkNotPreempted() error = %v, want nil when the query is unsupported", err)
+// TestCheckNotPreempted_OnlyOwnedInterfaces is the scoping this check got
+// wrong once, and the reason it is worth its own test. A shared uplink
+// carries another CNI's tcx program as a matter of course -- it is that
+// CNI's interface too, and this datapath's receive classification happens
+// on a bond's slaves rather than the master. Checking such an interface
+// reported every node in a fleet unhealthy over the ordinary arrangement.
+//
+// The discriminator is the usid_egress filter: present means this datapath
+// owns the interface exclusively, absent means it does not.
+func TestCheckNotPreempted_OnlyOwnedInterfaces(t *testing.T) {
+	origLinkList := linkListFn
+	origFilterList := filterListFn
+	origTCXQuery := tcxQueryFn
+	origProgramName := programNameFn
+	t.Cleanup(func() {
+		linkListFn = origLinkList
+		filterListFn = origFilterList
+		tcxQueryFn = origTCXQuery
+		programNameFn = origProgramName
+	})
+
+	uplink := preemptTestLink("bond0", 2)
+	linkListFn = func() ([]netlink.Link, error) { return []netlink.Link{uplink}, nil }
+	// An uplink carries usid_ingress, never usid_egress.
+	filterListFn = func(netlink.Link, uint32) ([]netlink.Filter, error) {
+		return []netlink.Filter{&netlink.BpfFilter{Name: filterName}}, nil
+	}
+	tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{101}, nil }
+	programNameFn = func(ebpf.ProgramID) (string, error) { return testForeignProgram, nil }
+
+	if err := checkNotPreempted(); err != nil {
+		t.Errorf("checkNotPreempted() error = %v, want nil: a shared uplink is not this datapath's "+
+			"to own, and another CNI's program there is expected", err)
+	}
+}
+
+// TestCheckNotPreempted_LookupFailuresDoNotFailHealth pins the handling of
+// this check's own inability to run. It is a diagnostic, and a failed query
+// says nothing about whether the datapath is carrying traffic, so health
+// must not turn on it.
+//
+// An earlier version returned nil on every error path, which made a passing
+// check indistinguishable from one that never ran -- and it did never run,
+// sitting inert in production against an interface that genuinely was
+// preempted. These paths now log, which is what makes the difference
+// observable; the assertion here is only that they do not fail health.
+func TestCheckNotPreempted_LookupFailuresDoNotFailHealth(t *testing.T) {
+	origLinkList := linkListFn
+	origFilterList := filterListFn
+	origTCXQuery := tcxQueryFn
+	origProgramName := programNameFn
+	t.Cleanup(func() {
+		linkListFn = origLinkList
+		filterListFn = origFilterList
+		tcxQueryFn = origTCXQuery
+		programNameFn = origProgramName
+	})
+
+	owned := preemptTestLink("G000000002abcH", 7)
+	linkListFn = func() ([]netlink.Link, error) { return []netlink.Link{owned}, nil }
+	filterListFn = func(netlink.Link, uint32) ([]netlink.Filter, error) {
+		return []netlink.Filter{&netlink.BpfFilter{Name: egressFilterName}}, nil
+	}
+
+	t.Run("tcx unsupported", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return nil, ebpf.ErrNotSupported }
+		if err := checkNotPreempted(); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil on a kernel without tcx", err)
 		}
 	})
 
-	// An attached program whose name cannot be read is not evidence of
-	// preemption by anything in particular, and a guess here would send an
-	// operator after the wrong component.
-	t.Run("unreadable program name does not claim preemption", func(t *testing.T) {
+	t.Run("query fails for another reason", func(t *testing.T) {
+		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) {
+			return nil, errors.New("simulated: query failed")
+		}
+		if err := checkNotPreempted(); err != nil {
+			t.Errorf("checkNotPreempted() error = %v, want nil when the query itself fails", err)
+		}
+	})
+
+	t.Run("program name unreadable", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{404}, nil }
 		programNameFn = func(ebpf.ProgramID) (string, error) {
 			return "", errors.New("simulated: program vanished")
 		}
-		if err := checkNotPreempted([]string{testIfaceEth0}); err != nil {
+		if err := checkNotPreempted(); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil when the name is unreadable", err)
+		}
+	})
+
+	// Listing links is this check's own precondition, not a per-interface
+	// diagnostic, so unlike the cases above it does surface.
+	t.Run("listing links fails", func(t *testing.T) {
+		linkListFn = func() ([]netlink.Link, error) {
+			return nil, errors.New("simulated: netlink down")
+		}
+		if err := checkNotPreempted(); err == nil {
+			t.Error("checkNotPreempted() error = nil, want an error when links cannot be listed")
 		}
 	})
 }


### PR DESCRIPTION
The check added in #513 was wrong twice, and the two faults hid each other.

**It never fired.** Every error path returned nil, so a passing check and one that never ran looked identical. In production it never ran. Deployed on eris, whose `bond0` carries both programs:

```
bond0(2) tcx/ingress    cil_from_netdev
bond0(2) clsact/ingress galactic_usid_ingress
```

`bond0` is in the resolved interface set, so the check should have reported. It reported nothing and the health service stayed serving. I built #513 to catch silent-invisible failures and gave it one.

**Had it fired it would have been wrong anyway.** It checked the shared uplinks `usid_ingress` attaches to, where another CNI's program is expected: the interface is that CNI's too, and this datapath's receive classification happens on a bond's slaves rather than on the master a cluster CNI attaches to, so a tcx program there is not in the way of anything. Every node in the fleet would have gone unhealthy over the ordinary arrangement.

## Scope

Restricted to interfaces this datapath owns exclusively, enumerated by the presence of its own `usid_egress` filter rather than from a caller-supplied list. An interface carrying that filter is by definition one of ours, so the set defines itself and cannot drift out of step with what is actually attached.

## Visibility

A tcx query that fails, or a program that cannot be named, still must not fail health: this is a diagnostic, and its own inability to run says nothing about whether the datapath is carrying traffic. Those paths now log, which is the difference between a check that is passing and one that is silently dead.

Only listing links surfaces as an error, being the check's own precondition rather than a per-interface diagnostic. A kernel without tcx stays silent, having no tcx program to be preempted by.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. The scoping now has its own test, since that is the fault worth pinning: a shared uplink carrying a foreign tcx program must read healthy, an owned interface carrying one must not.
