### PR TITLE
fix(ingresssidecar): keep a route a second EndpointSlice still claims

### DIFF
--- a/internal/ingresssidecar/store.go
+++ b/internal/ingresssidecar/store.go
@@ -250,14 +250,24 @@ func (s *Store) Sweep(ctx context.Context, now time.Time) {
 		}
 		if r.installed {
 			v, ok := s.vrfs[r.vpc]
-			if !ok {
+			switch {
+			case !ok:
 				slog.Error("ingresssidecar: sweep found route with no tracked VRF", "key", key, "vpc", r.vpc)
-			} else if err := s.backend.RemoveRoute(r.prefix, v.tableID); err != nil {
-				s.countError("remove_route")
-				slog.Error("ingresssidecar: remove route", "key", key, "vpc", r.vpc, "error", err)
-				liveVPCs[r.vpc] = struct{}{} // keep the VPC alive; retry next sweep
-				pendingRoutes++
-				continue
+			case s.prefixClaimedByOtherLocked(key, r.vpc, r.prefix, now):
+				// Hand the kernel route over instead of deleting it -- see
+				// prefixClaimedByOtherLocked's own doc comment. This key is
+				// still forgotten below; only the removal is skipped.
+				slog.Info("ingresssidecar: expired route still claimed by another EndpointSlice, keeping kernel route",
+					"key", key, "vpc", r.vpc, "prefix", r.prefix.String())
+				liveVPCs[r.vpc] = struct{}{}
+			default:
+				if err := s.backend.RemoveRoute(r.prefix, v.tableID); err != nil {
+					s.countError("remove_route")
+					slog.Error("ingresssidecar: remove route", "key", key, "vpc", r.vpc, "error", err)
+					liveVPCs[r.vpc] = struct{}{} // keep the VPC alive; retry next sweep
+					pendingRoutes++
+					continue
+				}
 			}
 			s.routeActiveDelta(-1)
 		}
@@ -348,6 +358,33 @@ func (s *Store) Inventory(ctx context.Context, now time.Time) error {
 		}
 	}
 	return nil
+}
+
+// prefixClaimedByOtherLocked reports whether any route other than
+// excludeKey still claims vpc/prefix and is not itself expiring in this
+// same sweep -- either still desired (zero absentSince) or still inside its
+// own grace period as of now. Callers must hold s.mu.
+//
+// Store tracks routes by EndpointSlice key while the kernel addresses them
+// by prefix+table, so two keys can legitimately name one underlying route:
+// an EndpointSlice republished under a new name has both entries live until
+// the old object is deleted. Removing the kernel route when the first key
+// expires strands the survivor -- its routeState still records installed,
+// so SetDesired no-ops, no backend call ever fails, and nothing reinstalls
+// the route until the process restarts and SeedFromAPI rebuilds it from
+// scratch. SeedFromAPI's own doc comment describes the same prefix-versus-
+// key mismatch for Inventory's synthetic "boot/..." keys; this is that
+// hazard between two real keys.
+func (s *Store) prefixClaimedByOtherLocked(excludeKey, vpc string, prefix *net.IPNet, now time.Time) bool {
+	for key, r := range s.routes {
+		if key == excludeKey || r.vpc != vpc || r.prefix.String() != prefix.String() {
+			continue
+		}
+		if r.absentSince.IsZero() || now.Sub(r.absentSince) < s.grace {
+			return true
+		}
+	}
+	return false
 }
 
 // routeKnownLocked reports whether some already-tracked route shares vpc

--- a/internal/ingresssidecar/store_test.go
+++ b/internal/ingresssidecar/store_test.go
@@ -272,3 +272,91 @@ var errTest = &testError{"boom"}
 type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
+
+// TestStoreSweepKeepsPrefixClaimedByAnotherKey verifies that expiring one
+// EndpointSlice key does not delete a kernel route a second, still-live key
+// claims for the same VPC and prefix. Two keys legitimately name one
+// underlying route while an EndpointSlice is being republished under a new
+// name, and the kernel addresses routes by prefix+table rather than by
+// Store's key -- so an unguarded removal strands the survivor with
+// installed still set and nothing left to reinstall it.
+func TestStoreSweepKeepsPrefixClaimedByAnotherKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		survivorAbsent bool
+		wantRoutes     int
+	}{
+		{"SurvivorStillDesired", false, 1},
+		{"SurvivorWithinItsOwnGrace", true, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			backend := newFakeBackend()
+			store := NewStore(backend, testGrace, nil)
+
+			prefix := mustPrefix(t, "fd00::3")
+			desired := &DesiredRoute{VPC: testVPC1, Prefix: prefix, SID: net.ParseIP("fd00:99::1")}
+			for _, key := range []string{"ns/old-name", "ns/new-name"} {
+				if err := store.SetDesired(ctx, key, desired); err != nil {
+					t.Fatalf("SetDesired(%s): %v", key, err)
+				}
+			}
+			if got := backend.routeCount(); got != 1 {
+				t.Fatalf("routeCount after both keys = %d, want 1", got)
+			}
+
+			start := time.Now()
+			if err := store.SetDesired(ctx, "ns/old-name", nil); err != nil {
+				t.Fatalf("SetDesired(old, nil): %v", err)
+			}
+			if tt.survivorAbsent {
+				// Marked absent later, so it is still inside its own grace
+				// when the old key's has already elapsed.
+				store.routes["ns/new-name"].absentSince = start.Add(testGrace)
+			}
+
+			store.Sweep(ctx, start.Add(testGrace+time.Second))
+
+			if got := backend.routeCount(); got != tt.wantRoutes {
+				t.Errorf("routeCount after sweep = %d, want %d", got, tt.wantRoutes)
+			}
+			if _, ok := store.routes["ns/old-name"]; ok {
+				t.Error("expired key ns/old-name still tracked after sweep")
+			}
+			if _, ok := store.routes["ns/new-name"]; !ok {
+				t.Error("surviving key ns/new-name dropped by sweep")
+			}
+		})
+	}
+}
+
+// TestStoreSweepRemovesPrefixOnceLastKeyExpires verifies the guard added by
+// TestStoreSweepKeepsPrefixClaimedByAnotherKey does not leak the kernel
+// route: once every key claiming the prefix has expired, it is removed.
+func TestStoreSweepRemovesPrefixOnceLastKeyExpires(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend()
+	store := NewStore(backend, testGrace, nil)
+
+	prefix := mustPrefix(t, "fd00::3")
+	desired := &DesiredRoute{VPC: testVPC1, Prefix: prefix, SID: net.ParseIP("fd00:99::1")}
+	for _, key := range []string{"ns/old-name", "ns/new-name"} {
+		if err := store.SetDesired(ctx, key, desired); err != nil {
+			t.Fatalf("SetDesired(%s): %v", key, err)
+		}
+	}
+
+	start := time.Now()
+	for _, key := range []string{"ns/old-name", "ns/new-name"} {
+		if err := store.SetDesired(ctx, key, nil); err != nil {
+			t.Fatalf("SetDesired(%s, nil): %v", key, err)
+		}
+	}
+
+	store.Sweep(ctx, start.Add(testGrace+time.Second))
+
+	if got := backend.routeCount(); got != 0 {
+		t.Errorf("routeCount after both keys expired = %d, want 0", got)
+	}
+}

--- a/internal/ingresssidecar/store_test.go
+++ b/internal/ingresssidecar/store_test.go
@@ -22,11 +22,13 @@ func mustPrefix(t *testing.T, s string) *net.IPNet {
 
 const testGrace = 10 * time.Second
 
-// testVPC1, testPodName, and testMalformedTenantID are fixture values
-// shared across this package's tests.
+// testVPC1, testPodName, testOldKey, testNewKey, and testMalformedTenantID
+// are fixture values shared across this package's tests.
 const (
 	testVPC1    = "vpc1"
 	testPodName = "pod-a"
+	testOldKey  = "ns/old-name"
+	testNewKey  = "ns/new-name"
 	// testMalformedTenantID has no "-" separator, so
 	// crdnames.ParseTenantIdentifier rejects it -- used by both
 	// controller_test.go and seed_test.go to build a selected-but-
@@ -297,7 +299,7 @@ func TestStoreSweepKeepsPrefixClaimedByAnotherKey(t *testing.T) {
 
 			prefix := mustPrefix(t, "fd00::3")
 			desired := &DesiredRoute{VPC: testVPC1, Prefix: prefix, SID: net.ParseIP("fd00:99::1")}
-			for _, key := range []string{"ns/old-name", "ns/new-name"} {
+			for _, key := range []string{testOldKey, testNewKey} {
 				if err := store.SetDesired(ctx, key, desired); err != nil {
 					t.Fatalf("SetDesired(%s): %v", key, err)
 				}
@@ -307,13 +309,13 @@ func TestStoreSweepKeepsPrefixClaimedByAnotherKey(t *testing.T) {
 			}
 
 			start := time.Now()
-			if err := store.SetDesired(ctx, "ns/old-name", nil); err != nil {
+			if err := store.SetDesired(ctx, testOldKey, nil); err != nil {
 				t.Fatalf("SetDesired(old, nil): %v", err)
 			}
 			if tt.survivorAbsent {
 				// Marked absent later, so it is still inside its own grace
 				// when the old key's has already elapsed.
-				store.routes["ns/new-name"].absentSince = start.Add(testGrace)
+				store.routes[testNewKey].absentSince = start.Add(testGrace)
 			}
 
 			store.Sweep(ctx, start.Add(testGrace+time.Second))
@@ -321,10 +323,10 @@ func TestStoreSweepKeepsPrefixClaimedByAnotherKey(t *testing.T) {
 			if got := backend.routeCount(); got != tt.wantRoutes {
 				t.Errorf("routeCount after sweep = %d, want %d", got, tt.wantRoutes)
 			}
-			if _, ok := store.routes["ns/old-name"]; ok {
+			if _, ok := store.routes[testOldKey]; ok {
 				t.Error("expired key ns/old-name still tracked after sweep")
 			}
-			if _, ok := store.routes["ns/new-name"]; !ok {
+			if _, ok := store.routes[testNewKey]; !ok {
 				t.Error("surviving key ns/new-name dropped by sweep")
 			}
 		})
@@ -341,14 +343,14 @@ func TestStoreSweepRemovesPrefixOnceLastKeyExpires(t *testing.T) {
 
 	prefix := mustPrefix(t, "fd00::3")
 	desired := &DesiredRoute{VPC: testVPC1, Prefix: prefix, SID: net.ParseIP("fd00:99::1")}
-	for _, key := range []string{"ns/old-name", "ns/new-name"} {
+	for _, key := range []string{testOldKey, testNewKey} {
 		if err := store.SetDesired(ctx, key, desired); err != nil {
 			t.Fatalf("SetDesired(%s): %v", key, err)
 		}
 	}
 
 	start := time.Now()
-	for _, key := range []string{"ns/old-name", "ns/new-name"} {
+	for _, key := range []string{testOldKey, testNewKey} {
 		if err := store.SetDesired(ctx, key, nil); err != nil {
 			t.Fatalf("SetDesired(%s, nil): %v", key, err)
 		}


### PR DESCRIPTION
## Summary

A gateway pod can permanently lose its path to a healthy VPC backend, serving 503 for a member that every layer above it reports as ready. It happens whenever two EndpointSlices name the same backend address and the older one expires, taking the shared kernel route with it. The surviving slice still records that route as installed, so nothing retries, no error is raised, and the path stays dead until the pod is restarted. This change keeps the route in place while any live claimant remains, and still removes it once the last one goes.

## Why it happens

Routes are tracked per EndpointSlice but removed from the kernel by address, and those two keys are not the same thing. Two slices legitimately name one route while a slice is being republished under a new name, so whichever expires first deletes a route the other is still using. The survivor keeps its installed flag, which makes every subsequent reconcile a no-op — recovery needs a full restart, because only startup seeding rebuilds routes from scratch.

## The fix

Teardown now checks whether another live claimant still holds the same VPC and address before removing anything, and skips the removal when one does. The expired entry is forgotten either way, so nothing leaks, and the route is still removed once its last claimant expires.

## Test plan

- [x] New test reproduces the defect — fails against the current teardown with the route deleted out from under the survivor, passes with the guard
- [x] Companion test confirms the route is still removed once every claimant has expired
- [x] Existing store suite passes under the race detector
- [x] Reproduced live in the staging lab — an affected backend served 503 while its route was absent, and 200 once the route was restored

Local verification ran the store logic in an isolated harness, because this package needs generated eBPF bindings and a Linux kernel to build; CI covers the full suite.

## Follow-up

Nothing re-verifies kernel state against desired state, so a route already lost this way stays lost until the process restarts — that is what happened in staging. Worth closing separately rather than widening this change.

Refs #472. That issue describes this exact symptom and both of its acceptance criteria are violated again today, so it may be worth reopening.
