### PR TITLE
fix(attach): keep preemption out of the health service

### DIFF
--- a/internal/plumbing/ebpf/attach/health.go
+++ b/internal/plumbing/ebpf/attach/health.go
@@ -53,7 +53,6 @@ func Health(objs *prog.UsidObjects, ifaces []string) error {
 		checkProgramReachable(objs.UsidIngress),
 		checkMapsReachable(objs),
 		checkAttached(ifaces),
-		checkNotPreempted(ownProgramIDs(objs)),
 	)
 }
 
@@ -205,6 +204,9 @@ func (h *Handle) Healthy() error {
 		return fmt.Errorf("attach: health: resolve interfaces: %w", err)
 	}
 
+	// Reported, never returned. See reportPreemption.
+	reportPreemption(h.Objs)
+
 	healthErr := Health(h.Objs, ifaces)
 	if healthErr != nil {
 		h.Watcher.Reconcile() // nil-safe no-op if no Watcher is wired up
@@ -278,6 +280,32 @@ func ownProgramIDs(objs *prog.UsidObjects) map[ebpf.ProgramID]struct{} {
 		}
 	}
 	return out
+}
+
+// reportPreemption logs, and deliberately does not return, whatever
+// checkNotPreempted finds.
+//
+// This must never reach the health service. Both the liveness and the
+// readiness probe point at that one service, so anything reported through
+// it restarts this container -- and a restart cannot remove another CNI's
+// program from an interface. Wiring preemption into it produced a
+// permanent crashloop: measured at six restarts in as many minutes on a
+// node with a foreign program deliberately attached, each restart
+// changing nothing about the condition that caused it.
+//
+// Every other check in Health is a condition a restart plausibly fixes,
+// since restarting reloads the programs and re-attaches them. This one is
+// not, so it belongs in the log next to the other things an operator reads
+// rather than in the signal that decides whether this container lives.
+func reportPreemption(objs *prog.UsidObjects) {
+	if objs == nil {
+		return
+	}
+	if err := checkNotPreempted(ownProgramIDs(objs)); err != nil {
+		slog.Warn("attach: health: another tc program runs ahead of this datapath; "+
+			"traffic it consumes never reaches this datapath, and restarting will not change that",
+			"err", err)
+	}
 }
 
 // checkNotPreempted confirms nothing runs ahead of this datapath on the

--- a/internal/plumbing/ebpf/attach/health_test.go
+++ b/internal/plumbing/ebpf/attach/health_test.go
@@ -541,3 +541,48 @@ func TestCheckNotPreempted_ReportsByIDWhenNameIsUnreadable(t *testing.T) {
 		t.Errorf("checkNotPreempted() error = %q, want it to name the interface", err)
 	}
 }
+
+// TestHealth_ExcludesPreemption pins the one thing about this check that
+// must not change: it does not reach the health service.
+//
+// Both the liveness and the readiness probe point at that single service,
+// so anything reported through it restarts this container. A restart
+// cannot remove another CNI's program from an interface, so wiring
+// preemption into it produced a permanent crashloop -- measured at six
+// restarts in as many minutes on a node with a foreign program attached,
+// each restart changing nothing about the condition that caused it.
+//
+// Asserted by failing the test if Health runs the tcx query at all. An
+// empty (non-nil) object set is enough to get past Health's own nil guard
+// and into the interface checks, which is where the preemption check used
+// to sit.
+func TestHealth_ExcludesPreemption(t *testing.T) {
+	origLinkByName := linkByNameFn
+	origLinkList := linkListFn
+	origFilterList := filterListFn
+	origTCXQuery := tcxQueryFn
+	t.Cleanup(func() {
+		linkByNameFn = origLinkByName
+		linkListFn = origLinkList
+		filterListFn = origFilterList
+		tcxQueryFn = origTCXQuery
+	})
+
+	owned := preemptTestLink("G000000002abcH", 7)
+	linkByNameFn = func(string) (netlink.Link, error) { return owned, nil }
+	linkListFn = func() ([]netlink.Link, error) { return []netlink.Link{owned}, nil }
+	filterListFn = func(netlink.Link, uint32) ([]netlink.Filter, error) {
+		return []netlink.Filter{
+			&netlink.BpfFilter{Name: filterName},
+			&netlink.BpfFilter{Name: egressFilterName},
+		}, nil
+	}
+	tcxQueryFn = func(int) ([]ebpf.ProgramID, error) {
+		t.Error("Health ran the preemption check; it must never gate the health service, " +
+			"which drives both liveness and readiness")
+		return nil, nil
+	}
+
+	// Errors about nil programs and maps are expected and irrelevant here.
+	_ = Health(&prog.UsidObjects{}, []string{"G000000002abcH"})
+}


### PR DESCRIPTION
Both the liveness and the readiness probe point at the one gRPC health service:

```
liveness={"port":5180,"service":"ebpf-datapath"}
readiness={"port":5180,"service":"ebpf-datapath"}
```

So anything reported through it restarts this container. A restart cannot remove another CNI's program from an interface, so reporting preemption there produced a permanent crashloop. Measured on eris with a foreign tcx program deliberately attached, then detached: six restarts in as many minutes, each changing nothing about the condition that caused it.

```
Warning Unhealthy  Liveness probe failed: service unhealthy (responded with "NOT_SERVING")
Normal  Killing    Container credential-refresh failed liveness probe, will be restarted
```

Every other check in `Health` is a condition a restart plausibly fixes, because restarting reloads the programs and re-attaches them. This one is not.

## The fix

It logs, next to the other things an operator reads, and stops deciding whether the container lives.

The detection itself was right and is unchanged. Within ten seconds of the program being attached it named the interface, carried the program id, and explained the mechanism:

```
an unidentified tc program (id 31401) runs ahead of this datapath (tcx precedes
clsact), so traffic it consumes never reaches usid_egress; run `bpftool prog
show id 31401` to name it
```

Only its consequence was wrong.

## Testing

`task lint` 0 issues, `task test:unit` 57 packages. A test now fails if `Health` runs the tcx query at all, since the point is that this check sits outside that path. An empty non-nil object set gets past `Health`'s nil guard and into the interface checks, which is where it used to sit.
