### PR TITLE
chore: Make networking the code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @datum-cloud/engineering
+* @datum-cloud/networking


### PR DESCRIPTION
## Summary

The organisation's teams now map one team to each service, and this repository belongs to networking.

Its code owner still named the whole-organisation engineering team, so review requests went to everyone rather than to the people who work here.

Reviews now go to networking.

The team's write access on this repository arrives through a separate change to the organisation declaration, and until that applies GitHub lists the owner as unknown.

## Test plan

- [ ] A new pull request requests review from networking
- [ ] GitHub reports no code owner errors once the team holds write access

Related to https://github.com/datum-cloud/infra/pull/4651

https://claude.ai/code/session_01NuAdj3Uxb5hCKPeskc2XYZ
