### PR TITLE
fix(attach): report preemption by program id, which needs no privilege

### DIFF
--- a/internal/plumbing/ebpf/attach/health.go
+++ b/internal/plumbing/ebpf/attach/health.go
@@ -53,7 +53,7 @@ func Health(objs *prog.UsidObjects, ifaces []string) error {
 		checkProgramReachable(objs.UsidIngress),
 		checkMapsReachable(objs),
 		checkAttached(ifaces),
-		checkNotPreempted(),
+		checkNotPreempted(ownProgramIDs(objs)),
 	)
 }
 
@@ -249,6 +249,37 @@ var programNameFn = func(id ebpf.ProgramID) (string, error) {
 	return info.Name, nil
 }
 
+// ownProgramIDs returns the kernel ids of this datapath's own programs, for
+// checkNotPreempted to recognize itself by.
+//
+// By id rather than by name, because reading a name means opening the
+// program by id, and BPF_PROG_GET_FD_BY_ID wants CAP_SYS_ADMIN or
+// CAP_PERFMON. This container carries neither (it drops ALL and adds BPF,
+// NET_ADMIN and NET_RAW), so that call returns EPERM here. An id needs no
+// such privilege: it comes from BPF_OBJ_GET_INFO_BY_FD on a descriptor
+// this process already holds.
+//
+// Getting this wrong is what made the first version of this check useless.
+// It compared names, could not read them, and treated the failure as
+// nothing to report -- so it sat inert on a node that genuinely was
+// preempted.
+func ownProgramIDs(objs *prog.UsidObjects) map[ebpf.ProgramID]struct{} {
+	out := make(map[ebpf.ProgramID]struct{}, 2)
+	for _, p := range []*ebpf.Program{objs.UsidIngress, objs.UsidEgress} {
+		if p == nil {
+			continue
+		}
+		info, err := p.Info()
+		if err != nil {
+			continue
+		}
+		if id, ok := info.ID(); ok {
+			out[id] = struct{}{}
+		}
+	}
+	return out
+}
+
 // checkNotPreempted confirms nothing runs ahead of this datapath on the
 // interfaces it owns exclusively.
 //
@@ -276,7 +307,7 @@ var programNameFn = func(id ebpf.ProgramID) (string, error) {
 // interface carrying this package's own usid_egress filter is by definition
 // one this datapath owns, so the set defines itself and cannot drift out of
 // step with what is actually attached.
-func checkNotPreempted() error {
+func checkNotPreempted(own map[ebpf.ProgramID]struct{}) error {
 	links, err := linkListFn()
 	if err != nil {
 		return fmt.Errorf("attach: health: list links to check for preemption: %w", err)
@@ -287,7 +318,7 @@ func checkNotPreempted() error {
 		if !hasEgressFilter(l) {
 			continue
 		}
-		if err := checkNotPreemptedOne(l); err != nil {
+		if err := checkNotPreemptedOne(l, own); err != nil {
 			errs = append(errs, fmt.Errorf("attach: health: interface %q: %w", l.Attrs().Name, err))
 		}
 	}
@@ -312,15 +343,18 @@ func hasEgressFilter(l netlink.Link) bool {
 // checkNotPreemptedOne reports whether anything precedes this datapath on
 // one owned interface.
 //
+// Reported by program id, with a name only when one can be read. The id
+// alone is enough to act on (`bpftool prog show id N` names it), and
+// insisting on the name is what left the first version of this check
+// unable to report anything at all -- see ownProgramIDs.
+//
 // A failure to look is logged rather than returned. This check is a
 // diagnostic, and its own inability to run says nothing about whether the
 // datapath is carrying traffic, so failing health on it would report the
-// wrong thing. Logged, though, and not swallowed: an earlier version of
-// this returned nil on every error path, which made it impossible to tell
-// a passing check from one that never ran -- it sat inert in production
-// against an interface that genuinely was preempted, and looked identical
-// to healthy.
-func checkNotPreemptedOne(l netlink.Link) error {
+// wrong thing. Logged, though, and not swallowed: silence that could mean
+// either "nothing is wrong" or "this never ran" is what allowed an inert
+// check to look identical to a passing one.
+func checkNotPreemptedOne(l netlink.Link, own map[ebpf.ProgramID]struct{}) error {
 	name := l.Attrs().Name
 
 	ids, err := tcxQueryFn(l.Attrs().Index)
@@ -339,15 +373,19 @@ func checkNotPreemptedOne(l netlink.Link) error {
 		return nil // nothing in front of clsact
 	}
 
-	first, err := programNameFn(ids[0])
-	if err != nil {
-		slog.Warn("attach: health: a tc program precedes this datapath but could not be identified",
-			"interface", name, "err", err)
+	first := ids[0]
+	if _, ours := own[first]; ours {
 		return nil
 	}
-	if first == prog.UsidProgUsidIngress || first == prog.UsidProgUsidEgress {
-		return nil
+
+	// Best effort, and expected to fail without CAP_SYS_ADMIN or
+	// CAP_PERFMON. The id carries the report either way.
+	if progName, nerr := programNameFn(first); nerr == nil {
+		return fmt.Errorf("tc program %q (id %d) runs ahead of this datapath "+
+			"(tcx precedes clsact), so traffic it consumes never reaches usid_egress",
+			progName, first)
 	}
-	return fmt.Errorf("tc program %q runs ahead of this datapath (tcx precedes clsact), "+
-		"so traffic it consumes never reaches usid_egress", first)
+	return fmt.Errorf("an unidentified tc program (id %d) runs ahead of this datapath "+
+		"(tcx precedes clsact), so traffic it consumes never reaches usid_egress; "+
+		"run `bpftool prog show id %d` to name it", first, first)
 }

--- a/internal/plumbing/ebpf/attach/health_test.go
+++ b/internal/plumbing/ebpf/attach/health_test.go
@@ -358,7 +358,7 @@ func TestCheckNotPreempted(t *testing.T) {
 
 	t.Run("no tcx program means clsact is first", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return nil, nil }
-		if err := checkNotPreempted(); err != nil {
+		if err := checkNotPreempted(nil); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil with no tcx program attached", err)
 		}
 	})
@@ -366,7 +366,7 @@ func TestCheckNotPreempted(t *testing.T) {
 	t.Run("a foreign tcx program in front is unhealthy", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{101}, nil }
 		programNameFn = func(ebpf.ProgramID) (string, error) { return testForeignProgram, nil }
-		err := checkNotPreempted()
+		err := checkNotPreempted(nil)
 		if err == nil {
 			t.Fatal("checkNotPreempted() error = nil, want an error for a foreign tcx program")
 		}
@@ -384,15 +384,16 @@ func TestCheckNotPreempted(t *testing.T) {
 	// Keeps this correct if this package moves to tcx itself, which is the
 	// intended direction: its own program running first is the end state,
 	// not a fault.
+	// Recognized by id, not name: reading a name needs a privilege the node
+	// agent does not hold, so an id comparison is the only one that works
+	// in production.
 	t.Run("this datapath first in the tcx chain is healthy", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{202, 203}, nil }
-		programNameFn = func(id ebpf.ProgramID) (string, error) {
-			if id == 202 {
-				return prog.UsidProgUsidEgress, nil
-			}
-			return testForeignProgram, nil
+		programNameFn = func(ebpf.ProgramID) (string, error) {
+			return "", errors.New("simulated: EPERM, as in production")
 		}
-		if err := checkNotPreempted(); err != nil {
+		own := map[ebpf.ProgramID]struct{}{202: {}}
+		if err := checkNotPreempted(own); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil when this datapath is first", err)
 		}
 	})
@@ -428,7 +429,7 @@ func TestCheckNotPreempted_OnlyOwnedInterfaces(t *testing.T) {
 	tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{101}, nil }
 	programNameFn = func(ebpf.ProgramID) (string, error) { return testForeignProgram, nil }
 
-	if err := checkNotPreempted(); err != nil {
+	if err := checkNotPreempted(nil); err != nil {
 		t.Errorf("checkNotPreempted() error = %v, want nil: a shared uplink is not this datapath's "+
 			"to own, and another CNI's program there is expected", err)
 	}
@@ -464,7 +465,7 @@ func TestCheckNotPreempted_LookupFailuresDoNotFailHealth(t *testing.T) {
 
 	t.Run("tcx unsupported", func(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return nil, ebpf.ErrNotSupported }
-		if err := checkNotPreempted(); err != nil {
+		if err := checkNotPreempted(nil); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil on a kernel without tcx", err)
 		}
 	})
@@ -473,20 +474,14 @@ func TestCheckNotPreempted_LookupFailuresDoNotFailHealth(t *testing.T) {
 		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) {
 			return nil, errors.New("simulated: query failed")
 		}
-		if err := checkNotPreempted(); err != nil {
+		if err := checkNotPreempted(nil); err != nil {
 			t.Errorf("checkNotPreempted() error = %v, want nil when the query itself fails", err)
 		}
 	})
 
-	t.Run("program name unreadable", func(t *testing.T) {
-		tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{404}, nil }
-		programNameFn = func(ebpf.ProgramID) (string, error) {
-			return "", errors.New("simulated: program vanished")
-		}
-		if err := checkNotPreempted(); err != nil {
-			t.Errorf("checkNotPreempted() error = %v, want nil when the name is unreadable", err)
-		}
-	})
+	// An unreadable name is deliberately absent here: it must still report,
+	// by id. That is the production case, covered by
+	// TestCheckNotPreempted_ReportsByIDWhenNameIsUnreadable.
 
 	// Listing links is this check's own precondition, not a per-interface
 	// diagnostic, so unlike the cases above it does surface.
@@ -494,8 +489,55 @@ func TestCheckNotPreempted_LookupFailuresDoNotFailHealth(t *testing.T) {
 		linkListFn = func() ([]netlink.Link, error) {
 			return nil, errors.New("simulated: netlink down")
 		}
-		if err := checkNotPreempted(); err == nil {
+		if err := checkNotPreempted(nil); err == nil {
 			t.Error("checkNotPreempted() error = nil, want an error when links cannot be listed")
 		}
 	})
+}
+
+// TestCheckNotPreempted_ReportsByIDWhenNameIsUnreadable is the production
+// case, and the one the first two versions of this check got wrong.
+//
+// Naming a program means opening it by id, and BPF_PROG_GET_FD_BY_ID wants
+// CAP_SYS_ADMIN or CAP_PERFMON. The node agent holds neither, so that call
+// returns EPERM on every real node. Measured with a foreign program
+// deliberately attached to an owned tap: the check logged "could not be
+// identified: get program by id: operation not permitted" every ten
+// seconds and never reported the preemption itself.
+//
+// So the id has to carry the report. It is enough to act on, and unlike a
+// name it needs no privilege at all.
+func TestCheckNotPreempted_ReportsByIDWhenNameIsUnreadable(t *testing.T) {
+	origLinkList := linkListFn
+	origFilterList := filterListFn
+	origTCXQuery := tcxQueryFn
+	origProgramName := programNameFn
+	t.Cleanup(func() {
+		linkListFn = origLinkList
+		filterListFn = origFilterList
+		tcxQueryFn = origTCXQuery
+		programNameFn = origProgramName
+	})
+
+	owned := preemptTestLink("G000000002abcH", 7)
+	linkListFn = func() ([]netlink.Link, error) { return []netlink.Link{owned}, nil }
+	filterListFn = func(netlink.Link, uint32) ([]netlink.Filter, error) {
+		return []netlink.Filter{&netlink.BpfFilter{Name: egressFilterName}}, nil
+	}
+	tcxQueryFn = func(int) ([]ebpf.ProgramID, error) { return []ebpf.ProgramID{31401}, nil }
+	programNameFn = func(ebpf.ProgramID) (string, error) {
+		return "", errors.New("get program by id: operation not permitted")
+	}
+
+	err := checkNotPreempted(nil)
+	if err == nil {
+		t.Fatal("checkNotPreempted() error = nil, want a report even though the name is unreadable")
+	}
+	// The id is the actionable part, so it must appear.
+	if !strings.Contains(err.Error(), "31401") {
+		t.Errorf("checkNotPreempted() error = %q, want it to carry the program id", err)
+	}
+	if !strings.Contains(err.Error(), "G000000002abcH") {
+		t.Errorf("checkNotPreempted() error = %q, want it to name the interface", err)
+	}
 }


### PR DESCRIPTION
#514 made this check log why it could not finish. On the first node it ran on, it said so every ten seconds:

```
WARN attach: health: a tc program precedes this datapath but could not be identified
     interface=G00000000leS9H err="get program by id: operation not permitted"
```

Measured with a foreign tcx program deliberately attached to an owned tap, then detached. The query found the program. Naming it is what failed.

Naming means opening the program by id, and `BPF_PROG_GET_FD_BY_ID` wants `CAP_SYS_ADMIN` or `CAP_PERFMON`. The container drops ALL and adds `BPF, NET_ADMIN, NET_RAW`:

```
capabilities: {"add": ["BPF", "NET_ADMIN", "NET_RAW"], "drop": ["ALL"]}
```

So the name is unavailable on every real node, and a check that needs one to report can never report. That is what kept #513 inert, and #514 surfaced the reason without removing the dependency.

## The fix

Report by id. It comes back from the query itself with no privilege, and `bpftool prog show id N` turns it into a name for anyone who wants one, so it carries the report alone. The name is still included when readable, as a convenience rather than a requirement.

Recognizing this datapath's own program moves to id comparison for the same reason, taken from `BPF_OBJ_GET_INFO_BY_FD` on descriptors this process already holds. That keeps working if the package moves to tcx itself, where its own program being first is the desired end state.

## The alternative

Granting the container `CAP_SYS_ADMIN`. For a diagnostic's convenience that is a bad trade: near root-equivalent, on the node agent, to read a string.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. The production case has its own test now, asserting a report is still produced when the name lookup returns EPERM, since that is the case both previous versions failed.
