### PR TITLE
docs: Trim function docstrings to purpose and contract

### DIFF
--- a/cmd/galactic-bgp/main.go
+++ b/cmd/galactic-bgp/main.go
@@ -58,21 +58,21 @@ func newRootCommand() *cobra.Command {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes always pipe the network config JSON on
-			// stdin and close it. If stdin is an interactive terminal
-			// instead, no config will ever arrive and skel's blocking
-			// stdin read would hang forever — print version info instead.
+			// Real CNI runtimes always pipe the network config on stdin and
+			// close it. When stdin is an interactive terminal instead, no
+			// config ever arrives and the library's blocking read would hang
+			// forever, so print version info instead.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Printf("%s version %s\n", appName, metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// This plugin never enters a network namespace — it only makes
-			// k8s API calls to publish BGP advertisements. For tap-mode
-			// attachments, CNI_NETNS points at the host netns which equals
-			// this process's ambient netns, so the CNI library's same-netns
-			// rejection check would fire without the override.
+			// This plugin never enters a network namespace; it only makes API
+			// calls to publish advertisements. For a tap attachment the
+			// namespace given is the host's, which equals this process's own,
+			// so the library's same-namespace rejection would fire without the
+			// override.
 			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")
 
 			cnibgp.RunPlugin()

--- a/cmd/galactic-gateway/gateway.go
+++ b/cmd/galactic-gateway/gateway.go
@@ -18,73 +18,48 @@ import (
 	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
-// gatewayDatapathKeepAlive holds the loaded *edgeprog.EdgedsrObjects and
-// every attached link.Link (one per public-interface XDP attach target --
-// see setupGatewayDatapath's doc comment on why there can be more than one)
-// for the life of this process, once setupGatewayDatapath's attach path
-// succeeds. Neither is Closed anywhere in this file — see
-// setupGatewayDatapath's doc comment for why — but a value that isn't
-// stored somewhere reachable is exactly as good as Closed: cilium/ebpf's
-// *ebpf.Program, *ebpf.Map, and link.Link types all
-// register a runtime finalizer that closes their underlying fd once the
-// garbage collector determines nothing reachable still points at them,
-// with no error surfaced anywhere when that happens. gateway.KernelDatapath
-// only keeps objs.VipTable (via edgemap.KernelTable) alive on its own, so
-// without this package-level var, objs.EdgeLb (the program) and the
-// link.Link returned by Attach — the two things actually keeping this
-// node's XDP attachment live on the wire — would eventually get GC'd and
-// silently detached, with every control-plane signal (the DaemonSet pod
-// healthy, ApplyRule succeeding, vip_table metrics populated) still looking
-// completely normal. Confirmed live: this is exactly what happened the
-// first time this path was ever exercised against a real interface
-// (ingress traffic for a registered rule was never intercepted at all,
-// bouncing between this node and its transit-facing peer via ordinary
-// kernel routing instead) — no unit test exercises this path with a real
-// attach for a GC cycle to occur during, and this repo's own manifests-only
-// validation predates any live underlay BGP peering that would have
-// delivered real traffic to notice the gap.
+// gatewayDatapathKeepAlive holds the loaded objects and every attached link for
+// the life of this process, once the attach path succeeds.
 //
-// This var, and the rest of this file, moved here unchanged from
-// cmd/galactic-router/gateway.go: the edge Maglev/DSR gateway datapath now
-// lives in its own process rather than sharing one with the tenant BGP
-// reconcilers.
+// Nothing here is closed explicitly, but a value not stored somewhere reachable
+// is exactly as good as closed: the eBPF program, map, and link types all
+// register a finalizer that closes the underlying descriptor once the garbage
+// collector sees nothing pointing at them, with no error surfaced anywhere.
+//
+// The datapath implementation keeps only the VIP table alive on its own, so
+// without this var the program and the link, the two things actually keeping
+// this node's XDP attachment live on the wire, would eventually be collected
+// and silently detached. Every control-plane signal would still look normal:
+// the pod healthy, rules applying, metrics populated, while ingress traffic for
+// a registered rule is never intercepted at all and routes past the node
+// ordinarily.
 var gatewayDatapathKeepAlive struct {
 	objs  *edgeprog.EdgedsrObjects
 	links []link.Link
 }
 
-// setupGatewayDatapath loads and attaches the edge Maglev/DSR eBPF datapath
-// to publicInterface and returns the gateway.Datapath this node's Engine
-// should use. Unlike cmd/galactic-router's identically-named predecessor
-// (now removed), publicInterface and
-// srv6Address are both required here, not a jointly-optional pair with a
-// gateway.NoopDatapath{} fallback: config.GatewayConfig.Validate already
-// rejects either being empty before runCmd ever calls this function, since
-// this binary only exists to run the gateway role.
+// setupGatewayDatapath loads and attaches the edge Maglev datapath to
+// publicInterface and returns the Datapath this node's engine should use.
 //
-// publicInterface is usually attached to directly, but if it names a Linux
-// bonding master, edgeattach.ResolveTargets expands it to that bond's slave
-// interfaces instead (native-mode XDP cannot attach to a bonding master at
-// all) -- so this may end up loading and attaching to more than one
-// interface. Every resulting sysctl configuration and XDP attachment
-// targets the same resolved set, not publicInterface itself in that case.
+// publicInterface and srv6Address are both required: configuration validation
+// rejects either being empty before this runs, since this binary exists only to
+// run the gateway role.
 //
-// The loaded *edgeprog.EdgedsrObjects and every returned link.Link are
-// stashed in gatewayDatapathKeepAlive (see that var's doc comment for why)
-// rather than Closed here: they, and the XDP attachment itself, must
-// survive for the life of this process — same convention as
-// internal/plumbing/ebpf/attach.Start's identical choice for the SRv6 uSID
-// datapath.
+// publicInterface is usually attached to directly, but one naming a Linux
+// bonding master is expanded to that bond's slaves instead, native-mode XDP
+// being unable to attach to a bonding master. Every sysctl and every attachment
+// then targets the resolved set rather than the named interface.
 //
-// srv6Address is written into encap_config_table as this node's own plain
-// SRv6-reachable encap source -- unlike this datapath's Full-NAT
-// predecessor, it is never a NAT/SNAT source and never has return-path
-// significance (see edgedsr.c's own header comment).
+// The loaded objects and every returned link are stashed in
+// gatewayDatapathKeepAlive rather than closed here: they, and the attachment
+// itself, must survive for the life of this process.
 //
-// metricsReg additionally gets an edgemetrics.Collector registered against
-// it once objs is loaded, reading vip_table/vip_stats_table/drop_reasons
-// live at every scrape — see that package's doc comment for why this is a
-// pull-based Collector rather than incrementally-updated Gauges.
+// srv6Address is written into the encapsulation config as this node's plain
+// SRv6-reachable source. It is never a translation source and has no
+// return-path significance.
+//
+// metricsReg additionally gets a collector registered against it once the
+// objects are loaded, reading the maps live at every scrape.
 func setupGatewayDatapath(
 	publicInterface, srv6Address string, metricsReg prometheus.Registerer,
 ) (gateway.Datapath, error) {
@@ -98,18 +73,13 @@ func setupGatewayDatapath(
 		return nil, fmt.Errorf("resolve edge gateway public interface %q: %w", publicInterface, err)
 	}
 
-	// Required for bpf_fib_lookup() (edgedsr.c's push_outer_header) to
-	// ever succeed on the interface the XDP program actually runs on --
-	// see ConfigureFIBLookupUplinkSysctls's own doc comment for why (a
-	// real, previously-undiagnosed blocker, not a hypothetical one).
-	// edgedsr.c looks up ctx->ingress_ifindex, i.e. whichever interface in
-	// targets the packet actually arrived on, so this must be applied to
-	// every resolved target, not publicInterface itself -- once
-	// publicInterface names a bond, its slaves (not the bond master) are
-	// what the kernel actually reports as the ingress interface. Best-
-	// effort/non-fatal, matching this package's own established
-	// sysctl-configuration convention (internal/cni already calls
-	// ConfigureInterfaceSysctls the same way for VRF interfaces).
+	// Required for the FIB lookup in the datapath's header push to succeed
+	// on the interface the program actually runs on. The lookup uses the
+	// ingress interface, meaning whichever resolved target the packet
+	// arrived on, so this must be applied to every one of them: once the
+	// named interface is a bond, its slaves rather than the master are
+	// what the kernel reports as ingress. Best-effort and non-fatal,
+	// matching how sysctls are configured elsewhere here.
 	for _, target := range targets {
 		if err := sysctl.ConfigureFIBLookupUplinkSysctls(target); err != nil {
 			return nil, fmt.Errorf("configure IPv6 forwarding on public interface %q: %w", target, err)
@@ -146,9 +116,8 @@ func setupGatewayDatapath(
 	return datapath, nil
 }
 
-// closeAll best-effort Closes every link in links, e.g. to unwind a
-// partially-set-up datapath after edgeattach.Attach already succeeded but a
-// later setupGatewayDatapath step failed.
+// closeAll best-effort closes every link, to unwind a partially set-up datapath
+// when attaching succeeded but a later step failed.
 func closeAll(links []link.Link) {
 	for _, l := range links {
 		_ = l.Close()

--- a/cmd/galactic-gateway/main.go
+++ b/cmd/galactic-gateway/main.go
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Command galactic-gateway is the edge XDP NAT+LB gateway control plane of
-// the Galactic data plane. It loads and attaches the edge NAT+LB eBPF
-// program (internal/plumbing/ebpf/edgeprog) to a gateway node's public/
-// underlay-facing uplink interface and drives it via the
-// NetworkGateway/NetworkRule reconcilers.
+// Command galactic-gateway is the edge XDP gateway control plane. It loads and
+// attaches the edge eBPF program to a gateway node's underlay-facing uplink and
+// drives it through the NetworkGateway and NetworkRule reconcilers.
 //
-// This binary was split out of galactic-router so that a crash on either
-// side (tenant BGP vs. the XDP-holding gateway engine) no longer takes the
-// other down with it. Tenant BGP (the embedded GoBGP server and the
-// BGPRouter/BGPPeer/
-// BGPAdvertisement/BGPPolicy/BGPVRFInstance reconcilers) still runs in
-// galactic-router, co-located on the same gateway node.
+// It is a separate binary from galactic-router so that a crash on either side,
+// tenant BGP or the gateway engine holding the XDP attachment, no longer takes
+// the other down. Tenant BGP still runs in the router, co-located on the same
+// node.
 package main
 
 import (
@@ -43,20 +39,14 @@ func main() {
 	}
 }
 
-// checkWatchPermissions issues a SelfSubjectAccessReview for each resource
-// type the manager watches, checking the watch verb. If any review denies
-// the request the informer cache will never sync and all reconcilers will
-// be silently blocked; this logs a clear, actionable message at startup so
-// the problem is immediately obvious. Mirrors
-// cmd/galactic-router/main.go's identically-named function, scoped to this
-// binary's own resource set instead of the BGP-family CRDs.
+// checkWatchPermissions issues an access review for the watch verb on each
+// resource the manager watches. A denial means the informer cache never syncs
+// and every reconciler is silently blocked, so this logs a clear, actionable
+// message at startup instead.
 //
-// resourceBGPRouters is included even though this binary has no BGP
-// client of its own: internal/controller/usidresolver.go's
-// buildBackendSIDIndex lists
-// BGPRouter CRDs directly (alongside BGPAdvertisement) to resolve a
-// NetworkRule backend's SRv6 uSID, so read access to bgprouters is a real
-// RBAC requirement here regardless of not needing a BGP runtime.
+// BGPRouter is included even though this binary has no BGP client of its own:
+// resolving a backend's uSID lists those CRDs directly, so read access to them
+// is a real requirement here.
 func checkWatchPermissions(mgr ctrl.Manager) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/cmd/galactic-gateway/root.go
+++ b/cmd/galactic-gateway/root.go
@@ -38,15 +38,10 @@ const (
  Find more information at: https://www.datum.net/docs`
 )
 
-// runCmd contains the application startup logic: it loads and attaches the
-// edge NAT+LB eBPF datapath to this node's public interface and registers
-// the NetworkGateway/NetworkRule reconcilers that drive it. Unlike
-// cmd/galactic-router's runCmd, there is no BGP runtime, RuntimeManager, or
-// BGP-family reconciler here at all: NetworkGatewayReconciler/
-// NetworkRuleReconciler need no BGP client of their own — they only
-// create/update/delete BGPAdvertisement CRDs, which the co-located
-// galactic-router (default role) picks up via its own
-// BGPAdvertisementReconciler.
+// runCmd is the application startup: it loads and attaches the edge eBPF
+// datapath to this node's public interface and registers the reconcilers that
+// drive it. There is no BGP runtime here at all; the reconcilers only create
+// and delete BGPAdvertisement CRDs, which the co-located router picks up.
 func runCmd(cfg *config.GatewayConfig) error {
 	nodeName := cfg.NodeName
 	metricsPort := cfg.MetricsPort
@@ -69,19 +64,17 @@ func runCmd(cfg *config.GatewayConfig) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	// ctx's cause distinguishes a normal signal-triggered shutdown from the
-	// health server's own Serve failure below (#360) -- see the cause check
-	// after mgr.Start.
+	// The cause distinguishes a normal signal-triggered shutdown from the
+	// health server's own Serve failure below. See the cause check after the
+	// manager returns.
 	ctx, cancel := context.WithCancelCause(ctrl.SetupSignalHandler())
 	defer cancel(nil)
 
-	// Start gRPC health server. grpchealth.NewServer() defaults the ""
-	// overall-health service to SERVING, so that must be overridden to
-	// NOT_SERVING here, explicitly and immediately: otherwise a probe could
-	// see "healthy" for the entire window before the datapath below is
-	// even attached, which is exactly the failure #360 describes. Only once
-	// the datapath is attached and the rule table is reachable does this
-	// flip to SERVING, further down.
+	// The health server defaults its overall service to serving, which must be
+	// overridden to not-serving here, immediately: otherwise a probe sees
+	// healthy for the whole window before the datapath is even attached. It
+	// flips to serving further down, once the datapath is attached and the
+	// rule table is reachable.
 	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcHealthPort))
 	if err != nil {
 		return fmt.Errorf("listen on gRPC health port %d: %w", grpcHealthPort, err)
@@ -91,11 +84,11 @@ func runCmd(cfg *config.GatewayConfig) error {
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	go func() {
-		// A Serve failure here is fatal, not merely logged: with no health
-		// server left running and nothing to notice, the process would
-		// otherwise carry on with no health signal at all. Canceling ctx
-		// with this error as its cause carries it out through mgr.Start
-		// below, the same way any other fatal startup error does.
+		// A Serve failure is fatal rather than merely logged: with no health
+		// server left and nothing to notice, the process would carry on
+		// with no health signal at all. Cancelling with this as the cause
+		// carries it out through the manager below, like any other fatal
+		// startup error.
 		if serveErr := grpcSrv.Serve(lis); serveErr != nil {
 			cancel(fmt.Errorf("gRPC health server: %w", serveErr))
 		}
@@ -105,31 +98,16 @@ func runCmd(cfg *config.GatewayConfig) error {
 		grpcSrv.GracefulStop()
 	}()
 
-	// Register field indexes. NetworkGatewayReconciler.resolveBGPRouterForNode
-	// (networkgateway_controller.go) lists BGPRouters by BGPRouterByTargetName
-	// -- an index, not a real API field, so it only resolves if something on
-	// this process's own manager registered it first. cmd/galactic-router
-	// registers it via the same call for its own, separate manager; galactic-
-	// gateway is a distinct binary/process/manager and never did, so every
-	// NetworkGateway reconcile here failed outright ("Index with name
-	// field:.spec.targetRef.name does not exist") until this call was added --
-	// found via a live containerlab deploy's own reconciler error loop.
+	// Register the field index the gateway reconciler queries. It is an index
+	// rather than a real API field, so it resolves only if this process's own
+	// manager registered it: every reconcile here fails outright without this,
+	// even though another binary registers the same index on its own manager.
 	//
-	// RegisterBGPRouterTargetIndex, not the full RegisterIndexes: galactic-
-	// gateway's reconcilers (networkgateway_controller.go,
-	// networkrule_controller.go, usidresolver.go) only ever query
-	// BGPRouterByTargetName -- never BGPPeerBySecretName/BGPPeerByRouterName/
-	// BGPPolicyByRouterName/BGPVRFInstanceByRouterName, which RegisterIndexes
-	// also registers. Calling the full RegisterIndexes here was wrong: it
-	// starts a live informer for BGPPeer/BGPPolicy/BGPVRFInstance too
-	// (RegisterIndexes' own doc comment explains why that's eager and
-	// unconditional), and config/galactic-gateway/rbac.yaml's ClusterRole
-	// grants none of those -- found live as a permanently-stuck manager
-	// (every controller blocked forever on WaitForCacheSync, logging nothing
-	// but "bgppeers ... is forbidden" reflector errors) the moment this was
-	// deployed. RegisterBGPRouterTargetIndex is the same narrower function
-	// cmd/galactic-nat66 already uses for exactly this reason -- see its own
-	// doc comment.
+	// Only this one index, not the full set. This binary's reconcilers query no
+	// other, and registering the rest starts live informers for kinds this
+	// binary's role grants no access to, which wedges the manager permanently
+	// with every controller blocked on cache sync behind forbidden reflector
+	// errors.
 	if err := controller.RegisterBGPRouterTargetIndex(ctx, mgr); err != nil {
 		return fmt.Errorf("register field indexes: %w", err)
 	}
@@ -137,31 +115,27 @@ func runCmd(cfg *config.GatewayConfig) error {
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 
-	// Load and attach the edge NAT+LB eBPF datapath. Always loads a real
-	// gateway.KernelDatapath -- unlike cmd/galactic-router's removed
-	// setupGatewayDatapath, there is no gateway.NoopDatapath{} case here:
-	// config.GatewayConfig.Validate already rejects an empty
-	// PublicInterface/SRv6Address before runCmd is ever reached.
+	// Load and attach the edge eBPF datapath. Always a real datapath, never a
+	// no-op: configuration validation rejects an empty public interface or SRv6
+	// address before this is reached.
 	gwDatapath, err := setupGatewayDatapath(cfg.PublicInterface, cfg.SRv6Address, ctrlmetrics.Registry)
 	if err != nil {
 		return fmt.Errorf("setup edge gateway eBPF datapath: %w", err)
 	}
-	// Only now is the datapath attached and its rule table reachable --
-	// report serving from here on, not from process start (#360).
+	// Only now is the datapath attached and its rule table reachable. Report
+	// serving from here on, not from process start.
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
-	// Real (not stubbed) QuotaEnforcer/TelemetryEmitter — see
-	// internal/gateway/quota.go and telemetry.go's doc comments for what
-	// each does and does not cover.
+	// Real quota and telemetry implementations, not stubs. See their own doc
+	// comments for what each does and does not cover.
 	gwQuota := gateway.NewNodeQuotaEnforcer(gateway.DefaultMaxRulesPerTenant, gateway.DefaultMaxRuleTableEntries)
 	gwTelemetry := gateway.NewPrometheusTelemetryEmitter()
 	gwTelemetry.MustRegister(ctrlmetrics.Registry)
 	gwEngine := gateway.NewEngine(gwDatapath, gwQuota, gwTelemetry)
 
-	// Register NetworkGateway controller (edge Maglev/DSR gateway engine).
-	// No SRv6Address to pass here anymore: DSR rewrites nothing, so a
-	// gateway node has no SNAT source of its own to publish (see
-	// controller.NetworkGatewayReconciler's package doc comment).
+	// The gateway engine reconciler. No SRv6 address is passed: this datapath
+	// rewrites nothing, so a gateway node has no translation source of its own
+	// to publish.
 	if err := (&controller.NetworkGatewayReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -171,9 +145,8 @@ func runCmd(cfg *config.GatewayConfig) error {
 		return fmt.Errorf("setup NetworkGateway controller: %w", err)
 	}
 
-	// Register NetworkRule controller (finalizer-guarded teardown ordering
-	// and one-time primary_node assignment; see
-	// internal/controller/networkrule_controller.go).
+	// The rule reconciler: finalizer-guarded teardown ordering and the Accepted
+	// condition.
 	if err := (&controller.NetworkRuleReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -185,10 +158,9 @@ func runCmd(cfg *config.GatewayConfig) error {
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("manager exited: %w", err)
 	}
-	// mgr.Start only returns nil once ctx is Done, and by then ctx always
-	// has a cause: either context.Canceled (an ordinary signal-triggered
-	// shutdown) or the gRPC health server's own fatal Serve error from
-	// above. Only the latter should fail the process.
+	// The manager returns nil only once the context is done, and by then it
+	// always has a cause: cancellation for an ordinary shutdown, or the health
+	// server's fatal error above. Only the latter should fail the process.
 	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
 		return cause
 	}

--- a/cmd/galactic-ipam/main.go
+++ b/cmd/galactic-ipam/main.go
@@ -51,22 +51,22 @@ func newRootCommand() *cobra.Command {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes (via IPAM delegation's ExecAdd/ExecDel/
-			// ExecCheck) always pipe the netconf JSON on stdin and close
-			// it. If stdin is an interactive terminal instead, no config
-			// will ever arrive and skel's blocking stdin read would hang
-			// forever — print version info instead.
+			// Real CNI runtimes, invoking this through IPAM delegation, always
+			// pipe the netconf on stdin and close it. When stdin is an
+			// interactive terminal instead, no config ever arrives and the
+			// library's blocking read would hang forever, so print version
+			// info instead.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Printf("%s version %s\n", appName, metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// This plugin never enters a network namespace — it only
-			// allocates addresses from on-disk marker files. For tap-mode
-			// attachments, CNI_NETNS points at the host netns which equals
-			// this process's ambient netns, so the CNI library's same-netns
-			// rejection check would fire without the override.
+			// This plugin never enters a network namespace; it only allocates
+			// addresses from on-disk markers. For a tap attachment the
+			// namespace given is the host's, which equals this process's own,
+			// so the library's same-namespace rejection would fire without the
+			// override.
 			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")
 
 			cniipam.RunPlugin()

--- a/cmd/galactic-nat66/main.go
+++ b/cmd/galactic-nat66/main.go
@@ -2,20 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Command galactic-nat66 is one shard of the sharded, stateful NAT66
-// egress tier of the Galactic data plane. It loads and attaches
-// internal/plumbing/ebpf/nat66prog's XDP program to this shard's own
-// fabric-facing uplink interface and registers the NAT66ShardReconciler
-// that publishes this shard's operator-configured identity
-// (Status.ShardAddress/Status.ShardSID) and Ready condition.
+// Command galactic-nat66 is one shard of the sharded, stateful NAT66 egress tier
+// of the Galactic data plane. It loads and attaches the NAT66 XDP program to
+// this shard's fabric-facing uplink and registers the reconciler that publishes
+// this shard's operator-configured identity and Ready condition.
 //
-// This binary is deliberately its own standalone datapath, not a
-// personality bolted onto galactic-gateway: tenant egress traffic
-// (backend -> arbitrary internet destination) is a different traffic
-// pattern from ingress (fixed VIP, fixed backend pool) and needs its own
-// placement ring, own state, own self-routing return path -- see
-// nat66prog's own doc comment and nat66.c's header comment for the full
-// design.
+// It is deliberately its own standalone datapath rather than a personality on
+// the edge gateway: tenant egress toward an arbitrary internet destination is a
+// different pattern from ingress toward a fixed VIP and backend pool, and needs
+// its own placement ring, state, and return path.
 package main
 
 import (
@@ -44,20 +39,13 @@ func main() {
 	}
 }
 
-// checkWatchPermissions issues a SelfSubjectAccessReview for each resource
-// NAT66ShardReconciler now touches, checking the watch verb. If a review
-// denies the request the informer cache will never sync and the
-// reconciler will be silently blocked; this logs a clear, actionable
-// message at startup so the problem is immediately obvious. Mirrors
-// cmd/galactic-gateway/main.go's identically-named function.
+// checkWatchPermissions issues an access review for each resource the shard
+// reconciler touches, checking the watch verb. A denial means the informer cache
+// never syncs and the reconciler is silently blocked, so this logs a clear,
+// actionable message at startup instead.
 //
-// bgprouters/bgpadvertisements are new here: NAT66ShardReconciler's own
-// doc comment used to describe this binary as reading no other CRD at
-// all, but applyShardAdvertisement (nat66shard_controller.go) now looks
-// up this node's BGPRouter and creates/updates/deletes a BGPAdvertisement
-// for Status.ShardSID -- the same RBAC surface
-// cmd/galactic-gateway/main.go's own checkWatchPermissions already checks
-// for NetworkGatewayReconciler's identical pattern.
+// It covers the routers and advertisements the shard advertisement path reads
+// and writes, not just the shard resource itself.
 func checkWatchPermissions(mgr ctrl.Manager) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/cmd/galactic-nat66/metrics.go
+++ b/cmd/galactic-nat66/metrics.go
@@ -15,22 +15,18 @@ import (
 
 const metricsNamespace = "galactic_nat66"
 
-// nat66Collector is a prometheus.Collector reading this shard's live eBPF
-// map state at every scrape: drops by reason (drop_reasons) and the
-// current nat66_conn_table occupancy -- mirroring
-// internal/plumbing/ebpf/edgemetrics.Collector's pull-based-collector
-// shape (reading live at scrape time rather than incrementally-updated
-// Gauges), scoped down to what nat66map actually exposes read access to
-// (see that package's doc comment for why nat66_conn_table is
-// observability-only: it is entirely datapath-owned).
+// nat66Collector reads this shard's live map state at every scrape: drops by
+// reason and the current connection-table occupancy. It is a pull-based
+// collector like the other datapaths', scoped to what the map layer exposes read
+// access to, the connection table being entirely datapath-owned and so
+// observability-only.
 type nat66Collector struct {
 	connTable   *nat66map.ConnTable
 	dropReasons nat66map.DropReasonsReader
 }
 
-// newNat66Collector builds a nat66Collector reading directly from a
-// loaded *nat66prog.Nat66Objects's Nat66ConnTable/DropReasons maps -- the
-// object internal/plumbing/ebpf/nat66attach.Load returns.
+// newNat66Collector builds a collector reading directly from a loaded object
+// set's maps.
 func newNat66Collector(objs *nat66prog.Nat66Objects) *nat66Collector {
 	return &nat66Collector{
 		connTable:   nat66map.NewConnTable(nat66map.KernelTable{Map: objs.Nat66ConnTable}),

--- a/cmd/galactic-nat66/nat66.go
+++ b/cmd/galactic-nat66/nat66.go
@@ -18,54 +18,42 @@ import (
 	"go.datum.net/galactic/internal/plumbing/sysctl"
 )
 
-// nat66DatapathKeepAlive holds the loaded *nat66prog.Nat66Objects and the
-// attached link.Link for the life of this process, once
-// setupNat66Datapath's attach path succeeds. Neither is Closed anywhere in
-// this file -- mirrors cmd/galactic-gateway/gateway.go's
-// gatewayDatapathKeepAlive var and its doc comment's full rationale
-// (cilium/ebpf's *ebpf.Program, *ebpf.Map, and link.Link types all
-// register a runtime finalizer that closes their underlying fd once the
-// garbage collector determines nothing reachable still points at them,
-// with no error surfaced anywhere when that happens -- confirmed live the
-// first time gatewayDatapathKeepAlive's absence was ever exercised against
-// a real interface: ingress traffic for a registered rule was silently
-// never intercepted at all). Without an equivalent var here,
-// objs.Nat66Ingress (the program) and the link.Link returned by Attach --
-// the two things actually keeping this shard's XDP attachment live on the
-// wire -- would eventually get GC'd and silently detached, with the
-// NAT66Shard's own Ready condition still reporting healthy.
+// nat66DatapathKeepAlive holds the loaded objects and the attached link for the
+// life of this process, once the attach path succeeds.
+//
+// Nothing here is closed explicitly, but a value not stored somewhere reachable
+// is as good as closed: the eBPF program, map, and link types all register a
+// finalizer that closes the underlying descriptor once the garbage collector
+// sees nothing pointing at them, with no error surfaced anywhere.
+//
+// Without this var, the program and the link, the two things keeping this
+// shard's XDP attachment live on the wire, would eventually be collected and
+// silently detached while the shard's Ready condition still reported healthy.
 var nat66DatapathKeepAlive struct {
 	objs *nat66prog.Nat66Objects
 	link link.Link
 }
 
-// nat66DatapathStatus implements controller.NAT66DatapathHealth,
-// reporting whether setupNat66Datapath has completed a successful
-// load+attach+configure pass. attached is only ever set true, once, by
-// setupNat66Datapath after every step below succeeds -- there is no
-// runtime detach detection here (the datapath is expected to survive for
-// this process's whole lifetime, mirroring gatewayDatapathKeepAlive's own
-// "attached once at startup, held open forever" convention), so an
-// atomic.Bool rather than a mutex-guarded struct is sufficient: it's only
-// ever written once and read concurrently by every subsequent
-// NAT66ShardReconciler.Reconcile call.
+// nat66DatapathStatus reports whether setup has completed a successful load,
+// attach, and configure pass. The flag is set true once, after every step
+// succeeds, and never cleared: there is no runtime detach detection, the
+// datapath being expected to survive the process's whole lifetime. That makes
+// an atomic sufficient, it being written once and read concurrently by every
+// later reconcile.
 type nat66DatapathStatus struct {
 	attached atomic.Bool
 }
 
 func (s *nat66DatapathStatus) Attached() bool { return s.attached.Load() }
 
-// setupNat66Datapath loads and attaches the NAT66 egress eBPF datapath to
-// uplinkInterface, writes shardSID/shardPubAddr into shard_config_table,
-// and registers this shard's Prometheus metrics, returning the
-// controller.NAT66DatapathHealth NAT66ShardReconciler uses to report its
-// Ready condition.
+// setupNat66Datapath loads and attaches the NAT66 egress datapath to
+// uplinkInterface, writes the shard's SID and public address into its config
+// map, and registers this shard's metrics. It returns the health reporter the
+// reconciler uses for its Ready condition.
 //
-// Mirrors cmd/galactic-gateway/gateway.go's setupGatewayDatapath: the
-// loaded *nat66prog.Nat66Objects and the returned link.Link are stashed in
-// nat66DatapathKeepAlive (see that var's doc comment for why) rather than
-// Closed here -- they, and the XDP attachment itself, must survive for the
-// life of this process.
+// The loaded objects and the returned link are stashed in
+// nat66DatapathKeepAlive rather than closed here: they, and the attachment
+// itself, must survive for the life of this process.
 func setupNat66Datapath(
 	uplinkInterface, shardSID, shardPubAddr string, metricsReg prometheus.Registerer,
 ) (*nat66DatapathStatus, error) {
@@ -78,13 +66,9 @@ func setupNat66Datapath(
 		return nil, fmt.Errorf("parse shard public address %q: %w", shardPubAddr, err)
 	}
 
-	// Required for bpf_fib_lookup() (nat66.c's push_outer_header, used by
-	// both the forward and return paths) to ever succeed on this interface
-	// -- see sysctl.ConfigureFIBLookupUplinkSysctls's own doc comment for
-	// why (a real, previously-undiagnosed blocker, first found against
-	// edgedsr.c but equally applicable here since both datapaths share the
-	// identical bpf_fib_lookup mechanism). Best-effort/non-fatal, matching
-	// cmd/galactic-gateway/gateway.go's identical call.
+	// Required for the FIB lookup in both the forward and return paths to
+	// succeed on this interface. Best-effort and non-fatal, matching how the
+	// gateway binary configures the same sysctls.
 	if err := sysctl.ConfigureFIBLookupUplinkSysctls(uplinkInterface); err != nil {
 		return nil, fmt.Errorf("configure IPv6 forwarding on uplink interface %q: %w", uplinkInterface, err)
 	}

--- a/cmd/galactic-nat66/root.go
+++ b/cmd/galactic-nat66/root.go
@@ -37,13 +37,9 @@ const (
  Find more information at: https://www.datum.net/docs`
 )
 
-// runCmd contains the application startup logic: it loads and attaches
-// this shard's NAT66 egress eBPF datapath to its fabric-facing uplink
-// interface and registers the NAT66ShardReconciler that publishes this
-// shard's identity/health. Mirrors cmd/galactic-gateway/root.go's runCmd
-// closely -- see that file's own doc comment for the gRPC health server's
-// NOT_SERVING-until-datapath-attached rationale (#360), which applies
-// unchanged here.
+// runCmd is the application startup: it loads and attaches this shard's NAT66
+// egress datapath to its fabric-facing uplink and registers the reconciler that
+// publishes this shard's identity and health.
 func runCmd(cfg *config.NAT66Config) error {
 	nodeName := cfg.NodeName
 	metricsPort := cfg.MetricsPort
@@ -66,18 +62,15 @@ func runCmd(cfg *config.NAT66Config) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	// ctx's cause distinguishes a normal signal-triggered shutdown from the
-	// health server's own Serve failure below (#360) -- see the cause check
-	// after mgr.Start.
+	// The cause distinguishes a normal signal-triggered shutdown from the
+	// health server's own Serve failure below.
 	ctx, cancel := context.WithCancelCause(ctrl.SetupSignalHandler())
 	defer cancel(nil)
 
-	// Start gRPC health server. grpchealth.NewServer() defaults the ""
-	// overall-health service to SERVING, so that must be overridden to
-	// NOT_SERVING here, explicitly and immediately: otherwise a probe could
-	// see "healthy" for the entire window before the datapath below is even
-	// attached. Only once the datapath is attached does this flip to
-	// SERVING, further down.
+	// The health server defaults its overall service to serving, which must be
+	// overridden to not-serving here, immediately: otherwise a probe sees
+	// healthy for the whole window before the datapath is attached. It flips to
+	// serving further down, once the datapath is attached.
 	lis, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf(":%d", grpcHealthPort))
 	if err != nil {
 		return fmt.Errorf("listen on gRPC health port %d: %w", grpcHealthPort, err)
@@ -87,11 +80,10 @@ func runCmd(cfg *config.NAT66Config) error {
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 	go func() {
-		// A Serve failure here is fatal, not merely logged: with no health
-		// server left running and nothing to notice, the process would
-		// otherwise carry on with no health signal at all. Canceling ctx
-		// with this error as its cause carries it out through mgr.Start
-		// below, the same way any other fatal startup error does.
+		// A Serve failure is fatal rather than merely logged: with no health
+		// server left and nothing to notice, the process would carry on
+		// with no health signal at all. Cancelling with this as the cause
+		// carries it out through the manager below.
 		if serveErr := grpcSrv.Serve(lis); serveErr != nil {
 			cancel(fmt.Errorf("gRPC health server: %w", serveErr))
 		}
@@ -101,25 +93,17 @@ func runCmd(cfg *config.NAT66Config) error {
 		grpcSrv.GracefulStop()
 	}()
 
-	// Register the one field index NAT66ShardReconciler.applyShardAdvertisement
-	// (nat66shard_controller.go) needs: BGPRouterByTargetName, to find the
-	// BGPRouter it advertises its shard SID through -- an index, not a
-	// real API field, so it only resolves if something on this process's
-	// own manager registered it first.
+	// Register the one field index the shard reconciler needs, to find the
+	// BGPRouter it advertises through. It is an index rather than a real API
+	// field, so it resolves only if this process's own manager registered it.
 	//
-	// Deliberately controller.RegisterBGPRouterTargetIndex, not the full
-	// controller.RegisterIndexes cmd/galactic-router and cmd/galactic-gateway
-	// call for their own managers: RegisterIndexes touches BGPPeer/
-	// BGPPolicy/BGPAdvertisement/BGPVRFInstance/BGPRouter, and
-	// controller-runtime's cache starts a live informer for every type any
-	// IndexField call touches immediately, regardless of whether this
-	// binary's own reconciler ever reads it again. Calling the full
-	// function here failed live at manager startup with "bgppolicies...is
-	// forbidden ... at the cluster scope": config/galactic-nat66/rbac.yaml
-	// only grants nat66shards/bgpadvertisements/bgprouters, on purpose (see
-	// that file's own "grant exactly what is used" principle) -- the
-	// narrower function keeps that principle intact instead of widening
-	// this binary's RBAC to match a function it doesn't need in full.
+	// Only this one, not the full set the other binaries register: the cache
+	// starts a live informer for every type any index touches, immediately and
+	// regardless of whether this binary ever reads it. Registering them all
+	// fails at manager startup against this binary's role, which deliberately
+	// grants only what it uses. The narrower call keeps that intact instead of
+	// widening the role to match a function this binary does not need in
+	// full.
 	if err := controller.RegisterBGPRouterTargetIndex(ctx, mgr); err != nil {
 		return fmt.Errorf("register field indexes: %w", err)
 	}
@@ -127,16 +111,15 @@ func runCmd(cfg *config.NAT66Config) error {
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 
-	// Load and attach the NAT66 egress eBPF datapath. Always loads a real
-	// datapath -- config.NAT66Config.Validate already rejects an empty
-	// UplinkInterface/ShardSID/ShardPubAddr before runCmd is ever reached,
-	// since this binary only exists to run a NAT66 shard.
+	// Load and attach the NAT66 egress datapath. Always a real datapath:
+	// configuration validation rejects an empty uplink, SID, or public address
+	// before this is reached, this binary existing only to run a shard.
 	datapathHealth, err := setupNat66Datapath(cfg.UplinkInterface, cfg.ShardSID, cfg.ShardPubAddr, ctrlmetrics.Registry)
 	if err != nil {
 		return fmt.Errorf("setup NAT66 egress eBPF datapath: %w", err)
 	}
-	// Only now is the datapath attached -- report serving from here on, not
-	// from process start (#360).
+	// Only now is the datapath attached. Report serving from here on, not from
+	// process start.
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 
 	// Register NAT66Shard controller.
@@ -154,10 +137,9 @@ func runCmd(cfg *config.NAT66Config) error {
 	if err := mgr.Start(ctx); err != nil {
 		return fmt.Errorf("manager exited: %w", err)
 	}
-	// mgr.Start only returns nil once ctx is Done, and by then ctx always
-	// has a cause: either context.Canceled (an ordinary signal-triggered
-	// shutdown) or the gRPC health server's own fatal Serve error from
-	// above. Only the latter should fail the process.
+	// The manager returns nil only once the context is done, and by then it
+	// always has a cause: cancellation for an ordinary shutdown, or the health
+	// server's fatal error above. Only the latter should fail the process.
 	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
 		return cause
 	}

--- a/cmd/galactic-route/main.go
+++ b/cmd/galactic-route/main.go
@@ -59,23 +59,22 @@ func newRootCommand() *cobra.Command {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes always pipe the network config JSON on
-			// stdin and close it. If stdin is an interactive terminal
-			// instead, no config will ever arrive and skel's blocking
-			// stdin read would hang forever — print version info instead.
+			// Real CNI runtimes always pipe the network config on stdin and
+			// close it. When stdin is an interactive terminal instead, no
+			// config ever arrives and the library's blocking read would hang
+			// forever, so print version info instead.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Printf("%s version %s\n", appName, metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// This plugin never enters a network namespace — it installs
-			// routes into the VRF table the master plugin already created.
-			// For tap-mode attachments, CNI_NETNS points at the host netns,
-			// which equals this process's ambient netns and would trigger
-			// the CNI library's same-netns rejection check. Set the override
-			// unconditionally (it is a no-op for veth-mode where CNI_NETNS
-			// differs from the ambient netns anyway).
+			// This plugin never enters a network namespace; it installs routes
+			// into the VRF table the master plugin created. For a tap
+			// attachment the namespace given is the host's, which equals this
+			// process's own and would trigger the library's same-namespace
+			// rejection. The override is set unconditionally, being a no-op
+			// for veth where the two differ anyway.
 			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")
 
 			cniroute.RunPlugin()

--- a/cmd/galactic-router/main.go
+++ b/cmd/galactic-router/main.go
@@ -37,11 +37,10 @@ func main() {
 	}
 }
 
-// checkWatchPermissions issues a SelfSubjectAccessReview for each resource
-// type the manager watches, checking the watch verb. If any review denies
-// the request the informer cache will never sync and all reconcilers will
-// be silently blocked; this logs a clear, actionable message at startup so
-// the problem is immediately obvious.
+// checkWatchPermissions issues an access review for the watch verb on each
+// resource the manager watches. A denial means the informer cache never syncs
+// and every reconciler is silently blocked, so this logs a clear, actionable
+// message at startup instead.
 func checkWatchPermissions(mgr ctrl.Manager) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/cmd/galactic-router/root.go
+++ b/cmd/galactic-router/root.go
@@ -47,10 +47,9 @@ const (
  Find more information at: https://www.datum.net/docs`
 )
 
-// resolveBGPLocalAddress returns explicit if non-empty. Otherwise it calls
-// detect to read the BGP local address from the host's lo interface,
-// returning an error if detection fails — there is no silent fallback to an
-// unset address.
+// resolveBGPLocalAddress returns explicit when non-empty, and otherwise calls
+// detect to read the BGP local address from the host's loopback. A detection
+// failure is an error; there is no silent fallback to an unset address.
 func resolveBGPLocalAddress(explicit string, detect func() (string, error)) (string, error) {
 	if explicit != "" {
 		return explicit, nil
@@ -89,12 +88,9 @@ func runCmd(cfg *config.RouterConfig) error {
 			BindAddress: fmt.Sprintf(":%d", metricsPort),
 		},
 	}
-	// The NetworkRule admission webhook (internal/webhook) is opt-in: it is
-	// the first webhook in this codebase, and enabling it requires TLS cert
-	// material (config/webhook/'s kustomization.yaml documents the
-	// cert-manager-or-equivalent prerequisite) plus the
-	// ValidatingWebhookConfiguration/Service manifests to actually be
-	// applied — see config.RouterConfig.WebhookEnabled's doc comment.
+	// The NetworkRule admission webhook is opt-in: enabling it requires TLS
+	// cert material plus the webhook configuration and service manifests to be
+	// applied.
 	if cfg.WebhookEnabled {
 		mgrOptions.WebhookServer = webhook.NewServer(webhook.Options{
 			Port:    cfg.WebhookPort,
@@ -107,10 +103,9 @@ func runCmd(cfg *config.RouterConfig) error {
 		return fmt.Errorf("create manager: %w", err)
 	}
 
-	// ctx carries a cause so that an ordinary signal-triggered shutdown can
-	// be told apart from the health server's own Serve failure below (#372),
-	// which cmd/galactic-gateway already treats as fatal -- see the cause
-	// check after mgr.Start.
+	// ctx carries a cause so an ordinary signal-triggered shutdown can be told
+	// apart from the health server's own Serve failure below. See the cause
+	// check after the manager returns.
 	ctx, cancel := context.WithCancelCause(ctrl.SetupSignalHandler())
 	defer cancel(nil)
 
@@ -124,13 +119,12 @@ func runCmd(cfg *config.RouterConfig) error {
 	grpc_health_v1.RegisterHealthServer(grpcSrv, healthSrv)
 	healthSrv.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
 	go func() {
-		// Serve returning non-nil means this node has lost its health
-		// signal for good: logging it and continuing would leave the
-		// router running unprobeable, with nothing to restart it and
-		// nothing to report it. Cancelling ctx with the failure as its
-		// cause routes it out through mgr.Start below, so it surfaces
-		// like any other fatal startup error. The GracefulStop path
-		// below is unaffected: Serve returns nil there.
+		// A non-nil return means this node has lost its health signal for
+		// good: logging and continuing would leave the router running
+		// unprobeable, with nothing to restart or report it. Cancelling
+		// with the failure as the cause routes it out through the manager
+		// below, so it surfaces like any other fatal startup error. The
+		// graceful-stop path is unaffected, returning nil.
 		if serveErr := grpcSrv.Serve(lis); serveErr != nil {
 			cancel(fmt.Errorf("gRPC health server: %w", serveErr))
 		}
@@ -142,9 +136,8 @@ func runCmd(cfg *config.RouterConfig) error {
 
 	if cfg.WebhookEnabled {
 		validator := &networkwebhook.NetworkRuleValidator{
-			// TODO(edge-gateway): AllowAllAuthorizer is a placeholder — see
-			// its doc comment. Wire a real Authorizer here once the
-			// companion operator integration exists.
+			// TODO(edge-gateway): a placeholder authorizer. Wire a real
+			// one here once the companion operator integration exists.
 			Authorizer: networkwebhook.AllowAllAuthorizer{},
 		}
 		if err := validator.SetupWebhookWithManager(mgr); err != nil {
@@ -155,26 +148,18 @@ func runCmd(cfg *config.RouterConfig) error {
 	// Pre-flight RBAC check.
 	checkWatchPermissions(mgr)
 
-	// Open this node's own vip_xlat_table handle for
-	// ServiceVIPBindingReconciler's EgressKindTap branch. This is new
-	// plumbing (docs/agents/ARCHITECTURE-ROUTER.md's "For Claude" table
-	// pre-dates it): galactic-router has never before needed to reach any
-	// of the eBPF uSID datapath's maps -- that program is loaded/attached
-	// once, elsewhere, by galactic-cni/internal/plumbing/ebpf/attach; this
-	// only opens a *second* handle onto the map it already pinned, the
-	// exact pattern internal/plumbing/ebpf/usidmap.OpenPinnedRegistry
-	// already established for the short-lived galactic-cni plugin binary.
-	// Unlike that binary, galactic-router is long-lived, so the returned
-	// closer is deferred to process shutdown rather than closed
-	// immediately -- it never affects the pinned map's own lifetime.
+	// Open this node's own vip_xlat_table handle for the ServiceVIPBinding
+	// reconciler's tap branch. The datapath program is loaded and attached
+	// elsewhere, by the CNI side; this only opens a second handle onto the map
+	// it already pinned. Being long-lived, this process defers the closer to
+	// shutdown rather than closing immediately, which never affects the pinned
+	// map's own lifetime.
 	//
-	// A missing pin (e.g. this node's eBPF uSID datapath hasn't loaded
-	// yet, or never will -- a route-reflector/control-role node has no
-	// CNI attach point at all) is not fatal: it only matters once a
-	// tap-kind ServiceVIPBinding is actually reconciled on this node, at
-	// which point ServiceVIPBindingReconciler.applyTapBind reports a
-	// clear, actionable error instead of silently no-op'ing. Every
-	// EgressKindVeth binding works regardless.
+	// A missing pin is not fatal. It means this node's datapath has not loaded
+	// yet, or never will on a control-role node with no CNI attach point. It
+	// matters only once a tap-kind binding is reconciled here, at which point
+	// the reconciler reports a clear error rather than silently doing nothing.
+	// Veth bindings work regardless.
 	var vipTranslationTable controller.VIPTranslationTable
 	vipXlatTable, vipXlatCloser, vipXlatErr := vipxlatmap.OpenPinnedVipXlatTable(attach.PinDir)
 	if vipXlatErr != nil {
@@ -190,13 +175,12 @@ func runCmd(cfg *config.RouterConfig) error {
 		return fmt.Errorf("register field indexes: %w", err)
 	}
 
-	// BGP peer session-state transitions are detected in real time by each
-	// GoBGPRuntime's own peer-event watcher (internal/runtime/gobgp/peer_monitor.go)
-	// rather than by polling BGPPeer.Status, since a flap that reverts
-	// between two peerStatusRequeue polls would otherwise leave no trace.
-	// PeerStateEventEmitter turns those transitions into Kubernetes Events on
-	// the corresponding BGPPeer; registering it with the manager gives its
-	// worker goroutine the same start/stop lifecycle as every reconciler.
+	// Peer session-state transitions are detected in real time by each
+	// runtime's own watcher rather than by polling status, since a flap
+	// between two polls would leave no trace. The emitter turns those
+	// transitions into Kubernetes events on the corresponding BGPPeer, and
+	// registering it with the manager gives its goroutine the same lifecycle
+	// as every reconciler.
 	peerEventEmitter := controller.NewPeerStateEventEmitter(mgr.GetClient(), mgr.GetEventRecorder(appName))
 	if err := mgr.Add(peerEventEmitter); err != nil {
 		return fmt.Errorf("register peer state event emitter: %w", err)
@@ -292,9 +276,9 @@ func runCmd(cfg *config.RouterConfig) error {
 		return fmt.Errorf("setup GC controller: %w", err)
 	}
 
-	// Start the GC ticker goroutine. It runs until the manager's context
-	// is cancelled. The initial GC pass waits for informer caches to sync
-	// so it doesn't see an empty BGPAdvertisement list and delete live VRFs.
+	// The GC ticker runs until the manager's context is cancelled. The
+	// first pass waits for informer caches to sync, so it does not see an
+	// empty advertisement list and delete live VRFs.
 	go func() {
 		ticker := time.NewTicker(cfg.GCInterval)
 		defer ticker.Stop()
@@ -319,29 +303,24 @@ func runCmd(cfg *config.RouterConfig) error {
 		return fmt.Errorf("manager exited: %w", err)
 	}
 
-	// mgr.Start returning nil means ctx is Done (signal-triggered shutdown
-	// or the health server's fatal Serve error above) -- either way, every
-	// GoBGP runtime this node was running is still holding its BGP/EVPN
-	// sessions open at this point, since the manager only stops registered
-	// Runnables and the GoBGP server goroutine is started independently of
-	// ctx (see internal/runtime/gobgp). Without this, the process just
-	// exits and peers only notice via TCP RST or hold-timer expiry --
-	// routes stay in the RIB and traffic blackholes until then. StopAll
-	// drives each runtime's Stop, which cancels its GoBGP server context and
-	// triggers GoBGP's own StopBgp, sending a Cease NOTIFICATION to every
-	// peer so routes are withdrawn immediately instead of on a timer. Use a
-	// fresh context (ctx is already Done) with a bounded timeout so a stuck
-	// runtime can't block shutdown forever.
+	// A nil return means the context is done, from a signal or the health
+	// server's fatal error above. Either way every GoBGP runtime is still
+	// holding its sessions open, the manager only stopping registered runnables
+	// while the GoBGP goroutine starts independently of that context. Without
+	// this the process just exits and peers notice only on a TCP reset or hold
+	// timer, leaving routes in the RIB and traffic blackholed until then.
+	// Stopping each runtime sends a cease notification to every peer so routes
+	// are withdrawn immediately. A fresh context with a bounded timeout keeps a
+	// stuck runtime from blocking shutdown forever.
 	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer stopCancel()
 	if err := runtimeMgr.StopAll(stopCtx); err != nil {
 		log.Printf("graceful runtime shutdown: %v", err)
 	}
 
-	// A nil return from mgr.Start means ctx is Done, so it always has a
-	// cause by now: context.Canceled for a signal-triggered shutdown, or
-	// the health server's fatal Serve error from above. Only the second
-	// should fail the process.
+	// A nil return means the context is done, so it always has a cause by now:
+	// cancellation for a signal-triggered shutdown, or the health server's
+	// fatal error. Only the second should fail the process.
 	if cause := context.Cause(ctx); cause != nil && !errors.Is(cause, context.Canceled) {
 		return cause
 	}

--- a/cmd/galactic-router/vip.go
+++ b/cmd/galactic-router/vip.go
@@ -13,15 +13,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vip"
 )
 
-// newVIPCommand builds the "vip" subcommand group: a thin, manual/debug
-// surface directly over internal/plumbing/vip's Bind/Unbind/Verify --
-// the same veth-branch mechanism ServiceVIPBindingReconciler
-// (internal/controller/servicevipbinding_controller.go) drives for every
-// EgressKindVeth ServiceVIPBinding. This is the first subcommand group
-// galactic-router's root command has ever had (see cmd/galactic-cni/main.go
-// for the established pattern this mirrors); the root command's own RunE
-// (root.go) still runs the router daemon itself when no subcommand is
-// given, unaffected by this addition.
+// newVIPCommand builds the "vip" subcommand group: a manual debugging surface
+// over the same bind, unbind, and verify mechanism the ServiceVIPBinding
+// reconciler drives for every veth-kind binding. The root command still runs the
+// router daemon when no subcommand is given.
 func newVIPCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vip",
@@ -35,9 +30,8 @@ only manipulates this node's own galactic-vip0 dummy interface.`,
 	return cmd
 }
 
-// parseVIPAddr parses addr as an IP address, returning a clear,
-// actionable error (rather than a nil net.IP silently propagating) if it
-// isn't one.
+// parseVIPAddr parses addr as an IP address, returning a clear error rather than
+// letting a nil address propagate silently.
 func parseVIPAddr(addr string) (net.IP, error) {
 	ip := net.ParseIP(addr)
 	if ip == nil {

--- a/cmd/galactic-tap/main.go
+++ b/cmd/galactic-tap/main.go
@@ -56,23 +56,22 @@ func newRootCommand() *cobra.Command {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes always pipe the network config JSON on
-			// stdin and close it. If stdin is an interactive terminal
-			// instead, no config will ever arrive and skel's blocking
-			// stdin read would hang forever — print version info instead.
+			// Real CNI runtimes always pipe the network config on stdin and
+			// close it. When stdin is an interactive terminal instead, no
+			// config ever arrives and the library's blocking read would hang
+			// forever, so print version info instead.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Printf("%s version %s\n", appName, metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// Tap mode never enters a network namespace — all operations
-			// are host-side. Set the override so the CNI library skips its
-			// same-netns rejection check, which would otherwise reject
-			// kraftlet workloads that pass the host netns. Unconditional
-			// here (unlike galactic-veth, which has no override logic at
-			// all): every invocation of this binary is tap mode, so there
-			// is no config content to peek at first.
+			// Tap mode never enters a network namespace; every operation is
+			// host-side. The override makes the library skip its same-namespace
+			// rejection check, which would otherwise reject a workload that
+			// passes the host namespace. Unconditional here, unlike the veth
+			// binary: every invocation of this one is tap mode, so there is no
+			// config to peek at first.
 			_ = os.Setenv("CNI_NETNS_OVERRIDE", "true")
 
 			cnitap.RunPlugin()

--- a/cmd/galactic-veth/main.go
+++ b/cmd/galactic-veth/main.go
@@ -53,26 +53,23 @@ func newRootCommand() *cobra.Command {
 				return version.All.Encode(os.Stdout)
 			}
 
-			// Real CNI runtimes (containerd, CRI-O) always pipe the network
-			// config JSON on stdin and close it. If stdin is an interactive
-			// terminal instead, no config will ever arrive, and both skel's
-			// blocking stdin read and the io.ReadAll below would hang
-			// forever. Detect that case up front and print version info
-			// rather than hanging.
+			// Real CNI runtimes always pipe the network config on stdin and
+			// close it. When stdin is an interactive terminal instead, no
+			// config ever arrives and both the library's blocking read and the
+			// read below would hang forever. Detect that up front and print
+			// version info instead.
 			if term.IsTerminal(int(os.Stdin.Fd())) {
 				fmt.Printf("galactic-veth version %s\n", metadata.Version)
 				fmt.Printf("CNI protocol versions supported: %s\n", strings.Join(version.All.SupportedVersions(), ", "))
 				return nil
 			}
 
-			// galactic-veth is veth-only: it always moves an interface into
-			// the container's own netns, so it always needs the CNI
-			// library's normal same-netns rejection check — unlike
-			// galactic-tap (which unconditionally sets
-			// CNI_NETNS_OVERRIDE, since tap workloads never enter a netns
-			// at all), there is no stdin-peeking tap-mode detection here
-			// anymore. Interface kind is which binary you invoke now, not a
-			// config field this process branches on.
+			// This binary is veth-only: it always moves an interface into the
+			// container's namespace, so it always needs the library's
+			// same-namespace rejection check. The tap binary unconditionally
+			// overrides that, tap workloads never entering a namespace.
+			// Interface kind is which binary you invoke, not a config field
+			// this process branches on.
 			cni.RunPlugin()
 			return nil
 		},

--- a/cmd/galactic-vrf/main.go
+++ b/cmd/galactic-vrf/main.go
@@ -2,23 +2,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Command galactic-vrf is #855's ingress sidecar: the second container in
-// the shared Envoy Gateway fleet's pod, responsible only for VPC backend
-// connectivity — Linux VRF device + SRv6 seg6 encap route lifecycle, driven
-// entirely by a cluster-scoped watch on discoveryv1.EndpointSlice objects
-// galactic-cni (#854) publishes per pod. See
-// docs/plans/855-ingress-sidecar-vpc-backend-connectivity.md and
-// internal/ingresssidecar's own doc comment for the full design; this
-// binary is just the process wiring (config, manager, metrics, RBAC
-// pre-flight) around that package.
+// Command galactic-vrf is the ingress sidecar: the second container in the
+// shared Envoy fleet's pod, responsible only for VPC backend connectivity,
+// meaning the Linux VRF device and SRv6 egress route lifecycle, driven entirely
+// by a cluster-scoped watch on the EndpointSlices the CNI publishes per pod.
+// This binary is the process wiring around internal/ingresssidecar: config,
+// manager, metrics, and an access pre-flight check.
 //
-// Unlike galactic-router/galactic-gateway, this binary exposes no gRPC
-// health server: neither of this repo's existing binaries has an
-// established /healthz convention to copy (galactic-router explicitly
-// disables its health probe; galactic-cni has none at all — see §5 of the
-// plan), so building one here would be new design work rather than
-// following a pattern, and container liveness (process exits, kubelet
-// restarts it) is enough for v1.
+// Unlike the router and gateway binaries it exposes no gRPC health server.
+// Neither has an established convention to copy, one disabling its probe and the
+// other having none, so building one here would be new design work rather than
+// following a pattern, and container liveness is enough.
 package main
 
 import (
@@ -44,15 +38,10 @@ func main() {
 	}
 }
 
-// checkWatchPermissions issues a SelfSubjectAccessReview for the "watch"
-// verb on endpointslices, the only resource this binary's manager watches.
-// If the review denies the request the informer cache will never sync and
-// the reconciler will be silently blocked; this logs a clear, actionable
-// message at startup so the problem is immediately obvious. Mirrors
-// cmd/galactic-router and cmd/galactic-gateway's identically-named
-// functions, scoped to this binary's own single resource — see §9 item 8
-// of the plan (the read-only ClusterRole decision this check exists to
-// help catch a misconfiguration of).
+// checkWatchPermissions issues an access review for the watch verb on
+// endpointslices, the only resource this binary's manager watches. A denial
+// means the informer cache never syncs and the reconciler is silently blocked,
+// so this logs a clear, actionable message at startup instead.
 func checkWatchPermissions(mgr ctrl.Manager) {
 	c, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {

--- a/cmd/galactic-vrf/root.go
+++ b/cmd/galactic-vrf/root.go
@@ -35,15 +35,13 @@ const (
  Find more information at: https://www.datum.net/docs`
 )
 
-// runCmd contains the application startup logic: it registers
-// internal/ingresssidecar's Reconciler against a cluster-scoped
-// EndpointSlice watch, then seeds Store from the live API state and runs
-// its startup inventory and periodic sweep. There is no BGP runtime here —
-// bgpv1alpha1 is registered on the scheme solely so the optional gateway
-// publisher below can read BGPRouter/BGPVRFInstance and write
-// BGPAdvertisement CRDs; see internal/config.VRFConfig's own doc comment
-// for why cfg.NodeName, unlike everything else this binary reads, has no
-// default and leaves that one feature off when unset.
+// runCmd is the application startup: it registers the ingress sidecar's
+// reconciler against a cluster-scoped EndpointSlice watch, then seeds the store
+// from live API state and runs its startup inventory and periodic sweep.
+//
+// There is no BGP runtime here. The BGP types are on the scheme solely so the
+// optional gateway publisher below can read routers and instances and write
+// advertisements, which stays off while no node name is configured.
 func runCmd(cfg *config.VRFConfig) error {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -74,44 +72,36 @@ func runCmd(cfg *config.VRFConfig) error {
 	backend := ingresssidecar.NewKernelBackend()
 	store := ingresssidecar.NewStore(backend, cfg.TeardownGracePeriod, metrics)
 
-	// Return-path gateway-advertisement publishing (docs/plans/855-return-
-	// path-gateway-advertisement.md) is opt-in on cfg.NodeName alone: most
-	// deployments of this sidecar don't set it yet, and leaving it unset
-	// here is exactly the no-op SetGatewayPublisher's own doc comment
-	// describes -- Store behaves identically to before this feature
-	// existed. mgr.GetClient() (the cached client) is fine for this: unlike
-	// the reconcile hot path, publishing only runs once per VRF's lifetime.
+	// Return-path gateway advertisement is opt-in on the node name alone,
+	// and leaving it unset is fully inert. The cached client is fine here:
+	// unlike the reconcile hot path, publishing runs once per VRF
+	// lifetime.
 	if cfg.NodeName != "" {
 		store.SetGatewayPublisher(
 			ingresssidecar.NewK8sGatewayPublisher(mgr.GetClient(), cfg.NodeName, cfg.Namespace),
 			ingresssidecar.NetlinkGatewayAddressResolver{},
 		)
 
-		// This node's own real, globally-routable underlay source address --
-		// see NodeSourceAddressResolver's own doc comment for why the
-		// default (srv6.ResolveNodeSourceAddress's local-netns
-		// auto-detection) resolves to the wrong address from inside Envoy's
-		// own pod netns, which is where this sidecar always runs. Gated on
-		// cfg.NodeName alone, like the gateway publisher above: both need
-		// this node's own identity, and mgr.GetClient() is fine here for
-		// the identical reason (one read per ensureEgressDatapath call, not
-		// a reconcile hot path).
+		// This node's real, globally routable underlay source address. The
+		// default local auto-detection resolves to the wrong address from
+		// inside Envoy's pod namespace, which is where this sidecar always
+		// runs. Gated on the node name like the publisher above, both needing
+		// this node's identity, and the cached client is fine for the same
+		// reason.
 		ingresssidecar.SetNodeSourceAddressResolver(
 			ingresssidecar.NewK8sNodeSourceAddressResolver(mgr.GetClient(), cfg.NodeName, cfg.Namespace),
 		)
 
-		// Gateway address *provisioning* is a second, independent opt-in on
-		// top of the publisher above -- see internal/config.VRFConfig's own
-		// GatewayPrefix doc comment for why it needs its own explicit
-		// platform-addressing decision, not a default. Without this, the
-		// publisher above stays permanently idle: NetlinkGatewayAddressResolver
-		// has nothing to find, so PublishGateway never actually fires.
+		// Gateway address provisioning is a second, independent opt-in on
+		// top of the publisher: it needs its own explicit platform
+		// addressing decision rather than a default. Without it the
+		// publisher stays idle, the resolver having nothing to find.
 		if cfg.GatewayPrefix != "" {
 			_, network, err := net.ParseCIDR(cfg.GatewayPrefix)
 			if err != nil {
-				// cfg.Validate() already checked this parses; a failure here
-				// would mean Validate and this call disagree, a real bug --
-				// fail loudly rather than silently run with no provisioning.
+				// Validation already checked this parses, so a failure here
+				// means the two disagree. Fail loudly rather than run
+				// silently with no provisioning.
 				return fmt.Errorf("parse gateway prefix %q: %w", cfg.GatewayPrefix, err)
 			}
 			ingresssidecar.SetGatewayAddressAssignment(network, cfg.NodeName)
@@ -129,17 +119,16 @@ func runCmd(cfg *config.VRFConfig) error {
 		return fmt.Errorf("setup EndpointSlice controller: %w", err)
 	}
 
-	// Startup seed + inventory + periodic sweep. Every EndpointSlice that
-	// exists at boot must be visible to Store *before* Inventory or Sweep
-	// ever run, or a live VPC/pod could be misjudged as orphaned -- see
-	// ingresssidecar.SeedFromAPI's own doc comment for why that can no
-	// longer be mgr.GetCache().WaitForCacheSync's job: a synced cache only
-	// guarantees the informer's initial List landed in the cache, not that
-	// the controller's own Reconcile has drained the workqueue that same
-	// List fed, so on a busy node at boot the two could race. SeedFromAPI
-	// uses mgr.GetAPIReader(), the manager's uncached reader, so it
-	// doesn't depend on cache/workqueue timing at all. Mirrors
-	// cmd/galactic-router's own GC-ticker startup goroutine.
+	// Startup seed, then inventory, then the periodic sweep. Every
+	// EndpointSlice existing at boot must be visible to the store before
+	// inventory or a sweep runs, or a live VPC could be misjudged as
+	// orphaned.
+	//
+	// Waiting for the cache to sync is not enough: that guarantees the
+	// informer's initial list landed in the cache, not that the
+	// controller's own reconciles have drained the workqueue that list
+	// fed, so on a busy node at boot the two race. Seeding uses the
+	// manager's uncached reader, which depends on neither.
 	go func() {
 		if err := ingresssidecar.SeedFromAPI(ctx, mgr.GetAPIReader(), store); err != nil {
 			log.Printf("startup seed: %v", err)
@@ -155,14 +144,12 @@ func runCmd(cfg *config.VRFConfig) error {
 		return fmt.Errorf("manager exited: %w", err)
 	}
 
-	// mgr.Start only returns nil once ctx is Done (signal-triggered
-	// shutdown -- there's no other source of cancellation here, unlike
-	// cmd/galactic-router/cmd/galactic-gateway's health-server-failure
-	// case). No proactive VRF/route teardown on exit: §6 of the plan
-	// leans toward leaving kernel state for the next instance to
-	// reconcile from scratch, since a live Envoy container next to a
-	// dying sidecar mid-rollout would otherwise blackhole in-flight
-	// connections.
+	// The manager returns nil only once the context is done, which here means
+	// a signal-triggered shutdown; there is no other source of cancellation.
+	//
+	// No proactive teardown on exit: kernel state is left for the next instance
+	// to reconcile from scratch, since a live Envoy container beside a dying
+	// sidecar mid-rollout would otherwise blackhole in-flight connections.
 	return nil
 }
 

--- a/hack/returnpath-lab/main.go
+++ b/hack/returnpath-lab/main.go
@@ -2,36 +2,30 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Command returnpath-lab is the Phase 0 proof harness for
-// docs/plans/855-return-path-ingress-decap.md. It is a lab tool, not a
-// shipped binary: it performs, by hand and reversibly, exactly what that
-// plan's Pieces 1-3 would automate, so the plan's three derived-but-
-// unproven kernel assumptions can be tested before any production code is
-// written against them.
+// Command returnpath-lab is a proof harness for the ingress sidecar's return
+// path. It is a lab tool, not a shipped binary: it performs by hand, and
+// reversibly, what production code would automate, so three kernel assumptions
+// can be tested before anything is written against them.
 //
-// The assumptions under test, and how a successful `up` + end-to-end
-// request proves each:
+// The assumptions, each proven by a successful `up` plus an end-to-end request:
 //
-//  1. bpf_fib_lookup with BPF_FIB_LOOKUP_TBID resolves against a bare
-//     Linux routing table that has no VRF device attached (plan D-7). `up`
-//     installs the return route into exactly such a table.
-//  2. bpf_redirect_peer from the host root netns into a VRF-enslaved
-//     pod-side veth end delivers to a socket that is SO_BINDTODEVICE-bound
-//     to that VRF master (plan §7.1). `up` builds precisely that topology.
-//  3. A packet arriving on one VRF-enslaved link is locally delivered for
-//     an address configured on a *different* link enslaved to the same VRF
-//     (plan §7.1 point 3) -- the gateway address lives on the sidecar's own
-//     ivsN veth, not on the link this tool creates.
+//  1. bpf_fib_lookup with a table id resolves against a bare Linux routing
+//     table with no VRF device attached. `up` installs the return route into
+//     exactly such a table.
+//  2. bpf_redirect_peer from the host root namespace into a VRF-enslaved
+//     pod-side veth end delivers to a socket bound to that VRF master. `up`
+//     builds that topology.
+//  3. A packet arriving on one VRF-enslaved link is locally delivered for an
+//     address configured on a different link in the same VRF: the gateway
+//     address lives on the sidecar's own veth, not the link this tool creates.
 //
-// It deliberately reuses the production packages (internal/plumbing/ebpf/
-// usidmap, internal/plumbing/intf, internal/plumbing/ebpf/uformat) rather
-// than hand-marshalling map keys with bpftool, both to avoid layout bugs
-// and so that whatever `up` proves is proven about the real code paths that
-// Phase 2 will move into galactic-router.
+// It reuses the production packages rather than hand-marshalling map keys, both
+// to avoid layout bugs and so what it proves is proven about the real code
+// paths.
 //
-// Must run in the host's root network namespace with CAP_NET_ADMIN, CAP_BPF
-// and hostPID (the pod-netns discovery below walks /proc), with the host's
-// bpffs mounted. See hack/returnpath-lab/README.md.
+// Must run in the host's root network namespace with CAP_NET_ADMIN, CAP_BPF,
+// and host PID, since namespace discovery walks /proc, with the host's bpffs
+// mounted. See the README beside it.
 package main
 
 import (
@@ -134,9 +128,9 @@ func main() {
 			"as UNKNOWN_FUNCTION instead of passing it through to the XDP/stack path that handles it.")
 	flag.Usage = usage
 
-	// The action is the first argument, consumed before flag.Parse: Go's
-	// flag package stops parsing at the first non-flag argument, so a
-	// trailing subcommand would silently swallow every flag after it.
+	// The action is the first argument, consumed before flag parsing: Go's flag
+	// package stops at the first non-flag argument, so a trailing subcommand
+	// would silently swallow every flag after it.
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(2)
@@ -194,9 +188,9 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-// derived holds the values every action computes from the flags, so the
-// key arithmetic lives in exactly one place and `status` prints the same
-// numbers `up` would write.
+// derived holds the values every action computes from the flags, so the key
+// arithmetic lives in one place and `status` prints the same numbers `up`
+// writes.
 type derived struct {
 	block       uint64
 	nodeID      uint16
@@ -316,17 +310,15 @@ type podNetns struct {
 	inode string
 }
 
-// findPodNetns locates the network namespace holding vrfName by walking
-// /proc, deduplicating by netns inode, and entering each distinct namespace
-// to look for that interface.
+// findPodNetns locates the network namespaces holding vrfName by walking /proc,
+// deduplicating by namespace inode, and entering each distinct namespace to look
+// for that interface.
 //
-// This is deliberately the same mechanism the plan's Open Question 1 needs
-// an answer for: identifying which pod's netns holds a given VPC's VRF, from
-// a root-netns process, with no CNI ADD ever having happened for that pod.
-// Proving it here is part of Phase 0's job. The VRF's name is fully
-// determined by the VPC id (intf.GenerateInterfaceNameVRF), so the interface
-// itself is the identifier -- no annotation, CRI call or published inode is
-// needed.
+// This is the mechanism for identifying which pod's namespace holds a given
+// VPC's VRF from a root-namespace process, with no CNI ADD ever having happened
+// for that pod. The VRF's name is fully determined by the VPC id, so the
+// interface itself is the identifier: no annotation, runtime call, or published
+// inode is needed.
 func findPodNetns(vrfName string) ([]podNetns, error) {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
@@ -553,11 +545,11 @@ func reportForwarding(hostIf string) {
 	}
 }
 
-// describePodNetns reports, from inside the pod's own namespace, the three
-// things the return path depends on there: the VRF and its table, which
-// links are enslaved to it, and which of those links actually carries the
-// gateway address (plan §7.1 point 3 -- delivery is cross-interface within
-// one VRF, so this is expected NOT to be the link this tool creates).
+// describePodNetns reports, from inside the pod's namespace, the three things
+// the return path depends on there: the VRF and its table, which links are
+// enslaved to it, and which of those carries the gateway address. Delivery is
+// cross-interface within one VRF, so that is expected not to be the link this
+// tool creates.
 func describePodNetns(path string, d derived) error {
 	return ns.WithNetNSPath(path, func(ns.NetNS) error {
 		vrfLink, err := netlink.LinkByName(d.vrfName)
@@ -608,12 +600,11 @@ func reportDropReasons(pinDir string) error {
 	}
 	defer func() { _ = m.Close() }()
 
-	// max_entries matters: attach.Load reuses an already-pinned map as-is,
-	// so a node whose bpffs pin predates a newly-added drop reason has a
-	// map too small to hold it, and count_drop for that index silently
-	// fails. Two nodes running the identical image can therefore expose
-	// different counters -- report the size so that is visible rather than
-	// looking like a genuine zero.
+	// The entry count matters: loading reuses an already-pinned map as-is, so a
+	// node whose pin predates a newly added drop reason has a map too small to
+	// hold it and the counter for that index silently fails. Two nodes running
+	// the same image can therefore expose different counters, so report the
+	// size rather than let it look like a genuine zero.
 	fmt.Printf("  (map max_entries=%d; usid.c currently defines 29)\n", m.MaxEntries())
 
 	any := false
@@ -633,12 +624,11 @@ func reportDropReasons(pinDir string) error {
 		any = true
 		name, ok := prog.DropReasonNames[idx]
 		if !ok {
-			// usid.c carries diagnostic TRACE_* counters above the Go
-			// mirror's DropReasonCount (16); prog.DropReasonNames stops
-			// there, and metrics/collector.go deliberately does not export
-			// them. They are the most useful signal for this harness, so
-			// name them locally rather than widening the production mirror
-			// for a set usid.c documents as temporary.
+			// The datapath carries diagnostic counters above the Go mirror's
+			// count, which stops there and which the metrics collector
+			// deliberately does not export. They are the most useful signal
+			// here, so name them locally rather than widen the production
+			// mirror for a set documented as temporary.
 			if n, tok := traceReasonNames[idx]; tok {
 				name = n
 			} else {
@@ -653,16 +643,15 @@ func reportDropReasons(pinDir string) error {
 	return nil
 }
 
-// traceReasonNames mirrors usid.c's DROP_REASON_TRACE_* diagnostic
-// checkpoints, which sit above prog.DropReasonCount and so have no entry in
-// prog.DropReasonNames. Read together they say how far usid_egress got:
-// ENTRY -> IFINDEX_HIT -> ADJUST_ROOM_OK -> REACHED_REDIRECT -> REDIRECT_OK
-// is a fully successful encapsulation.
+// traceReasonNames mirrors the datapath's diagnostic checkpoints, which sit
+// above the Go mirror's drop-reason count and so have no name there. Read
+// together they say how far usid_egress got: entry, ifindex hit, room adjusted,
+// reached redirect, redirect ok is a fully successful encapsulation.
 //
-// Slots 29-32 are the same idea for usid_ingress, which had no success
-// counter at all: ING_REACHED_REDIRECT -> ING_REDIRECT_OK brackets its own
-// step 9. ing_last_ifindex is a value, not a count -- the ifindex
-// bpf_fib_lookup resolved, printed as-is. fib_no_ifindex is a real drop.
+// The higher slots are the same idea for usid_ingress, which had no success
+// counter at all, bracketing its own redirect step. One of them is a value
+// rather than a count, the ifindex the FIB lookup resolved, printed as-is. One
+// is a real drop.
 var traceReasonNames = map[uint32]string{
 	16: "trace_multicast_ll_bail",
 	17: "trace_miss_vrf",
@@ -728,10 +717,9 @@ func up(cfg config, d derived) error {
 		return nil
 	}
 
-	// 1 + 2: the veth. Both ends are created in this (root) netns, then the
-	// peer is moved -- the same order galactic-cni uses for a tenant pod,
-	// and the reason the router can know the peer's MAC (needed by step 4)
-	// without ever entering the pod's namespace.
+	// The veth. Both ends are created in this root namespace and then the peer
+	// is moved, the same order the CNI uses for a tenant pod, and the reason
+	// this side can know the peer's MAC without entering the pod's namespace.
 	peerMAC, err := ensureVeth(d)
 	if err != nil {
 		return err
@@ -762,9 +750,8 @@ func up(cfg config, d derived) error {
 	}
 	fmt.Printf("  [3]   route %s/128 dev %s table %d\n", d.gwAddr, d.hostIf, cfg.tableID)
 
-	// 4: the permanent neighbor entry. Without this, bpf_fib_lookup returns
-	// BPF_FIB_LKUP_RET_NO_NEIGH and usid_ingress drops the packet -- see
-	// internal/hostgw.installGatewayNeighbor's doc comment.
+	// The permanent neighbor entry. Without it, bpf_fib_lookup returns
+	// NO_NEIGH and usid_ingress drops the packet.
 	if err := netlink.NeighSet(&netlink.Neigh{
 		LinkIndex:    hostLink.Attrs().Index,
 		Family:       netlink.FAMILY_V6,
@@ -903,9 +890,8 @@ func down(cfg config, d derived) error {
 
 	var errs []error
 
-	// Unregister the map entry before the veth goes, so a decapped packet
-	// can never be redirected at a freed ifindex (plan §8's one ordering
-	// requirement).
+	// Unregister the map entry before the veth goes, so a decapsulated packet
+	// can never be redirected at a freed ifindex.
 	if registry, closer, err := usidmap.OpenPinnedRegistry(cfg.pinDir); err != nil {
 		errs = append(errs, fmt.Errorf("open pinned registry: %w", err))
 	} else {
@@ -968,24 +954,22 @@ func down(cfg config, d derived) error {
 // probe
 // ---------------------------------------------------------------------
 
-// probe opens a TCP connection from inside the Envoy pod's own network
-// namespace, bound to that VPC's VRF device with SO_BINDTODEVICE -- the
-// exact socket shape #856's extension server configures on Envoy's upstream
-// clusters (network-services-operator's mutate.ApplyVPCPodSocketBind). What
-// comes back classifies the return path:
+// probe opens a TCP connection from inside the Envoy pod's network namespace,
+// bound to that VPC's VRF device, the exact socket shape the extension server
+// configures on Envoy's upstream clusters. What comes back classifies the
+// return path:
 //
-//   - connected, or refused (RST): the return path WORKS. Both outcomes
-//     require a packet to have travelled backend -> VRF -> SRv6 encap ->
-//     fabric -> this node -> usid_ingress decap -> veth -> this socket.
-//     A RST is as good a proof as a SYN-ACK.
-//   - timeout: nothing came back. Either the forward path did not reach the
-//     backend, or the reply was lost on the return path. `status`'s
-//     vrf_table counters and drop_reasons disambiguate which.
+//   - Connected, or refused: the return path works. Both require a packet to
+//     have travelled backend, VRF, encapsulation, fabric, this node,
+//     decapsulation, veth, socket. A reset proves it as well as a handshake.
+//   - Timeout: nothing came back. Either the forward path never reached the
+//     backend or the reply was lost returning. The map counters and drop
+//     reasons `status` prints disambiguate which.
 //
-// Raw syscalls rather than net.Dialer: the socket must be created on the
-// same OS thread that is currently attached to the pod's netns, and Go's
-// netpoll offers no guarantee about which thread performs the underlying
-// socket(2). SO_SNDTIMEO bounds the blocking connect(2).
+// Raw syscalls rather than a dialer: the socket must be created on the same OS
+// thread currently attached to the pod's namespace, and Go's netpoll offers no
+// guarantee about which thread performs the underlying socket call. A send
+// timeout bounds the blocking connect.
 func probe(cfg config, d derived) error {
 	if cfg.backend == "" {
 		return errors.New("-backend is required for probe")
@@ -1045,9 +1029,9 @@ func connectOnce(vrfName string, backend net.IP, port int, timeout time.Duration
 	}
 	defer func() { _ = syscall.Close(fd) }()
 
-	// SO_BINDTODEVICE against the VRF master is what sends this socket's
-	// route lookup into that VPC's own table, and what makes a reply
-	// arriving on a VRF-enslaved link match this socket at all (plan §7.1).
+	// Binding to the VRF master is what sends this socket's route lookup into
+	// that VPC's table, and what makes a reply arriving on a VRF-enslaved link
+	// match this socket at all.
 	if err := syscall.SetsockoptString(fd, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, vrfName); err != nil {
 		return "SO_BINDTODEVICE FAILED", "", err
 	}
@@ -1089,16 +1073,16 @@ func connectOnce(vrfName string, backend net.IP, port int, timeout time.Duration
 // egress-route
 // ---------------------------------------------------------------------
 
-// egressRoute answers the one question that separates "the backend never
-// replied" from "the backend replied but its node had nowhere to send the
-// reply": does egress_route_table hold an entry for this address in this
-// VRF's table, and if so toward which SID?
+// egressRoute answers the one question separating "the backend never replied"
+// from "the backend replied but its node had nowhere to send the reply": does
+// egress_route_table hold an entry for this address in this VRF's table, and if
+// so toward which SID?
 //
-// Run on a backend node with the *gateway* address and that node's own
-// tenant VRF table id. A hit means galactic-router imported the sidecar's
-// BGPAdvertisement and usid_egress will encapsulate replies toward the
-// gateway node. A miss means the reply leaves unencapsulated (or not at
-// all), and no amount of decap state on the gateway node can help.
+// Run it on a backend node with the gateway address and that node's own tenant
+// VRF table id. A hit means the router imported the sidecar's advertisement and
+// usid_egress will encapsulate replies toward the gateway node. A miss means
+// the reply leaves unencapsulated, or not at all, and no amount of decap state
+// on the gateway node can help.
 func egressRoute(cfg config, _ derived) error {
 	if cfg.addr == "" || cfg.egressTable == 0 {
 		return errors.New("-addr and -egress-table are both required for egress-route")
@@ -1148,29 +1132,26 @@ func mustAddr(ip net.IP) netip.Addr {
 // inject
 // ---------------------------------------------------------------------
 
-// inject sends one genuine SRv6/IPv6-in-IPv6 encapsulated packet at a
-// gateway node's uplink, addressed to that node's return SID, carrying an
-// inner TCP SYN from a VPC backend address to the gateway address.
+// inject sends one genuine encapsulated packet at a gateway node's uplink,
+// addressed to that node's return SID and carrying an inner TCP SYN from a VPC
+// backend address to the gateway address.
 //
-// This is what finally isolates the decap path. Every other way of
-// generating the reply depends on a tenant workload actually replying:
+// This is what isolates the decap path. Every other way of generating the reply
+// depends on a tenant workload actually replying:
 //
-//   - probing the backend from Envoy needs the backend to answer, and this
-//     lab's VPC-2 backends are Kraftlet unikernels behind a tap that do not
-//     (see the fib_no_neigh drops on their own node).
-//   - probing the gateway address from the backend node's own root-netns
+//   - Probing the backend from Envoy needs the backend to answer, and a
+//     unikernel behind a tap may not.
+//   - Probing the gateway address from the backend node's own root-namespace
 //     VRF does not work either, and the reason is instructive: usid_egress
-//     attaches to the *ingress* hook of a tenant's tap/veth -- where a
-//     tenant's own outbound traffic arrives from the workload -- so a packet
-//     the host itself originates into that VRF never traverses it, and
-//     leaves via the VRF's NAT66 default route instead.
+//     attaches to the ingress hook of a tenant's tap or veth, where a tenant's
+//     outbound traffic arrives from the workload, so a packet the host itself
+//     originates into that VRF never traverses it and leaves through the VRF's
+//     NAT66 default instead.
 //
-// So the encapsulation is done here, by the kernel, on our behalf: an
-// AF_INET6 SOCK_RAW socket with protocol 41 (IPv6-in-IPv6) makes the kernel
-// build the outer header -- next-header 41, source address chosen from the
-// host's own routing, which is what keeps it past BCP38 filtering -- with
-// our inner packet as its payload. Byte-for-byte what a backend node's
-// usid_egress would have produced.
+// So the encapsulation is done here, by the kernel: a raw IPv6 socket with
+// protocol 41 makes the kernel build the outer header, with a source address
+// chosen from the host's own routing, which is what keeps it past source
+// filtering. Byte for byte what a backend node's usid_egress would produce.
 func inject(cfg config, d derived) error {
 	innerSrc := net.ParseIP(cfg.innerSrc)
 	if innerSrc == nil {
@@ -1221,10 +1202,10 @@ func inject(cfg config, d derived) error {
 }
 
 // buildInnerSYN builds a 60-byte inner packet: a 40-byte IPv6 header plus a
-// 20-byte TCP SYN, with the TCP checksum computed over the RFC 2460
-// pseudo-header. usid_ingress requires the inner packet's own version nibble
-// to be 4 or 6 and reads its addresses for the step 8 FIB lookup, so this
-// has to be genuinely well-formed, not a stub payload.
+// 20-byte TCP SYN, with the checksum computed over the pseudo-header.
+// usid_ingress requires the inner packet's version nibble to be 4 or 6 and
+// reads its addresses for the FIB lookup, so it must be genuinely well formed
+// rather than a stub payload.
 func buildInnerSYN(src, dst net.IP, sport, dport uint16) []byte {
 	const tcpLen = 20
 	pkt := make([]byte, 40+tcpLen)
@@ -1273,19 +1254,16 @@ func checksum(b []byte) uint16 {
 // filters
 // ---------------------------------------------------------------------
 
-// filters lists the clsact ingress filter chain on an interface, in the
-// order the kernel evaluates it (ascending priority).
+// filters lists the clsact ingress filter chain on an interface, in the order
+// the kernel evaluates it.
 //
-// This exists because a correct usid_ingress with correct maps still does
-// nothing if it never runs. usid.c attaches direct-action at a fixed
-// priority (attach.go's defaultFilterPriority) to the same native-device
-// ingress hook Cilium uses, and returns TC_ACT_UNSPEC on every fail-open
-// path specifically so a Cilium filter at a *later* priority still sees the
-// packet. That reasoning only holds while galactic actually sits earlier in
-// the chain and is still present: in direct-action mode an earlier filter
-// returning TC_ACT_OK is a final verdict that ends the chain, and a filter
-// installed at the same priority by another agent replaces rather than
-// stacks.
+// A correct program with correct maps still does nothing if it never runs. It
+// attaches direct-action at a fixed priority to the same hook a cluster CNI
+// uses, and returns TC_ACT_UNSPEC on every fail-open path so a filter at a
+// later priority still sees the packet. That reasoning holds only while it sits
+// earlier in the chain and is still present: in direct-action mode an earlier
+// filter returning TC_ACT_OK ends the chain, and a filter installed at the same
+// priority by another agent replaces rather than stacks.
 func filters(cfg config, _ derived) error {
 	if cfg.iface == "" {
 		return errors.New("-iface is required for filters")
@@ -1335,17 +1313,16 @@ func filters(cfg config, _ derived) error {
 // verify-maps
 // ---------------------------------------------------------------------
 
-// verifyMaps checks the assumption every other action here silently rests
-// on: that the maps reachable through bpffs pins are the same kernel objects
-// the *attached* program actually reads.
+// verifyMaps checks the assumption every other action rests on: that the maps
+// reachable through bpffs pins are the same kernel objects the attached program
+// reads.
 //
-// They can diverge. attach.Load pins each map under pinDir and reuses an
-// existing pin as-is, but a schema-incompatible reload replaces the
-// program's maps; anything still holding, or newly opening, the old pin then
-// reads and writes an orphaned map that no attached program consults. The
-// symptom is exactly what it looks like from outside: registrations that
-// appear to succeed, a program that is demonstrably attached and receiving
-// packets, and counters that never move.
+// They can diverge. Loading pins each map and reuses an existing pin as-is, but
+// a schema-incompatible reload replaces the program's maps, and anything still
+// holding, or newly opening, the old pin then reads and writes an orphan no
+// attached program consults. The symptom is what it looks like from outside:
+// registrations that appear to succeed, a program demonstrably attached and
+// receiving packets, and counters that never move.
 func verifyMaps(cfg config, _ derived) error {
 	if cfg.progID == 0 {
 		return errors.New("-prog-id is required (take it from the filters output)")
@@ -1408,19 +1385,17 @@ func verifyMaps(cfg config, _ derived) error {
 // attach-iface / detach-iface
 // ---------------------------------------------------------------------
 
-// attachIface attaches an already-loaded usid_ingress (by program id, from
-// the filters output) to an additional interface, via the same
-// attach.Attach path production uses.
+// attachIface attaches an already-loaded usid_ingress, by program id from the
+// filters output, to an additional interface, through the same path production
+// uses.
 //
-// It exists to test one specific failure: attach.ResolveInterfaces picks the
-// interfaces carrying the IPv6 default route and then deliberately skips
-// WireGuard links (attach/interfaces.go's excludedLinkType), because a
-// WireGuard mesh can install a default-ish route of its own and
-// srv6.ResolveNodeSourceAddress would then bake its ULA in as this node's
-// source address. On a Talos cluster with KubeSpan enabled, that same
-// WireGuard interface is what actually carries inter-node traffic --
-// including the iBGP sessions and every SRv6-encapsulated packet -- so the
-// skip removes the only interface the datapath needed.
+// It exists to test one failure: interface resolution picks the interfaces
+// carrying the IPv6 default route and then skips WireGuard links, because a
+// mesh can install a default route of its own and this node's source address
+// would then be a mesh address unreachable off-node. On a cluster where that
+// same WireGuard interface carries inter-node traffic, including the BGP
+// sessions and every encapsulated packet, the skip removes the only interface
+// the datapath needed.
 func attachIface(cfg config, _ derived) error {
 	if cfg.progID == 0 || cfg.iface == "" {
 		return errors.New("-prog-id and -iface are both required")

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -15,18 +15,16 @@ var ConfFile = config.DefaultConfFile
 // Initialized by InitCNIConfig() (called from cmd/galactic-veth/main.go).
 var cniConfig *config.CNIConfig
 
-// InitCNIConfig initializes the shared config resolver for CNI env var
-// resolution. Callers should invoke this once at process startup before any
-// config lookups.
+// InitCNIConfig initializes the shared config resolver. Call it once at process
+// startup, before any config lookup.
 func InitCNIConfig() {
 	cniConfig = config.NewCNIConfig()
 }
 
-// parseConf unmarshals the CNI configuration from stdin data, validates the
-// base62-encoded identifier fields, and resolves logging. The actual logic
-// is shared with galactic-tap — see internal/cnimaster.ParseConf — since
-// none of it is veth-specific; this is a thin wrapper binding it to this
-// binary's own cniConfig/ConfFile.
+// parseConf unmarshals the CNI configuration from data, validates the base62
+// identifier fields, and resolves logging. The logic is shared with the tap
+// plugin, none of it being veth-specific; this binds it to this binary's own
+// resolver and conflist path.
 func parseConf(data []byte) (*PluginConf, error) {
 	return cnimaster.ParseConf(data, cniConfig, ConfFile)
 }

--- a/internal/cni/doc.go
+++ b/internal/cni/doc.go
@@ -2,30 +2,22 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cni implements galactic-veth, the veth master plugin for wiring
-// container workloads into SRv6-backed VPC networks. Tap-based workloads
-// (Kata, Firecracker, kraftlet/Unikraft) are galactic-tap's own master
-// plugin (internal/cnitap) — interface kind is which binary is invoked now,
-// not a config field either binary branches on.
+// Package cni implements galactic-veth, the veth master plugin wiring container
+// workloads into SRv6-backed VPC networks. Tap-based workloads are a separate
+// master plugin: interface kind is which binary the runtime invokes, not a
+// config field either branches on.
 //
-// On ADD the plugin creates a VRF, a veth pair, and patches the pod's NAD
-// with the host interface name. On DEL it performs best-effort cleanup in
-// reverse order. CHECK and STATUS validate that managed kernel resources are
-// intact. IPAM allocation, termination-route installation, and
-// BGPAdvertisement/BGPVRFInstance publish are no longer this package's
-// concern — they're galactic-ipam's, galactic-route's, and galactic-bgp's
-// own, chained after this plugin per the conflist (see
-// internal/cniipam, internal/cniroute, internal/cnibgp).
+// On ADD it creates a VRF, a veth pair, and patches the pod's attachment
+// definition with the host interface name. On DEL it cleans up best-effort in
+// reverse order. CHECK and STATUS validate that the managed kernel resources
+// are intact.
 //
-// Subpackages isolate kernel primitives:
+// Address allocation, termination routes, and BGP publishing are each their own
+// chain-invoked binary, not this package's concern.
 //
-//   - veth: veth pair creation for container workloads
-//
-// internal/cni/ipam, internal/cni/route, and internal/cni/tap are the same
-// kind of kernel-primitive package, but are no longer used by this package
-// itself — they're used exclusively by internal/cniipam, internal/cniroute,
-// and internal/cnitap respectively, now that IPAM, termination routes, and
-// tap are each their own chain-invoked binary.
+// Subpackages isolate kernel primitives: veth creates the pair for container
+// workloads. The sibling ipam, route, and tap packages are the same kind of
+// package but are used by their own binaries rather than by this one.
 //
 // Usage:
 //

--- a/internal/cni/ipam/dualstack.go
+++ b/internal/cni/ipam/dualstack.go
@@ -6,20 +6,17 @@ package ipam
 
 import "net"
 
-// DualStackAllocator wraps an optional IPv6 PoolAllocator and an optional
-// IPv4 IPv4PoolAllocator, allocating from whichever are configured in a
-// single call. Both families are optional: when the CNI config does not
-// carry an IPv6 pool, DualStackAllocator behaves as IPv4-only, and vice
-// versa.
+// DualStackAllocator wraps an optional IPv6 and an optional IPv4 pool allocator,
+// allocating from whichever are configured in one call. Both are optional: with
+// no IPv6 pool it behaves as IPv4-only, and the reverse.
 type DualStackAllocator struct {
 	ipv6 *PoolAllocator
 	ipv4 *IPv4PoolAllocator
 }
 
-// DualStackResult carries the addresses allocated for a single container.
-// IPv6Subnet/IPv6Gateway are nil when the allocator was constructed without
-// an IPv6 pool; IPv4Address/IPv4Gateway are nil when constructed without an
-// IPv4 pool.
+// DualStackResult carries the addresses allocated for one container. The IPv6
+// fields are nil when the allocator was built without an IPv6 pool, and the IPv4
+// fields likewise.
 type DualStackResult struct {
 	IPv6Subnet  *net.IPNet
 	IPv6Gateway net.IP
@@ -27,14 +24,10 @@ type DualStackResult struct {
 	IPv4Gateway net.IP
 }
 
-// NewDualStackAllocator creates a DualStackAllocator. If ipv6Pool is empty,
-// the resulting allocator only allocates IPv4 addresses (IPv6 fields in
-// DualStackResult are left nil). If ipv4Pool is empty, the resulting
-// allocator only allocates IPv6 addresses (IPv4 fields in DualStackResult
-// are left nil). lockDir is passed straight through to both
-// NewPoolAllocator and NewIPv4PoolAllocator (see DefaultLockDir for the
-// production path) — one shared root serves both families, since each
-// pool's own CIDR namespaces its state into a distinct subdirectory.
+// NewDualStackAllocator creates a DualStackAllocator. An empty pool for either
+// family leaves that family's result fields nil. lockDir passes straight through
+// to both underlying allocators: one shared root serves both families, since each
+// pool's CIDR namespaces its state into its own subdirectory.
 func NewDualStackAllocator(
 	ipv6Pool, ipv6Gateway, ipv4Pool, ipv4Gateway, lockDir string,
 ) (*DualStackAllocator, error) {
@@ -59,9 +52,8 @@ func NewDualStackAllocator(
 	return a, nil
 }
 
-// Allocate allocates an IPv6 subnet (if an IPv6 pool was configured) and an
-// IPv4 address (if an IPv4 pool was configured) for the given container ID.
-// Thread-safe (delegates to the underlying allocators' own locking).
+// Allocate allocates from whichever pools were configured for the given
+// container. Thread-safe, delegating to the underlying allocators' locking.
 func (a *DualStackAllocator) Allocate(containerID string) (*DualStackResult, error) {
 	result := &DualStackResult{}
 

--- a/internal/cni/ipam/ipam.go
+++ b/internal/cni/ipam/ipam.go
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package ipam provides IPv6 subnet allocation for the Galactic CNI. Each
-// allocation returns a subnet (default /96) from a larger CIDR pool (e.g. a
-// /64 region subnet).
+// allocation returns a subnet, a /96 by default, from a larger CIDR pool.
 //
-// Allocations persist as an on-disk marker file per allocated subnet, keyed
-// by the pool CIDR (mirroring IPv4PoolAllocator's own scheme) — required
-// because each CNI ADD/DEL is a separate OS process: an in-memory-only
-// record (as this package used before) is discarded the moment the ADD
-// process that created it exits, leaving DEL with nothing to look up.
+// Allocations persist as an on-disk marker file per allocated subnet, keyed by
+// the pool CIDR. That is required because each CNI ADD and DEL is a separate
+// process: an in-memory record is discarded the moment the ADD that created it
+// exits, leaving DEL nothing to look up.
 package ipam
 
 import (
@@ -32,24 +30,21 @@ const (
 	// A /96 gives 2^32 addresses per pod subnet.
 	DefaultSubnetLen = 96
 
-	// poolLockFileName is the flock target within each pool's state
-	// directory; every other entry in that directory is an allocation
-	// marker file named after the subnet it reserves.
+	// poolLockFileName is the flock target within each pool's state directory.
+	// Every other entry there is an allocation marker named after the subnet it
+	// reserves.
 	poolLockFileName = "lock"
 )
 
-// DefaultLockDir is the well-known parent directory for the node-local
-// on-disk lock and allocation state both PoolAllocator (IPv6) and
-// IPv4PoolAllocator use to stay correct across separate CNI plugin
-// invocations. Both families share one root — each pool's own CIDR
-// namespaces its state into a distinct subdirectory (sanitizePoolDirName),
-// so an IPv6 pool and an IPv4 pool never collide here.
+// DefaultLockDir is the node-local parent directory for the on-disk lock and
+// allocation state both allocators use to stay correct across separate plugin
+// invocations. Each pool's CIDR namespaces its state into its own
+// subdirectory, so an IPv6 and an IPv4 pool never collide.
 const DefaultLockDir = "/var/lib/cni/galactic-ipam"
 
 // PoolAllocator allocates IPv6 subnets from a CIDR pool, persisting each
-// allocation as a marker file under a lock directory, guarded by a
-// cross-process flock — see IPv4PoolAllocator's own doc comment for why
-// this is required rather than optional.
+// allocation as a marker file under a lock directory and guarding it with a
+// cross-process flock.
 type PoolAllocator struct {
 	pool      *net.IPNet // the master pool (e.g. a /64 region subnet)
 	subnetLen int        // prefix length per allocation (e.g. 96)
@@ -61,19 +56,16 @@ type PoolAllocator struct {
 	state     lockedState
 }
 
-// NewPoolAllocator creates a new pool allocator from an IPv6 CIDR pool, an
-// optional gateway address, a subnet prefix length, and a parent directory
-// for this pool's on-disk lock and allocation state (see DefaultLockDir for
-// the production path; lockDir must not be empty). The pool must be an
-// IPv6 prefix with a length of subnetLen or fewer bits (e.g. a /64 region
-// subnet when subnetLen is the default /96, though any pool length <=
-// subnetLen is accepted). If gateway is empty, the first address in the pool
-// (host bits = 1) is used as the gateway. If subnetLen is 0, DefaultSubnetLen
-// (96) is used. The subnet containing the gateway is reserved and never
-// handed out by Allocate — otherwise the endpoint owning that subnet could
-// self-assign the gateway's own address to one of its secondary/pod
-// addresses, colliding with the address every other endpoint in the pool
-// routes its default route through.
+// NewPoolAllocator creates a pool allocator over an IPv6 CIDR pool.
+//
+// gateway may be empty, in which case the first address in the pool is used.
+// subnetLen may be 0, in which case DefaultSubnetLen applies; the pool's own
+// prefix must be no longer than it. lockDir is this pool's parent directory for
+// on-disk lock and allocation state and must not be empty.
+//
+// The subnet containing the gateway is reserved and never handed out, since
+// otherwise the endpoint owning it could self-assign the gateway's address and
+// collide with the address every other endpoint routes its default through.
 func NewPoolAllocator(poolCIDR, gateway string, subnetLen int, lockDir string) (*PoolAllocator, error) {
 	_, pool, err := net.ParseCIDR(poolCIDR)
 	if err != nil {
@@ -136,18 +128,19 @@ func NewPoolAllocator(poolCIDR, gateway string, subnetLen int, lockDir string) (
 	return pa, nil
 }
 
-// Allocate assigns the next available IPv6 subnet from the pool for the
-// given container ID, skipping the subnet that contains the pool's gateway
-// address and any subnet another allocation already holds (per the on-disk
-// marker files, so this is correct across separate CNI plugin invocations
-// on the same pool). If containerID already holds an allocation in this
-// pool, that same subnet is returned rather than a fresh one being handed
-// out — the CNI spec permits a runtime to retry ADD for the same container
-// after a transient failure, and without this check each retry would leak
-// the marker file from the previous attempt (findContainerMarker only ever
-// returns the first match, so only one of the leaked markers would ever be
-// recoverable via DEL). Returns the allocated subnet CIDR or an error if the
-// pool is exhausted. Thread-safe.
+// Allocate assigns the next available IPv6 subnet from the pool to containerID,
+// skipping the subnet holding the gateway and any subnet another allocation
+// already holds according to the on-disk markers, which is what makes it
+// correct across separate plugin invocations.
+//
+// A containerID that already holds an allocation gets the same subnet back
+// rather than a fresh one. The CNI spec permits a runtime to retry ADD for the
+// same container after a transient failure, and without that check each retry
+// would leak the previous attempt's marker, only one of which is ever
+// recoverable on DEL.
+//
+// Returns the allocated subnet, or an error if the pool is exhausted.
+// Thread-safe.
 func (a *PoolAllocator) Allocate(containerID string) (*net.IPNet, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -203,9 +196,8 @@ func (a *PoolAllocator) Allocate(containerID string) (*net.IPNet, error) {
 	return result, nil
 }
 
-// usedSubnets reads the pool's state directory and returns the set of
-// subnet CIDR strings currently marked allocated. Callers must hold both mu
-// and the pool's flock.
+// usedSubnets returns the set of subnet CIDR strings currently marked
+// allocated. Callers must hold both mu and the pool's flock.
 func (a *PoolAllocator) usedSubnets() (map[string]struct{}, error) {
 	entries, err := a.state.entries()
 	if err != nil {
@@ -218,10 +210,9 @@ func (a *PoolAllocator) usedSubnets() (map[string]struct{}, error) {
 	return used, nil
 }
 
-// Deallocate removes the allocation for the given subnet CIDR string.
-// Silently ignores unknown subnets. Serialized the same way as Allocate.
-// Callers that only know the containerID (not the allocated value) should
-// use DeallocateContainer instead.
+// Deallocate removes the allocation for subnetCIDR, ignoring an unknown subnet.
+// Serialized like Allocate. A caller that knows only the containerID should use
+// DeallocateContainer.
 func (a *PoolAllocator) Deallocate(subnetCIDR string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -231,9 +222,9 @@ func (a *PoolAllocator) Deallocate(subnetCIDR string) {
 	})
 }
 
-// LookupContainer reports the subnet CIDR, if any, allocated to
-// containerID, without removing it — used by CHECK to confirm an
-// allocation is still in place. Returns ("", false) if none is found.
+// LookupContainer reports the subnet allocated to containerID, without removing
+// it, for CHECK to confirm an allocation is still in place. Returns ("", false)
+// when none is found.
 func (a *PoolAllocator) LookupContainer(containerID string) (string, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -250,14 +241,12 @@ func (a *PoolAllocator) LookupContainer(containerID string) (string, bool) {
 	return desanitizeMarkerName(name), true
 }
 
-// DeallocateContainer removes the allocation, if any, held by containerID,
-// without the caller needing to already know the allocated subnet — the
-// on-disk marker file records which containerID holds each subnet, so this
-// is a direct scan of this pool's own state, no external lookup (e.g. a
-// CRD read) required. The scan and the removal happen under a single flock
-// acquisition (via lockedState.withLock) so a concurrent process sharing
-// this pool can never interleave between them. Returns the deallocated
-// subnet CIDR and true if one was found; ("", false) otherwise.
+// DeallocateContainer removes the allocation held by containerID without the
+// caller needing to know the subnet: the marker records which container holds
+// each one, so this is a direct scan of this pool's state with no external
+// lookup. The scan and removal share a single flock acquisition, so a
+// concurrent process on the same pool cannot interleave between them. Returns
+// the deallocated subnet and true, or ("", false).
 func (a *PoolAllocator) DeallocateContainer(containerID string) (string, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -312,15 +301,13 @@ func (a *StaticAllocator) Allocate(_ string, addr string) (net.IP, error) {
 	return ip.To16(), nil
 }
 
-// incSubnet increments an IP by one subnet step and returns it in place.
-// The step size is 2^(128-subnetLen), advancing to the next subnet boundary.
+// incSubnet advances ip by one subnet step, in place, the step being
+// 2^(128-subnetLen).
 //
-// Only bytes strictly after the network boundary are zeroed on each call; the
-// boundary byte itself is left untouched so it can keep counting up across
-// repeated calls on the same IP (as Allocate does when walking pool
-// boundaries). Zeroing the boundary byte on every call — as an earlier
-// version of this function did — reset the counter back to its just-computed
-// value each time, so a chained sequence of calls never advanced past the
+// Only bytes strictly after the network boundary are zeroed; the boundary byte
+// itself keeps counting up across repeated calls on the same IP, which is how
+// Allocate walks pool boundaries. Zeroing it on every call resets the counter
+// to its just-computed value, so a chained sequence never advances past the
 // second subnet in the pool.
 func incSubnet(ip net.IP, subnetLen int) net.IP {
 	// Zero out host bits strictly after the network boundary byte.
@@ -338,10 +325,9 @@ func incSubnet(ip net.IP, subnetLen int) net.IP {
 	return ip
 }
 
-// desanitizeMarkerName reverses sanitizePoolDirName's "/" -> "-" replacement
-// for a subnet CIDR marker filename. A CIDR string carries exactly one "/",
-// so replacing the first "-" back is unambiguous (subnet strings otherwise
-// contain only hex digits and ":").
+// desanitizeMarkerName reverses the "/" to "-" replacement in a subnet marker
+// filename. A CIDR carries exactly one "/", so replacing the first "-" is
+// unambiguous: subnet strings otherwise contain only hex digits and ":".
 func desanitizeMarkerName(name string) string {
 	before, after, found := strings.Cut(name, "-")
 	if !found {
@@ -351,14 +337,13 @@ func desanitizeMarkerName(name string) string {
 }
 
 // parseAllocatedSubnet parses a subnet CIDR string previously produced by
-// Allocate (via (*net.IPNet).String()) back into a *net.IPNet, preserving
-// its IP exactly as allocated. net.ParseCIDR is deliberately not used here:
-// it returns the *masked* network address, which would zero out incSubnet's
-// per-subnet counter byte — the byte incSubnet advances sits inside what a
-// strict /subnetLen mask treats as host bits (see incSubnet's own doc
-// comment), so re-masking a stored subnet string would silently collapse
-// every allocated subnet in the pool back down to the same reserved-subnet
-// address.
+// Allocate back into a *net.IPNet, preserving its address exactly.
+//
+// net.ParseCIDR is deliberately not used: it returns the masked network
+// address, which zeroes the per-subnet counter byte incSubnet advances, since
+// that byte sits inside what a strict mask treats as host bits. Re-masking a
+// stored subnet would collapse every allocated subnet in the pool back to the
+// same reserved address.
 func parseAllocatedSubnet(cidr string) (*net.IPNet, error) {
 	ipStr, prefixStr, found := strings.Cut(cidr, "/")
 	if !found {

--- a/internal/cni/ipam/ipv4.go
+++ b/internal/cni/ipam/ipv4.go
@@ -18,26 +18,25 @@ const (
 	// ipv4Bits is the number of bits in an IPv4 address.
 	ipv4Bits = 32
 
-	// ipv4LockFileName is the flock target within each pool's state
-	// directory; every other entry in that directory is an allocation
-	// marker file named after the address it reserves.
+	// ipv4LockFileName is the flock target within each pool's state directory.
+	// Every other entry there is an allocation marker named after the address
+	// it reserves.
 	ipv4LockFileName = "lock"
 )
 
-// IPv4PoolAllocator allocates individual IPv4 /32 addresses from a CIDR pool.
-// Unlike PoolAllocator's ephemeral in-memory tracking, IPv4PoolAllocator
-// persists each allocation as a marker file under a lock directory, keyed by
-// the pool CIDR, and guards reads/writes of that state with a cross-process
-// flock. This is required because PR #740's IPv4 pool is a site-wide /20
-// shared by every VPC at that site: each CNI invocation is a separate OS
-// process, so two pods in different VPCs concurrently ADDing on the same
-// node construct independent allocator instances against the identical pool
-// — an in-memory-only "used" set (as PoolAllocator uses for IPv6, where each
-// VPCAttachment's pool is exclusively its own) would let both instances
-// allocate the same address. Four addresses in the pool are reserved and
-// never handed out: the network address (first address), the gateway
-// address (network address + 1, or an explicit gateway), the second-to-last
-// address (platform reserved), and the last address (broadcast-equivalent).
+// IPv4PoolAllocator allocates individual IPv4 addresses from a CIDR pool,
+// persisting each allocation as a marker file under a lock directory keyed by
+// the pool CIDR and guarding that state with a cross-process flock.
+//
+// The cross-process guard is required because the IPv4 pool is a site-wide
+// prefix shared by every VPC at that site. Each CNI invocation is a separate
+// process, so two pods in different VPCs adding concurrently on one node build
+// independent allocators against the same pool, and an in-memory used set would
+// let both pick the same address. The IPv6 allocator does not need this, each
+// attachment's pool being exclusively its own.
+//
+// Four addresses are reserved and never handed out: the network address, the
+// gateway, the second-to-last address, and the last.
 type IPv4PoolAllocator struct {
 	pool     *net.IPNet // the master pool (e.g. a /20 site subnet)
 	gateway  net.IP     // gateway IP address
@@ -46,12 +45,10 @@ type IPv4PoolAllocator struct {
 	state    lockedState
 }
 
-// NewIPv4PoolAllocator creates a new IPv4 pool allocator from a CIDR pool and
-// an optional gateway address. The pool must be an IPv4 prefix. If gateway is
-// empty, the network address plus 1 is used as the gateway. lockDir is the
-// parent directory for this pool's on-disk lock and allocation state (see
-// DefaultLockDir for the production path); it must not be empty, and a
-// pool-scoped subdirectory under it is created if it doesn't already exist.
+// NewIPv4PoolAllocator creates an allocator over an IPv4 CIDR pool. An empty
+// gateway defaults to the network address plus one. lockDir is the parent
+// directory for this pool's on-disk lock and allocation state and must not be
+// empty; a pool-scoped subdirectory under it is created if absent.
 func NewIPv4PoolAllocator(poolCIDR, gateway, lockDir string) (*IPv4PoolAllocator, error) {
 	_, pool, err := net.ParseCIDR(poolCIDR)
 	if err != nil {
@@ -98,17 +95,14 @@ func NewIPv4PoolAllocator(poolCIDR, gateway, lockDir string) (*IPv4PoolAllocator
 	return a, nil
 }
 
-// Allocate assigns the next available IPv4 /32 address from the pool for the
-// given container ID, skipping reserved addresses (the network address, the
-// gateway, the second-to-last address, and the last address of the pool). If
-// containerID already holds an allocation in this pool, that same address is
-// returned rather than a fresh one being handed out — see
-// PoolAllocator.Allocate's doc comment (IPv6) for why this idempotency check
-// matters for CNI ADD retries. Returns an error if the pool is exhausted.
-// The read-modify-write against the on-disk allocation state is serialized
-// both within this process (via mu) and across processes sharing the same
-// pool (via a flock on the pool's lock file), so concurrent ADDs from
-// different VPCs on the same node never return the same address.
+// Allocate assigns the next available address from the pool to containerID,
+// skipping the reserved ones. A containerID that already holds an allocation
+// gets the same address back rather than a fresh one, which is what makes an
+// ADD retry safe. Returns an error if the pool is exhausted.
+//
+// The read-modify-write against the on-disk state is serialized both within
+// this process and across processes sharing the pool, so concurrent adds from
+// different VPCs on one node never return the same address.
 func (a *IPv4PoolAllocator) Allocate(containerID string) (net.IP, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -168,9 +162,9 @@ func (a *IPv4PoolAllocator) Deallocate(addr string) {
 	})
 }
 
-// LookupContainer reports the address, if any, allocated to containerID,
-// without removing it — used by CHECK to confirm an allocation is still in
-// place. Returns ("", false) if none is found.
+// LookupContainer reports the address allocated to containerID, without
+// removing it, for CHECK to confirm an allocation is still in place. Returns
+// ("", false) when none is found.
 func (a *IPv4PoolAllocator) LookupContainer(containerID string) (string, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -184,12 +178,9 @@ func (a *IPv4PoolAllocator) LookupContainer(containerID string) (string, bool) {
 	return addr, ok
 }
 
-// DeallocateContainer removes the allocation, if any, held by containerID,
-// without the caller needing to already know the allocated address —
-// mirrors PoolAllocator.DeallocateContainer (IPv6); see its doc comment for
-// why the scan and the removal must happen under a single flock acquisition.
-// Returns the deallocated address and true if one was found; ("", false)
-// otherwise.
+// DeallocateContainer removes the allocation held by containerID without the
+// caller needing to know the address. The scan and removal share a single flock
+// acquisition. Returns the deallocated address and true, or ("", false).
 func (a *IPv4PoolAllocator) DeallocateContainer(containerID string) (string, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -218,9 +209,8 @@ func (a *IPv4PoolAllocator) IsAllocated(addr string) bool {
 	return err == nil
 }
 
-// usedAddresses reads the pool's state directory and returns the set of
-// addresses currently marked allocated by any process sharing this pool.
-// Callers must hold both mu and the pool's flock.
+// usedAddresses returns the set of addresses currently marked allocated by any
+// process sharing this pool. Callers must hold both mu and the pool's flock.
 func (a *IPv4PoolAllocator) usedAddresses() (map[string]struct{}, error) {
 	entries, err := a.state.entries()
 	if err != nil {
@@ -245,9 +235,8 @@ func (a *IPv4PoolAllocator) Gateway() net.IP {
 	return a.gateway
 }
 
-// reservedAddresses returns the set of addresses in the pool that are never
-// handed out by Allocate: the network address, the gateway address, the
-// second-to-last address, and the last address.
+// reservedAddresses returns the addresses Allocate never hands out: the network
+// address, the gateway, the second-to-last, and the last.
 func (a *IPv4PoolAllocator) reservedAddresses() map[string]struct{} {
 	ones, bits := a.pool.Mask.Size()
 	total := uint64(1) << uint(bits-ones)

--- a/internal/cni/ipam/lock.go
+++ b/internal/cni/ipam/lock.go
@@ -11,13 +11,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// fileLock is a cross-process advisory lock backed by flock(2). Each CNI ADD
-// or DEL is a separate OS process, so in-process synchronization (a
-// sync.Mutex or sync.Map) does nothing to serialize concurrent invocations
-// against state shared across processes, such as a site-wide IPv4 pool.
-// fileLock closes that gap: flock(2) locks are held per open file
-// description, so any number of processes (or goroutines, each opening their
-// own file description) opening the same path contend for the same lock.
+// fileLock is a cross-process advisory lock. Each CNI ADD or DEL is a separate
+// process, so in-process synchronization does nothing to serialize concurrent
+// invocations against state shared across processes, such as a site-wide IPv4
+// pool. These locks are held per open file description, so any number of
+// processes opening the same path contend for the same lock.
 type fileLock struct {
 	f *os.File
 }

--- a/internal/cni/ipam/lockedstate.go
+++ b/internal/cni/ipam/lockedstate.go
@@ -10,26 +10,23 @@ import (
 	"path/filepath"
 )
 
-// lockedState wraps the on-disk state directory and cross-process flock
-// pattern shared by PoolAllocator (IPv6) and IPv4PoolAllocator: a directory
-// holding a "lock" file plus one allocation marker file per allocated
-// subnet/address, guarded by a flock so separate CNI plugin invocations
-// (each ADD/DEL/CHECK is its own OS process) never race against each other
-// over the same pool.
+// lockedState wraps the on-disk state directory and cross-process lock both
+// allocators share: a directory holding a lock file plus one marker file per
+// allocation, guarded so separate plugin invocations, each its own process,
+// never race over the same pool.
 type lockedState struct {
 	stateDir     string
 	lockFileName string
 }
 
-// withLock acquires the pool's cross-process flock, runs fn, and releases
-// the lock unconditionally before returning. Every read-modify-write against
-// stateDir must go through this — in particular, a scan (to find which
-// marker file, if any, belongs to a given containerID) and any removal that
-// follows it must happen inside the *same* withLock call. Splitting them
-// across two separate lock/unlock cycles, as an earlier version of
-// findContainerMarker plus its callers did, leaves a window between the scan
-// and the removal where a concurrent process sharing this pool can allocate
-// or deallocate the very entry being acted on.
+// withLock acquires the pool's cross-process lock, runs fn, and releases the
+// lock unconditionally before returning.
+//
+// Every read-modify-write against the state directory must go through it. In
+// particular a scan, to find which marker belongs to a container, and any
+// removal that follows must happen inside the same call: splitting them across
+// two lock cycles leaves a window where a concurrent process sharing the pool
+// can allocate or release the very entry being acted on.
 func (s lockedState) withLock(fn func() error) error {
 	lock, err := newFileLock(filepath.Join(s.stateDir, s.lockFileName))
 	if err != nil {
@@ -43,9 +40,8 @@ func (s lockedState) withLock(fn func() error) error {
 	return fn()
 }
 
-// entries reads stateDir and returns every marker filename except the lock
-// file itself. Callers must already hold the flock (call from inside
-// withLock).
+// entries reads the state directory and returns every marker filename except the
+// lock file. Callers must already hold the lock.
 func (s lockedState) entries() ([]os.DirEntry, error) {
 	all, err := os.ReadDir(s.stateDir)
 	if err != nil {
@@ -61,9 +57,9 @@ func (s lockedState) entries() ([]os.DirEntry, error) {
 	return markers, nil
 }
 
-// findContainerMarkerLocked scans stateDir for the marker file whose
-// content matches containerID, returning its filename. Callers must already
-// hold the flock (call from inside withLock).
+// findContainerMarkerLocked scans the state directory for the marker whose
+// content matches containerID and returns its filename. Callers must already
+// hold the lock.
 func (s lockedState) findContainerMarkerLocked(containerID string) (string, bool) {
 	entries, err := s.entries()
 	if err != nil {

--- a/internal/cni/netns.go
+++ b/internal/cni/netns.go
@@ -13,9 +13,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// configureInterfaceInNetns applies IP addresses and default routes to the
-// guest interface inside the container network namespace. ipv4Net/ipv4GW are
-// nil for an IPv6-only attachment.
+// configureInterfaceInNetns applies addresses and default routes to the guest
+// interface inside the container network namespace. The IPv4 arguments are nil
+// on an IPv6-only attachment.
 func configureInterfaceInNetns(
 	netnsPath, ifName string,
 	ipv6Net *net.IPNet, ipv6GW net.IP,
@@ -60,13 +60,14 @@ func configureInterfaceInNetns(
 	return nil
 }
 
-// addAddrAndDefaultRoute assigns ipNet to link and, if gateway is set,
-// installs a default route via it. No-op when ipNet is nil (family not in
-// use for this attachment). Both the address and the route are added
-// idempotently: a call that finds its target already in place (e.g. a
-// retried CNI ADD against a netns that a previous, non-DEL'd ADD already
-// configured) succeeds without touching kernel state; a call that finds
-// different, conflicting state fails loudly instead of overwriting it.
+// addAddrAndDefaultRoute assigns ipNet to link and, when gateway is set,
+// installs a default route through it. A nil ipNet, meaning that family is
+// unused here, is a no-op.
+//
+// Both are added idempotently: finding the target already in place, as a
+// retried ADD against a namespace a previous ADD configured would, succeeds
+// without touching kernel state, while finding conflicting state fails loudly
+// rather than overwriting it.
 func addAddrAndDefaultRoute(
 	handle *netlink.Handle, link netlink.Link, ifName string, ipNet *net.IPNet, gateway net.IP,
 ) error {
@@ -93,11 +94,10 @@ func addrFamily(ip net.IP) int {
 	return netlink.FAMILY_V6
 }
 
-// addAddrIfMissing adds ipNet to link unless an identical address (same IP
-// and prefix length) is already present, in which case it is a no-op. A
-// link can legitimately carry multiple distinct addresses per family, so no
-// existing address is ever treated as a conflict here — only an exact match
-// short-circuits the add.
+// addAddrIfMissing adds ipNet to link unless an identical address is already
+// present. A link can legitimately carry several distinct addresses per family,
+// so only an exact match short-circuits the add; no existing address is treated
+// as a conflict.
 func addAddrIfMissing(handle *netlink.Handle, link netlink.Link, ifName string, ipNet *net.IPNet) error {
 	want := netlink.Addr{IPNet: ipNet}
 
@@ -117,11 +117,10 @@ func addAddrIfMissing(handle *netlink.Handle, link netlink.Link, ifName string, 
 	return nil
 }
 
-// addDefaultRouteIfMissing installs a default route via gateway on link
-// unless a default route via that same gateway already exists, in which
-// case it is a no-op. If a default route via a *different* gateway already
-// exists, that's a real misconfiguration (not something a retried ADD
-// should paper over), so it is returned as an error instead.
+// addDefaultRouteIfMissing installs a default route through gateway on link
+// unless one through that same gateway already exists. One through a different
+// gateway is a real misconfiguration rather than something a retried ADD should
+// paper over, so it returns an error.
 func addDefaultRouteIfMissing(handle *netlink.Handle, link netlink.Link, ifName string, gateway net.IP) error {
 	existing, err := handle.RouteList(link, addrFamily(gateway))
 	if err != nil {
@@ -138,11 +137,11 @@ func addDefaultRouteIfMissing(handle *netlink.Handle, link netlink.Link, ifName 
 			ifName, r.Gw, gateway)
 	}
 
-	// onlink: the IPv4 pool allocates a /32 host address (no on-link subnet
-	// route to the gateway), so the kernel refuses this route with
-	// ENETUNREACH unless told to treat the gateway as directly reachable.
-	// IPv6's /96 subnet allocation already covers the gateway, so the flag
-	// is a no-op there — safe to set unconditionally for both families.
+	// The on-link flag: the IPv4 pool allocates a host address with no on-link
+	// subnet route to the gateway, so the kernel refuses this route unless told
+	// to treat the gateway as directly reachable. The IPv6 subnet allocation
+	// already covers its gateway, making the flag a no-op there, so it is safe
+	// to set for both families.
 	defaultRoute := &netlink.Route{
 		Dst:       nil, // default route
 		Gw:        gateway,
@@ -155,10 +154,9 @@ func addDefaultRouteIfMissing(handle *netlink.Handle, link netlink.Link, ifName 
 	return nil
 }
 
-// isDefaultRouteDst reports whether dst represents a default route
-// (0.0.0.0/0 or ::/0). netlink represents this as a nil Dst on routes it
-// creates itself, but routes read back from the kernel may instead carry an
-// explicit zero-length-prefix net.IPNet.
+// isDefaultRouteDst reports whether dst is a default route. Netlink represents
+// one as a nil destination on routes it creates, while routes read back from the
+// kernel may carry an explicit zero-length prefix instead.
 func isDefaultRouteDst(dst *net.IPNet) bool {
 	if dst == nil {
 		return true
@@ -167,23 +165,21 @@ func isDefaultRouteDst(dst *net.IPNet) bool {
 	return ones == 0
 }
 
-// flushGuestNetnsConfig removes any IP addresses and default routes
-// configured on ifName inside the container netns, without deleting the
-// link itself. No-op if ifName is not present.
+// flushGuestNetnsConfig removes any addresses and default routes on ifName
+// inside the container namespace, without deleting the link. A no-op when
+// ifName is absent.
 //
-// DEL normally relies on hostDevice DEL moving the guest veth end back out
-// of the container netns to flush this state as a side effect: the kernel
-// strips a link's addresses/routes when it genuinely crosses a namespace
-// boundary. But that move is a no-op — and so triggers no such flush — when
-// the "container" netns is the same namespace the link already lives in
-// (e.g. a hostNetwork pod with a Multus secondary attachment, where
-// args.Netns resolves to the host's own root netns rather than a distinct
-// per-sandbox namespace). Left unflushed, that state survives indefinitely
-// (there is no ephemeral sandbox netns to tear down and reclaim it), and the
-// next ADD on that same interface fails with "file exists" trying to add a
-// default route that never went away. Calling this unconditionally in DEL,
-// ahead of hostDevice DEL, makes cleanup reliable regardless of whether the
-// move-triggered flush fires.
+// DEL normally relies on the delegated move of the guest end back out of the
+// container namespace to flush this as a side effect, the kernel stripping a
+// link's addresses and routes when it genuinely crosses a namespace boundary.
+// That move is a no-op, and triggers no flush, when the container namespace is
+// the one the link already lives in, as for a host-network pod with a secondary
+// attachment. Left unflushed the state survives indefinitely, there being no
+// ephemeral namespace to reclaim it, and the next ADD fails trying to add a
+// default route that never went away.
+//
+// Calling this unconditionally in DEL, ahead of the delegated step, makes
+// cleanup reliable either way.
 func flushGuestNetnsConfig(netnsPath, ifName string) error {
 	containerNS, err := ns.GetNS(netnsPath)
 	if err != nil {
@@ -266,12 +262,11 @@ func readGuestInterface(netnsPath, ifName string) (string, int, error) {
 	return mac, mtu, err
 }
 
-// cleanupContainerNetns removes any existing veth interface with the given name
-// from the container network namespace. This is needed to handle stale state
-// from previous CNI ADD runs that may have left interfaces behind.
+// cleanupContainerNetns removes any existing veth named ifName from the
+// container namespace, clearing stale state left behind by a previous ADD.
 //
-// Only *netlink.Veth interfaces are deleted; other types produce a clear error
-// to prevent accidental deletion of unrelated interfaces.
+// Only veth interfaces are deleted; any other type produces a clear error, to
+// prevent deleting an unrelated interface.
 func cleanupContainerNetns(netnsPath, ifName string) error {
 	containerNS, err := ns.GetNS(netnsPath)
 	if err != nil {

--- a/internal/cni/ops_add.go
+++ b/internal/cni/ops_add.go
@@ -22,23 +22,18 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// cmdAdd uses a named return (err) so that the deferred selective rollback
-// below always observes the real failure — see the doc comment on the
-// original version of this function for why a named return matters here;
-// still true with fewer branches. galactic-veth's own ADD ends by printing
-// its own result and returning: BGP/SRv6/eBPF publish is galactic-bgp's
-// job, invoked next by the CNI runtime per conflist order, not by this
-// process.
+// cmdAdd uses a named return so the deferred selective rollback always observes
+// the real failure. It ends by printing its own result: BGP and eBPF publishing
+// is the next plugin's job, invoked by the runtime per conflist order.
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
 		return err
 	}
 
-	// Validate prevResult structure when present. The preceding plugin in the
-	// CNI chain should have produced a result with at least one interface or IP
-	// assignment. A nil or structurally broken prevResult indicates a mis-
-	// configured chain that galactic-veth should not silently ignore.
+	// Validate a previous result when present. The preceding plugin should have
+	// produced one with at least one interface or address; a structurally broken
+	// one means a misconfigured chain this plugin should not silently ignore.
 	if pluginConf.PrevResult != nil {
 		if err := cnimaster.ValidatePrevResultAdd(pluginConf.PrevResult); err != nil {
 			return &types.Error{Code: 6, Msg: fmt.Sprintf("prevResult validation in ADD: %v", err)}
@@ -57,11 +52,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment,
 		"namespace", namespace, "nodeName", nodeName)
 
-	// Chain-completeness check, before any kernel state is created: a
-	// conflist missing galactic-bgp would otherwise attach successfully
-	// with no BGP/SRv6 path to its VPC (issue #331). k8sClient/podNamespace
-	// are created here rather than at the NAD-annotation site below so a
-	// stale conflist fails ADD with nothing to roll back yet.
+	// Chain-completeness check, before any kernel state is created: a conflist
+	// missing the BGP plugin would otherwise attach successfully with no path
+	// to its VPC. The client and namespace are resolved here rather than at the
+	// annotation site below, so a stale conflist fails ADD with nothing to roll
+	// back yet.
 	k8sClient, err := cnimaster.NewK8sClient()
 	if err != nil {
 		return fmt.Errorf("create k8s client: %w", err)
@@ -80,11 +75,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		vpc:           pluginConf.VPC,
 		vpcAttachment: pluginConf.VPCAttachment,
 	}
-	// Record IPAM delegation intent up front, before configureIPAM (called
-	// from buildVethResult below) ever runs — see resourceTracker's
-	// ipamDelegated doc comment for why rollback needs this set
-	// unconditionally on "ipam" block presence, not just after a
-	// successful ExecAdd.
+	// Record the delegation intent up front, before allocation runs. Rollback
+	// needs it set on the ipam block's presence alone, not only after a
+	// successful delegated add.
 	if pluginConf.IPAM != nil {
 		tracker.ipamDelegated = true
 		tracker.ipamType = pluginConf.IPAM.Type
@@ -118,10 +111,10 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	hostMTU := hostLink.Attrs().MTU
 	slog.Debug("ADD: host interface ready", "name", hostName, "mac", hostMac, "mtu", hostMTU)
 
-	// Annotate the NAD with the host interface name. The NAD must already
-	// exist (created by the external VPC operator); a missing or otherwise
-	// unpatchable NAD is a hard failure. Reuses the k8sClient/podNamespace
-	// resolved above for the chain-completeness check.
+	// Annotate the attachment definition with the host interface name. It must
+	// already exist, created by the external VPC operator, so a missing or
+	// unpatchable one is a hard failure. Reuses the client and namespace
+	// resolved above.
 	nadCtx, nadCancel := context.WithTimeout(context.Background(), cnimaster.NADPatchTimeout)
 	defer nadCancel()
 	if err := nadpatch.AnnotateNAD(nadCtx, k8sClient, pluginConf.Name, podNamespace, hostName); err != nil {

--- a/internal/cni/ops_check.go
+++ b/internal/cni/ops_check.go
@@ -21,10 +21,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
-// cmdCheck validates that the container's network state matches what was
-// established during cmdAdd. Per the CNI spec, CHECK is called by the runtime
-// to probe the status of an existing container and should return an error if
-// managed resources are missing or in an invalid state.
+// cmdCheck validates that the container's network state matches what ADD
+// established. Per the CNI spec, the runtime calls CHECK to probe an existing
+// container, and it must return an error when a managed resource is missing or
+// invalid.
 func cmdCheck(args *skel.CmdArgs) error {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -45,8 +45,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 		errs = append(errs, fmt.Errorf("guest interface %q: %w", guestName, err))
 	}
 
-	// Termination routes are galactic-route's own CHECK now (see
-	// internal/cniroute's checkTerminationRoutes) — this plugin's CHECK no
+	// Termination routes are the routing plugin's own CHECK now; this one no
 	// longer verifies them.
 
 	// Validate kernel state against prevResult (CNI spec §4.3).
@@ -75,9 +74,8 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdStatus implements the CNI spec STATUS operation — see
-// internal/cnimaster.RunStatus for the full reasoning, shared verbatim with
-// galactic-tap.
+// cmdStatus implements the CNI STATUS operation, shared verbatim with the tap
+// plugin.
 func cmdStatus(args *skel.CmdArgs) error {
 	return cnimaster.RunStatus(args.StdinData, cniConfig, ConfFile)
 }
@@ -105,9 +103,9 @@ func checkGuestInterface(netnsPath, ifName string) error {
 	})
 }
 
-// checkPrevResult validates that kernel state matches the interfaces and IPs
-// recorded in the prevResult returned by the most recent ADD. Per the CNI spec
-// §4.3, CHECK must verify that managed resources have not drifted.
+// checkPrevResult validates that kernel state still matches the interfaces and
+// addresses the most recent ADD recorded, which the CNI spec requires CHECK to
+// verify.
 func checkPrevResult(rawPrevResult map[string]interface{}, _ string, netns string) error {
 	// RawPrevResult is map[string]interface{} — marshal back to JSON, then
 	// parse as a versioned CNI result.

--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -36,11 +36,10 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 	vpc, vpcAtt := pluginConf.VPC, pluginConf.VPCAttachment
 
-	// Deallocate the pod's IPAM subnet. This is pod-specific and safe to
-	// release immediately. Delegating at all (or not) is entirely
-	// pluginConf.IPAM's own presence — no k8s client needed here at all
-	// now that galactic-ipam's own DEL looks its allocation up locally
-	// (see internal/cniipam's doc comment).
+	// Deallocate the pod's IPAM subnet, which is pod-specific and safe to
+	// release immediately. Whether to delegate at all is decided purely by the
+	// presence of the ipam block, and needs no Kubernetes client now that the
+	// IPAM plugin's own DEL looks its allocation up locally.
 	if pluginConf.IPAM != nil {
 		if err := ipam.ExecDel(pluginConf.IPAM.Type, args.StdinData); err != nil {
 			slog.Warn("DEL: IPAM delegation failed, allocation may not have been released", "err", err,
@@ -48,63 +47,54 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Explicitly flush the address/default-route galactic-veth's IPAM step
-	// installed on the guest interface, ahead of host-device delegation.
-	// hostDevice DEL's move of the guest veth end back out of the container
-	// netns normally flushes this as a side effect of crossing a namespace
-	// boundary, but that side effect never fires when args.Netns is the same
-	// namespace the link already lives in (e.g. a hostNetwork pod with a
-	// Multus secondary attachment) — the move is then a no-op, and the
-	// leftover route survives indefinitely since there's no ephemeral
-	// sandbox netns to reclaim it, wedging the next ADD with "file exists".
+	// Flush the address and default route the IPAM step installed on the guest
+	// interface, ahead of host-device delegation. Moving the guest end back out
+	// of the container namespace normally flushes them as a side effect of
+	// crossing a namespace boundary, but that never happens when the target is
+	// the namespace the link already lives in, as for a host-network pod with a
+	// secondary attachment. The move is then a no-op, and with no ephemeral
+	// sandbox namespace to reclaim it the leftover route survives and wedges
+	// the next ADD.
 	if err := flushGuestNetnsConfig(args.Netns, args.IfName); err != nil {
 		slog.Warn("DEL: failed to flush guest interface address/route, may still be in the netns",
 			"err", err, "containerID", args.ContainerID, "netns", args.Netns)
 	}
 
-	// Forward DEL to host-device delegated plugin (CNI spec §4). This moves
-	// the guest veth end back out of the container netns and restores its
-	// original (host-side) name.
+	// Forward DEL to the delegated host-device plugin, which moves the guest
+	// end back out of the container namespace and restores its original name.
 	//
-	// DEL must always return success per the CNI spec, so an error here
-	// (e.g. the device was never moved into the netns because ADD failed
-	// before reaching that step, or the netns is already gone) is logged
-	// rather than propagated.
+	// DEL must always return success per the CNI spec, so an error here, such
+	// as the device never having been moved because ADD failed earlier or the
+	// namespace already being gone, is logged rather than propagated.
 	if err := hostDevice("DEL", args, pluginConf); err != nil {
 		slog.Warn("DEL: host-device DEL failed, guest interface may still be in the netns",
 			"err", err, "containerID", args.ContainerID, "netns", args.Netns)
 	}
 
-	// Unregister this attachment's own ifindex_vrf_table entry (Milestone
-	// 7.1's ifindex_vrf_table addition), right before the host interface
-	// itself is destroyed below. Like the veth pair, this row is genuinely
-	// private to this one attachment's own ifindex — no sibling pod can
-	// ever share it — so it belongs in the same "no ADD-race to defer to GC
-	// for" category as veth.Delete just below, not the shared VRF/BGP CRD
-	// cleanup deferred further down. Best-effort/log-only, matching every
-	// other step in this function: DEL must always succeed regardless.
+	// Unregister this attachment's ifindex_vrf_table entry, right before the
+	// interface itself is destroyed. Like the veth pair, that row is private to
+	// this attachment's own ifindex and no sibling can share it, so it belongs
+	// with the immediate cleanup below rather than the shared state deferred to
+	// GC. Best-effort and log-only, since DEL must always succeed.
 	unregisterIfindexVRFEntry(vpc, vpcAtt, args.ContainerID)
 
-	// Delete this attachment's own host/guest veth pair. Unlike the VRF and
-	// BGP CRDs below, the veth pair is genuinely private to this attachment
-	// (see resourceTracker.cleanup's doc comment) — no sibling pod can ever
-	// still be depending on it, so there is no ADD-race to defer to GC for.
-	// Deleting the host end removes both ends of the pair regardless of
-	// which netns the guest end currently lives in, so this reclaims the
-	// interface even when the host-device DEL step above failed or no-op'd.
+	// Delete this attachment's veth pair. Unlike the VRF and CRDs below, it is
+	// private to this attachment, so no sibling pod can still depend on it and
+	// there is no race to defer to GC. Deleting the host end removes both ends
+	// whichever namespace the guest end is in, so this reclaims the interface
+	// even when the delegated DEL above failed or did nothing.
 	if err := veth.Delete(vpc, vpcAtt); err != nil {
 		slog.Warn("DEL: failed to delete host/guest veth pair", "err", err,
 			"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 	}
 
-	// Shared resources (VRF, BGPAdvertisement, BGPVRFInstance) are keyed by
-	// (vpc, vpcAttachment) or (vpc, node) and may still be in use by another
-	// pod. Deleting them here races with cmdAdd during pod restarts — the old
-	// pod's DEL can destroy resources the new pod just created.
+	// Shared resources, the VRF and the BGP CRDs, are keyed by attachment or by
+	// node and may still be in use by another pod. Deleting them here races
+	// cmdAdd during a pod restart, letting the old pod's DEL destroy what the
+	// new pod just created.
 	//
-	// The GC runs periodically and removes orphaned resources safely by checking
-	// whether any live container still references them. See gc.CollectOrphanedCRDs
-	// and gc.CollectOrphanedVRFs.
+	// GC removes them safely instead, on its own schedule, by checking whether
+	// any live container still references them.
 	slog.Info("DEL: skipping shared resource cleanup (handled by GC)",
 		"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 
@@ -114,23 +104,21 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// unregisterIfindexVRFEntry removes this attachment's own ifindex_vrf_table
-// entry (internal/plumbing/ebpf/ifindexvrfmap), if one exists. The host
-// interface's ifindex is resolved by its deterministic name
-// (intf.GenerateInterfaceNameHost, the same name registerEBPFDatapath
-// resolved it by at ADD time — internal/cnibgp/bgp.go), *before*
-// veth.Delete tears the interface down, since there is nothing left to
-// resolve an ifindex from afterward. Every failure here (interface already
-// gone, pinned map not present because the eBPF datapath isn't enabled,
-// etc.) is logged and swallowed, matching every other step in cmdDel: DEL
-// must always succeed.
+// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table entry
+// if one exists. The interface's ifindex is resolved by its deterministic name,
+// the same name the ADD path resolved it by, and before the interface is torn
+// down, since there is nothing to resolve from afterward.
+//
+// Every failure, whether the interface is already gone or the pinned map is
+// absent because the datapath is not enabled, is logged and swallowed: DEL must
+// always succeed.
 func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	link, err := netlink.LinkByName(hostName)
 	if err != nil {
-		// Nothing to unregister if the host interface is already gone (a
-		// prior DEL attempt may have already run this step, or ADD never
-		// got far enough to create it).
+		// Nothing to unregister when the host interface is already gone, from a
+		// prior DEL attempt or an ADD that never got far enough to create
+		// it.
 		return
 	}
 

--- a/internal/cni/resource.go
+++ b/internal/cni/resource.go
@@ -13,56 +13,44 @@ import (
 	"go.datum.net/galactic/internal/cnimaster"
 )
 
-// resourceTracker tracks resources created during cmdAdd for selective
-// rollback. galactic-veth is veth-only, and its ADD only ever creates the
-// VRF, the veth pair, and (if delegated) an IPAM allocation — BGP/SRv6/eBPF
-// publish is galactic-bgp's own, separately chain-invoked plugin now, with
-// its own smaller tracker (internal/cnibgp); termination routes are
-// galactic-route's own, with its own smaller tracker (internal/cniroute);
-// so this one no longer needs to know anything about either.
+// resourceTracker tracks the resources cmdAdd created, for selective rollback.
+// This plugin's ADD only ever creates the VRF, the veth pair, and, when
+// delegated, an IPAM allocation. BGP publishing and termination routes are
+// separate chain-invoked plugins with their own trackers.
 type resourceTracker struct {
 	vpc, vpcAttachment string
 
-	// ipamDelegated, ipamType, and ipamStdin record enough to release the
-	// IPAM allocation during rollback. Set as soon as pluginConf.IPAM != nil
-	// is known (before configureIPAM/ipam.ExecAdd is even attempted) rather
-	// than only after a successful ExecAdd: ipam.ExecDel is idempotent per
-	// the CNI IPAM delegation protocol (galactic-ipam's own cmdDel no-ops
-	// when it finds no allocation for the containerID), so calling it
-	// unconditionally whenever an "ipam" block was configured is safe and
-	// covers every failure path, including ones where ExecAdd itself never
-	// ran. Without this, a failed ADD that got past IPAM permanently burns
-	// an address/subnet out of the pool — the on-disk marker file has no
-	// implicit teardown the way the old in-memory-only allocator did.
+	// ipamDelegated, ipamType, and ipamStdin record enough to release the IPAM
+	// allocation during rollback.
+	//
+	// They are set as soon as an ipam block is known to be present, before the
+	// delegated add is even attempted, rather than only after it succeeds. The
+	// delegated delete is idempotent per the protocol, doing nothing when it
+	// finds no allocation, so calling it whenever a block was configured is safe
+	// and covers every failure path including ones where the add never ran.
+	// Without that, a failed ADD past the IPAM step permanently burns an address
+	// out of the pool, the on-disk marker having no implicit teardown.
 	ipamDelegated bool
 	ipamType      string
 	ipamStdin     []byte
 }
 
-// cleanup rolls back all tracked resources in reverse creation order.
-// Errors are logged but never returned — the caller already has a failure.
-// Takes no context: unlike before this split, the only non-kernel call left
-// here is ipam.ExecDel, which (like ExecAdd) shells out to the delegated
-// plugin binary rather than making a k8s API call (BGP CRD/eBPF rollback is
-// galactic-bgp's own tracker now).
+// cleanup rolls back every tracked resource in reverse creation order. Errors
+// are logged and never returned, the caller already having a failure. It takes
+// no context: the only non-kernel call left is the delegated IPAM delete, which
+// shells out to a binary rather than making an API call.
 //
-// Deliberately absent: deleting the VRF. veth.Delete below only removes
-// this attachment's own host/guest veth pair, which is genuinely private to
-// it — but the VRF itself is now shared by every attachment on this VPC on
-// this node (internal/plumbing/vrf keys it by VPC alone), and vrf.Add is
-// idempotent, so there's no way to distinguish "I created it" from "a
-// sibling attachment already had." Deleting it on this attachment's own
-// failed ADD could tear down a still-live sibling's VRF out from under it —
-// the same reasoning internal/cnibgp's resourceTracker applies to the
-// BGPVRFInstance CRD and eBPF vrf_table entry. Reclaiming it is exclusively
-// galactic-router's GC controller's job, once it has confirmed via every
-// BGPAdvertisement for this VPC/node that none remain.
+// Deliberately absent: deleting the VRF. Removing this attachment's veth pair is
+// safe, that pair being private to it, but the VRF is shared by every
+// attachment on this VPC on this node, and creating it is idempotent, so there
+// is no way to tell "I created it" from "a sibling already had". Deleting it on
+// a failed ADD could tear down a live sibling's VRF. Reclaiming it is garbage
+// collection's job, once it has confirmed no advertisement for this VPC and
+// node remains.
 func (rt *resourceTracker) cleanup() {
-	// Release the IPAM allocation first (if pluginConf carried an "ipam"
-	// block at all — see the ipamDelegated field doc comment for why this
-	// fires unconditionally on that alone, not just after a confirmed
-	// ExecAdd). Interface/VRF cleanup is shared with galactic-tap's own
-	// tracker, so it lives in cnimaster.CleanupAttachment.
+	// Release the IPAM allocation first, whenever an ipam block was configured
+	// at all. Interface and VRF cleanup is shared with the tap plugin's tracker,
+	// so it lives in the shared master-plugin package.
 	if rt.ipamDelegated {
 		if err := ipam.ExecDel(rt.ipamType, rt.ipamStdin); err != nil {
 			slog.Error("Rollback: failed to release IPAM allocation", "err", err, "ipamType", rt.ipamType)

--- a/internal/cni/result.go
+++ b/internal/cni/result.go
@@ -50,12 +50,11 @@ func buildResult(
 	return result
 }
 
-// buildVethResult handles veth-specific result building: host-device
-// delegation, IPAM, host gateway configuration, guest interface reading,
-// and result printing. galactic-bgp (chained next by the runtime) picks up
-// everything it needs — the allocated addresses, and that this was a veth
-// attachment — from the result this prints, not from a Go-level return
-// value.
+// buildVethResult handles the veth-specific result: delegating the device move,
+// allocating addresses, configuring the host gateway, reading back the guest
+// interface, and printing. The BGP plugin chained next picks up everything it
+// needs, the allocated addresses and that this was a veth attachment, from the
+// printed result rather than a Go return value.
 func buildVethResult(
 	args *skel.CmdArgs,
 	pluginConf *PluginConf,
@@ -63,13 +62,13 @@ func buildVethResult(
 	hostMac string,
 	hostMTU int,
 ) error {
-	// Only call host-device ADD if the guest interface is still in the host
-	// namespace. If a prior attempt already moved it to the container netns but
-	// failed at a later step, we must not try to move it again.
+	// Only delegate the move if the guest interface is still in the host
+	// namespace. A prior attempt that moved it and then failed later must not
+	// move it again.
 	if _, linkErr := netlink.LinkByName(guestName); linkErr == nil {
-		// Clean up any stale interface in the container netns left by a
-		// previous run. The host-device plugin renames the moved interface
-		// to args.IfName, so a prior run may have left that name behind.
+		// Clean up a stale interface left in the container namespace by a
+		// previous run: the delegate renames the moved interface, so a prior
+		// run may have left that name behind.
 		if err := cleanupContainerNetns(args.Netns, args.IfName); err != nil {
 			return fmt.Errorf("cleanup container netns: %w", err)
 		}
@@ -78,10 +77,9 @@ func buildVethResult(
 		}
 	}
 
-	// Configure IP address on the guest interface inside the container netns.
-	// Delegating at all is this plugin's own call, decided solely by "ipam"
-	// block presence — no config field or env var elsewhere can override
-	// that (see internal/cniipam's doc comment for the explicit contract).
+	// Configure the address on the guest interface inside the container
+	// namespace. Whether to delegate at all is this plugin's own call, decided
+	// solely by the ipam block's presence.
 	var ipamResult *cniipam.IPAMResult
 	if pluginConf.IPAM != nil {
 		result, err := configureIPAM(args, pluginConf, args.IfName)
@@ -106,10 +104,8 @@ func buildVethResult(
 		return fmt.Errorf("parse guest interface MAC %q: %w", guestMac, err)
 	}
 
-	// Configure the host-side gateway address and VRF route before printing
-	// the result — kernel-interface work this plugin owns (see
-	// internal/hostgw's doc comment for why galactic-bgp no longer does
-	// this itself).
+	// Configure the host-side gateway address and VRF route before printing the
+	// result: kernel-interface work this plugin owns.
 	if err := hostgw.ConfigureHostGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult, guestHWAddr); err != nil {
 		return fmt.Errorf("configure host gateway: %w", err)
 	}
@@ -122,14 +118,13 @@ func buildVethResult(
 	return nil
 }
 
-// configureIPAM delegates IPAM allocation to whatever binary pluginConf's
-// own "ipam.type" names (per the CNI IPAM delegation protocol — see
-// github.com/containernetworking/plugins/pkg/ipam.ExecAdd), then applies
-// the returned addresses to the guest interface inside the container
-// network namespace with both families (when dual-stack). args.StdinData
-// is passed straight through as the delegate's own netconf: it already
-// contains the "ipam" block (plus everything else in this plugin's own
-// config, which the delegate simply ignores).
+// configureIPAM delegates allocation to whatever binary the config's ipam type
+// names, then applies the returned addresses to the guest interface inside the
+// container namespace, for both families when dual-stack.
+//
+// The plugin's own stdin is passed through as the delegate's netconf: it already
+// contains the ipam block, plus everything else in this plugin's config, which
+// the delegate ignores.
 func configureIPAM(args *skel.CmdArgs, pluginConf *PluginConf, guestName string) (*cniipam.IPAMResult, error) {
 	cniResult, err := ipam.ExecAdd(pluginConf.IPAM.Type, args.StdinData)
 	if err != nil {

--- a/internal/cni/tap/tap.go
+++ b/internal/cni/tap/tap.go
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package tap manages tap interfaces for VM-based workloads (Kata, Firecracker,
-// QEMU). Unlike veth, tap interfaces are L2 file descriptors opened by userspace
-// VMMs; the CNI plugin only configures the host side.
+// Package tap manages tap interfaces for VM-based workloads. Unlike a veth, a
+// tap is an L2 file descriptor opened by a userspace VMM; the CNI plugin only
+// configures the host side.
 package tap
 
 import (
@@ -60,9 +60,9 @@ func updateForwardRule(interfaceName string, action string) error {
 	return nil
 }
 
-// Add creates a tap interface with the given MTU, enslaves it to the VRF,
-// applies sysctls and iptables FORWARD rules. Idempotent — repairs state
-// if the tap already exists (crash-recovery).
+// Add creates a tap interface with the given MTU, enslaves it to the VRF, and
+// applies the sysctls and firewall rules it needs. Idempotent, repairing state
+// when the tap already exists.
 func Add(vpc, vpcAttachment string, mtu int) error {
 	vrfName := intf.GenerateInterfaceNameVRF(vpc)
 	tapName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
@@ -97,9 +97,8 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 		return err
 	}
 
-	// Enslave to VRF, add iptables rules, bring up, then apply sysctls.
-	// Sysctl files (rp_filter, forwarding) are only populated by the kernel
-	// after the interface is brought UP.
+	// Enslave to the VRF, add the rules, bring the link up, then apply sysctls:
+	// the kernel only populates the sysctl files once the interface is up.
 	if err := netlink.LinkSetMaster(tapLink, vrfLink); err != nil {
 		return fmt.Errorf("enslave tap to VRF: %w", err)
 	}

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -11,11 +11,9 @@ import (
 	"go.datum.net/galactic/internal/hostconf"
 )
 
-// PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-veth, the veth master plugin. It's the same shape
-// galactic-tap (internal/cnitap) uses — see internal/cnimaster's own
-// doc comment — so both packages alias the one canonical definition rather
-// than each declaring their own copy.
+// PluginConf is the CNI plugin configuration passed on stdin. It is the same
+// shape the tap master uses, so both packages alias the one canonical definition
+// rather than each declaring a copy.
 type PluginConf = cnimaster.PluginConf
 
 // HostConf holds node-local settings read from /etc/cni/net.d/10-galactic.conflist.

--- a/internal/cni/veth/veth.go
+++ b/internal/cni/veth/veth.go
@@ -35,9 +35,9 @@ func isLinkNotFoundError(err error) bool {
 	return strings.Contains(msg, "no such device") || strings.Contains(msg, "not found")
 }
 
-// isIptablesRuleNotFoundError reports whether err indicates that an iptables
-// rule does not exist. The go-iptables package returns a generic error whose
-// message contains "rule not found" when the target rule is absent.
+// isIptablesRuleNotFoundError reports whether err means the rule does not
+// exist. The library returns a generic error whose message names that
+// condition.
 func isIptablesRuleNotFoundError(err error) bool {
 	if err == nil {
 		return false
@@ -84,9 +84,9 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	guestName := intf.GenerateInterfaceNameGuest(vpc, vpcAttachment)
 
-	// If the host veth already exists (e.g. left behind by a failed cmdAdd
-	// with no corresponding cmdDel), clean up the stale guest end and recreate
-	// the pair so the guest side is in a known-good state.
+	// A host veth left behind by a failed ADD with no matching DEL: clean up
+	// the stale guest end and recreate the pair, so the guest side is in a
+	// known-good state.
 	if existing, err := netlink.LinkByName(hostName); err == nil {
 		slog.Warn("veth: removing stale host veth left behind by a previous ADD attempt",
 			"host", hostName, "guest", guestName)

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -2,30 +2,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnibgp implements galactic-bgp, the SRv6/BGP/eBPF publish plugin
-// in the galactic CNI chain. It is chain-invoked (per CNI conflist order)
-// after the master plugin (galactic-veth or galactic-tap), not called
-// as a library — it has zero kernel-interface *configuration* dependency:
-// every address it advertises comes from prevResult (see prevresult.go),
-// never from a runtime call into the interface it doesn't own.
-// Host-interface gateway configuration lives in internal/hostgw instead,
-// called directly by the master plugins, for exactly this reason.
+// Package cnibgp implements galactic-bgp, the SRv6/BGP/eBPF publish plugin in
+// the galactic CNI chain. It is chain-invoked after the master plugin
+// (galactic-veth or galactic-tap), never called as a library. Every address it
+// advertises comes from prevResult, so it never configures the interface it
+// does not own; host-interface gateway configuration lives in internal/hostgw,
+// called directly by the master plugins.
 //
-// One narrow, deliberate exception: registerEBPFDatapath (bgp.go) resolves
-// this attachment's own host-side interface's ifindex via a read-only
-// netlink.LinkByName lookup, to key its ifindex_vrf_table registration
-// (internal/plumbing/ebpf/ifindexvrfmap) on it. This is not a configuration
-// call — it neither creates, moves, nor mutates the interface the master
-// plugin already built, only reads its already-assigned kernel identity —
-// and the interface's name is fully deterministic
-// (intf.GenerateInterfaceNameHost(vpc, vpcAttachment), the same helper the
-// master plugin itself used to create it), so no prevResult plumbing is
-// needed to learn it. Kept here rather than threaded back through
-// prevResult because the (Block, Argument) values ifindex_vrf_table's row
-// pairs with are only known at this call site (registerEBPFDatapath is
-// where vrf_table's own registration for this same attachment already
-// happens), mirroring the design note's own point-6 guidance to key
-// ifindex_vrf_table at that exact call site.
+// Two narrow exceptions touch kernel state here. registerEBPFDatapath resolves
+// the host-side interface's ifindex with a read-only netlink.LinkByName to key
+// its ifindex_vrf_table row, because the (Block, Argument) values that row
+// pairs with are known only at that call site, and the interface name is
+// deterministic. installNAT66EgressRoute writes a real kernel route, because
+// the optional routing plugin in this chain may be absent from a conflist and
+// the route must exist wherever a NAT66 shard is configured.
 package cnibgp
 
 import (
@@ -64,14 +54,12 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// maxRetries is the maximum number of retry attempts for transient k8s API
-// errors during the BGP state publish phase. The total number of attempts
-// is maxRetries+1 (initial + retries).
+// maxRetries is the number of retry attempts for transient Kubernetes API
+// errors during the publish phase. Total attempts are maxRetries+1.
 const maxRetries = 2
 
-// ifaceTypeVeth and ifaceTypeTap are the two values publishConfig.ifaceType
-// accepts, inferred from prevResult (see prevresult.go) rather than a
-// config field.
+// ifaceTypeVeth and ifaceTypeTap are the values publishConfig.ifaceType
+// accepts. Inferred from prevResult, not from a config field.
 const (
 	ifaceTypeVeth = "veth"
 	ifaceTypeTap  = "tap"
@@ -81,41 +69,33 @@ const (
 // publishing needs.
 type publishConfig struct {
 	vpc, vpcAttachment string
-	// ifaceType selects the eBPF vrf_table egress_kind (veth vs tap) — see
-	// egressKindForInterfaceType. Inferred from prevResult, never a config
-	// field.
+	// ifaceType selects the vrf_table egress_kind, veth or tap. Inferred from
+	// prevResult, never a config field.
 	ifaceType string
 }
 
-// publishResult records what publishBGPState actually created, so cmdAdd
-// can fold it into its own rollback tracker. There is no record of the eBPF
-// vrf_table registration: it's shared by every attachment on this VPC/node
-// (see crdnames.BGPVRFInstanceName) with no "did I just create this"
-// signal the way a k8s object's CreateOrUpdate result gives us, so a failed
-// ADD must never unregister it — see resourceTracker.cleanup's doc comment.
+// publishResult records what publishBGPState created, so cmdAdd can fold it
+// into its rollback tracker. It records nothing about the vrf_table
+// registration: that entry is shared by every attachment on this VPC and node,
+// so a failed ADD must never unregister it.
 type publishResult struct {
 	advertisementCreated bool
-	// vrfInstanceCreated is true only when this ADD's own CreateOrUpdate
-	// call for the (shared) BGPVRFInstance reported OperationResultCreated —
-	// i.e. this is the first attachment on this VPC/node, not one reusing an
-	// already-live sibling's CRD. See resourceTracker.cleanup's doc comment
-	// for why that distinction, not "CreateOrUpdate succeeded" alone, is
-	// what makes rollback-deletion safe.
+	// vrfInstanceCreated is true only when this ADD's CreateOrUpdate for the
+	// shared BGPVRFInstance actually created it, meaning this is the first
+	// attachment on this VPC and node rather than one reusing a live sibling's
+	// CRD. Rollback may delete the CRD only in that case.
 	vrfInstanceCreated bool
-	// sid is the computed SRv6 uSID for this attachment (see
-	// internal/plumbing/srv6.ComputeSID), valid (netip.Addr.IsValid()) only
-	// when this node's BGPRouter has SRv6Locator/nodeID configured — the
-	// same condition registerEBPFDatapath's own skip case checks. Consumed
-	// by the EndpointSlice publish step (endpointslice.go), which runs as
-	// its own step after publishBGPState returns, not folded into its retry
-	// closure — see Phase 4's rollback-risk note in the #854 plan for why.
+	// sid is the computed SRv6 uSID for this attachment. Valid only when this
+	// node's BGPRouter has an SRv6 locator and node ID configured, the same
+	// condition registerEBPFDatapath skips on. Consumed by the EndpointSlice
+	// publish step, which runs after publishBGPState returns rather than
+	// inside its retry closure.
 	sid netip.Addr
 }
 
-// isTransientError reports whether err is a transient failure that may
-// resolve itself on retry (API server unavailable, timeout, network blip).
-// Returns false for validation errors, not-found, and other permanent
-// failures that should not be retried.
+// isTransientError reports whether err may resolve on retry: API server
+// unavailable, a timeout, or a network blip. Validation errors, not-found, and
+// other permanent failures return false.
 func isTransientError(err error) bool {
 	if err == nil {
 		return false
@@ -141,10 +121,9 @@ func isTransientError(err error) bool {
 	return false
 }
 
-// retryK8sOps runs fn with up to maxRetries+1 attempts, retrying on
-// transient k8s API errors with exponential backoff. The context passed to
-// fn has a timeout derived from timeout. Non-transient errors are returned
-// immediately without retry.
+// retryK8sOps runs fn up to maxRetries+1 times, backing off between attempts
+// that fail with a transient Kubernetes API error. Each call gets a context
+// bounded by timeout. A non-transient error returns immediately.
 func retryK8sOps(timeout time.Duration, fn func(ctx context.Context) error) error {
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -174,9 +153,9 @@ type bgpConfig struct {
 	nodeID      int32
 }
 
-// routeTarget returns the RT in "ASN:NN" format using the low 32 bits of the
-// VPC identifier. All nodes in the same VRF produce the same value, enabling
-// VPC-scoped route import/export. vpcHex is the 16-bit hex VPC identifier.
+// routeTarget returns the route target in "ASN:NN" form, from the low 32 bits
+// of the 16-bit hex VPC identifier vpcHex. Every node in the same VRF derives
+// the same value, which is what scopes route import and export to a VPC.
 func routeTarget(asNumber int64, vpcHex string) (string, error) {
 	v, err := strconv.ParseUint(vpcHex, 16, 64)
 	if err != nil {
@@ -186,11 +165,10 @@ func routeTarget(asNumber int64, vpcHex string) (string, error) {
 }
 
 // allocateArgument returns the 12-bit Argument value for the VPC attachment
-// named vrfInstanceName under routerName: the value already registered if a
-// BGPVRFInstance with that exact name exists (an idempotent CNI ADD retry,
-// or a repeat ADD on an attachment that is already live), or — if none does
-// — the lowest unused value in [uformat.ArgumentMin, uformat.ArgumentMax]
-// among that router's other BGPVRFInstances.
+// named vrfInstanceName under routerName. An existing BGPVRFInstance of that
+// name keeps its value, which makes a repeat ADD idempotent. Otherwise the
+// lowest value in [uformat.ArgumentMin, uformat.ArgumentMax] unused by that
+// router's other instances is returned.
 func allocateArgument(
 	ctx context.Context, k8s client.Client, namespace, routerName, vrfInstanceName string,
 ) (int32, error) {
@@ -219,10 +197,10 @@ func allocateArgument(
 		routerName, uint16(uformat.ArgumentMin), uint16(uformat.ArgumentMax), len(used))
 }
 
-// checkArgumentCollision detects whether a race condition occurred where
-// another BGPVRFInstance on the same router was assigned the same VRFID
-// concurrently. Any other instance found still holding this VRFID is
-// treated as a collision.
+// checkArgumentCollision reports whether another BGPVRFInstance on the same
+// router already holds vrfID, which happens when two first attachments race
+// onto the same free slot. Any other instance still holding the value counts
+// as a collision.
 func checkArgumentCollision(
 	ctx context.Context, k8s client.Client, namespace, routerName, vrfName string, vrfID int32,
 ) error {
@@ -289,7 +267,7 @@ func buildVRFInstanceSpec(routerName, rtValue string, vrfID int32) bgpv1alpha1.B
 }
 
 // buildAdvertisementSpec constructs the BGPAdvertisementSpec for a VPC
-// attachment's pod subnet(s) — one IPv6 prefix, plus an IPv4 prefix when the
+// attachment's pod subnets: one IPv6 prefix, plus an IPv4 prefix when the
 // attachment is dual-stack.
 func buildAdvertisementSpec(
 	routerName, rtValue string, prefixes []string, vrfID int32,
@@ -309,11 +287,10 @@ func buildAdvertisementSpec(
 	}
 }
 
-// ipamAdvertisementPrefixes derives the BGPAdvertisement prefixes to
-// originate, plus the per-family values to record in the annotations, from
-// ipamResult (reconstructed from prevResult — see prevresult.go). ipamResult
-// is nil when the attachment has no IPAM allocation (e.g. a tap workload
-// that manages its own addressing), in which case prefixes is empty.
+// ipamAdvertisementPrefixes derives the prefixes to originate, plus the
+// per-family values recorded in annotations, from ipamResult. A nil ipamResult
+// means the attachment has no IPAM allocation, such as a tap workload managing
+// its own addressing, and yields no prefixes.
 func ipamAdvertisementPrefixes(ipamResult *cniipam.IPAMResult) (prefixes []string, ipv6Subnet, ipv4Addr string) {
 	if ipamResult == nil {
 		return nil, "", ""
@@ -329,23 +306,16 @@ func ipamAdvertisementPrefixes(ipamResult *cniipam.IPAMResult) (prefixes []strin
 	return prefixes, ipv6Subnet, ipv4Addr
 }
 
-// allAdvertisedPrefixes derives the full set of BGP-advertised prefixes for
-// a BGPAdvertisement CRD from every subnet annotation currently present on
-// it, rather than from just the container currently being processed — see
-// crdnames' doc comment for why a single BGPAdvertisement can be shared by
-// more than one container.
+// allAdvertisedPrefixes derives the full prefix set for a BGPAdvertisement
+// from every subnet annotation on it, not just from the container being
+// processed, because one BGPAdvertisement can be shared by several containers.
 //
 // The result is deduplicated by CIDR value. spec.Prefixes is
-// x-kubernetes-list-type=set, so a duplicate value is rejected outright by
-// the API server: when a replaced pod's IPAM allocation lands on the same
-// subnet its predecessor held (the common case — IPAM re-allocates the same
-// subnet for the same vpcAttachment identity), the predecessor's own
-// per-containerID annotation is often still present (see
-// pruneDeadContainerAnnotations's doc comment for why that can outlast the
-// pod), and without this dedup the two identical-value annotations would
-// both land in Prefixes and permanently fail every CNI ADD retry for this
-// attachment. Deduplicating here is a hard backstop independent of whether
-// pruning above has run yet.
+// x-kubernetes-list-type=set, so the API server rejects a duplicate outright.
+// A replacement pod usually gets the same subnet its predecessor held, whose
+// per-container annotation can still be present, and without this dedup those
+// two identical values would both land in Prefixes and fail every ADD retry
+// for the attachment.
 func allAdvertisedPrefixes(annotations map[string]string) []string {
 	seen := make(map[string]struct{})
 	var prefixes []string
@@ -372,25 +342,18 @@ func allAdvertisedPrefixes(annotations map[string]string) []string {
 // real netns bind-mount under /var/run/netns.
 var netNSExistsFn = gc.NetNSExists
 
-// pruneDeadContainerAnnotations removes every per-container annotation
-// (netns plus allocated-subnet-ipv6/ipv4) belonging to a containerID whose
-// recorded netns path no longer exists on this node.
+// pruneDeadContainerAnnotations removes every per-container annotation, netns
+// and allocated subnet alike, whose recorded netns path no longer exists on
+// this node.
 //
-// Without this, a replaced pod's dead sibling containerID's annotations
-// survive on the shared BGPAdvertisement forever: galactic-router's GC
-// controller (internal/gc.CollectOrphanedCRDs) only ever deletes the whole
-// CRD, and only once every container that has ever referenced it is dead —
-// which never happens while the vpcAttachment has any live pod, i.e.
-// exactly the pod-replacement case this exists to handle. So the set of
-// per-container annotations on a long-lived, frequently-churned
-// vpcAttachment (e.g. a Deployment) grows without bound, and whenever a
-// replacement pod's IPAM allocation reuses a dead sibling's subnet (the
-// common case), allAdvertisedPrefixes' dedup is the only thing standing
-// between that and a rejected update. Pruning here, on the write path that
-// already holds this attachment's current annotation set, is what actually
-// keeps it bounded and self-heals the moment a new container attaches —
-// independent of GC's periodic tick, which for this case never fires at
-// all.
+// Garbage collection deletes only the whole CRD, and only once every container
+// that ever referenced it is gone, which never happens while the attachment
+// still has a live pod. Without pruning, annotations on a frequently churned
+// attachment grow without bound, and a replacement pod reusing a dead
+// sibling's subnet leaves allAdvertisedPrefixes' dedup as the only thing
+// preventing a rejected update. This runs on the write path that already holds
+// the current annotation set, so it self-heals the moment a container
+// attaches.
 func pruneDeadContainerAnnotations(annotations map[string]string) {
 	prefix := crdnames.AnnotationNetNS + "."
 	for key, netnsPath := range annotations {
@@ -408,9 +371,8 @@ func pruneDeadContainerAnnotations(annotations map[string]string) {
 }
 
 // publishBGPState creates the BGPVRFInstance and BGPAdvertisement CRDs and
-// registers the eBPF uSID datapath entry, with retry on transient k8s API
-// errors. Assumes the host gateway is already configured (internal/cni/
-// hostgw, called by the master plugin before this ever runs).
+// registers the eBPF uSID datapath entry, retrying transient Kubernetes API
+// errors. The host gateway must already be configured by the master plugin.
 func publishBGPState(
 	args *skel.CmdArgs, cfg publishConfig, nodeName, namespace string, ipamResult *cniipam.IPAMResult,
 	vpcHex string, k8s client.Client,
@@ -422,11 +384,9 @@ func publishBGPState(
 			return err
 		}
 
-		// The BGPVRFInstance name is keyed by (vpc, node) — not (vpc,
-		// vpcAttachment) — since the underlying kernel VRF is shared by every
-		// attachment on this VPC on this node. allocateArgument's own
-		// idempotent-by-name lookup means every attachment sharing a VPC/node
-		// converges on the same CRD and the same Argument.
+		// Keyed by (vpc, node) rather than (vpc, attachment): the kernel VRF
+		// is shared by every attachment on this VPC on this node, so they all
+		// converge on one CRD and one Argument.
 		vrfName := crdnames.BGPVRFInstanceName(cfg.vpc, nodeName)
 		vrfID, err := allocateArgument(ctx, k8s, namespace, bgp.routerName, vrfName)
 		if err != nil {
@@ -457,29 +417,21 @@ func publishBGPState(
 		slog.Debug("BGP: BGPVRFInstance applied", "name", vrfName, "namespace", namespace,
 			"vrfID", vrfID, "routeTarget", rtValue, "router", bgp.routerName, "operation", op)
 
-		// A collision here means allocateArgument's read-then-write raced
-		// against another VPC's first attachment on this same node landing
-		// on the same "lowest free slot" before either write was visible to
-		// the other — only possible when this CreateOrUpdate was a genuine
-		// create (result.vrfInstanceCreated), never when reusing an
-		// already-live sibling's CRD (whose VRFID was already validated
-		// when it was first created). Rollback needs that distinction to
-		// safely self-heal this race — see resourceTracker.cleanup.
+		// A collision means allocateArgument's read-then-write raced another
+		// VPC's first attachment onto the same free slot. That is possible
+		// only on a genuine create, never when reusing a live sibling's CRD,
+		// whose VRFID was validated when it was created.
 		if err := checkArgumentCollision(ctx, k8s, namespace, bgp.routerName, vrfName, vrfID); err != nil {
 			return err
 		}
 
-		// Computed here, ahead of registerEBPFDatapath below, so this
-		// attachment's own prefix(es) can be registered as local
-		// pass-through egress_route_table entries — see
-		// registerEBPFDatapath's own doc comment for why.
+		// Computed ahead of registerEBPFDatapath so this attachment's own
+		// prefixes can be registered as local pass-through egress routes.
 		prefixes, ipv6Subnet, ipv4Addr := ipamAdvertisementPrefixes(ipamResult)
 
-		// Reuses registerEBPFDatapath's own "SRv6 not configured, skip
-		// silently" sentinel: if this node's router has no
-		// srv6Locator/nodeID configured, there's nothing to publish, so
-		// leave result.sid at its zero value (IsValid() == false) rather
-		// than computing a SID for an attachment that has no SRv6 endpoint.
+		// Nothing to publish when this node's router has no SRv6 locator or
+		// node ID, so leave result.sid invalid rather than compute a SID for
+		// an attachment that has no SRv6 endpoint.
 		if bgp.srv6Locator != "" && bgp.nodeID != 0 {
 			sid, err := srv6.ComputeSID(bgp.srv6Locator, bgp.nodeID, vrfID, bgpv1alpha1.SRv6FunctionEndDT46)
 			if err != nil {
@@ -488,10 +440,8 @@ func publishBGPState(
 			result.sid = sid
 		}
 
-		// The return values aren't tracked for rollback: the vrf_table entry
-		// they'd describe is shared by every attachment on this VPC/node,
-		// same as the BGPVRFInstance above — see resourceTracker.cleanup's
-		// doc comment for why a failed ADD must never unregister it.
+		// Not tracked for rollback: the vrf_table entry is shared by every
+		// attachment on this VPC and node, like the BGPVRFInstance above.
 		if _, err := registerEBPFDatapath(
 			bgp, cfg.vpc, cfg.vpcAttachment, cfg.ifaceType, uint16(vrfID), ebpfPinDir, prefixes,
 		); err != nil {
@@ -516,22 +466,18 @@ func publishBGPState(
 			if ipv4Addr != "" {
 				adv.Annotations[crdnames.SubnetKeyIPv4(args.ContainerID)] = ipv4Addr
 			}
-			// ipamResult is nil when this attachment's config carries no
-			// "ipam" block at all (e.g. a tap workload managing its own
-			// addressing) — mark the advertisement so its empty
-			// spec.prefixes reads as intentional, not as addressing that
-			// silently failed to arrive (#342). Cleared the moment any ADD
-			// for this attachment does carry an allocation.
+			// The attachment's config carries no "ipam" block, such as a tap
+			// workload managing its own addressing. Mark the advertisement so
+			// its empty spec.prefixes reads as intentional rather than as
+			// addressing that failed to arrive. Cleared once any ADD for this
+			// attachment does carry an allocation.
 			if ipamResult == nil {
 				adv.Annotations[crdnames.AnnotationNoAddressing] = crdnames.AnnotationNoAddressingValue
 			} else {
 				delete(adv.Annotations, crdnames.AnnotationNoAddressing)
 			}
-			// Prune dead siblings before merging: a replaced pod's stale
-			// annotation must not be allowed to collide with this ADD's own
-			// (often identical, since IPAM re-allocates the same subnet for
-			// the same vpcAttachment identity) prefix — see
-			// pruneDeadContainerAnnotations's doc comment.
+			// Prune dead siblings first, so a replaced pod's stale annotation
+			// cannot collide with this ADD's usually identical prefix.
 			pruneDeadContainerAnnotations(adv.Annotations)
 			mergedPrefixes = allAdvertisedPrefixes(adv.Annotations)
 			adv.Spec = buildAdvertisementSpec(bgp.routerName, rtValue, mergedPrefixes, vrfID)
@@ -540,14 +486,10 @@ func publishBGPState(
 		if err != nil {
 			return fmt.Errorf("apply BGPAdvertisement: %w", err)
 		}
-		// Gated on OperationResultCreated, mirroring vrfInstanceCreated's
-		// existing pattern exactly: a BGPAdvertisement is reused (updated,
-		// not created) across pod churn on the same vpcAttachment, so
-		// marking it created on every successful write — including a mere
-		// update of an already-live sibling's CRD — would let
-		// resourceTracker.cleanup delete a BGPAdvertisement still backing a
-		// different, live container's route if a later ADD step fails. See
-		// the #854 plan's Phase 4 rollback-risk note.
+		// Gated on a genuine create, like vrfInstanceCreated above. A
+		// BGPAdvertisement is reused across pod churn on the same attachment,
+		// so marking it created on a mere update would let rollback delete one
+		// still backing a live container's route.
 		if advOp == controllerutil.OperationResultCreated {
 			result.advertisementCreated = true
 		}
@@ -562,28 +504,18 @@ func publishBGPState(
 }
 
 // registerEBPFDatapath registers this attachment against the eBPF uSID
-// datapath's pinned maps. registered is false, with a nil error, only when
-// this router has no srv6Locator/nodeID configured at all — SRv6 is
-// intentionally not set up for this attachment. Any other failure is
-// returned as an error.
+// datapath's pinned maps. registered is false with a nil error only when this
+// router has no SRv6 locator or node ID configured, meaning SRv6 is
+// deliberately not set up for it. Any other failure returns an error.
 //
-// prefixes is this attachment's own IPAM-derived prefix(es)
-// (ipamAdvertisementPrefixes' first return value, computed by the caller
-// ahead of this call) — each is registered as a local pass-through
-// egress_route_table entry (registerLocalEgressRoutes) in this VPC's
-// VRF, so this attachment's own prefix always wins the LPM lookup over a shorter
-// entry (in practice, the VRF's own ::/0 NAT66 default installed just
-// above by installNAT66EgressRoute). Without this, a sibling attachment
-// sharing this same VRF on this node — with a perfectly good kernel
-// connected route already routing between them — has that traffic
-// silently hijacked by the ::/0 default and redirected toward a NAT66
-// shard SID instead of ever being delivered locally: found live in
-// containerlab's ns30 fixture (two attachments, one VPC, one node), the
-// same class of bug as usid_egress's own multicast/link-local carve-out,
-// just for ordinary same-VRF unicast peers instead of NDP. nil/empty is
-// valid (an attachment with no "ipam" block at all, e.g. a
-// self-addressing tap workload — see ipamAdvertisementPrefixes' own doc
-// comment) and simply registers nothing.
+// prefixes are this attachment's IPAM-derived CIDRs, computed by the caller.
+// Each is registered as a local pass-through egress_route_table entry in this
+// VPC's VRF, so the attachment's own prefix wins the longest-prefix lookup
+// over the VRF's ::/0 NAT66 default. Without them, a sibling attachment in the
+// same VRF on the same node, reachable over an ordinary connected route, has
+// its traffic hijacked by that default and redirected toward a NAT66 shard
+// instead of delivered locally. An empty slice is valid and registers
+// nothing.
 func registerEBPFDatapath(
 	bgp bgpConfig, vpc, vpcAttachment, ifaceType string, argument uint16, pinDir string, prefixes []string,
 ) (registered bool, err error) {
@@ -615,16 +547,10 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("look up VRF table id for eBPF registration: %w", err)
 	}
 
-	// Installs (or refreshes) this VRF's NAT66 default egress route --
-	// see installNAT66EgressRoute's own doc comment. A second, deliberate
-	// exception to this package's doc comment's "zero kernel-interface
-	// configuration dependency" claim, alongside registerEBPFDatapath's
-	// existing ifindex_vrf_table registration: unlike that one, this
-	// mutates a real kernel route, not just an eBPF map, but the
-	// alternative (routing table setup) plugin in this chain
-	// (internal/cniroute/galactic-route) is optional, and this route must
-	// exist whenever any shard is configured, regardless of whether a
-	// given conflist happens to include galactic-route.
+	// Installs or refreshes this VRF's NAT66 default egress route. The
+	// optional routing plugin in this chain may be absent from a given
+	// conflist, and this route must exist wherever a shard is configured, so
+	// it is written here.
 	if err := installNAT66EgressRoute(vrfTableID); err != nil {
 		return false, fmt.Errorf("install NAT66 default egress route: %w", err)
 	}
@@ -633,10 +559,9 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("register local pass-through egress route: %w", err)
 	}
 
-	// The host-side interface's own ifindex, needed to key this
-	// attachment's ifindex_vrf_table row below — see this package's own
-	// doc comment for why this one read-only netlink call is an accepted
-	// exception to galactic-bgp's otherwise prevResult-only design.
+	// The host-side interface's ifindex keys this attachment's
+	// ifindex_vrf_table row. See the package doc comment for why this
+	// read-only netlink call is an accepted exception.
 	hostIfindex, err := hostInterfaceIndex(vpc, vpcAttachment)
 	if err != nil {
 		return false, fmt.Errorf("resolve host interface ifindex for eBPF registration: %w", err)
@@ -668,50 +593,33 @@ func registerEBPFDatapath(
 		return false, fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
 	}
 
-	// Attach usid_egress to this attachment's own host-side interface --
-	// see attachUsidEgress's own doc comment for why this was, until now,
-	// entirely missing: it's a real, previously-undiscovered gap, not
-	// specific to NAT66 at all, in every veth/tap ServiceVIPBinding's own
-	// reply path.
+	// Attach usid_egress to this attachment's host-side interface. This is
+	// what translates a reply's source address on the way back out.
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	if err := attachUsidEgress(pinDir, hostName); err != nil {
 		return false, fmt.Errorf("attach eBPF usid_egress to host interface %q: %w", hostName, err)
 	}
 
-	// Registers this node's own SRv6 source address into
-	// node_src_addr_table -- see registerNodeSourceAddress's own doc
-	// comment. A per-node constant, not per-attachment, but idempotent
-	// and cheap enough (one netlink route/address query, one map write)
-	// to simply redo on every attachment ADD, the same way every other
-	// registration in this function already is, rather than adding a
-	// separate once-per-node lifecycle hook.
+	// Register this node's SRv6 source address. A per-node constant rather
+	// than a per-attachment one, but idempotent and cheap enough to redo on
+	// every ADD instead of adding a once-per-node lifecycle hook.
 	//
-	// Deliberately non-fatal to this ADD, unlike every other registration
-	// step above: ResolveNodeSourceAddress needs a converged main-table
-	// IPv6 default route, which a node can genuinely, transiently lack
-	// early in its own boot sequence (before the underlay eBGP session
-	// comes up) -- failing every pod attach on the whole node until that
-	// converges would be a real availability regression from today's
-	// behavior, where a missing egress route only ever failed traffic to
-	// the *specific* destination that needed it, never CNI ADD itself.
-	// usid_egress's own "not yet configured" check already fails open
-	// (TC_ACT_UNSPEC) for exactly this gap; a later attachment's ADD (or
-	// this same one's next retry) succeeds here once the route exists.
+	// Non-fatal, unlike the registrations above. Resolving the address needs a
+	// converged main-table IPv6 default route, which a node can transiently
+	// lack before its underlay session comes up. Failing every pod attach on
+	// the node until then is worse than the alternative, where only traffic
+	// needing the route fails. usid_egress fails open for exactly this gap,
+	// and a later ADD succeeds once the route exists.
 	if err := registerNodeSourceAddress(pinDir); err != nil {
 		slog.Warn("ADD: could not register this node's own SRv6 source address; "+
 			"egress routing will fail open until this succeeds", "err", err)
 	}
 
-	// Registers this node's own fabric-uplink next hop into
-	// public_uplink_table -- see registerPublicUplink's own doc comment.
-	// Same per-node-constant, redo-on-every-ADD, non-fatal-on-failure
-	// shape as registerNodeSourceAddress just above, and for the
-	// identical reason: ResolvePublicUplink needs a converged underlay
-	// neighbor, which a node can transiently lack early in its own boot
-	// sequence. usid_egress's own "not configured yet" check on this map
-	// (link_ifindex == 0, absent entirely) already fails open (falling
-	// through to egress_route_table, the pre-existing behavior) for
-	// exactly this gap.
+	// Register this node's fabric-uplink next hop. Same per-node,
+	// redo-on-every-ADD, non-fatal shape as registerNodeSourceAddress above,
+	// for the same reason: resolving it needs a converged underlay neighbor.
+	// usid_egress falls through to egress_route_table while the entry is
+	// absent.
 	if err := registerPublicUplink(pinDir); err != nil {
 		slog.Warn("ADD: could not register this node's own public uplink; "+
 			"a DSR backend's VIP-sourced reply traffic will fail open to egress_route_table until this succeeds",
@@ -721,17 +629,12 @@ func registerEBPFDatapath(
 	return true, nil
 }
 
-// registerNodeSourceAddress resolves this node's own SRv6/underlay-facing
-// source address (srv6.ResolveNodeSourceAddress) and writes it into
-// node_src_addr_table (egressroutemap.NodeSourceAddress) -- the value
-// usid_egress's egress-routing extension stamps into every outer header
-// it pushes (docs/plans/tc-bpf-egress-srv6-encap.md). Without this, every
-// egress_route_table hit fails open (TC_ACT_UNSPEC) rather than
-// encapsulating at all -- see usid.c's own "not yet configured" check on
-// this map -- so this must succeed before EgressDefaultRouteAdd/
-// RouteEgressAdd's own installed entries can ever actually carry traffic.
-// See this function's own call site for why a failure here doesn't fail
-// the whole CNI ADD.
+// registerNodeSourceAddress resolves this node's underlay-facing SRv6 source
+// address and writes it into node_src_addr_table, the value usid_egress stamps
+// into every outer header it pushes. While the entry is missing, every
+// egress_route_table hit fails open instead of encapsulating, so no installed
+// egress route can carry traffic. pinDir is the bpffs directory holding the
+// pinned map. Failure here does not fail the CNI ADD; see the call site.
 func registerNodeSourceAddress(pinDir string) error {
 	addr, err := srv6.ResolveNodeSourceAddress()
 	if err != nil {
@@ -745,21 +648,13 @@ func registerNodeSourceAddress(pinDir string) error {
 	return nodeSrc.Set(addr)
 }
 
-// registerPublicUplink resolves this node's own fabric-uplink interface's
-// real next hop (srv6.ResolvePublicUplink) and writes it into
-// public_uplink_table (egressroutemap.PublicUplink) -- the value
-// usid_egress redirects a DSR backend's VIP-sourced reply toward,
-// unconditionally, immediately after apply_vip_xlat rewrites that
-// reply's source address, bypassing egress_route_table's own NAT66
-// default entirely. Without this, a DSR-served ServiceVIPBinding whose
-// backend lives in a VRF with a NAT66 default configured (any VRF on a
-// node with NAT66ShardSIDs set, i.e. every VRF today) has its reply
-// wrongly re-SNAT'd through a NAT66 shard instead of ever reaching the
-// real client -- found live, confirmed via nat66_conn_table gaining a
-// fresh forward-flow entry keyed on the VIP as if it were an ordinary
-// tenant backend originating a new outbound connection. See this
-// function's own call site for why a failure here doesn't fail the
-// whole CNI ADD.
+// registerPublicUplink resolves this node's fabric-uplink next hop and writes
+// it into public_uplink_table, the value usid_egress redirects a DSR backend's
+// VIP-sourced reply toward once apply_vip_xlat has rewritten that reply's
+// source address, bypassing egress_route_table's NAT66 default. Without it,
+// such a reply is re-translated through a NAT66 shard instead of reaching the
+// real client. pinDir is the bpffs directory holding the pinned map. Failure
+// here does not fail the CNI ADD; see the call site.
 func registerPublicUplink(pinDir string) error {
 	linkIndex, dmac, smac, err := srv6.ResolvePublicUplink()
 	if err != nil {
@@ -773,29 +668,16 @@ func registerPublicUplink(pinDir string) error {
 	return uplink.Set(linkIndex, dmac, smac)
 }
 
-// attachUsidEgress loads usid_egress from its own pin (attach.Load pins it
-// there, alongside every usid_ingress map, specifically so a short-lived
-// process like this one can reach it -- see that function's own doc
-// comment) and attaches it to ifaceName's TC ingress hook.
+// attachUsidEgress loads usid_egress from its pin and attaches it to
+// ifaceName's TC ingress hook. attach.Load pins the program there so a
+// short-lived process like this one can reach it without reloading.
 //
-// This was a real, previously-undiscovered gap: usid_egress has existed
-// since the DSR/Maglev redesign's component 0.1/2 work (NPTv6 and tap-VIP
-// substitution's outbound-direction translation), but nothing anywhere in
-// this codebase ever called attach.AttachEgress (or any equivalent) to
-// actually put it on an interface -- confirmed live via `tc filter show`
-// on a real backend's own host-side veth: no filter at all, on either
-// direction. Every fix this redesign made to the *forward* path (client
-// -> VIP -> backend) worked and was validated without ever exercising
-// this gap, because none of them depended on the *reply* leaving with its
-// source address translated back -- only once the forward path, the
-// NAT66 egress route, and everything else were all working at once did a
-// real end-to-end curl's TCP handshake finally depend on it, and stall
-// with the reply silently discarded by the client (its source address
-// never got translated from the backend's real address back to the VIP).
+// The forward path works without this, because nothing on it depends on a
+// reply leaving with its source address translated. Only a full round trip
+// needs it, and a missing attachment stalls the handshake, with the client
+// discarding replies that arrive from an address it never contacted.
 //
-// Idempotent (attach.AttachEgress's own FilterReplace semantics) and safe
-// to call on every attachment ADD, the same way every other registration
-// in this function already is.
+// Idempotent, so it is safe to call on every attachment ADD.
 func attachUsidEgress(pinDir, ifaceName string) error {
 	program, err := ebpf.LoadPinnedProgram(filepath.Join(pinDir, attach.UsidEgressPinName), nil)
 	if err != nil {
@@ -806,33 +688,19 @@ func attachUsidEgress(pinDir, ifaceName string) error {
 	return attach.AttachEgress(program, ifaceName)
 }
 
-// registerLocalEgressRoutes registers each of prefixes as a local
-// pass-through egress_route_table entry in Linux VRF table vrfTableID --
-// see registerEBPFDatapath's own doc comment for why this attachment's
-// own prefix needs one. Idempotent (a plain map Put under the hood) and
-// safe to call on every attachment ADD, including a repeat ADD for the
-// same attachment or a sibling attachment re-registering an unrelated
-// prefix in the same VRF.
+// registerLocalEgressRoutes registers each of prefixes as a local pass-through
+// egress_route_table entry in Linux VRF table vrfTableID, so an attachment's
+// own prefix outranks the VRF's NAT66 default. pinDir is the bpffs directory
+// holding the pinned map. Idempotent, so a repeat ADD, or a sibling
+// re-registering an unrelated prefix in the same VRF, is safe.
 //
-// Opens egress_route_table directly via egressroutemap, keyed on the
-// caller's own pinDir -- unlike installNAT66EgressRoute below, this
-// deliberately does not go through srv6's RouteEgressAdd/
-// EgressDefaultRouteAdd wrappers, which resolve their own pinned-map
-// directory from a package-level var defaulting to attach.PinDir rather
-// than accepting one as a parameter: fine for those (always called with
-// the real production bpffs mount), but wrong here, where
-// registerEBPFDatapath is explicitly designed to run against an
-// arbitrary pinDir (see its own usidmap.OpenPinnedRegistry/
-// ifindexvrfmap.OpenPinned calls) -- mirrors registerNodeSourceAddress's
-// identical choice, just below, for the same reason.
+// It opens the map through egressroutemap rather than the srv6 wrappers, which
+// resolve their pin directory from a package var instead of a parameter:
+// registerEBPFDatapath is designed to run against an arbitrary pinDir.
 //
-// prefixes are the exact CIDR strings ipamAdvertisementPrefixes already
-// produces for this attachment's own BGPAdvertisement (an IPv6 subnet
-// and/or an IPv4 host route) -- a parse failure here would mean that
-// function produced something unparseable, which would already have
-// failed the BGPAdvertisement CreateOrUpdate below with a bad prefix, so
-// treating it as a hard error here rather than skipping it silently
-// keeps both paths equally strict.
+// prefixes are the CIDR strings ipamAdvertisementPrefixes already produced, so
+// a parse failure means that function emitted something unparseable. It is a
+// hard error here rather than a silent skip.
 func registerLocalEgressRoutes(pinDir string, vrfTableID uint32, prefixes []string) error {
 	if len(prefixes) == 0 {
 		return nil
@@ -855,29 +723,18 @@ func registerLocalEgressRoutes(pinDir string, vrfTableID uint32, prefixes []stri
 	return nil
 }
 
-// installNAT66EgressRoute installs (or refreshes) vrfTableID's default
-// egress route toward every configured NAT66 shard -- see
-// config.EnvCNINAT66ShardSIDs's own doc comment for where the shard list
-// comes from, and srv6.EgressDefaultRouteAdd's own doc comment for why
-// this is a multipath route rather than a per-flow hash. Idempotent
-// (RouteReplace under the hood) and safe to call on every attachment ADD
-// sharing this VRF, the same way vrf.Add itself already is.
+// installNAT66EgressRoute installs or refreshes vrfTableID's default egress
+// route toward the configured NAT66 shards. Idempotent, so it is safe on every
+// attachment ADD sharing this VRF.
 //
-// An operator who hasn't configured any shard yet (the common case before
-// this mechanism is rolled out to a given fabric) sees no error at all:
-// parseShardSIDs returns an empty, nil-error slice for an empty string,
-// and srv6.EgressDefaultRouteAdd itself no-ops on an empty list. A
-// misconfigured shard SID (invalid address, or one with no reachable
-// route yet -- e.g. this node came up before NAT66ShardReconciler's own
-// BGPAdvertisement had propagated) fails this attachment's ADD outright
-// rather than silently leaving the VRF with no egress at all.
+// No shard configured is not an error: the shard list parses to an empty slice
+// and srv6.EgressDefaultRouteAdd no-ops. A shard SID that is invalid, or that
+// has no reachable route yet, fails this attachment's ADD rather than leaving
+// the VRF with no egress at all.
 func installNAT66EgressRoute(vrfTableID uint32) error {
-	// cniConfig is nil unless something has already called InitCNIConfig
-	// (cmd/galactic-bgp's main.go, before any cmdAdd can run) or a test set
-	// it up directly -- several existing unit tests in this package call
-	// registerEBPFDatapath straight through without either, mirroring
-	// ops_del_test.go's own cniConfig-may-be-nil stance. Treated the same
-	// as "no shard configured yet," not a panic.
+	// cniConfig is nil until InitCNIConfig runs, which several unit tests
+	// calling registerEBPFDatapath directly never do. Treated as "no shard
+	// configured" rather than a panic.
 	if cniConfig == nil {
 		return nil
 	}
@@ -891,14 +748,11 @@ func installNAT66EgressRoute(vrfTableID uint32) error {
 	return srv6.EgressDefaultRouteAdd(vrfTableID, shardSIDs)
 }
 
-// parseShardSIDs splits a comma-separated NAT66 shard SID list (as
-// resolved into config.CNIConfig.NAT66ShardSIDs) into IP addresses,
-// trimming whitespace around each entry and skipping blank ones -- so a
-// trailing comma or stray space in the operator-supplied env var/conflist
-// value doesn't fail every attachment ADD in the cluster. An entry that
-// survives trimming but still isn't a valid IP address is a real
-// misconfiguration and fails loudly rather than silently dropping one
-// shard from the list.
+// parseShardSIDs splits a comma-separated NAT66 shard SID list into addresses,
+// trimming whitespace and skipping blank entries, so a trailing comma or stray
+// space in the operator-supplied value does not fail every attachment ADD in
+// the cluster. An entry that survives trimming but is not a valid IP address
+// is a real misconfiguration and fails loudly.
 func parseShardSIDs(raw string) ([]net.IP, error) {
 	var sids []net.IP
 	for _, part := range strings.Split(raw, ",") {
@@ -915,11 +769,10 @@ func parseShardSIDs(raw string) ([]net.IP, error) {
 	return sids, nil
 }
 
-// hostInterfaceIndex resolves this attachment's own host-side veth/tap
-// interface's kernel ifindex, by name -- the same deterministic name
-// (intf.GenerateInterfaceNameHost) the master plugin (internal/cni or
-// internal/cnitap) already used to create it, so no value needs threading
-// through prevResult to find it again here.
+// hostInterfaceIndex resolves this attachment's host-side veth or tap
+// interface's kernel ifindex by name, using the same deterministic name the
+// master plugin used to create it, so no value needs threading through
+// prevResult to find it again.
 func hostInterfaceIndex(vpc, vpcAttachment string) (uint32, error) {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	link, err := netlink.LinkByName(hostName)
@@ -929,10 +782,10 @@ func hostInterfaceIndex(vpc, vpcAttachment string) (uint32, error) {
 	return uint32(link.Attrs().Index), nil
 }
 
-// egressKindForInterfaceType maps a "veth"/"tap" interface type string to the
-// vrf_table egress_kind value usid.c's step 9 uses to pick between
-// bpf_redirect_peer (veth, crosses into the container's netns) and plain
-// bpf_redirect (tap, which never leaves this netns).
+// egressKindForInterfaceType maps a "veth" or "tap" interface type to the
+// vrf_table egress_kind value the datapath uses to choose between
+// bpf_redirect_peer, which crosses into the container's netns, and plain
+// bpf_redirect, which does not.
 func egressKindForInterfaceType(ifaceType string) (uint32, error) {
 	switch ifaceType {
 	case ifaceTypeVeth:

--- a/internal/cnibgp/cnibgp.go
+++ b/internal/cnibgp/cnibgp.go
@@ -16,14 +16,10 @@ import (
 
 const cniTimeout = 10 * time.Second
 
-// ebpfPinDir is the bpffs directory this package's own eBPF registration
-// (registerEBPFDatapath, bgp.go), rollback (resourceTracker.cleanup,
-// resource.go), and CHECK (checkEBPFEntry, ops_check.go) all read/write
-// pinned uSID maps under. A package var defaulting to attach.PinDir, rather
-// than every call site reading that constant directly, so tests can point
-// it at a throwaway pin directory instead of the real production one —
-// attach.PinDir being a const otherwise gives production callers no seam
-// for that (see resource_test.go's resourceTracker.cleanup tests).
+// ebpfPinDir is the bpffs directory this package's eBPF registration, rollback,
+// and CHECK paths read and write pinned uSID maps under. A package var rather
+// than every call site reading the constant directly, so tests can point it at a
+// throwaway directory instead of the production one.
 var ebpfPinDir = attach.PinDir
 
 // RunPlugin starts galactic-bgp, handling the CNI ADD, DEL, CHECK, and

--- a/internal/cnibgp/config.go
+++ b/internal/cnibgp/config.go
@@ -23,20 +23,17 @@ import (
 
 var ConfFile = config.DefaultConfFile
 
-// cniConfig is the shared config resolver for env var resolution.
-// Initialized by InitCNIConfig() (called from cmd/galactic-bgp/main.go).
+// cniConfig is the shared config resolver for environment resolution,
+// initialized once at process startup by InitCNIConfig.
 //
-// Reuses internal/config.CNIConfig (the GALACTIC_CNI_* env var names) as-is
-// rather than defining a GALACTIC_BGP_* set: node_name/kubeconfig/namespace
-// are shared node-level settings, not domain-specific behavior the way
-// galactic-ipam's own enable-local-ipam flag is — every binary in the chain
-// resolves them from the same static conflist file (see
-// go.datum.net/galactic/internal/hostconf's doc comment).
+// It reuses the shared CNI environment names rather than defining a set of its
+// own: the node name, kubeconfig, and namespace are node-level settings every
+// binary in the chain resolves from the same static conflist, not
+// domain-specific behavior.
 var cniConfig *config.CNIConfig
 
-// InitCNIConfig initializes the shared config resolver for CNI env var
-// resolution. Callers should invoke this once at process startup before any
-// config lookups.
+// InitCNIConfig initializes the shared config resolver. Call it once at process
+// startup, before any config lookup.
 func InitCNIConfig() {
 	cniConfig = config.NewCNIConfig()
 }
@@ -64,9 +61,9 @@ func isValidBase62(s string) bool {
 	return true
 }
 
-// loadHostConf loads node-local settings from the static per-node conflist.
-// If the file is missing, it returns a zero-value HostConf (tolerating local
-// test runs) but still defaulting Namespace to config.DefaultNamespace.
+// loadHostConf loads node-local settings from the static per-node conflist. A
+// missing file yields a zero-value HostConf, tolerating local test runs, with
+// the namespace still defaulted.
 func loadHostConf(filePath string) (*HostConf, error) {
 	if filePath == "" {
 		filePath = config.DefaultConfFile
@@ -147,9 +144,9 @@ func parseStatusConf(data []byte) error {
 	return nil
 }
 
-// parseConf unmarshals the CNI configuration from stdin data (the same
-// document the master plugin received), validates the base62-encoded
-// identifier fields, and resolves node-level settings and logging.
+// parseConf unmarshals the CNI configuration from data, the same document the
+// master plugin received, validates the base62 identifier fields, and resolves
+// node-level settings and logging.
 func parseConf(data []byte) (*PluginConf, error) {
 	conf := &PluginConf{}
 	if err := json.Unmarshal(data, &conf); err != nil {
@@ -201,21 +198,18 @@ func parseConf(data []byte) (*PluginConf, error) {
 	}
 	_ = os.Setenv("KUBECONFIG", cniConfig.Kubeconfig)
 
-	// Bridges the conflist-resolved interface list into the raw env var
-	// attach.ResolveInterfaces itself checks, exactly the same
-	// "downstream library reads via plain os.Getenv" reason the
-	// KUBECONFIG bridge just above exists for. Without this, every
-	// srv6.ResolveNodeSourceAddress/ResolvePublicUplink call this
-	// process makes (registerNodeSourceAddress/registerPublicUplink,
-	// bgp.go) falls back to attach.ResolveInterfaces' own
-	// default-IPv6-route auto-detection -- wrong on any node where that
-	// route's interface isn't the fabric one (found live: this exact gap
-	// produced a plausible-but-wrong public_uplink_table entry with no
-	// error at all). Only sets it when the process's own environment
-	// doesn't already carry it, so an operator who genuinely does set
-	// GALACTIC_CNI_EBPF_INTERFACES on this exec environment directly
-	// (unlike this lab, which only sets it on the DaemonSet container's
-	// own env, never on a CNI plugin's) is never overridden.
+	// Bridge the conflist-resolved interface list into the raw environment
+	// variable the attach package reads directly, the same reason the
+	// kubeconfig bridge above exists.
+	//
+	// Without it, every source-address and uplink resolution this process
+	// makes falls back to the attach package's own default-route
+	// auto-detection, which is wrong on any node where that route's
+	// interface is not the fabric one and produces a plausible but wrong
+	// uplink entry with no error at all.
+	//
+	// Set only when this process's environment does not already carry it,
+	// so an operator who does set it directly is never overridden.
 	if os.Getenv(config.EnvCNIEBPFInterfaces) == "" && cniConfig.EBPFInterfaces != "" {
 		_ = os.Setenv(config.EnvCNIEBPFInterfaces, cniConfig.EBPFInterfaces)
 	}

--- a/internal/cnibgp/endpointslice.go
+++ b/internal/cnibgp/endpointslice.go
@@ -21,23 +21,18 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 )
 
-// publishEndpointSlice creates or updates the per-pod discoveryv1.EndpointSlice
-// that the HTTP-ingress extension server discovers VPC backends through (see
-// crdnames.LabelTenantID's doc comment — Open Decision 2 of the #854 plan).
-// One EndpointSlice per pod, named after the pod (crdnames.EndpointSliceName),
-// IPv6-only (Open Decision 1: a dual-stack pod's IPv4 address is not
-// published).
+// publishEndpointSlice creates or updates the per-pod EndpointSlice the HTTP
+// ingress extension server discovers VPC backends through. One slice per pod,
+// named after the pod, and IPv6-only: a dual-stack pod's IPv4 address is not
+// published.
 //
-// Runs as its own step after publishBGPState returns successfully, not
-// folded into its retry closure — see the #854 plan's Phase 4 rollback-risk
-// note for why that sequencing, combined with fixing advertisementCreated's
-// gating (bgp.go), is what keeps a failure here from ever causing rollback to
-// delete a BGPAdvertisement still backing a live sibling.
+// It runs as its own step after the BGP publish succeeds, not inside its retry
+// closure. That sequencing is what keeps a failure here from causing rollback to
+// delete an advertisement still backing a live sibling.
 //
-// Also sets metadata.ownerReferences to the owning Pod (Open Decision 6 /
-// Phase 8: the k8s garbage collector's own reclaim is the backstop for
-// force-deleted/never-DEL'd pods; cmdDel's explicit delete, ops_del.go, is
-// the fast, deterministic path for the common case).
+// It also sets an owner reference to the pod, so the cluster's garbage collector
+// is the backstop for pods that are force-deleted and never see a DEL. The
+// explicit delete on DEL is the fast path for the common case.
 func publishEndpointSlice(
 	ctx context.Context, k8s client.Client, namespace, podName, vpc, vpcAttachment string, addr net.IP, sid netip.Addr,
 ) error {
@@ -53,11 +48,10 @@ func publishEndpointSlice(
 	getErr := k8s.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, slice)
 	switch {
 	case getErr == nil:
-		// Naming-collision defensive check: EndpointSliceName is a trivial
-		// passthrough of the pod's own name, so nothing but convention stops
-		// some other EndpointSlice (Service-backed or otherwise) from
-		// landing on this exact name/namespace. Bail rather than silently
-		// start mutating an object this plugin doesn't own.
+		// Defensive against a naming collision: the slice name is a
+		// passthrough of the pod's name, so nothing but convention stops
+		// another slice from landing on this exact name. Bail rather than
+		// silently mutate an object this plugin does not own.
 		if _, ok := slice.Labels[crdnames.LabelTenantID]; !ok {
 			return fmt.Errorf(
 				"EndpointSlice %s/%s already exists without a %s label — refusing to overwrite an object this plugin doesn't own",
@@ -103,11 +97,10 @@ func publishEndpointSlice(
 			},
 		}}
 
-		// Same namespace (Pod and EndpointSlice always are, here), so the
-		// cross-namespace-owner restriction doesn't apply. Not a controller
-		// ref (SetOwnerReference, not SetControllerReference) and
-		// BlockOwnerDeletion left at its default false — ordering doesn't
-		// matter for this object.
+		// Pod and slice are always in the same namespace here, so the
+		// cross-namespace restriction does not apply. Not a controller
+		// reference, and not blocking owner deletion: ordering does not matter
+		// for this object.
 		return controllerutil.SetOwnerReference(pod, slice, k8s.Scheme())
 	})
 	if err != nil {
@@ -118,9 +111,8 @@ func publishEndpointSlice(
 	return nil
 }
 
-// deleteEndpointSlice deletes the per-pod EndpointSlice cmdAdd published,
-// treating not-found as success — see cmdDel's own doc comment for why DEL,
-// unlike the rest of the chain's DEL paths, does real work here.
+// deleteEndpointSlice deletes the per-pod EndpointSlice the ADD path published,
+// treating not-found as success.
 func deleteEndpointSlice(ctx context.Context, k8s client.Client, namespace, podName string) error {
 	slice := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/cnibgp/ops_add.go
+++ b/internal/cnibgp/ops_add.go
@@ -16,11 +16,9 @@ import (
 	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
-// cmdAdd is galactic-bgp's own ADD: the last (per the design note's sample
-// conflists) plugin in the chain, publishing SRv6/BGP/eBPF state for
-// whatever the master plugin already created. It never touches a kernel
-// interface — everything it needs (which interface kind, which addresses)
-// comes from prevResult (see prevresult.go).
+// cmdAdd is this plugin's ADD: the last in the chain, publishing SRv6, BGP, and
+// eBPF state for whatever the master plugin created. It never touches a kernel
+// interface; everything it needs comes from the previous result.
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -50,17 +48,17 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		if err != nil {
 			slog.Error("ADD: failed, rolling back created resources", "err", err,
 				"containerID", args.ContainerID, "vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment)
-			// rollbackCtx is created here, fresh, rather than up front and
-			// shared with the work that just failed: publishBGPState's own
-			// retryK8sOps (bgp.go) can burn up to ~30s across its retries,
-			// each on its own fresh cniTimeout context. A context created
-			// before that call and reused here could already be expired by
-			// the time cleanup runs, so Delete would fail with "context
-			// deadline exceeded" instead of NotFound — client.IgnoreNotFound
-			// doesn't catch that, and the just-created CRDs would leak.
-			// Giving rollback its own full cniTimeout budget, on the failure
-			// path only, also means a successful ADD never allocates (and
-			// must remember to cancel) a context it doesn't use.
+			// A fresh context, rather than one created up front and shared
+			// with the work that just failed. The publish path's retries
+			// can burn tens of seconds, each on its own fresh timeout, so
+			// a context created before that call could already be expired
+			// here and the delete would fail with a deadline error rather
+			// than not-found. That is not treated as an ignorable
+			// not-found, so the just-created CRDs would leak.
+			//
+			// Giving rollback its own full budget, on the failure path
+			// only, also means a successful ADD never allocates a context
+			// it does not use.
 			rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), cniTimeout)
 			tracker.cleanup(rollbackCtx)
 			rollbackCancel()
@@ -85,21 +83,15 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		return err
 	}
 
-	// EndpointSlice publish is a separate step after publishBGPState
-	// succeeds, not folded into its retry closure — see the #854 plan's
-	// Phase 4 rollback-risk note. ipamResult == nil or carrying no IPv6
-	// address is the same "no address to publish" skip
-	// registerEBPFDatapath's own SRv6-not-configured case already
-	// establishes: not an error, and not tap/VM-specific (see Open Decision
-	// 5) — an attachment with no IPv6 allocation has nothing for an
-	// EndpointSlice to carry either way.
+	// The EndpointSlice publish is a separate step after the CRDs succeed,
+	// rather than folded into their retry closure. No IPAM result, or one with
+	// no IPv6 address, is the same "nothing to publish" skip the SRv6
+	// registration already makes: not an error, and not specific to tap
+	// workloads.
 	if ipamResult != nil && ipamResult.IPv6Subnet != nil {
 		podName := nadpatch.ParsePodName(args.Args)
-		// The EndpointSlice is created in the pod's own namespace, per
-		// docs/cni/configuration.md's "EndpointSlice publish" section —
-		// distinct from `namespace` above, which is where the BGP CRDs
-		// live (defaults to galactic-system) and is very often a
-		// different namespace from the workload pod's own.
+		// The EndpointSlice goes in the pod's own namespace, distinct from the
+		// one holding the BGP CRDs, which is very often different.
 		podNamespace := nadpatch.ParsePodNamespace(args.Args)
 		if podName == "" || podNamespace == "" {
 			return fmt.Errorf(
@@ -116,10 +108,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 	}
 
-	// Pass prevResult through unchanged: this plugin adds no new interfaces
-	// or IPs of its own, so its own CNI result is exactly what it received.
-	// Per the design note's sample conflists, galactic-bgp is the last
-	// plugin in the chain, so this becomes the runtime's authoritative
-	// result for the ADD.
+	// Pass the previous result through unchanged: this plugin adds no interfaces
+	// or addresses of its own. Being last in the chain, this becomes the
+	// runtime's authoritative result for the ADD.
 	return types.PrintResult(prevResult, pluginConf.CNIVersion)
 }

--- a/internal/cnibgp/ops_check.go
+++ b/internal/cnibgp/ops_check.go
@@ -32,13 +32,10 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// cmdCheck verifies that the BGP state cmdAdd published is still in place:
-// the BGPVRFInstance and BGPAdvertisement CRDs exist, and — when this
-// node's BGPRouter has SRv6 configured — the eBPF vrf_table entry for this
-// attachment is still registered. None of this is a move from
-// internal/cni's own CHECK; it's genuinely new, since nothing before this
-// split ever verified CRD/eBPF state independently of kernel interface
-// state.
+// cmdCheck verifies that the state cmdAdd published is still in place: the
+// BGPVRFInstance and BGPAdvertisement exist, and, when this node's BGPRouter
+// has SRv6 configured, the eBPF entries for this attachment are still
+// registered.
 func cmdCheck(args *skel.CmdArgs) error {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -64,10 +61,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 		errs = append(errs, fmt.Errorf("BGPVRFInstance %s: %w", vrfName, vrfErr))
 	}
 
-	// checkEndpointSlice's SID check and checkEBPFEntry below both need
-	// this node's BGPRouter (keyed by cniConfig.NodeName/pluginConf.Namespace)
-	// once the BGPVRFInstance lookup above succeeded; look it up here once
-	// and hand the result to both instead of each fetching it independently.
+	// Both the EndpointSlice SID check and the eBPF check below need this
+	// node's BGPRouter once the instance lookup has succeeded. Look it up once
+	// and hand it to both rather than have each fetch it.
 	var bgp bgpConfig
 	if vrfErr == nil {
 		var bgpErr error
@@ -83,17 +79,15 @@ func cmdCheck(args *skel.CmdArgs) error {
 		errs = append(errs, fmt.Errorf("BGPAdvertisement %s: %w", advName, err))
 	}
 
-	// ipamResult == nil or carrying no IPv6 address means cmdAdd never
-	// published an EndpointSlice for this attachment in the first place —
-	// same "no address to publish" skip as cmdAdd's own (see ops_add.go),
-	// not tap/VM-specific (Open Decision 5).
+	// No IPAM result, or one carrying no IPv6 address, means cmdAdd never
+	// published an EndpointSlice for this attachment, the same skip the ADD
+	// path takes.
 	if _, ipamResult, _, prevErr := inferFromPrevResult(pluginConf.RawPrevResult); prevErr != nil {
 		errs = append(errs, fmt.Errorf("infer from prevResult: %w", prevErr))
 	} else if ipamResult != nil && ipamResult.IPv6Subnet != nil {
 		podName := nadpatch.ParsePodName(args.Args)
-		// The EndpointSlice lives in the pod's own namespace (see ops_add.go's
-		// cmdAdd), not pluginConf.Namespace — that's only where the BGP CRDs
-		// checked above live.
+		// The EndpointSlice lives in the pod's own namespace, not the one the
+		// BGP CRDs checked above live in.
 		podNamespace := nadpatch.ParsePodNamespace(args.Args)
 		if podName == "" || podNamespace == "" {
 			errs = append(errs, errors.New("EndpointSlice: no K8S_POD_NAME/K8S_POD_NAMESPACE in CNI_ARGS"))
@@ -104,10 +98,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 		}
 	}
 
-	// The eBPF vrf_table entry is only checkable once the BGPVRFInstance
-	// lookup succeeded (it carries the Argument value the entry is keyed
-	// on) and this node's router actually has SRv6 configured — matches
-	// registerEBPFDatapath's own no-op case.
+	// The eBPF entries are only checkable once the instance lookup succeeded,
+	// it carrying the Argument they are keyed on, and this node's router
+	// actually has SRv6 configured.
 	if vrfErr == nil {
 		if err := checkEBPFEntry(pluginConf, uint16(vrfInst.Spec.VRFID), bgp); err != nil {
 			errs = append(errs, err)
@@ -125,19 +118,17 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-// checkEBPFEntry verifies every eBPF table registerEBPFDatapath wrote for
-// this attachment still exists and is intact: the locator_table entry (this
-// router's own node), the function_table entry (SRv6 End.DT46 behavior),
-// and the vrf_table entry (still resolving to this attachment's own VRF
-// table id) — plus the same nodeID range check ADD treats as a hard error.
-// Checking vrf_table alone would miss a corrupted/missing locator or
-// function entry, or a nodeID that drifted out of range after ADD, while
-// still reporting the attachment healthy. Returns nil (not an error) when
-// this node's router has no SRv6Locator/nodeID configured — SRv6 was
-// intentionally never set up for this attachment, matching
-// registerEBPFDatapath's own no-op case. bgp is this node's BGPRouter,
-// looked up once by the caller (cmdCheck) and shared with checkEndpointSlice
-// rather than each fetching it independently.
+// checkEBPFEntry verifies every eBPF entry the ADD path wrote for this
+// attachment still exists and is intact: the locator entry for this node, the
+// function entry for the endpoint behavior, and the VRF entry still resolving
+// to this attachment's table, plus the same node ID range check ADD treats as
+// fatal. Checking the VRF entry alone would miss a missing locator or function
+// entry, or a node ID that drifted out of range, while still reporting the
+// attachment healthy.
+//
+// Returns nil, not an error, when this node's router has no locator or node ID
+// configured: SRv6 was intentionally never set up. bgp is this node's
+// BGPRouter, looked up once by the caller.
 func checkEBPFEntry(pluginConf *PluginConf, argument uint16, bgp bgpConfig) error {
 	if bgp.srv6Locator == "" || bgp.nodeID == 0 {
 		return nil
@@ -199,18 +190,15 @@ func checkEBPFEntry(pluginConf *PluginConf, argument uint16, bgp bgpConfig) erro
 	return errors.Join(errs...)
 }
 
-// checkEndpointSlice verifies the per-pod EndpointSlice cmdAdd published
-// (endpointslice.go) is still in place: it exists, carries the pod's
-// current address, and its tenant-id/SID label and annotations match
-// freshly recomputed expected values. bgp is this node's BGPRouter, looked
-// up once by the caller (cmdCheck) and shared with checkEBPFEntry rather
-// than fetched here independently; a zero-value bgp (as when the
-// BGPVRFInstance lookup in cmdCheck above failed) means the SID can't be
-// recomputed, so its annotation is not checked — matches
-// registerEBPFDatapath/checkEBPFEntry's own "can't check what we can't
-// compute" convention. podNamespace is the pod's own namespace (parsed from
-// CNI_ARGS) — where cmdAdd created the EndpointSlice — distinct from
-// pluginConf.Namespace, which is only where the BGP CRDs live.
+// checkEndpointSlice verifies the per-pod EndpointSlice the ADD path published
+// is still in place: it exists, carries the pod's current address, and its
+// label and annotations match freshly recomputed values.
+//
+// bgp is this node's BGPRouter, looked up once by the caller. A zero value,
+// which is what a failed instance lookup leaves, means the SID cannot be
+// recomputed, so its annotation is not checked. podNamespace is the pod's own
+// namespace, where the slice was created, distinct from the namespace holding
+// the BGP CRDs.
 func checkEndpointSlice(
 	ctx context.Context, k8s client.Client, pluginConf *PluginConf, podName, podNamespace string,
 	addr net.IP, bgp bgpConfig, vrfID int32,
@@ -255,9 +243,8 @@ func checkEndpointSlice(
 	return errors.Join(errs...)
 }
 
-// cmdStatus implements the CNI spec STATUS operation — galactic-bgp talks
-// to the API server (BGP CRD reads/writes), so this probes it the same way
-// internal/cni's own cmdStatus does.
+// cmdStatus implements the CNI STATUS operation. This plugin talks to the API
+// server, so this probes it.
 func cmdStatus(args *skel.CmdArgs) error {
 	if err := parseStatusConf(args.StdinData); err != nil {
 		return err

--- a/internal/cnibgp/ops_del.go
+++ b/internal/cnibgp/ops_del.go
@@ -15,27 +15,21 @@ import (
 	"go.datum.net/galactic/internal/nadpatch"
 )
 
-// cmdDel deletes the per-pod EndpointSlice cmdAdd published, then falls
-// through to the same no-op the rest of the chain's DEL paths follow for
-// the BGPVRFInstance/BGPAdvertisement CRDs and eBPF vrf_table entry: those
-// are keyed by (vpc, vpcAttachment) and may still be in use by another
-// pod/VM sharing the same attachment, so deleting them here would race with
-// a concurrent ADD during restarts — cleanup for those stays galactic-
-// router's GC controller's job (see internal/cni's own cmdDel for the full
-// reasoning, identical here).
+// cmdDel deletes the per-pod EndpointSlice the ADD path published, then falls
+// through to the same no-op the rest of the chain's DEL paths follow for the BGP
+// CRDs and the vrf_table entry. Those are keyed by attachment and may still be
+// in use by another pod sharing it, so deleting them here would race a
+// concurrent ADD during a restart; that cleanup stays garbage collection's job.
 //
-// The EndpointSlice is a deliberate, correct divergence from that pattern:
-// it's 1:1 with exactly one pod, never shared, so there's no "might belong
-// to a live sibling" risk to avoid — see the #854 plan's Phase 5. Deletion
-// is best-effort: any failure (including failing to build a k8s client at
-// all) is logged and DEL still returns success, since a k8s API hiccup
-// during pod teardown shouldn't block the pod from actually going away —
-// Phase 8's ownerReference-to-Pod is the backstop for exactly this case.
+// The EndpointSlice is a deliberate divergence: it is one per pod and never
+// shared, so there is no live sibling to endanger. Deletion is best-effort, and
+// any failure, including failing to build a client at all, is logged while DEL
+// still returns success: an API hiccup during teardown must not block the pod
+// from going away. The owner reference is the backstop for exactly that case.
 func cmdDel(args *skel.CmdArgs) error {
-	// DEL is idempotent per the CNI spec: always return success, even if
-	// parsing the config fails — logging vpc/vpcAttachment (when parseable)
-	// is the only reason to parse at all here, since there's no cleanup to
-	// gate on it.
+	// DEL is idempotent per the CNI spec and always returns success, even when
+	// the config fails to parse. Parsing exists only to log the identifiers when
+	// they are available; no cleanup is gated on it.
 	pluginConf, parseErr := parseConf(args.StdinData)
 	if parseErr != nil {
 		slog.Error("DEL: failed to parse CNI config, skipping cleanup", "err", parseErr,
@@ -56,10 +50,9 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 // deleteEndpointSliceBestEffort deletes this pod's EndpointSlice, logging
-// (never failing DEL) on any error — see cmdDel's own doc comment for why.
-// The EndpointSlice lives in the pod's own namespace (parsed from CNI_ARGS
-// below, same as podName), not pluginConf.Namespace — that's only where the
-// BGP CRDs live, and cmdDel deliberately leaves those alone (see above).
+// rather than failing DEL on any error. The slice lives in the pod's own
+// namespace, not the one holding the BGP CRDs, which this path deliberately
+// leaves alone.
 func deleteEndpointSliceBestEffort(args *skel.CmdArgs) {
 	podName := nadpatch.ParsePodName(args.Args)
 	podNamespace := nadpatch.ParsePodNamespace(args.Args)

--- a/internal/cnibgp/prevresult.go
+++ b/internal/cnibgp/prevresult.go
@@ -15,42 +15,30 @@ import (
 	"go.datum.net/galactic/internal/cniipam"
 )
 
-// inferFromPrevResult reconstructs the ipamResult and infers whether the
-// preceding master plugin created a veth or tap interface, both from
-// rawPrevResult — the raw JSON form of the CNI chain's accumulated result
-// so far (PluginConf.RawPrevResult; the typed PluginConf.PrevResult field
-// is never populated by plain JSON unmarshal, per its "json:\"-\"" tag —
-// ops_check.go elsewhere in this repo already reads prevResult the same,
-// correct way).
+// inferFromPrevResult reconstructs the IPAM result and infers whether the
+// preceding master plugin created a veth or a tap, both from rawPrevResult, the
+// raw JSON of the chain's accumulated result so far. The typed field is never
+// populated by a plain unmarshal, so the raw form is the one to read.
 //
-// type100.NewResult only accepts a Result whose own CNIVersion field is
-// exactly "1.0.0" or "1.1.0" (github.com/containernetworking/cni's
-// pkg/types/100 supportedVersions) — and the master plugin's printed Result
-// carries the conflist's own cniVersion value verbatim (buildResult/
-// buildTapResult set CNIVersion: pluginConf.CNIVersion), not a value this
-// plugin controls. A conflist authored with an older cniVersion (e.g.
-// "0.4.0") therefore fails ADD here for every attachment in the chain. This
-// is a real, hard requirement on every conflist in this repo's CNI chain —
-// see docs/cni/configuration.md's cniVersion paragraph — not just an
-// implementation detail of this function.
+// This plugin has no kernel-interface access or IPAM knowledge of its own, so
+// this is the only way it learns either.
 //
-// galactic-bgp has no kernel-interface access or IPAM knowledge of its own
-// — this is the only way it learns either. Interface-kind inference: a
-// veth master's own result declares one interface with a non-empty Sandbox
-// (the guest end, moved into the container netns — see internal/cni/
-// result.go's buildResult); a tap master's declares zero (the tap device
-// stays on the host — internal/cnitap/result.go's buildTapResult). This
-// counts Sandbox-carrying interfaces rather than len(Interfaces) itself,
-// on purpose: #306 chains galactic-route into this same prevResult next,
-// and total interface count is not this plugin's to own — if anything
-// appended later adds a host-side interface entry of its own, a raw count
-// would silently reclassify a tap master as veth (or vice versa) instead
-// of failing loudly, because both 1 and 2 are valid switch cases. Whether
-// an interface was moved into the container's netns is the actual property
-// that distinguishes veth from tap, not how many entries happen to be in
-// the slice — see the design note's "Split the veth/tap master into two
-// binaries" section for why no interface_type field exists anywhere in the
-// chain to make this explicit instead.
+// Result parsing accepts only the current CNI result versions, and the master
+// plugin's printed result carries the conflist's version verbatim rather than
+// one this plugin controls. A conflist authored with an older version therefore
+// fails ADD here for every attachment in the chain. That is a hard requirement
+// on every conflist in this chain, not an implementation detail.
+//
+// Interface-kind inference: a veth master's result declares one interface with a
+// non-empty sandbox, the guest end moved into the container namespace, while a
+// tap master's declares none, the device staying on the host.
+//
+// It counts sandbox-carrying interfaces rather than interfaces outright, on
+// purpose. Another plugin chained after this one may append a host-side entry,
+// and a raw count would then silently reclassify a tap master as veth, or the
+// reverse, instead of failing loudly, both counts being valid cases. Whether an
+// interface was moved into the container's namespace is the property that
+// actually distinguishes the two.
 func inferFromPrevResult(
 	rawPrevResult map[string]interface{},
 ) (ifaceType string, ipamResult *cniipam.IPAMResult, parsed types.Result, err error) {
@@ -97,9 +85,9 @@ func inferFromPrevResult(
 		return "", nil, nil, fmt.Errorf("convert prevResult IPs: %w", err)
 	}
 	if ipamResult.IPv6Subnet == nil && ipamResult.IPv4Address == nil {
-		// No IPAM allocation at all (e.g. a tap workload managing its own
-		// addressing) — nil, not a zero-value result, matches what every
-		// other caller in this chain already treats as "no IPAM."
+		// No IPAM allocation at all, as for a tap workload managing its own
+		// addressing. Nil rather than a zero-value result, matching what
+		// every other caller in this chain treats as no IPAM.
 		ipamResult = nil
 	}
 	return ifaceType, ipamResult, parsed, nil

--- a/internal/cnibgp/resource.go
+++ b/internal/cnibgp/resource.go
@@ -41,18 +41,13 @@ func newK8sClient() (client.Client, error) {
 	return c, nil
 }
 
-// resourceTracker tracks resources created during cmdAdd for selective
-// rollback. galactic-bgp's own ADD only ever creates BGP CRDs and an eBPF
-// vrf_table entry — the kernel-interface/VRF cleanup that used to live
-// alongside these in one process-wide tracker is now each master plugin's
-// own, smaller tracker (internal/cni, internal/cnitap), scoped to exactly
-// what its own ADD creates.
+// resourceTracker tracks the resources cmdAdd created, for selective rollback.
+// This plugin's ADD only ever creates BGP CRDs and an eBPF vrf_table entry;
+// kernel-interface cleanup belongs to each master plugin's own tracker.
 //
-// publishResult is embedded, rather than its five fields being copied over
-// field-by-field, so a future field added to one struct can't silently stop
-// being tracked in the other with no compiler error to catch it — cmdAdd
-// assigns the whole publishResult from publishBGPState in one shot
-// (tracker.publishResult = result).
+// publishResult is embedded rather than copied field by field, so a field added
+// to one struct cannot silently stop being tracked in the other with no
+// compiler error to catch it.
 type resourceTracker struct {
 	vpc, vpcAttachment, nodeName string
 	namespace                    string
@@ -61,30 +56,23 @@ type resourceTracker struct {
 	publishResult
 }
 
-// cleanup rolls back all tracked resources. Errors are logged but never
-// returned — the caller already has a failure.
+// cleanup rolls back the tracked resources. Errors are logged and never
+// returned, the caller already having a failure.
 //
-// Deliberately conditional: deleting the BGPVRFInstance CRD only when this
-// ADD's own attempt just created it (vrfInstanceCreated), and never
-// unregistering the eBPF vrf_table entry registerEBPFDatapath wrote at all.
-// Unlike the BGPAdvertisement below (still a reliable 1:1 key per
-// attachment — see crdnames.BGPAdvertisementName), both the BGPVRFInstance
-// and the vrf_table entry are shared by every attachment on this VPC on
-// this node (crdnames.BGPVRFInstanceName): once a second attachment's ADD
-// reuses an already-live sibling's CRD/eBPF entry (publishBGPState's
-// CreateOrUpdate and usidmap.VRF.Register are both idempotent-by-name/key,
-// so this is the ordinary case, not an edge case), unconditionally rolling
-// either back here would tear down a live sibling's VRF out from under it.
-// This is the same reasoning internal/cni/veth and internal/plumbing/vrf
-// already apply on the kernel side (see vrf.Delete's doc comment): shared
-// per-(vpc,node) state is exclusively galactic-router's GC controller's job
-// to reclaim, once it has confirmed via every BGPAdvertisement for this
-// VPC/node that none remain (internal/gc's CollectOrphanedCRDs and
-// SweepEBPFVRFTable) — the eBPF entry has no cheap "did I just create this"
-// signal the way a k8s object's CreateOrUpdate result gives us, so it stays
-// unconditional there; the BGPVRFInstance does, which is what lets a
-// checkArgumentCollision rejection of a freshly-created instance (see
-// publishBGPState) self-heal on retry instead of wedging permanently.
+// Deliberately conditional. The BGPVRFInstance is deleted only when this ADD's
+// own attempt created it, and the vrf_table entry is never unregistered at all.
+// Unlike the advertisement, which is a reliable one-per-attachment key, both are
+// shared by every attachment on this VPC on this node. Once a second
+// attachment's ADD reuses a live sibling's, which is the ordinary case since
+// both writes are idempotent, rolling either back would tear down that
+// sibling's VRF.
+//
+// Reclaiming shared per-node state is garbage collection's job, once it has
+// confirmed no advertisement for this VPC and node remains. The map entry has no
+// cheap "did I just create this" signal the way an API object's write result
+// does, so it stays unconditional there. The CRD does have one, which is what
+// lets a rejected freshly created instance self-heal on retry rather than
+// wedging permanently.
 func (rt *resourceTracker) cleanup(ctx context.Context) {
 	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
 		"vpc", rt.vpc, "vpcAttachment", rt.vpcAttachment)

--- a/internal/cnibgp/types.go
+++ b/internal/cnibgp/types.go
@@ -10,12 +10,10 @@ import (
 	"go.datum.net/galactic/internal/hostconf"
 )
 
-// PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-bgp — the same document the master plugin itself
-// received, since the CNI runtime passes each chain entry its own stanza
-// plus prevResult; galactic-bgp only reads vpc/vpcattachment/namespace out
-// of it (mtu, terminations, ipam are the master's/galactic-ipam's own
-// concerns).
+// PluginConf is the CNI plugin configuration passed on stdin, the same document
+// the master plugin received, since the runtime passes each chain entry its own
+// stanza plus the previous result. This plugin reads only the identifiers and
+// namespace out of it; the rest belongs to other plugins in the chain.
 type PluginConf struct {
 	types.PluginConf
 	VPC           string `json:"vpc"`

--- a/internal/cniipam/allocate.go
+++ b/internal/cniipam/allocate.go
@@ -15,20 +15,17 @@ import (
 	"go.datum.net/galactic/internal/cni/ipam"
 )
 
-// localIPAMDefaultPool is the IPv6 CIDR pool used when local IPAM is enabled
-// but neither static_ip nor ipv6_subnet/ipv4_subnet is set in the ipam
-// block. Allocations from it use ipam.DefaultSubnetLen (/96).
+// localIPAMDefaultPool is the IPv6 pool used when local IPAM is enabled but the
+// ipam block names no static address and no subnet.
 const localIPAMDefaultPool = "fd00:10:ff01::/64"
 
-// lockDir is the on-disk allocation-state root both PoolAllocator and
-// IPv4PoolAllocator persist to. Overridable in tests so unit tests never
-// touch the real production path.
+// lockDir is the on-disk allocation-state root both allocators persist to.
+// Overridable so tests never touch the production path.
 var lockDir = ipam.DefaultLockDir
 
-// allocate assigns addresses for the given container according to conf's
-// mode: presence of Addresses selects the pre-decided addresses path,
-// presence of StaticIP the legacy static path; otherwise the pool path
-// (either family alone, or both).
+// allocate assigns addresses for a container according to conf's mode: an
+// addresses list selects the pre-decided path, a static address the legacy
+// path, and otherwise the pool path, for either family alone or both.
 func allocate(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	switch {
 	case len(conf.Addresses) > 0:
@@ -41,9 +38,8 @@ func allocate(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 }
 
 // allocateAddresses assigns the addresses the config already carries, exactly
-// as given — prefix length included, both families, gateways honored. Nothing
-// is allocated and nothing is persisted: the addresses belong to whoever
-// decided them.
+// as given, prefix lengths included and gateways honored. Nothing is allocated
+// and nothing is persisted: the addresses belong to whoever decided them.
 func allocateAddresses(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	parsed, err := parseAddresses(conf.Addresses)
 	if err != nil {
@@ -76,9 +72,9 @@ func defaultRoutes(ipv6, ipv4 bool) []*net.IPNet {
 	return routes
 }
 
-// allocateStatic validates and returns the pre-assigned static IPv6 address
-// from static_ip. No IPv4 address is ever allocated for static IPAM — it is
-// a single fixed address, not a dual-stack pool.
+// allocateStatic validates and returns the pre-assigned static IPv6 address. No
+// IPv4 address is ever allocated on this path, it being a single fixed address
+// rather than a pool.
 func allocateStatic(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	alloc := ipam.NewStaticAllocator()
 	allocIP, err := alloc.Allocate(args.ContainerID, conf.StaticIP)
@@ -93,12 +89,10 @@ func allocateStatic(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	return &IPAMResult{IPv6Subnet: subnet}, nil
 }
 
-// allocatePool allocates a dual-stack, IPv6-only, or IPv4-only pool-based
-// endpoint address for the given container, via ipam.DualStackAllocator.
-// IPv6Subnet and IPv4Subnet each independently supply a pool CIDR for their
-// family; at least one must be set (falling back to localIPAMDefaultPool
-// for IPv6 when GALACTIC_IPAM_ENABLE_LOCAL_IPAM is set and both are unset —
-// see parseConf, which fills that default in before this ever runs).
+// allocatePool allocates a dual-stack, IPv6-only, or IPv4-only endpoint address
+// for a container. Each family's subnet independently supplies a pool, and at
+// least one must be set; config parsing fills in the default IPv6 pool before
+// this runs when local IPAM is enabled and neither is.
 func allocatePool(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	if conf.IPv6Subnet == "" && conf.IPv4Subnet == "" {
 		return nil, errors.New("ipam.ipv6_subnet or ipam.ipv4_subnet is required (or enable GALACTIC_IPAM_ENABLE_LOCAL_IPAM)")
@@ -129,15 +123,14 @@ func allocatePool(args *skel.CmdArgs, conf *IPAM) (*IPAMResult, error) {
 	}, nil
 }
 
-// effectiveIPv6Subnet returns conf.IPv6Subnet if either family's subnet was
-// ever explicitly set. Otherwise — neither ipv6_subnet nor ipv4_subnet is
-// set — the only pool an allocation could possibly have come from is
-// parseConf's default-filler pool, so that's returned directly instead of
-// re-deriving it from GALACTIC_IPAM_ENABLE_LOCAL_IPAM. deallocate/
-// checkAllocation must not depend on that env var still agreeing at DEL/
-// CHECK time with whatever it resolved to at ADD time: if it flips in
-// between, re-checking it here would see an empty subnet and silently skip
-// cleanup/verification, leaking the allocation instead of releasing it.
+// effectiveIPv6Subnet returns the configured IPv6 subnet when either family's
+// subnet was explicitly set, and otherwise the default pool directly.
+//
+// Returning it directly, rather than re-deriving it from the local-IPAM
+// environment flag, is what keeps deallocation and checking independent of that
+// flag still agreeing at DEL or CHECK time with what it resolved to at ADD. A
+// flag that flipped in between would leave an empty subnet here, silently
+// skipping cleanup and leaking the allocation.
 func effectiveIPv6Subnet(conf *IPAM) string {
 	if conf.IPv6Subnet != "" || conf.IPv4Subnet != "" {
 		return conf.IPv6Subnet
@@ -146,13 +139,12 @@ func effectiveIPv6Subnet(conf *IPAM) string {
 }
 
 // deallocate releases whatever allocation containerID holds against conf's
-// pools — entirely local: each family's own on-disk marker file is looked
-// up directly by containerID (internal/cni/ipam's DeallocateContainer), no
-// external state (a CRD read, a Kubernetes client) required. A missing
-// allocation for one family (e.g. a v6-only pod, or a partial ADD failure
-// that never reached IPv4 allocation) does not prevent cleanup of the
-// other — each call is independent and silently no-ops if nothing is
-// found.
+// pools. It is entirely local: each family's marker file is looked up by
+// container ID, needing no CRD read or API client.
+//
+// A missing allocation for one family, from an IPv6-only pod or a partial ADD
+// failure, does not prevent cleanup of the other: each call is independent and
+// silently does nothing when it finds none.
 func deallocate(containerID string, conf *IPAM) {
 	if len(conf.Addresses) > 0 {
 		// Externally decided addresses were never allocated here, so there is nothing to release.
@@ -185,12 +177,10 @@ func deallocate(containerID string, conf *IPAM) {
 	}
 }
 
-// checkAllocation verifies that containerID still holds an allocation
-// against every family conf configures — used by CHECK. An externally
-// decided address (addresses, static_ip) has nothing persisted to check
-// (it's validated once, at ADD, and never stored), so it always passes.
-// Returns one error per missing/unreachable family; nil means every
-// configured family checked out.
+// checkAllocation verifies containerID still holds an allocation against every
+// family conf configures, returning one error per missing family and nil when
+// all check out. An externally decided address has nothing persisted to check,
+// being validated once at ADD and never stored, so it always passes.
 func checkAllocation(containerID string, conf *IPAM) []error {
 	if len(conf.Addresses) > 0 || conf.StaticIP != "" {
 		return nil

--- a/internal/cniipam/config.go
+++ b/internal/cniipam/config.go
@@ -17,9 +17,9 @@ import (
 const errInvalidCNIConfig = "invalid CNI config"
 
 const (
-	// maxIPv6SubnetPrefixLen mirrors internal/cni's own constraint: pool
-	// prefix must be no longer than the per-allocation subnet length, and
-	// dual-stack tenant addressing allocates /96 endpoints.
+	// maxIPv6SubnetPrefixLen bounds the pool prefix: it must be no longer than
+	// the per-allocation subnet length, and dual-stack tenant addressing
+	// allocates /96 endpoints.
 	maxIPv6SubnetPrefixLen = 96
 	maxIPv4SubnetPrefixLen = 32
 )
@@ -33,11 +33,10 @@ const (
 // sanitizeForError's printable-ASCII check.
 const sanitizeForErrorBinary = "<binary>"
 
-// parseConf unmarshals the full CNI config document (the same one the
-// master plugin itself received) and validates/normalizes the "ipam"
-// block. Returns a *types.Error (CNI error code 7) for anything a real IPAM
-// invocation should never see, since a master plugin only ever delegates
-// here when its own "ipam" block is present.
+// parseConf unmarshals the full CNI config document, the same one the master
+// plugin received, and validates and normalizes the ipam block. It returns a
+// CNI validation error for anything a real IPAM invocation should never see,
+// since a master plugin only delegates here when that block is present.
 func parseConf(data []byte) (*pluginConf, error) {
 	conf := &pluginConf{}
 	if err := json.Unmarshal(data, conf); err != nil {
@@ -64,10 +63,10 @@ func parseConf(data []byte) (*pluginConf, error) {
 		}
 	}
 
-	// Default-filler: only when the ipam block is present but specifies
-	// neither a static address nor a pool CIDR for either family. Cannot
-	// manufacture an ipam block out of thin air — that decision already
-	// happened in the master plugin, before this process was even execed.
+	// Fill in a default only when the ipam block is present but names
+	// neither a static address nor a pool for either family. It cannot
+	// manufacture the block itself: that decision was made in the master
+	// plugin, before this process was execed.
 	if len(conf.IPAM.Addresses) == 0 && conf.IPAM.StaticIP == "" &&
 		conf.IPAM.IPv6Subnet == "" && conf.IPAM.IPv4Subnet == "" {
 		if config.IPAMGetEnableLocalIPAM() {
@@ -75,11 +74,9 @@ func parseConf(data []byte) (*pluginConf, error) {
 		}
 	}
 
-	// Unset means "no restriction" — allocate from whatever pool(s) are
-	// configured, exactly like before this field had any effect at all.
-	// Defaulting an unset field to ["ipv6"] here would silently turn every
-	// existing dual-stack or IPv4-only config that has never set this field
-	// into IPv6-only once the filter below is applied.
+	// Unset means no restriction: allocate from whatever pools are configured.
+	// Defaulting an unset field to IPv6 would silently turn every existing
+	// dual-stack or IPv4-only config that never set it into IPv6-only.
 	if len(conf.IPAM.AddressFamilies) > 0 {
 		var wantIPv6, wantIPv4 bool
 		for _, af := range conf.IPAM.AddressFamilies {
@@ -96,9 +93,9 @@ func parseConf(data []byte) (*pluginConf, error) {
 			}
 		}
 
-		// Meaningless for the paths that carry addresses they were given
-		// rather than allocating: both are selected on their own field's
-		// presence, regardless of what else is configured.
+		// Meaningless for the paths carrying addresses they were given
+		// rather than allocating, both being selected on their own field's
+		// presence whatever else is configured.
 		if conf.IPAM.StaticIP == "" && len(conf.IPAM.Addresses) == 0 {
 			if !wantIPv6 {
 				conf.IPAM.IPv6Subnet = ""
@@ -118,9 +115,9 @@ func parseConf(data []byte) (*pluginConf, error) {
 	return conf, nil
 }
 
-// parsedAddresses is the addresses path's config, validated and parsed:
-// at most one address per family, each keeping the exact prefix length it
-// was given.
+// parsedAddresses is the pre-decided addresses path's config, validated and
+// parsed: at most one address per family, each keeping the exact prefix length
+// it was given.
 type parsedAddresses struct {
 	ipv6        *net.IPNet
 	ipv6Gateway net.IP
@@ -147,9 +144,8 @@ func validateAddressesMode(conf *IPAM) error {
 	return err
 }
 
-// parseAddresses validates and parses the addresses block. Every address
-// must carry an explicit prefix length, which is preserved exactly: an
-// endpoint block decided upstream as a /96 stays a /96.
+// parseAddresses validates and parses the addresses block. Every address must
+// carry an explicit prefix length, which is preserved exactly.
 func parseAddresses(addresses []Address) (*parsedAddresses, error) {
 	parsed := &parsedAddresses{}
 	for _, addr := range addresses {
@@ -271,9 +267,9 @@ func sanitizeForError(s string) string {
 	return s
 }
 
-// parseStatusConf validates that STATUS's config is minimally parseable.
-// galactic-ipam has no attachment-specific or API-server state to check —
-// STATUS just confirms the binary can parse a well-formed CNI config.
+// parseStatusConf validates that a STATUS config is minimally parseable. This
+// plugin has no attachment-specific or API-server state to check, so STATUS
+// confirms only that it can parse a well-formed config.
 func parseStatusConf(data []byte) error {
 	var sc struct {
 		CNIVersion string `json:"cniVersion"`

--- a/internal/cniipam/ops.go
+++ b/internal/cniipam/ops.go
@@ -13,9 +13,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-// cmdAdd implements the CNI IPAM delegation ADD path. Being invoked at all
-// is the master plugin's own signal that its "ipam" block was present —
-// this function always allocates, it never re-checks whether it should.
+// cmdAdd implements the IPAM delegation ADD path. Being invoked at all is the
+// master plugin's signal that its ipam block was present, so this always
+// allocates and never re-checks whether it should.
 func cmdAdd(args *skel.CmdArgs) error {
 	conf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -38,9 +38,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdDel implements the CNI IPAM delegation DEL path. Per the CNI spec,
-// DEL is idempotent: a config parse failure or a missing allocation is not
-// an error, since there may be nothing left to clean up.
+// cmdDel implements the IPAM delegation DEL path. Per the CNI spec it is
+// idempotent: a config parse failure or a missing allocation is not an error,
+// there possibly being nothing left to clean up.
 func cmdDel(args *skel.CmdArgs) error {
 	slog.Info("DEL: starting", "containerID", args.ContainerID)
 
@@ -55,9 +55,8 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdCheck implements the CNI IPAM delegation CHECK path: confirm the
-// containerID's allocation, if any, is still present in each family conf
-// configures.
+// cmdCheck implements the IPAM delegation CHECK path: confirm the container's
+// allocation, if any, is still present for each family the config names.
 func cmdCheck(args *skel.CmdArgs) error {
 	conf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -73,9 +72,9 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdStatus implements the CNI spec STATUS operation. galactic-ipam has no
-// API server or attachment-specific state to probe — it either parses a
-// well-formed config or it doesn't.
+// cmdStatus implements the CNI STATUS operation. This plugin has no API server
+// or attachment-specific state to probe: it either parses a well-formed config
+// or it does not.
 func cmdStatus(args *skel.CmdArgs) error {
 	if err := parseStatusConf(args.StdinData); err != nil {
 		return err

--- a/internal/cniipam/result.go
+++ b/internal/cniipam/result.go
@@ -13,10 +13,10 @@ import (
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 )
 
-// BuildCNIResult constructs the type100.Result IPAM delegation returns —
-// ips/routes only, no interfaces. The master plugin owns interface
-// creation entirely; keeping interfaces out of this result is exactly what
-// delegation exists to enforce (see the package doc comment).
+// BuildCNIResult constructs the result IPAM delegation returns: addresses and
+// routes only, no interfaces. The master plugin owns interface creation
+// entirely, and keeping interfaces out of this result is what delegation exists
+// to enforce.
 func BuildCNIResult(cniVersion string, res *IPAMResult) *type100.Result {
 	result := &type100.Result{CNIVersion: cniVersion}
 	if res == nil {
@@ -40,14 +40,11 @@ func BuildCNIResult(cniVersion string, res *IPAMResult) *type100.Result {
 	return result
 }
 
-// ResultToIPAMResult converts a CNI result — as returned by
-// github.com/containernetworking/cni/pkg/ipam.ExecAdd back to the master
-// plugin that just delegated an ADD — into the local shape callers apply
-// directly (configureInterfaceInNetns for veth, or read straight into a
-// tap/BGP-advertisement result). Marshals and re-parses via type100 rather
-// than a direct type assertion, since the concrete type returned by
-// ExecAdd depends on CNI version negotiation (mirrors the same pattern
-// internal/cni's own prevResult validation already uses).
+// ResultToIPAMResult converts a CNI result, as returned to a master plugin that
+// just delegated an ADD, into the local shape callers apply directly.
+//
+// It marshals and re-parses rather than type-asserting, since the concrete type
+// returned depends on CNI version negotiation.
 func ResultToIPAMResult(res types.Result) (*IPAMResult, error) {
 	jsonBytes, err := json.Marshal(res)
 	if err != nil {

--- a/internal/cniipam/types.go
+++ b/internal/cniipam/types.go
@@ -2,41 +2,34 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cniipam implements galactic-ipam, the delegated CNI IPAM plugin
-// in the galactic CNI chain (see github.com/containernetworking/cni/pkg/ipam
-// for the delegation protocol both master plugins, galactic-veth and
-// galactic-tap, invoke this through via ExecAdd/ExecDel/ExecCheck).
+// Package cniipam implements galactic-ipam, the delegated CNI IPAM plugin in
+// the galactic chain, which both master plugins invoke through the standard
+// delegation protocol.
 //
-// Explicit contract: a master plugin delegates here if and only if its own
-// "ipam" block is present at all — no environment variable or sibling
-// config field can trigger or suppress that decision (that's the master's
-// own call, made before this package is ever invoked). Once delegated to,
-// mode selection is entirely this package's own, decided by which fields
-// are present and rejected as a config error if they disagree:
+// A master plugin delegates here if and only if its own "ipam" block is
+// present; no environment variable or sibling field can trigger or suppress
+// that. Once delegated to, mode selection belongs entirely to this package,
+// decided by which fields are present and rejected as a config error if they
+// disagree:
 //
-//   - ipam.addresses — the addresses were decided upstream (Datum's
-//     networking layer allocates an IPv6 endpoint block, typically a /96,
-//     optionally an IPv4 /32, each with a gateway). Nothing is allocated:
-//     every address is assigned exactly as given, prefix length included,
-//     for both families, and nothing is persisted. Cannot be combined with
-//     the fields below.
-//   - ipam.static_ip — the legacy single-address path: one IPv6 address,
-//     assigned with a /64, no IPv4. Superseded by ipam.addresses.
-//   - ipam.ipv6_subnet/ipv4_subnet (either family alone, or both) — the
-//     pool path: this package chooses the address.
+//   - ipam.addresses: the addresses were decided upstream. Nothing is
+//     allocated; every address is assigned exactly as given, prefix length
+//     included, for both families, and nothing is persisted. Cannot be
+//     combined with the fields below.
+//   - ipam.static_ip: one IPv6 address assigned with a /64 and no IPv4.
+//     Superseded by ipam.addresses.
+//   - ipam.ipv6_subnet and ipam.ipv4_subnet, either alone or together: the
+//     pool path, where this package chooses the address.
 //
-// GALACTIC_IPAM_ENABLE_LOCAL_IPAM only fills in a default IPv6
-// pool CIDR when the ipam block is present but specifies no addresses, no
-// static_ip and no subnet — it can no longer manufacture an ipam block out
-// of thin air the way its GALACTIC_CNI_ENABLE_LOCAL_IPAM predecessor did.
+// The local-IPAM environment flag only fills in a default IPv6 pool CIDR when
+// the ipam block is present but names no addresses, no static address, and no
+// subnet. It cannot manufacture an ipam block.
 //
-// Allocation state persists in on-disk marker files (internal/cni/ipam),
-// keyed by containerID, so this package never needs a Kubernetes client
-// at all: DEL looks its own allocation up locally instead of reading it
-// back from a BGPAdvertisement CRD annotation galactic-bgp wrote. Only the
-// pool path persists anything: an address decided elsewhere (addresses,
-// static_ip) is validated at ADD and never stored, so DEL has nothing to
-// release and CHECK nothing to verify.
+// Allocation state persists in on-disk marker files keyed by container ID, so
+// this package needs no Kubernetes client: DEL looks its own allocation up
+// locally rather than reading it back from a CRD annotation. Only the pool path
+// persists anything; an address decided elsewhere is validated at ADD and never
+// stored, so DEL has nothing to release and CHECK nothing to verify.
 package cniipam
 
 import (
@@ -45,16 +38,13 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-// IPAM is the JSON shape of a CNI config's "ipam" block, as galactic-ipam
-// itself parses it (the master plugins each embed the same shape as
-// *IPAM in their own PluginConf, since the full netconf — including this
-// block — is what gets passed through to the delegate unmodified).
+// IPAM is the JSON shape of a CNI config's "ipam" block. The master plugins
+// embed the same shape, since the full netconf including this block is passed
+// through to the delegate unmodified.
 type IPAM struct {
-	// Type names the delegated binary (e.g. "galactic-ipam") — a CNI IPAM
-	// delegation implementation detail (github.com/containernetworking/cni/
-	// pkg/ipam.ExecAdd/ExecDel read this to know which binary to exec), not
-	// a mode selector. Mode is decided from which of the fields below are
-	// present instead — see the package doc comment.
+	// Type names the delegated binary, which the delegation protocol reads to
+	// know what to exec. It is not a mode selector: mode is decided from which
+	// of the fields below are present.
 	Type string `json:"type"`
 	// StaticIP is the legacy single-address path: one IPv6 address, no
 	// prefix length of its own, no IPv4. Addresses supersedes it.
@@ -62,20 +52,17 @@ type IPAM struct {
 	IPv6Subnet string `json:"ipv6_subnet,omitempty"`
 	IPv4Subnet string `json:"ipv4_subnet,omitempty"`
 	// AddressFamilies, when non-empty, restricts allocation to the listed
-	// families ("ipv6"/"ipv4"): parseConf clears whichever of
-	// IPv6Subnet/IPv4Subnet names an excluded family before allocate/
-	// deallocate/checkAllocation ever see them. It only narrows whichever
-	// pools are already configured — it can't widen allocation to a family
-	// with no pool CIDR set. Empty means no restriction (allocate from every
-	// configured pool, same as if this field didn't exist). Meaningless for
-	// the static_ip and addresses paths, which carry exactly what they were
-	// given regardless of this field.
+	// families: whichever subnet names an excluded family is cleared before
+	// allocation ever sees it. It only narrows the pools already configured and
+	// cannot widen allocation to a family with no pool set. Empty means no
+	// restriction. Meaningless for the static and upstream-decided paths, which
+	// carry what they were given regardless.
 	AddressFamilies []string `json:"address_families,omitempty"`
 	// Routes is declared but not read by any allocation path.
 	Routes []Route `json:"routes,omitempty"`
-	// Addresses carries addresses decided outside galactic-ipam. Presence
-	// selects the addresses path, which assigns exactly these -- both
-	// families, prefix lengths preserved -- rather than allocating anything.
+	// Addresses carries addresses decided outside this plugin. Its presence
+	// selects the path that assigns exactly these, both families with prefix
+	// lengths preserved, rather than allocating anything.
 	Addresses []Address `json:"addresses,omitempty"`
 }
 
@@ -92,9 +79,9 @@ type Address struct {
 	Gateway string `json:"gateway,omitempty"`
 }
 
-// IPAMResult holds the allocation details a master plugin uses to build
-// its own CNI result and, for veth, to configure the guest interface.
-// IPv4Address/IPv4Gateway are nil when the attachment is IPv6-only.
+// IPAMResult holds the allocation details a master plugin uses to build its CNI
+// result and, for veth, to configure the guest interface. The IPv4 fields are
+// nil on an IPv6-only attachment.
 type IPAMResult struct {
 	IPv6Subnet  *net.IPNet
 	IPv6Gateway net.IP
@@ -103,12 +90,10 @@ type IPAMResult struct {
 	Routes      []*net.IPNet
 }
 
-// pluginConf is the full CNI config document galactic-ipam receives as
-// args.StdinData — the same document the master plugin itself parsed,
-// passed through unmodified per the IPAM delegation protocol. Only the
-// "ipam" key (plus cniVersion, for result versioning) is ever read; the
-// master-plugin-specific fields (vpc, vpcattachment, terminations, ...)
-// are present in the JSON but simply ignored here.
+// pluginConf is the full CNI config document this plugin receives on stdin, the
+// same one the master plugin parsed, passed through unmodified. Only the "ipam"
+// key and the CNI version are read; the master-plugin fields are present in the
+// JSON and ignored.
 type pluginConf struct {
 	types.PluginConf
 	IPAM *IPAM `json:"ipam"`

--- a/internal/cnimaster/check.go
+++ b/internal/cnimaster/check.go
@@ -23,14 +23,12 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// RunStatus implements the CNI spec STATUS operation shared by both master
-// plugins: config is parseable and the API server is reachable for
-// BGPAdvertisement CRD operations. Attachment-specific kernel resources
-// (VRF, host interface) are NOT checked because STATUS must succeed before
-// any ADD has ever run.
+// RunStatus implements the CNI STATUS operation shared by both master plugins:
+// the config parses and the API server is reachable. Attachment-specific kernel
+// resources are not checked, since STATUS must succeed before any ADD has run.
 //
-// cniConfig and confFile are the caller's own package state — see
-// ParseConf's doc comment for why these aren't shared globals.
+// cniConfig and confFile are the caller's own package state rather than shared
+// globals.
 func RunStatus(stdinData []byte, cniConfig *config.CNIConfig, confFile string) error {
 	// Validate config is parseable (minimal check — no VPC/VPCAttachment
 	// validation since STATUS must succeed before any ADD has run).
@@ -69,11 +67,9 @@ func RunStatus(stdinData []byte, cniConfig *config.CNIConfig, confFile string) e
 	return nil
 }
 
-// ProbeAPIServerFn performs a lightweight GET against the in-cluster API
-// server to verify reachability. Returns nil when the server responds (any
-// HTTP status code) or when running outside a cluster with no kubeconfig.
-//
-// ProbeAPIServer is a variable so tests can override it.
+// ProbeAPIServerFn performs a lightweight request against the in-cluster API
+// server to check reachability. It returns nil when the server responds with any
+// status, and when running outside a cluster with no kubeconfig.
 var ProbeAPIServerFn = func() error {
 	kubeconfig, err := ctrl.GetConfig()
 	if err != nil {
@@ -105,16 +101,14 @@ var ProbeAPIServerFn = func() error {
 	return nil
 }
 
-// ProbeAPIServer is the seam cmdStatus/RunStatus call through; tests
-// override it (and restore ProbeAPIServerFn afterward) to simulate API
-// server reachability failures without a real cluster.
+// ProbeAPIServer is the seam the status paths call through, overridden by tests
+// to simulate an unreachable API server without a real cluster.
 var ProbeAPIServer = ProbeAPIServerFn
 
-// CheckNodeLevelState verifies that node-level networking resources exist:
-// the VRF interface and the host-side endpoint interface. Returns the host
-// interface name (for callers that need it, e.g. cmdCheck's prevResult
-// validation) and a slice of errors (nil when all checks pass) so callers
-// can accumulate and report all failures at once.
+// CheckNodeLevelState verifies the node-level resources exist: the VRF
+// interface and the host-side endpoint interface. It returns the host interface
+// name, for callers that need it, and a slice of errors, nil when everything
+// passes, so a caller can report every failure at once.
 func CheckNodeLevelState(vpc, vpcAttachment string) (string, []error) {
 	var errs []error
 

--- a/internal/cnimaster/config.go
+++ b/internal/cnimaster/config.go
@@ -21,17 +21,13 @@ import (
 	"go.datum.net/galactic/internal/hostconf"
 )
 
-// PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of either master plugin (galactic-veth or galactic-tap).
+// PluginConf is the CNI plugin configuration passed on stdin to either master
+// plugin.
 //
-// IPAM addressing fields (ipv6_subnet, ipv4_subnet, address_families,
-// static_ip) live entirely inside the "ipam" block — see
-// go.datum.net/galactic/internal/cniipam's doc comment for the explicit
-// delegation contract: this struct only decides *whether* to delegate
-// (IPAM != nil), never anything about how allocation itself works.
-// Termination routes are galactic-route's own concern (see
-// internal/cniroute) — neither master plugin's own JSON stanza carries a
-// "terminations" field of its own to read.
+// Addressing fields live entirely inside the "ipam" block; this struct decides
+// only whether to delegate, never anything about how allocation works.
+// Termination routes are the routing plugin's concern, so neither master
+// plugin's stanza carries a field for them.
 type PluginConf struct {
 	types.PluginConf
 	VPC           string        `json:"vpc"`
@@ -53,11 +49,10 @@ const (
 	errVPCAttachmentRequired = "vpcattachment is required and must be a non-empty base62 string"
 )
 
-// IsValidBase62 reports whether s contains only valid base62 characters
-// ([0-9a-zA-Z]) and is non-empty. VPC and VPCAttachment identifiers are
-// base62-encoded and used throughout the ADD path (interface naming,
-// BGP CRD population). Rejecting them early in ParseConf prevents cryptic
-// errors deep in the stack after partial kernel state has been created.
+// IsValidBase62 reports whether s is non-empty and contains only base62
+// characters. VPC and attachment identifiers are base62 and used throughout the
+// ADD path for interface naming and CRD population, so rejecting them early
+// avoids cryptic errors deep in the stack after partial kernel state exists.
 func IsValidBase62(s string) bool {
 	if len(s) == 0 {
 		return false
@@ -70,9 +65,9 @@ func IsValidBase62(s string) bool {
 	return true
 }
 
-// LoadHostConf loads node-local settings from the static per-node conflist.
-// If the file is missing, it returns a zero-value HostConf (tolerating local
-// test runs) but still defaulting Namespace to config.DefaultNamespace.
+// LoadHostConf loads node-local settings from the static per-node conflist. A
+// missing file yields a zero-value HostConf, tolerating local test runs, with
+// Namespace still defaulted.
 func LoadHostConf(filePath string) (*hostconf.HostConf, error) {
 	if filePath == "" {
 		filePath = config.DefaultConfFile
@@ -90,10 +85,9 @@ func LoadHostConf(filePath string) (*hostconf.HostConf, error) {
 	return conf, nil
 }
 
-// UnwrapPathError returns the innermost *os.PathError-shaped error wrapped
-// by err, if any, so os.IsNotExist (which does not itself traverse %w
-// wrapping) can still recognize a missing conflist file wrapped by
-// hostconf.Load's fmt.Errorf("read conflist file %q: %w", ...).
+// UnwrapPathError returns the innermost path error wrapped by err, if any, so a
+// missing-file check can recognise a missing conflist through the wrapping the
+// loader adds.
 func UnwrapPathError(err error) error {
 	for {
 		unwrapped := errors.Unwrap(err)
@@ -104,10 +98,10 @@ func UnwrapPathError(err error) error {
 	}
 }
 
-// ParseLogLevel maps a config-supplied level name to a slog.Level. Matching
-// is case-insensitive. An empty string resolves to config.DefaultLogLevel.
-// Unrecognized values return an error alongside the info-level fallback, so
-// callers can warn without failing the CNI operation over a typo'd setting.
+// ParseLogLevel maps a config-supplied level name to a slog level,
+// case-insensitively. An empty string resolves to the default. An unrecognised
+// value returns an error alongside the info-level fallback, so callers can warn
+// without failing the CNI operation over a typo.
 func ParseLogLevel(s string) (slog.Level, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "":
@@ -126,11 +120,9 @@ func ParseLogLevel(s string) (slog.Level, error) {
 	}
 }
 
-// SetupLogging configures the slog default logger to write to the specified
-// path at the specified verbosity. If opening the file fails, it logs a
-// warning to os.Stderr and falls back. An unrecognized logLevel also logs a
-// warning and falls back to config.DefaultLogLevel rather than failing the
-// operation.
+// SetupLogging points the default logger at logPath with verbosity logLevel. A
+// failure to open the file, or an unrecognised level, logs a warning to stderr
+// and falls back rather than failing the operation.
 func SetupLogging(logPath, logLevel string) {
 	if logPath == "" {
 		logPath = config.DefaultLogFile
@@ -155,20 +147,17 @@ func SetupLogging(logPath, logLevel string) {
 	slog.SetDefault(slog.New(handler))
 }
 
-// statusConf holds the minimal CNI config fields needed for STATUS validation.
-//
-// STATUS only checks that the config is parseable and the API server is
-// reachable; it does not validate attachment-specific fields (VPC,
-// VPCAttachment) because STATUS must succeed before any ADD has ever run.
+// statusConf holds the minimal config fields STATUS validation needs. STATUS
+// only checks that the config parses and the API server is reachable, not
+// attachment-specific fields, since it must succeed before any ADD has run.
 type statusConf struct {
 	CNIVersion string `json:"cniVersion"`
 	Type       string `json:"type"`
 }
 
-// ParseStatusConf validates that the CNI config is parseable and contains
-// the required top-level fields (cniVersion, type). Unlike ParseConf, it
-// does not validate VPC or VPCAttachment because STATUS must succeed on a
-// freshly started node before any ADD has run.
+// ParseStatusConf validates that the CNI config parses and carries the required
+// top-level fields. Unlike ParseConf it does not validate the attachment
+// identifiers, since STATUS must succeed on a freshly started node.
 func ParseStatusConf(data []byte) error {
 	var sc statusConf
 	if err := json.Unmarshal(data, &sc); err != nil {
@@ -183,11 +172,9 @@ func ParseStatusConf(data []byte) error {
 	return nil
 }
 
-// ValidatePrevResult checks that the prevResult (from a preceding plugin in
-// the CNI chain) is a valid, parseable CNI result. Returns an error if the
-// result is non-nil but cannot be parsed as a versioned CNI result, ensuring
-// the master plugin fails fast rather than silently operating on garbage
-// state.
+// ValidatePrevResult checks that a preceding plugin's result is a parseable,
+// versioned CNI result. A non-nil result that cannot be parsed is an error, so
+// the master plugin fails fast rather than operating on garbage.
 func ValidatePrevResult(res types.Result) error {
 	if res == nil {
 		return nil
@@ -204,12 +191,9 @@ func ValidatePrevResult(res types.Result) error {
 	return nil
 }
 
-// ValidatePrevResultAdd performs content-level validation of prevResult
-// during the ADD operation. It ensures the preceding plugin produced a
-// result with at least one interface or IP assignment, which is the minimum
-// expected structure for any meaningful CNI chain. Returns nil when
-// prevResult is nil (no preceding plugin) or structurally valid with
-// expected content.
+// ValidatePrevResultAdd checks a preceding plugin's result during ADD for at
+// least one interface or IP assignment, the minimum for a meaningful chain. A
+// nil result, meaning no preceding plugin, is fine.
 func ValidatePrevResultAdd(res types.Result) error {
 	if res == nil {
 		return nil
@@ -233,15 +217,13 @@ func ValidatePrevResultAdd(res types.Result) error {
 	return nil
 }
 
-// ParseConf unmarshals the CNI configuration from stdin data and validates
-// the base62-encoded identifier fields. It resolves the host configuration
-// and sets up process environment variables and logging.
+// ParseConf unmarshals the CNI configuration from data, validates the
+// base62 identifier fields, resolves the host configuration, and sets up
+// process environment and logging.
 //
-// cniConfig is the caller's own *config.CNIConfig singleton (each master
-// plugin binary owns one, initialized once via its own InitCNIConfig() at
-// process startup) and confFile is the caller's own ConfFile package var —
-// both are caller state, not shared, since each binary resolves its own
-// GALACTIC_CNI_* environment independently.
+// cniConfig and confFile are the caller's own state, one per master plugin
+// binary, since each resolves its own environment independently. confFile names
+// the conflist for error reporting.
 func ParseConf(data []byte, cniConfig *config.CNIConfig, confFile string) (*PluginConf, error) {
 	conf := &PluginConf{}
 	if err := json.Unmarshal(data, &conf); err != nil {
@@ -281,10 +263,9 @@ func ParseConf(data []byte, cniConfig *config.CNIConfig, confFile string) (*Plug
 		LogLevel:   hostConf.LogLevel,
 	})
 
-	// NodeName fallback: auto-detect from the Kubernetes API by matching local
-	// interface addresses against node InternalIPs. This handles cases where
-	// the conflist file is missing (e.g. hostPath mount issues in container-
-	// based environments like Kind).
+	// Fall back to auto-detecting the node name from the API by matching local
+	// interface addresses against node addresses, for when the conflist is
+	// missing.
 	if cniConfig.NodeName == "" {
 		detected, detectErr := hostconf.DetectNodeNameFromAPI()
 		if detectErr != nil {
@@ -311,23 +292,20 @@ func ParseConf(data []byte, cniConfig *config.CNIConfig, confFile string) (*Plug
 	SetupLogging(cniConfig.LogFile, cniConfig.LogLevel)
 	slog.Debug("CNI config received", "stdin", string(data))
 
-	// Refuse a config still written against the old flat addressing shape
-	// before anything else happens — those keys would otherwise be dropped
-	// as unknown fields and the pod would attach with no addresses at all.
+	// Refuse a config written against the old flat addressing shape before
+	// anything else: those keys would be dropped as unknown fields and the pod
+	// would attach with no addresses at all.
 	if err := hostconf.RejectMovedIPAMKeys(data); err != nil {
 		return nil, err
 	}
 
 	// Whether IPAM runs at all is decided entirely by whether "ipam" is
-	// present — no environment variable or sibling field can trigger or
-	// suppress that. Addressing fields (ipv6_subnet, ipv4_subnet,
-	// address_families, static_ip) and their own default-filling/CIDR
-	// validation live inside internal/cniipam, since they're only ever
-	// read by whichever binary "ipam.type" names — the master plugin passes
-	// its own StdinData straight through unmodified when it delegates, so
-	// validating them here too would just be redundant work on the same
-	// bytes. Their *placement* is this plugin's concern, though — see the
-	// RejectMovedIPAMKeys call above.
+	// present; no environment variable or sibling field can trigger or suppress
+	// it. The addressing fields and their own validation live in the IPAM
+	// package, since only the binary named by "ipam.type" reads them and the
+	// master plugin passes its stdin through unmodified when it delegates.
+	// Their placement is this plugin's concern, which the check above
+	// enforces.
 
 	if conf.PrevResult != nil {
 		if err := ValidatePrevResult(conf.PrevResult); err != nil {

--- a/internal/cnimaster/doc.go
+++ b/internal/cnimaster/doc.go
@@ -2,19 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnimaster holds logic shared by galactic-veth (internal/cni, the
-// veth master plugin) and galactic-tap (internal/cnitap, the tap master
-// plugin). Both own the same node-level lifecycle — parse the CNI config,
-// resolve node/API settings, create a VRF, patch the pod's NAD, and answer
-// CHECK/STATUS — differing only in which kernel interface primitive they
-// call (veth vs tap) and, for CHECK, whether there's a guest-side netns to
-// inspect (tap never enters one). That interface-specific sliver stays in
-// each package; everything else lives here so a fix only has to happen
-// once.
+// Package cnimaster holds the logic the two master plugins share. Both own the
+// same node-level lifecycle: parse the config, resolve node and API settings,
+// create a VRF, patch the pod's attachment definition, and answer CHECK and
+// STATUS. They differ only in which kernel interface primitive they call and,
+// for CHECK, whether there is a guest namespace to inspect, since tap never
+// enters one. That sliver stays in each package; everything else lives here so a
+// fix happens once.
 //
-// PluginConf is the shared CNI config shape; internal/cni and internal/cnitap
-// each declare their own `type PluginConf = cnimaster.PluginConf` alias
-// (mirroring the existing HostConf alias pattern from internal/hostconf) so
-// call sites in either package keep referring to their own package's
-// PluginConf.
+// PluginConf is the shared config shape, which each master plugin aliases so its
+// own call sites keep referring to their own package's type.
 package cnimaster

--- a/internal/cnimaster/resource.go
+++ b/internal/cnimaster/resource.go
@@ -18,28 +18,24 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// NADPatchTimeout bounds each k8s call a master plugin makes with the
-// client from NewK8sClient: the chain-completeness Get run right after
-// creating it, and the NAD-annotation Patch later in the same ADD — veth's
-// and tap's own ADD both use the same budget for both calls.
+// NADPatchTimeout bounds each API call a master plugin makes with the client
+// from NewK8sClient: the chain-completeness read right after creating it, and
+// the annotation patch later in the same ADD.
 const NADPatchTimeout = 10 * time.Second
 
 var scheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	// bgpv1alpha1 is registered even though neither master plugin reads or
-	// writes BGP CRDs itself (that's galactic-bgp's own, chain-invoked
-	// concern now) — kept here only because nothing else needs its own
-	// scheme, and NAD annotation's unstructured.Unstructured Patch call
-	// doesn't require any scheme registration at all. Harmless to leave;
-	// trim if this scheme ever needs to shrink for another reason.
+	// The BGP types are registered even though neither master plugin reads or
+	// writes them, that being the BGP plugin's concern. Nothing else needs its
+	// own scheme, and the annotation patch uses an unstructured object needing
+	// no registration at all. Harmless to leave.
 	utilruntime.Must(bgpv1alpha1.AddToScheme(scheme))
 }
 
-// NewK8sClient creates a new Kubernetes client using the in-cluster config.
-// The only k8s call either master plugin makes directly is the NAD
-// annotation patch.
+// NewK8sClient creates a Kubernetes client from the in-cluster config. The only
+// call either master plugin makes directly is the annotation patch.
 func NewK8sClient() (client.Client, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
@@ -52,20 +48,17 @@ func NewK8sClient() (client.Client, error) {
 	return c, nil
 }
 
-// CleanupAttachment rolls back a failed ADD's host-side interface for
-// selective rollback. Errors are logged but never returned — the caller
-// already has a failure to report.
+// CleanupAttachment rolls back a failed ADD's host-side interface. Errors are
+// logged and never returned, the caller already having a failure to report.
 //
-// ifaceKind names the interface kind for log messages ("veth", "tap"); del
-// removes the attachment's own host/guest interface pair.
+// ifaceKind names the interface kind for log messages, and del removes the
+// attachment's own interface pair.
 //
-// Deliberately absent: deleting the VRF. The VRF is shared by every
-// attachment on this VPC on this node (internal/plumbing/vrf keys it by
-// VPC alone), and vrf.Add is idempotent, so there's no way to distinguish
-// "I created it" from "a sibling attachment already had." Deleting it on
-// this attachment's own failed ADD could tear down a still-live sibling's
-// VRF out from under it. Reclaiming it is exclusively galactic-router's GC
-// controller's job.
+// Deliberately absent: deleting the VRF. It is shared by every attachment on
+// this VPC on this node, and creating it is idempotent, so there is no way to
+// tell "I created it" from "a sibling already had". Deleting it on a failed ADD
+// could tear down a live sibling's VRF. Reclaiming it is garbage collection's
+// job.
 func CleanupAttachment(vpc, vpcAttachment, ifaceKind string, del func(vpc, vpcAttachment string) error) {
 	slog.Info("Selective rollback: cleaning up resources created during failed ADD",
 		"vpc", vpc, "vpcAttachment", vpcAttachment)

--- a/internal/cnimaster/result.go
+++ b/internal/cnimaster/result.go
@@ -13,14 +13,12 @@ import (
 	"go.datum.net/galactic/internal/cniipam"
 )
 
-// AppendIPConfigs adds one IPConfig per allocated address family in ipRes
-// (IPv6, and IPv4 when present) plus any default routes, all pointing at
-// the given Interfaces index. No-op when ipRes is nil.
+// AppendIPConfigs adds one address configuration per allocated family in ipRes,
+// plus any default routes, all pointing at the given interface index. A nil
+// ipRes is a no-op.
 //
-// Shared verbatim between galactic-veth (internal/cni) and galactic-tap
-// (internal/cnitap): only the ifaceIndex and ipv4Mask each passes in differ
-// (veth's guest interface vs tap's own host interface, /32 vs /25), never
-// the logic itself.
+// Shared verbatim between the two master plugins: only the interface index and
+// IPv4 mask each passes differ, never the logic.
 func AppendIPConfigs(result *type100.Result, ipRes *cniipam.IPAMResult, ifaceIndex int, ipv4Mask net.IPMask) {
 	if ipRes == nil {
 		return

--- a/internal/cniroute/config.go
+++ b/internal/cniroute/config.go
@@ -23,20 +23,17 @@ import (
 
 var ConfFile = config.DefaultConfFile
 
-// cniConfig is the shared config resolver for env var resolution.
-// Initialized by InitCNIConfig() (called from cmd/galactic-route/main.go).
+// cniConfig is the shared config resolver for environment resolution,
+// initialized once at process startup by InitCNIConfig.
 //
-// galactic-route has no k8s dependency, so — unlike every other binary in
-// the chain — it never resolves NodeName or Kubeconfig. It uses
-// config.CNIConfig purely for LogFile/LogLevel's env-var > conflist >
-// default precedence, so logging behaves the same way here as everywhere
-// else in the chain (see internal/hostconf's doc comment on the one
-// static conflist file every binary shares).
+// This plugin has no Kubernetes dependency, so unlike the others in the chain
+// it never resolves a node name or kubeconfig. It uses the shared resolver
+// purely for the log file and level's environment-over-conflist-over-default
+// precedence, so logging behaves the same way here as everywhere else.
 var cniConfig *config.CNIConfig
 
-// InitCNIConfig initializes the shared config resolver for CNI env var
-// resolution. Callers should invoke this once at process startup before any
-// config lookups.
+// InitCNIConfig initializes the shared config resolver. Call it once at process
+// startup, before any config lookup.
 func InitCNIConfig() {
 	cniConfig = config.NewCNIConfig()
 }
@@ -64,9 +61,8 @@ func isValidBase62(s string) bool {
 	return true
 }
 
-// loadHostConf loads node-local settings from the static per-node conflist.
-// If the file is missing, it returns a zero-value HostConf (tolerating local
-// test runs).
+// loadHostConf loads node-local settings from the static per-node conflist. A
+// missing file yields a zero-value HostConf, tolerating local test runs.
 func loadHostConf(filePath string) (*HostConf, error) {
 	if filePath == "" {
 		filePath = config.DefaultConfFile
@@ -131,10 +127,10 @@ type statusConf struct {
 	Type       string `json:"type"`
 }
 
-// parseStatusConf validates that the CNI config is parseable and contains
-// the required top-level fields. galactic-route has no attachment-specific
-// or API-server state to check — STATUS must succeed on a freshly started
-// node before any ADD has run.
+// parseStatusConf validates that a STATUS config parses and carries the
+// required top-level fields. This plugin has no attachment-specific or
+// API-server state to check, and STATUS must succeed on a freshly started
+// node.
 func parseStatusConf(data []byte) error {
 	var sc statusConf
 	if err := json.Unmarshal(data, &sc); err != nil {
@@ -149,9 +145,9 @@ func parseStatusConf(data []byte) error {
 	return nil
 }
 
-// parseConf unmarshals the CNI configuration from stdin data (the same
-// document the master plugin received), validates the base62-encoded
-// identifier fields, and resolves logging.
+// parseConf unmarshals the CNI configuration from data, the same document the
+// master plugin received, validates the base62 identifier fields, and resolves
+// logging.
 func parseConf(data []byte) (*PluginConf, error) {
 	conf := &PluginConf{}
 	if err := json.Unmarshal(data, &conf); err != nil {

--- a/internal/cniroute/ops_add.go
+++ b/internal/cniroute/ops_add.go
@@ -18,11 +18,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
-// cmdAdd installs each of pluginConf's termination routes into the VRF
-// routing table the preceding master plugin (galactic-veth/galactic-tap)
-// already created, then passes prevResult through unchanged — galactic-
-// route adds no interfaces or IPs of its own, only kernel routes alongside
-// whatever came before it in the chain.
+// cmdAdd installs each configured termination route into the VRF routing table
+// the master plugin already created, then passes the previous result through
+// unchanged. This plugin adds no interfaces or addresses of its own, only kernel
+// routes.
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -38,10 +37,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment,
 		"terminations", len(pluginConf.Terminations))
 
-	// The host interface name is derived from (vpc, vpcAttachment) alone —
-	// identical for a veth master's host end and a tap master's tap device
-	// (both call intf.GenerateInterfaceNameHost), so galactic-route needs no
-	// interface-kind inference the way galactic-bgp does.
+	// The host interface name derives from the identifiers alone and is
+	// identical for a veth master's host end and a tap master's device, so this
+	// plugin needs none of the interface-kind inference the BGP plugin does.
 	dev := intf.GenerateInterfaceNameHost(pluginConf.VPC, pluginConf.VPCAttachment)
 
 	tracker := &resourceTracker{vpc: pluginConf.VPC, vpcAttachment: pluginConf.VPCAttachment, dev: dev}
@@ -66,12 +64,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	return types.PrintResult(prevResult, pluginConf.CNIVersion)
 }
 
-// parsePrevResult parses rawPrevResult (PluginConf.RawPrevResult; the typed
-// PluginConf.PrevResult field is never populated by plain JSON unmarshal,
-// per its "json:\"-\"" tag) into a versioned CNI result galactic-route can
-// pass straight back through as its own ADD result. galactic-route is
-// optional in the chain, but when present it must be chained after a
-// master plugin, which always produces a prevResult.
+// parsePrevResult parses the raw previous result into a versioned CNI result
+// this plugin can pass straight back as its own. The typed field is never
+// populated by a plain unmarshal, so the raw form is the one to read. This
+// plugin is optional in the chain, but when present it is chained after a master
+// plugin, which always produces a result.
 func parsePrevResult(rawPrevResult map[string]interface{}) (types.Result, error) {
 	if rawPrevResult == nil {
 		return nil, errors.New("no prevResult: galactic-route must be chained after a master plugin")

--- a/internal/cniroute/ops_check.go
+++ b/internal/cniroute/ops_check.go
@@ -16,12 +16,8 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// cmdCheck verifies that the termination routes cmdAdd installed are still
-// present in the VRF routing table. Per the plan's CHECK/STATUS
-// distribution, this is galactic-route's entire CHECK story — moved
-// unchanged from internal/cni/ops_check.go (also mirrored in
-// internal/cnitap), since the underlying kernel state it verifies didn't
-// change shape by moving which process installs it.
+// cmdCheck verifies that the termination routes ADD installed are still present
+// in the VRF routing table. That is this plugin's entire CHECK story.
 func cmdCheck(args *skel.CmdArgs) error {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -41,11 +37,10 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdStatus implements the CNI spec STATUS operation. galactic-route has no
-// API server or attachment-specific state to probe — it either parses a
-// well-formed config or it doesn't, matching galactic-ipam's own trivial
-// STATUS (see the plan's CHECK/STATUS distribution: implemented for
-// uniformity across the chain, not skipped).
+// cmdStatus implements the CNI STATUS operation. This plugin has no API server
+// or attachment-specific state to probe: it either parses a well-formed config
+// or it does not. Implemented for uniformity across the chain rather than
+// skipped.
 func cmdStatus(args *skel.CmdArgs) error {
 	if err := parseStatusConf(args.StdinData); err != nil {
 		return err
@@ -79,10 +74,9 @@ func checkTerminationRoutes(vpc, vpcAttachment string, terminations []Terminatio
 
 	dev := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	for _, term := range terminations {
-		// An empty Via is not an error: assembleRoute (route.go) installs a
-		// valid on-link route for it, device-scoped with no gateway, and
-		// cmdAdd installs it fine. Only reject a non-empty Via that fails to
-		// parse.
+		// An empty via is not an error: the route assembly installs a valid
+		// on-link, device-scoped route for it, and ADD installs it fine.
+		// Only a non-empty via that fails to parse is rejected.
 		var viaIP net.IP
 		if term.Via != "" {
 			viaIP = net.ParseIP(term.Via)

--- a/internal/cniroute/ops_del.go
+++ b/internal/cniroute/ops_del.go
@@ -12,15 +12,10 @@ import (
 	type100 "github.com/containernetworking/cni/pkg/types/100"
 )
 
-// cmdDel is a no-op, same as every other binary in the chain: the
-// termination routes this plugin's own ADD installed are keyed by (vpc,
-// vpcAttachment) and may still be in use by another pod/VM sharing the
-// same attachment. Deleting them here would race with a concurrent ADD
-// during restarts. Cleanup is left entirely to galactic-router's GC
-// controller — see internal/cni's own cmdDel for the full reasoning,
-// identical here. This also matches the pre-split behavior: the old
-// monolithic plugin's own DEL never deleted termination routes either,
-// for the same reason.
+// cmdDel is a no-op, as in every other binary in the chain. The termination
+// routes this plugin's ADD installed are keyed by attachment and may still be in
+// use by another pod sharing it, so deleting them here would race a concurrent
+// ADD during a restart. Cleanup is left to garbage collection.
 func cmdDel(args *skel.CmdArgs) error {
 	slog.Info("DEL: skipping shared resource cleanup (handled by GC)", "containerID", args.ContainerID)
 

--- a/internal/cniroute/resource.go
+++ b/internal/cniroute/resource.go
@@ -10,11 +10,10 @@ import (
 	"go.datum.net/galactic/internal/cni/route"
 )
 
-// resourceTracker tracks routes created during cmdAdd for selective
-// rollback. galactic-route's own ADD only ever creates termination
-// routes — route-delete only, per the plan's decision that each binary's
-// tracker unwinds exactly what its own ADD created (the VRF/veth-or-tap
-// it runs alongside belongs to the master plugin's own tracker instead).
+// resourceTracker tracks the routes cmdAdd created, for selective rollback.
+// This plugin's ADD only ever creates termination routes, so route deletion is
+// all it unwinds: the VRF and interface it runs alongside belong to the master
+// plugin's own tracker.
 type resourceTracker struct {
 	vpc, vpcAttachment, dev string
 	added                   []Termination

--- a/internal/cniroute/types.go
+++ b/internal/cniroute/types.go
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cniroute implements galactic-route, the termination-route plugin
-// in the galactic CNI chain — chained after galactic-veth/galactic-tap
-// and before galactic-bgp per conflist order (optional: only present when
-// an attachment has terminations to install). It installs kernel routes
-// into the VRF routing table the preceding master plugin already created,
-// then passes prevResult through unchanged, adding no interfaces or IPs of
-// its own.
+// Package cniroute implements galactic-route, the termination-route plugin in
+// the galactic CNI chain. It is chained after a master plugin and before the BGP
+// plugin, and is optional: present only when an attachment has terminations to
+// install.
 //
-// Unlike every other binary in the chain, galactic-route has no Kubernetes
-// dependency at all: it neither reads nor writes any CRD, and never needs
-// a namespace.
+// It installs kernel routes into the VRF routing table the master plugin already
+// created, then passes the previous result through unchanged, adding no
+// interfaces or addresses of its own.
+//
+// Unlike every other binary in the chain it has no Kubernetes dependency at all:
+// it neither reads nor writes any CRD and never needs a namespace.
 package cniroute
 
 import (
@@ -28,12 +28,10 @@ type Termination struct {
 	Via     string `json:"via,omitempty"`
 }
 
-// PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-route — the same document the master plugin
-// itself received, since the CNI runtime passes each chain entry its own
-// stanza plus prevResult. galactic-route only reads vpc/vpcattachment/
-// terminations out of it (mtu, ipam, namespace are the master's/
-// galactic-ipam's/galactic-bgp's own concerns).
+// PluginConf is the CNI plugin configuration passed on stdin, the same document
+// the master plugin received, since the runtime passes each chain entry its own
+// stanza plus the previous result. This plugin reads only the identifiers and
+// terminations out of it; the rest belongs to other plugins in the chain.
 type PluginConf struct {
 	types.PluginConf
 	VPC           string        `json:"vpc"`

--- a/internal/cnitap/config.go
+++ b/internal/cnitap/config.go
@@ -15,18 +15,16 @@ var ConfFile = config.DefaultConfFile
 // Initialized by InitCNIConfig() (called from cmd/galactic-tap/main.go).
 var cniConfig *config.CNIConfig
 
-// InitCNIConfig initializes the shared config resolver for CNI env var
-// resolution. Callers should invoke this once at process startup before any
-// config lookups.
+// InitCNIConfig initializes the shared config resolver. Call it once at process
+// startup, before any config lookup.
 func InitCNIConfig() {
 	cniConfig = config.NewCNIConfig()
 }
 
-// parseConf unmarshals the CNI configuration from stdin data, validates the
-// base62-encoded identifier fields, and resolves logging. The actual logic
-// is shared with galactic-veth — see internal/cnimaster.ParseConf — since
-// none of it is tap-specific; this is a thin wrapper binding it to this
-// binary's own cniConfig/ConfFile.
+// parseConf unmarshals the CNI configuration from data, validates the base62
+// identifier fields, and resolves logging. The logic is shared with the veth
+// plugin, none of it being tap-specific; this binds it to this binary's own
+// resolver and conflist path.
 func parseConf(data []byte) (*PluginConf, error) {
 	return cnimaster.ParseConf(data, cniConfig, ConfFile)
 }

--- a/internal/cnitap/ops_add.go
+++ b/internal/cnitap/ops_add.go
@@ -26,11 +26,11 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// cmdAdd mirrors internal/cni's own cmdAdd, minus everything specific to a
-// guest-side netns: no host-device delegation, no guest interface, no
-// netns IP configuration. The VM manages its own interface entirely.
-// BGP/SRv6/eBPF publish is galactic-bgp's job, invoked next by the CNI
-// runtime per conflist order, not by this process.
+// cmdAdd mirrors the veth plugin's own, minus everything specific to a guest
+// namespace: no device-move delegation, no guest interface, no in-namespace
+// address configuration. The VM manages its own interface. BGP and eBPF
+// publishing is the next plugin's job, invoked by the runtime per conflist
+// order.
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -55,11 +55,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		"vpc", pluginConf.VPC, "vpcAttachment", pluginConf.VPCAttachment,
 		"namespace", namespace, "nodeName", nodeName)
 
-	// Chain-completeness check, before any kernel state is created: a
-	// conflist missing galactic-bgp would otherwise attach successfully
-	// with no BGP/SRv6 path to its VPC (issue #331). k8sClient/podNamespace
-	// are created here rather than at the NAD-annotation site below so a
-	// stale conflist fails ADD with nothing to roll back yet.
+	// Chain-completeness check, before any kernel state is created: a conflist
+	// missing the BGP plugin would otherwise attach successfully with no path
+	// to its VPC. The client and namespace are resolved here rather than at the
+	// annotation site below, so a stale conflist fails ADD with nothing to roll
+	// back yet.
 	k8sClient, err := cnimaster.NewK8sClient()
 	if err != nil {
 		return fmt.Errorf("create k8s client: %w", err)
@@ -122,10 +122,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	// Termination routes are galactic-route's job now — chained next after
 	// this plugin, when the attachment has any (see internal/cniroute).
 
-	// Allocate IPAM for the tap interface via delegation (only if pluginConf
-	// carries an "ipam" block at all — see internal/cniipam's doc comment
-	// for the explicit contract). The VM manages its own guest interface;
-	// this plugin only configures the host side.
+	// Allocate addresses for the tap through delegation, only when the config
+	// carries an ipam block. The VM manages its own guest interface; this plugin
+	// configures the host side.
 	var ipamResult *cniipam.IPAMResult
 	if pluginConf.IPAM != nil {
 		cniResult, err := ipam.ExecAdd(pluginConf.IPAM.Type, args.StdinData)
@@ -143,21 +142,18 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			"ipv4Address", ipamResult.IPv4Address, "ipv4Gateway", ipamResult.IPv4Gateway)
 	}
 
-	// Configure the gateway address on the host tap and install the VRF
-	// route — kernel-interface work this plugin owns (see
-	// internal/hostgw's doc comment).
+	// Configure the gateway address on the host tap and install the VRF route:
+	// kernel-interface work this plugin owns.
 	if err := hostgw.ConfigureHostGateway(pluginConf.VPC, pluginConf.VPCAttachment, ipamResult, nil); err != nil {
 		return err
 	}
 	if ipamResult != nil && ipamResult.IPv6Gateway != nil {
 		slog.Debug("ADD: host gateway configured", "name", hostName, "gateway", ipamResult.IPv6Gateway)
 
-		// Record this attachment for periodic Router Advertisement resend
-		// by galactic-cni's long-lived installer daemon, rather than
-		// sending an RA from here: this process exits as soon as ADD
-		// returns, almost always before the VM guest it's attached to has
-		// even booted far enough to be listening for one — see
-		// internal/plumbing/radv's own doc comment.
+		// Record this attachment for periodic Router Advertisement resend by the
+		// long-lived node daemon, rather than sending one from here: this
+		// process exits as ADD returns, almost always before the guest has
+		// booted far enough to be listening.
 		if err := radv.RecordAttachment(radv.DefaultStateDir, hostName, hostMTU); err != nil {
 			slog.Warn("ADD: failed to record attachment for router advertisement (non-fatal)",
 				"err", err, "name", hostName)

--- a/internal/cnitap/ops_check.go
+++ b/internal/cnitap/ops_check.go
@@ -17,10 +17,9 @@ import (
 	"go.datum.net/galactic/internal/cnimaster"
 )
 
-// cmdCheck validates that the node's tap-side networking state matches what
-// was established during cmdAdd. Unlike internal/cni's own cmdCheck, there
-// is no guest interface to verify — tap mode never enters a container
-// netns.
+// cmdCheck validates that the node's tap-side state matches what ADD
+// established. Unlike the veth plugin's, there is no guest interface to verify:
+// tap mode never enters a container namespace.
 func cmdCheck(args *skel.CmdArgs) error {
 	pluginConf, err := parseConf(args.StdinData)
 	if err != nil {
@@ -34,8 +33,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	hostName, nodeErrs := cnimaster.CheckNodeLevelState(pluginConf.VPC, pluginConf.VPCAttachment)
 	errs = append(errs, nodeErrs...)
 
-	// Termination routes are galactic-route's own CHECK now (see
-	// internal/cniroute's checkTerminationRoutes) — this plugin's CHECK no
+	// Termination routes are the routing plugin's own CHECK now; this one no
 	// longer verifies them.
 
 	if pluginConf.RawPrevResult != nil {
@@ -63,16 +61,15 @@ func cmdCheck(args *skel.CmdArgs) error {
 	return nil
 }
 
-// cmdStatus implements the CNI spec STATUS operation — see
-// internal/cnimaster.RunStatus for the full reasoning, shared verbatim with
-// galactic-veth.
+// cmdStatus implements the CNI STATUS operation, shared verbatim with the veth
+// plugin.
 func cmdStatus(args *skel.CmdArgs) error {
 	return cnimaster.RunStatus(args.StdinData, cniConfig, ConfFile)
 }
 
-// checkPrevResult validates that kernel state matches the host interface
-// recorded in the prevResult returned by the most recent ADD. Tap mode has
-// no guest-side interface or netns to validate against.
+// checkPrevResult validates that kernel state still matches the host interface
+// the most recent ADD recorded. Tap mode has no guest interface or namespace to
+// validate against.
 func checkPrevResult(rawPrevResult map[string]interface{}, _ string) error {
 	jsonBytes, err := json.Marshal(rawPrevResult)
 	if err != nil {

--- a/internal/cnitap/ops_del.go
+++ b/internal/cnitap/ops_del.go
@@ -20,9 +20,8 @@ import (
 	"go.datum.net/galactic/internal/plumbing/radv"
 )
 
-// cmdDel mirrors internal/cni's own cmdDel, minus everything guest-netns
-// specific (no flushGuestNetnsConfig, no host-device DEL delegation — tap
-// mode never touches a container netns at all).
+// cmdDel mirrors the veth plugin's own, minus everything guest-namespace
+// specific: tap mode never touches a container namespace at all.
 func cmdDel(args *skel.CmdArgs) error {
 	// DEL is idempotent per the CNI spec: always return success.
 	slog.Info("DEL: starting", "containerID", args.ContainerID, "netns", args.Netns)
@@ -44,40 +43,34 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Unregister this attachment's own ifindex_vrf_table entry -- mirrors
-	// internal/cni's own cmdDel (same reasoning: genuinely private to this
-	// one attachment's own ifindex, so it belongs alongside tap.Delete
-	// below, not the shared VRF/BGP CRD cleanup deferred further down).
-	// Resolved and removed *before* tap.Delete tears the interface down,
-	// since there is nothing left to resolve an ifindex from afterward.
+	// Unregister this attachment's ifindex_vrf_table entry. Private to this
+	// attachment's own ifindex, so it belongs alongside the device deletion
+	// below rather than the shared cleanup deferred to GC. Resolved and removed
+	// before the interface is torn down, since there is nothing to resolve an
+	// ifindex from afterward.
 	unregisterIfindexVRFEntry(vpc, vpcAtt, args.ContainerID)
 
-	// Stop galactic-cni's installer daemon from resending Router
-	// Advertisements for this attachment — best-effort and unconditional,
-	// same as tap.Delete below: a missing record (no IPv6 gateway was ever
-	// allocated for this attachment) is not an error, and DEL must stay
-	// idempotent regardless.
+	// Stop the node daemon resending Router Advertisements for this attachment.
+	// Best-effort and unconditional: a missing record, from an attachment that
+	// never had an IPv6 gateway allocated, is not an error, and DEL must stay
+	// idempotent.
 	removeRadvState(vpc, vpcAtt, args.ContainerID)
 
-	// Delete this attachment's own tap device. Unlike the VRF and BGP CRDs
-	// below, the tap device is genuinely private to this attachment (see
-	// resourceTracker.cleanup's doc comment) — no sibling VM can ever still
-	// be depending on it, so there is no ADD-race to defer to GC for.
+	// Delete this attachment's tap device. Unlike the VRF and CRDs below it is
+	// private to this attachment, so no sibling VM can still depend on it and
+	// there is no race to defer to GC.
 	//
-	// A VMM (Kata/Firecracker/QEMU) that still holds the tap's fd open at
-	// this point can make the kernel delete lazily rather than immediately,
-	// but never blocks or fails this call — tap.Delete is best-effort and
-	// idempotent either way, matching every other step in this function.
+	// A VMM still holding the device's descriptor open can make the kernel
+	// delete lazily rather than immediately, but never blocks or fails this
+	// call.
 	if err := tap.Delete(vpc, vpcAtt); err != nil {
 		slog.Warn("DEL: failed to delete tap device", "err", err,
 			"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 	}
 
-	// Shared resources (VRF, BGPAdvertisement, BGPVRFInstance) are keyed by
-	// (vpc, vpcAttachment) or (vpc, node) and may still be in use by another
-	// VM. Deleting them here races with cmdAdd during restarts, so cleanup
-	// is left to galactic-router's GC controller — see internal/cni's own
-	// cmdDel for the full reasoning.
+	// Shared resources, the VRF and the BGP CRDs, are keyed by attachment or by
+	// node and may still be in use by another VM. Deleting them here races
+	// cmdAdd during a restart, so cleanup is left to garbage collection.
 	slog.Info("DEL: skipping shared resource cleanup (handled by GC)",
 		"containerID", args.ContainerID, "vpc", vpc, "vpcAttachment", vpcAtt)
 
@@ -87,11 +80,9 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// unregisterIfindexVRFEntry removes this attachment's own ifindex_vrf_table
-// entry (internal/plumbing/ebpf/ifindexvrfmap), if one exists -- mirrors
-// internal/cni's own identical helper (see its doc comment for the full
-// reasoning), adapted to a tap device's own host-side interface instead of
-// a veth pair's.
+// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table entry
+// if one exists, mirroring the veth plugin's identical helper but resolving a
+// tap device's host-side interface rather than a veth pair's.
 func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	link, err := netlink.LinkByName(hostName)
@@ -111,11 +102,10 @@ func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 	}
 }
 
-// removeRadvState removes this attachment's router-advertisement resend
-// record (internal/plumbing/radv), if any -- mirrors
-// unregisterIfindexVRFEntry above (same reasoning: genuinely private to this
-// one attachment's own host interface, so it belongs alongside tap.Delete
-// rather than the shared VRF/BGP CRD cleanup deferred to GC).
+// removeRadvState removes this attachment's router-advertisement resend record,
+// if any. Private to this attachment's own host interface, so it belongs
+// alongside the device deletion rather than the shared cleanup deferred to
+// GC.
 func removeRadvState(vpc, vpcAttachment, containerID string) {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
 	if err := radv.RemoveAttachment(radv.DefaultStateDir, hostName); err != nil {

--- a/internal/cnitap/resource.go
+++ b/internal/cnitap/resource.go
@@ -13,40 +13,34 @@ import (
 	"go.datum.net/galactic/internal/cnimaster"
 )
 
-// resourceTracker tracks resources created during cmdAdd for selective
-// rollback. galactic-tap's ADD only ever creates the VRF, the tap
-// device, and (if delegated) an IPAM allocation — BGP/SRv6/eBPF publish is
-// galactic-bgp's own, separately chain-invoked plugin now, with its own
-// smaller tracker (internal/cnibgp); termination routes are galactic-
-// route's own, with its own smaller tracker (internal/cniroute).
+// resourceTracker tracks the resources cmdAdd created, for selective rollback.
+// This plugin's ADD only ever creates the VRF, the tap device, and, when
+// delegated, an IPAM allocation. BGP publishing and termination routes are
+// separate chain-invoked plugins with their own trackers.
 type resourceTracker struct {
 	vpc, vpcAttachment string
 
-	// ipamDelegated, ipamType, and ipamStdin record enough to release the
-	// IPAM allocation during rollback — see internal/cni's own
-	// resourceTracker for the full doc comment on why this fires
-	// unconditionally on "ipam" block presence rather than only after a
-	// confirmed ExecAdd.
+	// ipamDelegated, ipamType, and ipamStdin record enough to release the IPAM
+	// allocation during rollback. They are set on the ipam block's presence
+	// alone, not only after a confirmed delegated add; see the veth plugin's
+	// tracker for the full reasoning.
 	ipamDelegated bool
 	ipamType      string
 	ipamStdin     []byte
 }
 
-// Deliberately absent: deleting the VRF. tap.Delete below only removes this
-// attachment's own tap device, which is genuinely private to it — but the
-// VRF itself is shared by every attachment on this VPC on this node
-// (internal/plumbing/vrf), and vrf.Add is idempotent, so a "vrfCreated" flag
-// here could never distinguish "I created it" from "a sibling attachment
-// already had." Deleting it on this attachment's own failed ADD could tear
-// down a still-live sibling's VRF out from under it — see internal/cni's own
-// resourceTracker.cleanup for the identical reasoning. Reclaiming it is
-// exclusively galactic-router's GC controller's job.
+// cleanup rolls back the tracked resources in reverse creation order.
+//
+// Deliberately absent: deleting the VRF. Removing this attachment's tap device
+// is safe, that device being private to it, but the VRF is shared by every
+// attachment on this VPC on this node, and creating it is idempotent, so a flag
+// here could never tell "I created it" from "a sibling already had". Deleting it
+// on a failed ADD could tear down a live sibling's VRF. Reclaiming it is garbage
+// collection's job.
 func (rt *resourceTracker) cleanup() {
-	// Release the IPAM allocation first — see internal/cni's own
-	// resourceTracker for the full doc comment on why this fires
-	// unconditionally on ipamDelegated alone. Interface/VRF cleanup is
-	// shared with galactic-veth's own tracker, so it lives in
-	// cnimaster.CleanupAttachment.
+	// Release the IPAM allocation first, whenever an ipam block was configured
+	// at all. Interface and VRF cleanup is shared with the veth plugin's
+	// tracker, so it lives in the shared master-plugin package.
 	if rt.ipamDelegated {
 		if err := ipam.ExecDel(rt.ipamType, rt.ipamStdin); err != nil {
 			slog.Error("Rollback: failed to release IPAM allocation", "err", err, "ipamType", rt.ipamType)

--- a/internal/cnitap/result.go
+++ b/internal/cnitap/result.go
@@ -13,13 +13,11 @@ import (
 	"go.datum.net/galactic/internal/cnimaster"
 )
 
-// buildTapResult constructs the CNI result for tap mode: a single host
-// interface with optional IPAM data. The guest VM manages its own
-// interface; the IP here describes the allocated subnet, which
-// galactic-bgp (chained next by the runtime) reads back out of this same
-// result to know what to advertise — see internal/cnibgp's doc comment.
-// The IPv4 address is reported with a /25 mask, matching the mask
-// hostgw.ConfigureHostGateway installs on the host side of the tap.
+// buildTapResult constructs the CNI result for tap mode: one host interface with
+// optional address data. The guest VM manages its own interface, and the address
+// here describes the allocated subnet, which the BGP plugin chained next reads
+// back out of this result to know what to advertise. The IPv4 address is
+// reported with the same mask the host side of the tap carries.
 func buildTapResult(
 	pluginConf *PluginConf,
 	ipRes *cniipam.IPAMResult,

--- a/internal/cnitap/types.go
+++ b/internal/cnitap/types.go
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnitap implements galactic-tap, the tap master plugin for
-// VM-based workloads (Kata, Firecracker, kraftlet/Unikraft). It mirrors
-// internal/cni (the veth master, galactic-veth) but never delegates to
-// host-device (no container netns to move anything into — the VM manages
-// its own guest interface) and never configures a guest-side netns.
+// Package cnitap implements galactic-tap, the tap master plugin for VM-based
+// workloads. It mirrors the veth master but never delegates a device move, there
+// being no container namespace to move anything into, the VM managing its own
+// guest interface, and never configures a guest-side namespace.
 package cnitap
 
 import (
@@ -14,11 +13,9 @@ import (
 	"go.datum.net/galactic/internal/hostconf"
 )
 
-// PluginConf is the CNI plugin configuration passed via stdin on each
-// invocation of galactic-tap. It's the same shape galactic-veth
-// (internal/cni) uses — see internal/cnimaster's own doc comment — so both
-// packages alias the one canonical definition rather than each declaring
-// their own copy.
+// PluginConf is the CNI plugin configuration passed on stdin. It is the same
+// shape the veth master uses, so both packages alias the one canonical
+// definition rather than each declaring a copy.
 type PluginConf = cnimaster.PluginConf
 
 // HostConf holds node-local settings read from /etc/cni/net.d/10-galactic.conflist.

--- a/internal/cnitestutil/cnitestutil.go
+++ b/internal/cnitestutil/cnitestutil.go
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package cnitestutil holds test helpers shared by internal/cni's and
-// internal/cnitap's own test suites — the same reasoning as internal/
-// cnimaster, but for test-only scaffolding rather than production code:
-// neither helper is specific to veth or tap, so a fix only has to happen
-// once. Not a _test.go file, since Go doesn't let one package's _test.go
-// import another package's _test.go — this is a regular importable package
-// that happens to only ever be imported from test code.
+// Package cnitestutil holds the test helpers both master plugins' test suites
+// share, the same reasoning as the shared production package but for test
+// scaffolding: neither helper is specific to veth or tap, so a fix happens once.
+//
+// It is a regular importable package rather than a test file, since one
+// package's test files cannot import another's.
 package cnitestutil
 
 import (
@@ -20,9 +19,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-// AssertCNIError verifies that err is a *types.Error with the expected Code
-// and that its Msg contains wantMsg (substring match). Pass wantMsg == "" to
-// skip the message check.
+// AssertCNIError verifies that err is a CNI error with the expected code and a
+// message containing wantMsg. Pass an empty wantMsg to skip the message check.
 func AssertCNIError(t *testing.T, err error, wantCode uint, wantMsg string) {
 	t.Helper()
 	var cniErr *types.Error

--- a/internal/config/cni.go
+++ b/internal/config/cni.go
@@ -19,52 +19,39 @@ const (
 	EnvNamespace           = "GALACTIC_CNI_NAMESPACE"
 	EnvNodeNameLegacy      = "NODE_NAME"
 
-	// EnvCNIEBPFInterfaces overrides auto-detection of the interface(s)
-	// the eBPF uSID datapath attaches its TC-BPF ingress hook to -- a
-	// comma-separated list of interface names, for multi-homed nodes
-	// where auto-detection (the interface(s) carrying the default IPv6
-	// route) is ambiguous.
+	// EnvCNIEBPFInterfaces overrides auto-detection of the interfaces the eBPF
+	// uSID datapath attaches its ingress hook to: a comma-separated list, for
+	// multi-homed nodes where detecting from the default IPv6 route is
+	// ambiguous.
 	EnvCNIEBPFInterfaces = "GALACTIC_CNI_EBPF_INTERFACES"
 
-	// EnvCNIEBPFFilterPriority overrides the tc priority the eBPF uSID
-	// datapath's own ingress filter attaches at (default: 1, the
-	// highest/lowest-numbered priority tc allows). Cilium also runs its
-	// own tc/bpf programs on the same native device ingress hook these
-	// interfaces use, and this package's priority-1 default has not been
-	// validated against every Cilium version/datapath mode for a
-	// collision. Override here if a deployment's Cilium install needs
-	// this filter at a different priority to run in the intended order
-	// relative to Cilium's own.
+	// EnvCNIEBPFFilterPriority overrides the tc priority the uSID datapath's
+	// ingress filter attaches at, the default being the highest tc allows. A
+	// cluster CNI may run its own programs on the same hook, and that default
+	// has not been validated against every version for a collision. Override it
+	// where a deployment needs this filter ordered differently.
 	EnvCNIEBPFFilterPriority = "GALACTIC_CNI_EBPF_FILTER_PRIORITY"
 
-	// EnvCNINAT66ShardSIDs is a comma-separated list of every live
-	// galactic-nat66 shard's Status.ShardSID (see NAT66ShardStatus's own
-	// doc comment in datum-cloud/network) -- the fabric-wide membership
-	// list internal/plumbing/srv6.EgressDefaultRouteAdd needs to install a
-	// tenant VRF's default egress route across every shard, since no
-	// single Kubernetes CRD is visible across this multi-cluster fabric's
-	// separate clusters/API servers the way BGP itself is (see that
-	// function's own doc comment for why membership is operator-supplied
-	// rather than learned from the BGP RIB in this phase). Same
-	// "operator-supplied, no in-cluster derivation yet" status as
-	// GALACTIC_GATEWAY_SRV6_ADDRESS and NAT66ShardStatus.ShardAddress/SID
-	// themselves. galactic-cni's own installer resolves this once at
-	// startup (its own real pod env, unlike a CNI plugin's minimal exec
-	// environment) and writes it into the static per-node conflist
-	// (HostConf.NAT66ShardSIDs) so internal/cnibgp -- invoked per-pod by
-	// the CNI runtime, not a long-lived process with configurable env --
-	// can read it the same way it reads NodeName/Namespace/etc. Unset or
-	// empty means no shard configured yet: a VRF gets no default route,
-	// the same "no egress capability" behavior as before this mechanism
-	// existed, not an error.
+	// EnvCNINAT66ShardSIDs is a comma-separated list of every live NAT66 shard's
+	// SID: the fabric-wide membership a tenant VRF's default egress route needs.
+	// It is operator-supplied because no single CRD is visible across this
+	// fabric's separate clusters the way BGP itself is.
+	//
+	// The installer resolves it once at startup, from its real pod environment
+	// rather than a plugin's minimal exec environment, and writes it into the
+	// static per-node conflist, so the BGP plugin can read it the way it reads
+	// every other node-level setting.
+	//
+	// Unset or empty means no shard is configured yet: a VRF gets no default
+	// route, which is no egress capability rather than an error.
 	EnvCNINAT66ShardSIDs = "GALACTIC_CNI_NAT66_SHARD_SIDS"
 )
 
 // --- CNIConfig -------------------------------------------------------------
 
-// CNIConfig resolves CNI configuration with three-tier precedence: env var >
-// conflist field > compiled-in default. Create once via NewCNIConfig() and
-// call Resolve() with conflist values to populate the exported fields.
+// CNIConfig resolves CNI configuration with three-tier precedence: environment
+// variable, then conflist field, then compiled-in default. Create one with
+// NewCNIConfig and call Resolve with the conflist values.
 type CNIConfig struct {
 	// Resolved fields (populated by Resolve).
 	NodeName   string
@@ -73,17 +60,14 @@ type CNIConfig struct {
 	LogFile    string
 	LogLevel   string
 
-	// NAT66ShardSIDs is the raw, comma-separated NAT66 shard SID list --
-	// see EnvCNINAT66ShardSIDs's own doc comment. Left unparsed here
-	// (internal/cnibgp splits and validates it) since this package has no
-	// IP-address type of its own to return.
+	// NAT66ShardSIDs is the raw comma-separated shard SID list, left unparsed
+	// here since this package has no IP type of its own to return. The BGP
+	// plugin splits and validates it.
 	NAT66ShardSIDs string
 
-	// EBPFInterfaces is the raw, comma-separated interface list -- see
-	// EnvCNIEBPFInterfaces' own doc comment and hostconf.HostConf.
-	// EBPFInterfaces' identical one for why this needs the same env >
-	// conflist > default resolution as NAT66ShardSIDs above, not just a
-	// plain os.Getenv at the call site.
+	// EBPFInterfaces is the raw comma-separated interface list. It needs the
+	// same environment-over-conflist-over-default resolution as NAT66ShardSIDs,
+	// not a plain environment read at the call site.
 	EBPFInterfaces string
 }
 
@@ -93,9 +77,9 @@ func NewCNIConfig() *CNIConfig {
 	return &CNIConfig{}
 }
 
-// Resolve populates the exported fields from the conflist values, overridden
-// by any matching environment variables. The conflist values act as the
-// "middle tier" between env vars and compiled-in defaults.
+// Resolve populates the exported fields from the conflist values, overridden by
+// any matching environment variable. The conflist is the middle tier between
+// the environment and the compiled-in defaults.
 func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 	var cnflistNode, cnflistKube, cnflistNS, cnflistLog, cnflistLevel, cnflistShardSIDs, cnflistEBPFIfaces string
 	if conflist != nil {
@@ -129,15 +113,11 @@ func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 	// LogLevel: env > conflist > default
 	c.LogLevel = resolveEnv(EnvLogLevel, cnflistLevel, DefaultLogLevel)
 
-	// NAT66ShardSIDs: env > conflist > (no default -- empty means "no
-	// shard configured", not an error; see EnvCNINAT66ShardSIDs's doc
-	// comment).
+	// No default: empty means no shard configured, not an error.
 	c.NAT66ShardSIDs = resolveEnv(EnvCNINAT66ShardSIDs, cnflistShardSIDs, "")
 
-	// EBPFInterfaces: env > conflist > (no default -- empty means "fall
-	// back to attach.ResolveInterfaces' own auto-detection," the
-	// pre-existing behavior, not an error; see EnvCNIEBPFInterfaces' own
-	// doc comment).
+	// No default: empty means fall back to the datapath's own interface
+	// auto-detection, not an error.
 	c.EBPFInterfaces = resolveEnv(EnvCNIEBPFInterfaces, cnflistEBPFIfaces, "")
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package config provides shared configuration defaults, environment variable
-// keys, and typed resolvers for both galactic-cni and galactic-router.
-//
-// Each component gets its own resolver (CNIConfig, RouterConfig).
-// Precedence: env var > conflist/flag > compiled-in default.
+// Package config provides the shared configuration defaults, environment
+// variable names, and typed resolvers every galactic binary uses. Each gets its
+// own resolver, all with the same precedence: environment variable, then
+// conflist or flag, then compiled-in default.
 package config
 
 import (
@@ -28,9 +27,8 @@ const (
 	LogLevelWarning = "warning"
 	LogLevelError   = "error"
 
-	// flagMetricsPort is the CLI flag name shared by RouterConfig,
-	// GatewayConfig, and VRFConfig's BindFlags -- each binds it to the same
-	// keyMetricsPort Viper key.
+	// flagMetricsPort is the CLI flag name several resolvers share, each
+	// binding it to the same key.
 	flagMetricsPort = "metrics-port"
 
 	// keyMetricsPort is the Viper key each component's MetricsPort field
@@ -44,12 +42,9 @@ const (
 
 // --- Shared CLI flag names --------------------------------------------
 
-// FlagNodeName/FlagMetricsPort/FlagGRPCHealthPort are the CLI flag name
-// strings every per-binary Config's BindFlags bindings table
-// (RouterConfig, GatewayConfig, NAT66Config) binds verbatim -- pulled out
-// to shared constants rather than left as three near-identical literal
-// copies (one per binary), which is exactly what golangci-lint's goconst
-// flags once a third copy exists.
+// FlagNodeName, FlagMetricsPort, and FlagGRPCHealthPort are the CLI flag names
+// every per-binary resolver binds verbatim, shared rather than repeated once
+// per binary.
 const (
 	FlagNodeName       = "node-name"
 	FlagMetricsPort    = "metrics-port"
@@ -58,11 +53,9 @@ const (
 
 // --- Shared Viper key names ---------------------------------------------
 
-// KeyNodeName/KeyMetricsPort/KeyGRPCHealthPort are the Viper key strings
-// every per-binary Config's SetDefault/BindFlags/readFields trio uses for
-// the same three fields FlagNodeName/FlagMetricsPort/FlagGRPCHealthPort
-// bind -- pulled out for the same goconst-across-three-near-identical-
-// binaries reason as the Flag* constants above.
+// KeyNodeName, KeyMetricsPort, and KeyGRPCHealthPort are the config keys every
+// per-binary resolver uses for the three fields the flags above bind, shared for
+// the same reason.
 const (
 	KeyNodeName       = "node_name"
 	KeyMetricsPort    = "metrics_port"

--- a/internal/config/gateway.go
+++ b/internal/config/gateway.go
@@ -16,15 +16,11 @@ import (
 // --- Gateway defaults --------------------------------------------------
 
 const (
-	// DefaultGatewayMetricsPort/DefaultGatewayGRPCHealthPort deliberately
-	// differ from DefaultRouterMetricsPort (9179) and
-	// DefaultRouterGRPCHealthPort (5179) and from galactic-cni's
-	// credential-refresh ports (grpc-health 5180, metrics 9180,
-	// config/galactic-cni/daemonset.yaml): every edge node runs
-	// galactic-gateway, galactic-router, and galactic-cni as separate
-	// hostNetwork: true DaemonSet pods, all sharing that one node's network
-	// namespace regardless of pod boundaries, so every port any of them
-	// binds must not collide with any of the others'.
+	// DefaultGatewayMetricsPort and DefaultGatewayGRPCHealthPort differ from
+	// every other galactic binary's ports. An edge node runs several of them as
+	// separate host-network DaemonSet pods, all sharing that node's network
+	// namespace regardless of pod boundaries, so no port any of them binds may
+	// collide with another's.
 	DefaultGatewayMetricsPort    = 8081
 	DefaultGatewayGRPCHealthPort = 5181
 )
@@ -36,31 +32,24 @@ const (
 	EnvGatewayMetricsPort    = "GALACTIC_GATEWAY_METRICS_PORT"
 	EnvGatewayGRPCHealthPort = "GALACTIC_GATEWAY_GRPC_HEALTH_PORT"
 
-	// EnvGatewayPublicInterface names this node's single public/underlay-
-	// facing uplink interface for the edge NAT+LB gateway datapath
-	// (internal/plumbing/ebpf/edgeprog). Unlike
-	// config.EnvRouterGatewayPublicInterface's predecessor field, this is
-	// required: galactic-gateway only ever runs as the gateway role, so
-	// there is no "not gateway role, return gateway.NoopDatapath{}" case
-	// to support — see GatewayConfig.Validate.
+	// EnvGatewayPublicInterface names this node's underlay-facing uplink for
+	// the edge gateway datapath. Required: this binary only ever runs the
+	// gateway role, so there is no "not this role, skip the datapath" case.
 	EnvGatewayPublicInterface = "GALACTIC_GATEWAY_PUBLIC_INTERFACE"
 
-	// EnvGatewaySRv6Address is this gateway node's own plain
-	// SRv6-reachable address, used as the outer-header encap source for
-	// every packet this node's DSR datapath forwards (edgedsr.c's
-	// encap_config_table) — never a NAT/SNAT source and never compared
-	// against anything on a receive path, unlike the removed Full-NAT
-	// design's identically-named field. Required — see
-	// EnvGatewayPublicInterface.
+	// EnvGatewaySRv6Address is this node's plain SRv6-reachable address, used
+	// as the outer-header source for every packet this datapath forwards. It is
+	// never a translation source and is never compared against anything on a
+	// receive path. Required.
 	EnvGatewaySRv6Address = "GALACTIC_GATEWAY_SRV6_ADDRESS"
 )
 
 // --- GatewayConfig -----------------------------------------------------
 
 // GatewayConfig resolves galactic-gateway configuration with three-tier
-// precedence: CLI flag > env var > compiled-in default. Create once via
-// NewGatewayConfig(), call BindFlags() to layer CLI flags, then read the
-// exported fields.
+// precedence: CLI flag, then environment variable, then compiled-in default.
+// Create one with NewGatewayConfig, call BindFlags to layer CLI flags, then read
+// the exported fields.
 type GatewayConfig struct {
 	v      *viper.Viper
 	prefix string
@@ -70,17 +59,15 @@ type GatewayConfig struct {
 	MetricsPort    int
 	GRPCHealthPort int
 
-	// PublicInterface/SRv6Address configure the edge Maglev/DSR gateway
-	// datapath -- see EnvGatewayPublicInterface's doc comment. Both
-	// required; GatewayConfig.Validate rejects either being empty.
+	// PublicInterface and SRv6Address configure the edge gateway datapath. Both
+	// are required; Validate rejects either being empty.
 	PublicInterface string
 	SRv6Address     string
 }
 
-// NewGatewayConfig creates a gateway config resolver with the
-// GALACTIC_GATEWAY env prefix and AutomaticEnv enabled. Exported fields are
-// populated from env vars and defaults; call BindFlags() to layer CLI
-// overrides.
+// NewGatewayConfig creates a config resolver reading the GALACTIC_GATEWAY
+// environment prefix. Exported fields are populated from the environment and
+// defaults; call BindFlags to layer CLI overrides.
 func NewGatewayConfig() *GatewayConfig {
 	v := viper.New()
 	v.SetEnvPrefix("GALACTIC_GATEWAY")
@@ -151,11 +138,9 @@ func (c *GatewayConfig) Validate() error {
 	if err != nil {
 		return fmt.Errorf("SRv6 address %q is not a valid IP address: %w", c.SRv6Address, err)
 	}
-	// Caught eventually anyway by internal/gateway/kerneldatapath.go's own
-	// identical Is6()/Is4In6() check, but late: only once setupGatewayDatapath
-	// has already loaded and attached the eBPF datapath. Reject it here
-	// instead, at startup, with a message that names the actual problem
-	// rather than surfacing as a deeper, less obvious kernel-datapath error.
+	// The datapath catches the same thing eventually, but only after it has
+	// been loaded and attached. Rejecting it at startup names the actual
+	// problem instead of surfacing as a deeper kernel-datapath error.
 	if !addr.Is6() || addr.Is4In6() {
 		return fmt.Errorf("SRv6 address %q must be a native IPv6 address, not IPv4", c.SRv6Address)
 	}

--- a/internal/config/ipam.go
+++ b/internal/config/ipam.go
@@ -9,22 +9,17 @@ import (
 	"strings"
 )
 
-// EnvIPAMEnableLocalIPAM is galactic-ipam's own local-IPAM default-filler
-// flag, read fresh on every invocation (mirrors CNIConfig's env-only
-// resolution — galactic-ipam has no conflist/kubeconfig to read a
-// middle-tier value from, since it has no k8s dependency at all).
+// EnvIPAMEnableLocalIPAM is the IPAM plugin's local default-filler flag, read
+// fresh on every invocation: that plugin has no conflist or kubeconfig to read a
+// middle-tier value from, having no Kubernetes dependency at all.
 //
-// Renamed from the historical GALACTIC_CNI_ENABLE_LOCAL_IPAM now that the
-// flag belongs entirely to galactic-ipam: it's no longer a trigger deciding
-// whether IPAM runs at all (that's the "ipam" block's presence, decided by
-// the master plugin before it ever delegates) — only a default-filler for
-// when the ipam block is present but under-specified. See
-// go.datum.net/galactic/internal/cniipam's own doc comment.
+// It is not a trigger deciding whether IPAM runs, which the ipam block's
+// presence decides in the master plugin before it delegates, but only a
+// default-filler for when that block is present and under-specified.
 const EnvIPAMEnableLocalIPAM = "GALACTIC_IPAM_ENABLE_LOCAL_IPAM"
 
-// IPAMGetEnableLocalIPAM reports whether galactic-ipam's local-IPAM
-// default-filler is enabled via environment variable. Returns false if the
-// variable is unset or not "true".
+// IPAMGetEnableLocalIPAM reports whether the local default-filler is enabled.
+// Returns false when the variable is unset or not "true".
 func IPAMGetEnableLocalIPAM() bool {
 	val := os.Getenv(EnvIPAMEnableLocalIPAM)
 	return strings.EqualFold(val, "true")

--- a/internal/config/nat66.go
+++ b/internal/config/nat66.go
@@ -16,20 +16,11 @@ import (
 // --- NAT66 defaults ---------------------------------------------------
 
 const (
-	// DefaultNAT66MetricsPort/DefaultNAT66GRPCHealthPort are the next
-	// unused values past every other hostNetwork: true galactic-* process
-	// already running on a node: fabric-router's BGP listener (179),
-	// galactic-router's grpc-health/metrics (5179/9179), galactic-cni's
-	// (5180/9180), and galactic-gateway's (5181/8081 -- see
-	// internal/config/gateway.go's own doc comment for why that pair
-	// isn't a clean continuation of the 517x/917x pattern). galactic-nat66
-	// runs hostNetwork: true on every galactic.datumapis.com/node=compute
-	// node (config/galactic-nat66/base/daemonset.yaml) -- the same nodes
-	// as galactic-router's default role and galactic-cni, disjoint from
-	// galactic-gateway's own edge-role nodes -- but a node's role labels
-	// are not mutually exclusive by construction, so these still avoid
-	// every value already claimed above rather than assuming no overlap
-	// will ever happen.
+	// DefaultNAT66MetricsPort and DefaultNAT66GRPCHealthPort are the next unused
+	// values past every other host-network process on a node. This binary runs
+	// on the same nodes as the router and CNI and disjoint from the gateway's,
+	// but a node's role labels are not mutually exclusive by construction, so
+	// these avoid every value already claimed rather than assume no overlap.
 	DefaultNAT66MetricsPort    = 9182
 	DefaultNAT66GRPCHealthPort = 5182
 )
@@ -41,38 +32,30 @@ const (
 	EnvNAT66MetricsPort    = "GALACTIC_NAT66_METRICS_PORT"
 	EnvNAT66GRPCHealthPort = "GALACTIC_NAT66_GRPC_HEALTH_PORT"
 
-	// EnvNAT66UplinkInterface names this shard's single fabric-facing
-	// uplink interface -- the interface
-	// internal/plumbing/ebpf/nat66prog's XDP program attaches to. Required:
-	// galactic-nat66 only ever runs as a dedicated NAT66 shard, so there is
-	// no "not this role, skip the datapath" case to support, mirroring
-	// config.EnvGatewayPublicInterface's identical reasoning.
+	// EnvNAT66UplinkInterface names this shard's fabric-facing uplink, the
+	// interface the NAT66 XDP program attaches to. Required: this binary only
+	// ever runs as a dedicated shard, so there is no "not this role, skip the
+	// datapath" case.
 	EnvNAT66UplinkInterface = "GALACTIC_NAT66_UPLINK_INTERFACE"
 
-	// EnvNAT66ShardSID is this shard's own SRv6 uSID
-	// (network.datumapis.com/v1alpha1's NAT66ShardStatus.ShardSID) --
-	// the outer destination a tenant's egress packet is encapsulated
-	// toward. Required -- see EnvNAT66UplinkInterface. Operator-supplied
-	// today (no in-cluster derivation mechanism yet -- the same gap
-	// BGPRouter.Spec.SRv6Locator/NodeID assignment and
-	// GALACTIC_GATEWAY_SRV6_ADDRESS both have today; see
-	// docs/agents/ARCHITECTURE-GATEWAY.md's "Argument-0 reservation"
-	// section for the established precedent this follows).
+	// EnvNAT66ShardSID is this shard's own SRv6 uSID, the outer destination a
+	// tenant's egress packet is encapsulated toward. Required, and
+	// operator-supplied: no in-cluster mechanism derives it yet, the same gap
+	// the router locator and the gateway address both have.
 	EnvNAT66ShardSID = "GALACTIC_NAT66_SHARD_SID"
 
-	// EnvNAT66ShardPubAddr is this shard's own publicly-routable
-	// masquerade source address (NAT66ShardStatus.ShardAddress) -- every
-	// flow this shard NATs is SNAT'd to an address:port within it.
-	// Required -- see EnvNAT66UplinkInterface.
+	// EnvNAT66ShardPubAddr is this shard's publicly routable masquerade source.
+	// Every flow this shard translates is given an address and port within it.
+	// Required.
 	EnvNAT66ShardPubAddr = "GALACTIC_NAT66_SHARD_PUB_ADDR"
 )
 
 // --- NAT66Config ---------------------------------------------------------
 
-// NAT66Config resolves galactic-nat66 configuration with three-tier
-// precedence: CLI flag > env var > compiled-in default. Create once via
-// NewNAT66Config(), call BindFlags() to layer CLI flags, then read the
-// exported fields.
+// NAT66Config resolves galactic-nat66 configuration with three-tier precedence:
+// CLI flag, then environment variable, then compiled-in default. Create one with
+// NewNAT66Config, call BindFlags to layer CLI flags, then read the exported
+// fields.
 type NAT66Config struct {
 	v      *viper.Viper
 	prefix string
@@ -82,17 +65,16 @@ type NAT66Config struct {
 	MetricsPort    int
 	GRPCHealthPort int
 
-	// UplinkInterface/ShardSID/ShardPubAddr configure the NAT66 egress
-	// shard datapath -- see EnvNAT66UplinkInterface's doc comment. All
-	// three required; NAT66Config.Validate rejects any being empty.
+	// UplinkInterface, ShardSID, and ShardPubAddr configure the egress shard
+	// datapath. All three are required; Validate rejects any being empty.
 	UplinkInterface string
 	ShardSID        string
 	ShardPubAddr    string
 }
 
-// NewNAT66Config creates a NAT66 config resolver with the GALACTIC_NAT66
-// env prefix and AutomaticEnv enabled. Exported fields are populated from
-// env vars and defaults; call BindFlags() to layer CLI overrides.
+// NewNAT66Config creates a config resolver reading the GALACTIC_NAT66
+// environment prefix. Exported fields are populated from the environment and
+// defaults; call BindFlags to layer CLI overrides.
 func NewNAT66Config() *NAT66Config {
 	v := viper.New()
 	v.SetEnvPrefix("GALACTIC_NAT66")
@@ -113,9 +95,8 @@ func NewNAT66Config() *NAT66Config {
 	return cfg
 }
 
-// BindFlags binds Cobra/pflag flags to the config resolver and re-reads
-// the exported fields. Each flag is bound to a Viper key using the key
-// argument.
+// BindFlags binds the CLI flags to the config resolver and re-reads the
+// exported fields.
 func (c *NAT66Config) BindFlags(flags *pflag.FlagSet) {
 	bindings := []struct {
 		flag string
@@ -149,15 +130,12 @@ func (c *NAT66Config) readFields() {
 	c.ShardPubAddr = c.v.GetString("shard_pub_addr")
 }
 
-// validateShardAddr parses and range-checks a shard identity address
-// (ShardSID or ShardPubAddr), rejecting anything that isn't a native
-// IPv6 address -- caught eventually anyway by
-// internal/plumbing/ebpf/nat66map's identical check, but late: only once
-// setupNat66Datapath has already loaded and attached the eBPF datapath.
-// Reject it here instead, at startup, with a message that names the
-// actual field rather than surfacing as a deeper, less obvious
-// kernel-datapath error -- mirrors GatewayConfig.Validate's identical
-// SRv6Address check.
+// validateShardAddr parses and range-checks a shard identity address, rejecting
+// anything that is not a native IPv6 address.
+//
+// The map layer catches the same thing eventually, but only after the datapath
+// has been loaded and attached. Rejecting it at startup names the actual field
+// instead of surfacing as a deeper kernel-datapath error.
 func validateShardAddr(field, value string) error {
 	addr, err := netip.ParseAddr(value)
 	if err != nil {

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -18,17 +18,15 @@ import (
 const (
 	DefaultRouterBGPListenPort = 179
 	DefaultRouterMetricsPort   = 9179
-	// DefaultRouterGRPCHealthPort avoids 5000: one of the most overloaded
-	// dev ports in existence (macOS AirPlay Receiver, Flask's dev server,
-	// Docker Registry), and on Talos specifically /sbin/dashboard
-	// permanently binds 127.0.0.1:5000 -- see docs/router/configuration.md.
+	// DefaultRouterGRPCHealthPort avoids 5000, one of the most overloaded dev
+	// ports there is, and permanently bound on the loopback interface by some
+	// host operating systems.
 	DefaultRouterGRPCHealthPort = 5179
 	DefaultRouterGCNamespace    = "galactic-system"
 	DefaultRouterGCInterval     = 5 * time.Minute
 
-	// DefaultRouterWebhookPort matches sigs.k8s.io/controller-runtime/pkg/webhook's
-	// own DefaultPort, named here so callers don't need that import just to
-	// read the default.
+	// DefaultRouterWebhookPort matches controller-runtime's own default, named
+	// here so callers need not import that package to read it.
 	DefaultRouterWebhookPort = 9443
 )
 
@@ -44,14 +42,11 @@ const (
 	EnvRouterGCNamespace    = "GALACTIC_ROUTER_GC_NAMESPACE"
 	EnvRouterGCInterval     = "GALACTIC_ROUTER_GC_INTERVAL"
 
-	// EnvRouterWebhookEnabled gates the NetworkRule admission webhook
-	// (internal/webhook). Defaults to false: this is the first webhook in
-	// this codebase, and enabling it requires TLS cert material
-	// (config/webhook/'s kustomization.yaml documents the cert-manager-or-
-	// equivalent prerequisite this repo does not itself provision) plus the
-	// ValidatingWebhookConfiguration/Service manifests to actually be
-	// applied — turning it on without both is a broken deployment, not a
-	// safe default.
+	// EnvRouterWebhookEnabled gates the NetworkRule admission webhook. It
+	// defaults to false: enabling it requires TLS cert material this repo does
+	// not provision, plus the webhook configuration and service manifests
+	// actually being applied. Turning it on without both is a broken deployment
+	// rather than a safe default.
 	EnvRouterWebhookEnabled = "GALACTIC_ROUTER_WEBHOOK_ENABLED"
 	EnvRouterWebhookPort    = "GALACTIC_ROUTER_WEBHOOK_PORT"
 	EnvRouterWebhookCertDir = "GALACTIC_ROUTER_WEBHOOK_CERT_DIR"
@@ -60,20 +55,20 @@ const (
 // --- RouterConfig ----------------------------------------------------------
 
 // RouterConfig resolves router configuration with three-tier precedence: CLI
-// flag > env var > compiled-in default. Create once via NewRouterConfig(),
-// call BindFlags() to layer CLI flags, then read the exported fields.
+// flag, then environment variable, then compiled-in default. Create one with
+// NewRouterConfig, call BindFlags to layer CLI flags, then read the exported
+// fields.
 type RouterConfig struct {
 	v      *viper.Viper
 	prefix string
 
 	// Resolved fields.
 	NodeName string
-	// Reflector marks every BGP peer this router instance adds as an iBGP
-	// route-reflector client (GoBGP's RouteReflectorClient flag), so this
-	// node reflects paths to those peers instead of requiring full-mesh
-	// iBGP. This is a distinct signal from BGPListenPort: whether a node
-	// accepts inbound BGP connections is not the same property as whether
-	// it is the fabric-facing route reflector.
+	// Reflector marks every peer this router adds as an iBGP route-reflector
+	// client, so this node reflects paths to them instead of requiring a full
+	// mesh. A distinct signal from the listen port: whether a node accepts
+	// inbound connections is not the same property as whether it is the
+	// fabric's route reflector.
 	Reflector      bool
 	BGPListenPort  int
 	BGPLocalAddr   string
@@ -82,17 +77,16 @@ type RouterConfig struct {
 	GCNamespace    string
 	GCInterval     time.Duration
 
-	// WebhookEnabled/WebhookPort/WebhookCertDir configure the NetworkRule
-	// admission webhook (internal/webhook) -- see
-	// EnvRouterWebhookEnabled's doc comment. Disabled by default.
+	// WebhookEnabled, WebhookPort, and WebhookCertDir configure the NetworkRule
+	// admission webhook. Disabled by default.
 	WebhookEnabled bool
 	WebhookPort    int
 	WebhookCertDir string
 }
 
-// NewRouterConfig creates a router config resolver with the GALACTIC_ROUTER
-// env prefix and AutomaticEnv enabled. Exported fields are populated from env
-// vars and defaults; call BindFlags() to layer CLI overrides.
+// NewRouterConfig creates a config resolver reading the GALACTIC_ROUTER
+// environment prefix. Exported fields are populated from the environment and
+// defaults; call BindFlags to layer CLI overrides.
 func NewRouterConfig() *RouterConfig {
 	v := viper.New()
 	v.SetEnvPrefix("GALACTIC_ROUTER")

--- a/internal/config/vrf.go
+++ b/internal/config/vrf.go
@@ -18,32 +18,21 @@ import (
 // --- VRF sidecar defaults ---------------------------------------------
 
 const (
-	// DefaultVRFMetricsPort deliberately avoids the port ranges the other
-	// binaries in this repo already use (9179 router, 8081 gateway, 9180
-	// CNI credential-refresh) for the same reason config.go's own
-	// DefaultGatewayMetricsPort comment gives: unlike those, though, this
-	// binary runs as a second container sharing its *pod's* network
-	// namespace with Envoy (not hostNetwork: true, see §1.5 of the #855
-	// plan), so the port only has to avoid Envoy's own well-known ports
-	// (9901 admin, 10000 default listener) within that one pod, not every
-	// other galactic-* process on the node.
+	// DefaultVRFMetricsPort avoids the ports the other binaries here use. This
+	// binary runs as a second container sharing its pod's network namespace
+	// with Envoy rather than the host's, so it only has to avoid Envoy's own
+	// ports within that pod, not every other process on the node.
 	DefaultVRFMetricsPort = 9182
 
-	// DefaultVRFTeardownGracePeriod is a conservative placeholder, not a
-	// tuned value: long enough to plausibly cover a typical Envoy Gateway
-	// extension server (#856/#857) config-push-plus-drain window, short
-	// enough not to wedge normal-churn testing. See §9 item 1's
-	// 2026-08-18 decision in docs/plans/855-ingress-sidecar-vpc-backend-
-	// connectivity.md -- revisit once #857 exists and its latency is
-	// observable.
+	// DefaultVRFTeardownGracePeriod is a conservative placeholder, not a tuned
+	// value: long enough to plausibly cover a config-push and drain window,
+	// short enough not to wedge normal-churn testing.
 	DefaultVRFTeardownGracePeriod = 30 * time.Second
 
-	// DefaultVRFSweepInterval controls how often Store.Sweep re-checks
-	// pending teardowns -- see internal/ingresssidecar.RunSweeper's doc
-	// comment for why this has to be polling-driven. Independent of (and
-	// deliberately much shorter than) DefaultVRFTeardownGracePeriod: this
-	// is the granularity of the grace-period clock, not the grace period
-	// itself.
+	// DefaultVRFSweepInterval controls how often pending teardowns are
+	// re-checked. It is the granularity of the grace-period clock, not the
+	// grace period itself, so it is deliberately much shorter than
+	// DefaultVRFTeardownGracePeriod.
 	DefaultVRFSweepInterval = 5 * time.Second
 )
 
@@ -55,43 +44,32 @@ const (
 	EnvVRFSweepInterval       = "GALACTIC_VRF_SWEEP_INTERVAL"
 
 	// EnvVRFNodeName and EnvVRFNamespace configure the return-path gateway
-	// BGPAdvertisement publisher (see NodeName/Namespace's own doc
-	// comments below) -- unset by default, matching every env var above,
-	// but unlike them this pair has no compiled-in default for NodeName:
-	// there is no generic value that could ever be right for "which node
-	// is this", the same reason GALACTIC_ROUTER_NODE_NAME/
-	// GALACTIC_GATEWAY_NODE_NAME have none either.
+	// advertisement publisher. Unset by default, and unlike the others
+	// NodeName has no compiled-in default: no generic value could be right for
+	// "which node is this".
 	EnvVRFNodeName  = "GALACTIC_VRF_NODE_NAME"
 	EnvVRFNamespace = "GALACTIC_VRF_NAMESPACE"
 
-	// EnvVRFGatewayPrefix configures return-path gateway *address
-	// provisioning* (docs/plans/855-return-path-gateway-advertisement.md's
-	// "Not implemented here" gap) -- see GatewayPrefix's own doc comment.
-	// Unset by default, same as EnvVRFNodeName and for the identical
-	// reason: no generic value could ever be right for "which address
-	// space is reserved for this on this platform."
+	// EnvVRFGatewayPrefix configures return-path gateway address provisioning.
+	// Unset by default and with no compiled-in value, for the same reason: no
+	// generic value could be right for which address space a platform
+	// reserves.
 	EnvVRFGatewayPrefix = "GALACTIC_VRF_GATEWAY_PREFIX"
 )
 
 // --- VRFConfig -----------------------------------------------------------
 
-// VRFConfig resolves galactic-vrf (the #855 ingress sidecar) configuration
-// with three-tier precedence: CLI flag > env var > compiled-in default.
-// Create once via NewVRFConfig(), call BindFlags() to layer CLI flags, then
-// read the exported fields.
+// VRFConfig resolves galactic-vrf configuration with three-tier precedence: CLI
+// flag, then environment variable, then compiled-in default. Create one with
+// NewVRFConfig, call BindFlags to layer CLI flags, then read the exported
+// fields.
 //
-// NodeName/Namespace are the exception to that precedence and to
-// RouterConfig/GatewayConfig's own pattern: this sidecar's *route*
-// reconciliation still has no CRD identity keyed by node and no
-// ConfigMap/CRD configuration surface (desired state derives entirely from
-// the EndpointSlice watch, per §1 of docs/plans/855-ingress-sidecar-vpc-
-// backend-connectivity.md's acceptance-criteria table) -- but publishing
-// this node's own return-path gateway advertisement (docs/plans/855-
-// return-path-gateway-advertisement.md) does need to know which BGPRouter
-// to attribute it to. NodeName's default is "" (feature disabled -- see
-// cmd/galactic-vrf's own startup logic, which only wires up a
-// GatewayPublisher when NodeName is non-empty), not a Validate failure,
-// since most deployments of this sidecar don't set it at all yet.
+// NodeName and Namespace are exceptions to that precedence. Route
+// reconciliation needs neither, deriving desired state entirely from the
+// EndpointSlice watch, but publishing this node's return-path gateway
+// advertisement needs to know which BGPRouter to attribute it to. NodeName
+// defaults to "", which disables that publisher rather than failing
+// validation, since most deployments do not set it.
 type VRFConfig struct {
 	v      *viper.Viper
 	prefix string
@@ -100,52 +78,38 @@ type VRFConfig struct {
 	MetricsPort         int
 	TeardownGracePeriod time.Duration
 	SweepInterval       time.Duration
-	// NodeName is this node's name, as it appears in a BGPRouter's
-	// spec.targetRef.name -- required only to enable the return-path
-	// gateway-advertisement publisher (see this type's own doc comment);
-	// "" leaves that feature disabled. Resolved from EnvVRFNodeName,
-	// falling back to the same EnvNodeNameLegacy ("NODE_NAME") downward-API
-	// convention internal/config.CNIConfig's own NodeName uses.
+	// NodeName is this node's name as it appears in a BGPRouter's target
+	// reference. It is required only to enable the gateway-advertisement
+	// publisher; "" leaves that disabled. Resolved from EnvVRFNodeName, falling
+	// back to the same downward-API variable the CNI config uses.
 	NodeName string
-	// Namespace is where this sidecar reads BGPRouter/BGPVRFInstance and
-	// writes BGPAdvertisement CRDs when the gateway-advertisement publisher
-	// is enabled -- defaults to DefaultNamespace ("galactic-system"),
-	// matching every other galactic-* binary's own default.
+	// Namespace is where this sidecar reads BGPRouter and BGPVRFInstance and
+	// writes BGPAdvertisement CRDs when the publisher is enabled. Defaults to
+	// DefaultNamespace, matching every other binary here.
 	Namespace string
-	// GatewayPrefix is a reserved IPv6 CIDR (a byte-aligned mask, e.g. a
-	// /80 or /96) this sidecar derives its own per-VPC return-path gateway
-	// address from (see internal/ingresssidecar.DeriveGatewayAddress) and
-	// assigns to the VRF-slave interface it already creates for
-	// usid_egress (see ensureEgressDatapath's own doc comment) -- closing
-	// docs/plans/855-return-path-gateway-advertisement.md's "Not
-	// implemented here" gap.
+	// GatewayPrefix is a reserved, byte-aligned IPv6 CIDR this sidecar derives
+	// its per-VPC return-path gateway address from and assigns to the VRF-slave
+	// interface it creates for usid_egress.
 	//
-	// This must be address space nothing else -- not this repo's own
-	// internal/cniipam, not whatever external system allocates a VPC's
-	// real tenant subnets -- ever hands out as a tenant pool. It is
-	// deliberately not derived from, or carved out of, any tenant VPC's
-	// own subnet: that space is owned by an allocator outside this
-	// repo's visibility (confirmed live: a real tenant address's own bit
-	// layout doesn't match this repo's own internal/cni/ipam allocator,
-	// so nothing here can prove a "reserved" sub-range of it is safe),
-	// so the only way to guarantee no collision is a prefix that's
-	// structurally disjoint from all of it, not merely improbable to
-	// collide. "" (the default) leaves gateway-address provisioning
-	// disabled entirely -- the same inert-by-default stance NodeName's own
-	// doc comment describes, and deliberately no compiled-in value: this
-	// is a real platform-addressing decision for whoever owns this
-	// deployment's IPAM plan to make explicitly, not a default to
-	// silently pick here. Only takes effect when NodeName is also set
-	// (GatewayPrefix alone would derive one, unadvertisable address, and
-	// an empty NodeName would make every replica of this sidecar collide
-	// on the identical address for a given VPC -- see
-	// DeriveGatewayAddress's own nodeID parameter).
+	// It must be address space nothing else ever hands out as a tenant pool,
+	// neither this repo's own IPAM nor whatever external system allocates a
+	// VPC's real subnets. It is deliberately not carved out of any tenant VPC's
+	// subnet: that space is owned by an allocator outside this repo's
+	// visibility, so nothing here can prove a reserved sub-range of it is safe,
+	// and only a structurally disjoint prefix guarantees no collision.
+	//
+	// "" disables gateway-address provisioning entirely, and there is
+	// deliberately no compiled-in value: this is a platform addressing decision
+	// for whoever owns the deployment's IPAM plan. It takes effect only when
+	// NodeName is also set, since a prefix alone derives one unadvertisable
+	// address, and an empty node identity makes every replica derive the same
+	// address for a given VPC.
 	GatewayPrefix string
 }
 
-// NewVRFConfig creates a config resolver with the GALACTIC_VRF env prefix
-// and AutomaticEnv enabled. Exported fields are populated from env vars and
-// defaults; call BindFlags() to layer CLI overrides.
+// NewVRFConfig creates a config resolver reading the GALACTIC_VRF environment
+// prefix. Exported fields are populated from the environment and defaults; call
+// BindFlags to layer CLI overrides.
 func NewVRFConfig() *VRFConfig {
 	v := viper.New()
 	v.SetEnvPrefix("GALACTIC_VRF")
@@ -198,10 +162,9 @@ func (c *VRFConfig) readFields() {
 
 	c.NodeName = c.v.GetString("node_name")
 	if c.NodeName == "" {
-		// Same downward-API fallback internal/config.CNIConfig's own
-		// NodeName resolution uses -- a plain os.Getenv, not viper, since
-		// EnvNodeNameLegacy ("NODE_NAME") deliberately carries no
-		// GALACTIC_VRF prefix for AutomaticEnv to match.
+		// The same downward-API fallback the CNI config uses. A plain Getenv
+		// rather than viper, since this variable carries no prefix for the
+		// automatic binding to match.
 		c.NodeName = os.Getenv(EnvNodeNameLegacy)
 	}
 	c.GatewayPrefix = c.v.GetString("gateway_prefix")

--- a/internal/controller/bgprouter_controller.go
+++ b/internal/controller/bgprouter_controller.go
@@ -33,9 +33,9 @@ import (
 // config hash across pod restarts, enabling no-op detection on reconcile.
 const annotationConfigHash = "galactic.datum.net/config-hash"
 
-// peerStatusRequeue is the interval at which the router reconciler re-checks
-// GoBGP session state. BGP FSM transitions are not Kubernetes events, so a
-// periodic requeue is required to keep BGPPeer status current.
+// peerStatusRequeue is how often the router reconciler re-checks GoBGP session
+// state. BGP state transitions are not Kubernetes events, so a periodic requeue
+// is what keeps BGPPeer status current.
 const peerStatusRequeue = 30 * time.Second
 
 // reasonAccepted is the shared condition Reason used across this
@@ -114,30 +114,27 @@ func (r *BGPRouterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("hash desired router: %w", hashErr)
 	}
 
-	// Fetch runtime status early so peer status updates happen on every
-	// reconcile, even when the config hash is unchanged.  Without this,
-	// BGP session state transitions (Idle → Established, etc.) would never
-	// be reflected in BGPPeer CR status because the no-op path returned
-	// before updatePeerStatuses was called.
+	// Fetched early so peer status updates happen on every reconcile, even when
+	// the config hash is unchanged. Otherwise session-state transitions would
+	// never reach BGPPeer status, the no-op path returning before the update
+	// runs.
 	runtimeStatus, statusErr := r.RuntimeManager.Status(ctx, req.NamespacedName)
 	if statusErr != nil {
 		logger.Error(statusErr, "get runtime status")
 	}
 
-	// Only skip Apply if the runtime is healthy, the config is unchanged, AND
-	// every desired peer is actually present in the runtime's live peer list.
-	// runtimeStatus.Healthy only reflects "is the GoBGP process up" — it says
-	// nothing about whether GoBGP still holds every desired peer. A peer can
-	// be silently dropped from GoBGP's live state (e.g. a GC cycle deletes
-	// and recreates the BGPVRFInstance/BGPAdvertisement CRs backing it, and
-	// whatever happens during that churn drops the peer) without the desired
-	// config's hash ever changing, since the recreated CRs hash identically
-	// to before. Without this check, the no-op branch below wedges
-	// permanently — Apply() (and its ListPeer/AddPeer diff) never runs again
-	// until something manually busts the config-hash annotation. If the
-	// runtime is unhealthy (e.g. after a controller restart where GoBGP was
-	// not yet running), we must also re-apply to restart GoBGP even if the
-	// desired config hash matches the annotation.
+	// Skip Apply only when the runtime is healthy, the config is unchanged, and
+	// every desired peer is actually present in the runtime's live list.
+	//
+	// Health reflects only whether the GoBGP process is up, not whether it
+	// still holds every desired peer. A peer can be dropped from live state
+	// without the desired config's hash changing, for instance when churn
+	// deletes and recreates the CRs backing it and they hash identically.
+	// Without the presence check the no-op branch wedges permanently, and Apply
+	// never runs again until something busts the hash annotation.
+	//
+	// An unhealthy runtime, such as after a restart where GoBGP is not yet
+	// running, must also re-apply even when the hash matches.
 	if router.Annotations[annotationConfigHash] == newHash && runtimeStatus.Healthy &&
 		allDesiredPeersPresent(desired.Peers, runtimeStatus) {
 		// True no-op: runtime is healthy with the current config.
@@ -247,9 +244,9 @@ func (r *BGPRouterReconciler) updateRouterStatus(router *bgpv1alpha1.BGPRouter, 
 	}
 }
 
-// updatePeerStatuses updates BGPPeer status only for peers that target this router.
-// It uses the routerRef name index for direct references and evaluates routerSelector
-// for selector-based bindings.
+// updatePeerStatuses updates BGPPeer status for the peers targeting this
+// router, resolving direct references through the name index and evaluating
+// selector-based bindings.
 func (r *BGPRouterReconciler) updatePeerStatuses(
 	ctx context.Context, router *bgpv1alpha1.BGPRouter,
 	rs model.RuntimeStatus,
@@ -295,11 +292,9 @@ func (r *BGPRouterReconciler) updatePeerStatuses(
 	}
 }
 
-// peersForRouter returns every BGPPeer that targets router, either via a
-// direct routerRef.name reference or a routerSelector matching the router's
-// own labels. Shared by updatePeerStatuses (polled every peerStatusRequeue)
-// and PeerStateEventEmitter (driven in real time by each runtime's own
-// peer-event watcher — see peer_events.go), so both resolve "which BGPPeer
+// peersForRouter returns every BGPPeer targeting router, whether by direct
+// reference or by a selector matching the router's labels. Shared by the polled
+// status update and the real-time event emitter, so both resolve "which BGPPeer
 // does this belong to" the same way.
 func peersForRouter(
 	ctx context.Context, c client.Client, router *bgpv1alpha1.BGPRouter,
@@ -457,13 +452,13 @@ func (r *BGPRouterReconciler) updateVRFInstanceStatuses(ctx context.Context, rou
 	}
 }
 
-// nptv6ConfiguredCondition validates spec (parseable CIDRs, matching prefix
-// lengths, and a supported prefix length — internal/plumbing/nptv6.Mapping's
-// own rules) and returns the ConditionNPTv6Configured condition reporting
-// the result. This reconciler has no access to the eBPF datapath's
-// nptv6_table map at all (galactic-router's DaemonSet has no /sys/fs/bpf
-// mount or CAP_BPF — see gc.SweepEBPFNPTv6Table's doc comment), so this
-// condition reflects spec validity only, never live kernel state.
+// nptv6ConfiguredCondition validates spec, checking that the CIDRs parse, that
+// the prefix lengths match, and that the length is supported, and returns the
+// condition reporting the result.
+//
+// This reconciler cannot reach the datapath's nptv6_table at all, its DaemonSet
+// having neither the bpffs mount nor CAP_BPF, so the condition reflects spec
+// validity only and never live kernel state.
 func nptv6ConfiguredCondition(spec *bgpv1alpha1.NPTv6Spec) metav1.Condition {
 	_, ula, err := net.ParseCIDR(spec.ULAPrefix)
 	if err != nil {
@@ -529,11 +524,9 @@ func (r *BGPRouterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // allDesiredPeersPresent reports whether every desired peer appears in the
-// runtime's live peer list, matched by normalized address (see normalizeIP).
-// This is what distinguishes a true no-op reconcile — config unchanged,
-// runtime healthy, AND every peer GoBGP is supposed to hold is actually
-// present — from a runtime that is nominally healthy but has silently lost
-// a peer, which must fall through to Apply() instead of being skipped.
+// runtime's live list, matched by normalized address. It is what separates a
+// true no-op reconcile from a runtime that is nominally healthy but has
+// silently lost a peer, which must fall through to Apply instead.
 func allDesiredPeersPresent(peers []model.DesiredPeer, rs model.RuntimeStatus) bool {
 	present := make(map[string]bool, len(rs.Peers))
 	for _, ps := range rs.Peers {
@@ -547,10 +540,9 @@ func allDesiredPeersPresent(peers []model.DesiredPeer, rs model.RuntimeStatus) b
 	return true
 }
 
-// normalizeIP returns the canonical text form of an IP address,
-// ensuring IPv6 addresses with leading zeros (e.g. 2607:ed40:01fb::2)
-// match their GoBGP-normalized form (2607:ed40:1fb::2). Falls back to
-// the original string if parsing fails.
+// normalizeIP returns the canonical text form of an IP address, so an IPv6
+// address written with leading zeros matches its normalized form. Falls back to
+// the original string when parsing fails.
 func normalizeIP(s string) string {
 	if ip := net.ParseIP(s); ip != nil {
 		return ip.String()

--- a/internal/controller/bgpvrfinstance_controller.go
+++ b/internal/controller/bgpvrfinstance_controller.go
@@ -26,9 +26,9 @@ type BGPVRFInstanceReconciler struct {
 
 // Reconcile enqueues the owning BGPRouter when a BGPVRFInstance changes.
 func (r *BGPVRFInstanceReconciler) Reconcile(_ context.Context, _ ctrl.Request) (ctrl.Result, error) {
-	// BGPVRFInstance changes are handled by enqueuing the owning router in
-	// SetupWithManager via EnqueueRequestsFromMapFunc. This reconciler is
-	// intentionally empty — the work is done by BGPRouterReconciler.
+	// Deliberately empty: a BGPVRFInstance change is handled by enqueuing the
+	// owning router through this reconciler's watch, and the work is done by
+	// BGPRouterReconciler.
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/gc_controller.go
+++ b/internal/controller/gc_controller.go
@@ -17,9 +17,9 @@ import (
 	"go.datum.net/galactic/internal/gc"
 )
 
-// GCReconciler runs periodic garbage collection to clean up stale BGP CRDs
-// and orphaned VRF interfaces left behind when containers are force-terminated
-// and CNI DEL never fires.
+// GCReconciler runs periodic garbage collection over the stale BGP CRDs and
+// orphaned VRF interfaces left behind when a container is force-terminated and
+// CNI DEL never fires.
 type GCReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
@@ -53,9 +53,9 @@ func (r *GCReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Resu
 	return ctrl.Result{RequeueAfter: r.Interval}, nil
 }
 
-// SetupWithManager registers the GCReconciler with the manager. The GC
-// reconciler is started by a ticker goroutine launched from root.go where
-// the manager's context is available.
+// SetupWithManager registers the reconciler with the manager. The actual pass is
+// driven by a ticker goroutine started where the manager's context is
+// available.
 func (r *GCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Interval == 0 {
 		r.Interval = 5 * time.Minute

--- a/internal/controller/indexer.go
+++ b/internal/controller/indexer.go
@@ -36,24 +36,17 @@ const (
 	BGPRouterByTargetName = ".spec.targetRef.name"
 )
 
-// RegisterIndexes registers all field indexes required by galactic-router's
-// and galactic-gateway's controllers (e.g. NetworkGatewayReconciler's own
-// BGPRouterByTargetName lookup) against mgr's cache. Each binary runs its
-// own separate manager/cache, so this must be called once per process --
-// it must be called before starting the manager.
+// RegisterIndexes registers every field index galactic-router's and
+// galactic-gateway's controllers need against mgr's cache. Each binary runs its
+// own manager and cache, so it must be called once per process, before starting
+// the manager.
 //
-// controller-runtime's cache starts a live informer for every type touched
-// by IndexField, immediately, regardless of whether any reconciler in this
-// process ever reads that type again -- calling this full function from a
-// binary whose RBAC doesn't cover every one of BGPPeer/BGPPolicy/
-// BGPAdvertisement/BGPVRFInstance/BGPRouter fails outright ("cannot list
-// resource ... at the cluster scope"), found live the first time
-// cmd/galactic-nat66 called this instead of RegisterBGPRouterTargetIndex
-// below. Only galactic-router's own manager (which already holds the full
-// BGP RBAC set) and galactic-gateway's (which inherits it via its second
-// ClusterRoleBinding onto galactic-router's ClusterRole, config/galactic-
-// gateway/rbac.yaml's own doc comment) should call this; anything narrower
-// should call one of the single-index functions below instead.
+// The cache starts a live informer for every type an index touches, immediately
+// and regardless of whether any reconciler here reads that type again. Calling
+// this from a binary whose role does not cover every BGP kind fails outright at
+// startup with a forbidden list error. Only the router's manager, which holds
+// the full BGP access, and the gateway's, which inherits it, should call this;
+// anything narrower should call one of the single-index functions below.
 func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	c := mgr.GetCache()
 
@@ -75,17 +68,13 @@ func RegisterIndexes(ctx context.Context, mgr ctrl.Manager) error {
 	return RegisterBGPRouterTargetIndex(ctx, mgr)
 }
 
-// RegisterBGPRouterTargetIndex registers only the BGPRouterByTargetName
-// index against mgr's cache -- the single index
-// NAT66ShardReconciler.applyShardAdvertisement's routerNameForNode lookup
-// actually needs (nat66shard_controller.go). Deliberately narrower than
-// RegisterIndexes: cmd/galactic-nat66's RBAC (config/galactic-nat66/rbac.yaml)
-// grants exactly nat66shards/bgpadvertisements/bgprouters, not the full BGP
-// CRD set RegisterIndexes' own doc comment explains that function requires
-// -- calling RegisterIndexes here failed live with a
-// bgppolicies-cluster-scope-forbidden error the moment the manager started
-// (its cache eagerly starts an informer for every type any IndexField call
-// touches, not just BGPRouter).
+// RegisterBGPRouterTargetIndex registers only the router-by-target index, the
+// one the shard reconciler's router lookup needs.
+//
+// Deliberately narrower than RegisterIndexes: this binary's role grants only the
+// kinds it uses, and the full function fails at manager startup with a forbidden
+// error, the cache eagerly starting an informer for every type any index
+// touches.
 func RegisterBGPRouterTargetIndex(ctx context.Context, mgr ctrl.Manager) error {
 	if err := mgr.GetCache().IndexField(
 		ctx, &bgpv1alpha1.BGPRouter{}, BGPRouterByTargetName, func(obj client.Object) []string {

--- a/internal/controller/nat66shard_controller.go
+++ b/internal/controller/nat66shard_controller.go
@@ -22,13 +22,9 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// NAT66DatapathHealth reports whether this node's NAT66 egress XDP
-// datapath (internal/plumbing/ebpf/nat66prog, loaded and attached by
-// cmd/galactic-nat66's setupNat66Datapath) is currently attached and
-// serving traffic -- the interface NAT66ShardReconciler uses to decide
-// whether to set its Ready condition True, mirroring GatewayEngine's
-// interface-seam pattern in networkgateway_controller.go for
-// test-fakeability.
+// NAT66DatapathHealth reports whether this node's NAT66 egress XDP datapath is
+// attached and serving traffic. NAT66ShardReconciler uses it to decide whether
+// to set its Ready condition, and it is an interface so tests can fake it.
 type NAT66DatapathHealth interface {
 	// Attached reports whether the datapath is loaded and attached.
 	Attached() bool
@@ -44,44 +40,29 @@ const (
 	reasonNAT66DatapathNotAttached = "DatapathNotAttached"
 )
 
-// NAT66ShardReconciler reconciles the single NAT66Shard object for this
-// node (spec.targetRef.name == NodeName), mirroring
-// NetworkGatewayReconciler's node-scoped root-object pattern -- simpler in
-// one respect (no rule/backend desired-state assembly) but, as of the
-// shard advertisement added below, no longer BGP-free: this reconciler's
-// job is to publish Status.ShardAddress/Status.ShardSID, echoing back the
-// operator-configured values this node's own cmd/galactic-nat66 process
-// was started with (ShardAddress/ShardSID below -- plain strings, not
-// re-derived from anything), set a Ready condition once the datapath is
-// confirmed attached, and -- exactly as NAT66ShardStatus.ShardSID's and
-// ShardAddress's own doc comments in datum-cloud/network already promise
-// -- create/withdraw a single /128-per-address BGPAdvertisement that
-// makes *both* actually reachable fabric-wide, the same RT-less,
-// VRFID/Function-less "plain node reachability" shape
-// NetworkGatewayReconciler.applyBGPAdvertisements uses for its own VIP
-// advertisements. Without ShardSID's route, internal/plumbing/srv6.
-// EgressDefaultRouteAdd (internal/cnibgp) would install a tenant VRF
-// default route toward a SID no node ever learns a kernel route to, so
-// no forward traffic would ever reach this shard at all; without
-// ShardAddress's route (found live, 2026-08-19 -- see this repo's own
-// docs/plans/dsr-maglev-nptv6-nat66-gateway-redesign.md for the
-// investigation), forward traffic reaches and is correctly SNATed by
-// this shard, but the reply has no route back to it from anywhere else
-// on the fabric -- a real TCP connection through NAT66 would then never
-// complete, even though every dataplane counter along the forward path
-// looks perfectly healthy.
+// NAT66ShardReconciler reconciles the single NAT66Shard object whose
+// spec.targetRef.name is this node. It publishes the shard address and SID this
+// node's datapath process was started with, echoing the operator-configured
+// values rather than deriving them, sets Ready once the datapath is confirmed
+// attached, and maintains one BGPAdvertisement carrying a /128 for each.
+//
+// That advertisement is what makes both addresses reachable across the fabric,
+// in the same route-target-less, VRFID-less shape the gateway's VIP
+// advertisements use. Without the SID's route, a tenant VRF default egress
+// route points at a SID no node ever learns a kernel route to, so no forward
+// traffic reaches this shard. Without the address's route, forward traffic
+// arrives and is correctly translated, but the reply has no route back from
+// anywhere else on the fabric, so a TCP connection never completes even while
+// every forward-path counter looks healthy.
 type NAT66ShardReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
 	NodeName string
 
-	// ShardAddress/ShardSID are this node's own operator-configured NAT66
-	// shard identity (config.NAT66Config.ShardPubAddr/ShardSID,
-	// already the values the running datapath was configured with -- see
-	// cmd/galactic-nat66's setupNat66Datapath). This reconciler publishes
-	// them, it does not compute them -- same division of responsibility
-	// as NetworkGatewayReconciler.SRv6Address/publishSelfAddress.
+	// ShardAddress and ShardSID are this node's operator-configured NAT66 shard
+	// identity, the same values the running datapath was configured with. This
+	// reconciler publishes them; it does not compute them.
 	ShardAddress string
 	ShardSID     string
 
@@ -97,16 +78,11 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	shard := &bgpv1alpha1.NAT66Shard{}
 	if err := r.Get(ctx, req.NamespacedName, shard); err != nil {
 		if apierrors.IsNotFound(err) {
-			// No finalizer on NAT66Shard (same deliberate choice
-			// NetworkGateway makes -- see that reconciler's own NotFound
-			// branch), so by the time this Get observes NotFound the object
-			// is already gone everywhere, on whichever node's process
-			// happens to handle the delete event -- not necessarily the
-			// shard's own node. Withdraw this shard's BGPAdvertisement keyed
-			// on req.Name (shardAdvertisementName is deterministic, derived
-			// from the name alone) rather than the now-unreadable deleted
-			// object, mirroring withdrawNodeAdvertisements's identical
-			// req.Name-keyed shape.
+			// NAT66Shard carries no finalizer, so by the time this Get sees
+			// NotFound the object is gone everywhere, on whichever node's
+			// process handled the event and not necessarily the shard's own.
+			// Withdraw keyed on req.Name, which the advertisement name is
+			// derived from, rather than on the unreadable deleted object.
 			if err := withdrawShardAdvertisement(ctx, r.Client, req.Namespace, req.Name); err != nil {
 				logger.Error(err, "withdraw BGPAdvertisement for deleted NAT66Shard", "nat66Shard", req.NamespacedName)
 				return ctrl.Result{}, err
@@ -123,11 +99,9 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if !shard.DeletionTimestamp.IsZero() {
-		// Not known to be reachable today -- no finalizer, so the NotFound
-		// branch above is the one that actually runs on a real delete (see
-		// its own comment) -- kept correct in case that changes later,
-		// mirroring NetworkGatewayReconciler's identical stance on its own
-		// equivalent branch.
+		// Not known to be reachable while there is no finalizer, the NotFound
+		// branch above being the one a real delete takes, but kept correct in
+		// case that changes.
 		if err := withdrawShardAdvertisement(ctx, r.Client, shard.Namespace, shard.Name); err != nil {
 			logger.Error(err, "withdraw BGPAdvertisement for terminating NAT66Shard", "nat66Shard", req.NamespacedName)
 			return ctrl.Result{}, err
@@ -158,30 +132,25 @@ func (r *NAT66ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return ctrl.Result{}, nil
 }
 
-// shardAdvertisementName derives the deterministic BGPAdvertisement name
-// for a given NAT66Shard, so withdrawal (keyed on a deletion event's
-// req.Name alone, per the NotFound branch above) never needs to read the
-// shard object it's naming. Named "-sid" from when this advertisement
-// carried only Status.ShardSID; kept unchanged now that it also carries
-// Status.ShardAddress (shardAdvertisementPrefixes, below) rather than
-// churning every existing shard's deterministic name for a cosmetic
-// rename.
+// shardAdvertisementName derives the deterministic BGPAdvertisement name for a
+// NAT66Shard, so withdrawal keyed on a deletion event's name alone never needs
+// to read the object it is naming. The "-sid" suffix predates the advertisement
+// also carrying the shard address, and is kept rather than churning every
+// existing shard's name for a cosmetic rename.
 func shardAdvertisementName(shardName string) string {
 	return shardName + "-sid"
 }
 
-// shardAdvertisementPrefixes builds the /128 prefixes
-// applyShardAdvertisement advertises for shard: Status.ShardSID (the
-// *forward*/tenant-to-shard leg -- the uSID decap SID a tenant VRF's own
-// default egress route, srv6.EgressDefaultRouteAdd, encapsulates toward)
-// and Status.ShardAddress (the *return* leg -- the shard's own public
-// address a reply's destination is rewritten to by nat66_ingress's SNAT,
-// which needs a route back from wherever that reply's next hop is, not
-// just from the shard's own node). Either may be independently unset (an
-// operator who hasn't finished configuring this node's shard identity
-// yet), in which case it's simply omitted rather than failing the whole
-// advertisement -- callers treat a fully-empty result as "nothing to
-// advertise yet," not an error.
+// shardAdvertisementPrefixes builds the /128 prefixes advertised for shard: the
+// shard SID, which is the forward leg a tenant VRF's default egress route
+// encapsulates toward, and the shard address, which is the return leg a reply's
+// destination is rewritten to and which needs a route back from wherever that
+// reply's next hop is, not just from this node.
+//
+// Either may be independently unset, by an operator who has not finished
+// configuring this node's identity, in which case it is omitted rather than
+// failing the whole advertisement. Callers treat an empty result as nothing to
+// advertise yet, not an error.
 func shardAdvertisementPrefixes(shard *bgpv1alpha1.NAT66Shard) ([]bgpv1alpha1.Prefix, error) {
 	var prefixes []bgpv1alpha1.Prefix
 	for _, raw := range []string{shard.Status.ShardSID, shard.Status.ShardAddress} {
@@ -198,17 +167,12 @@ func shardAdvertisementPrefixes(shard *bgpv1alpha1.NAT66Shard) ([]bgpv1alpha1.Pr
 }
 
 // applyShardAdvertisement reconciles this shard's single BGPAdvertisement
-// covering both Status.ShardSID and Status.ShardAddress (see
-// shardAdvertisementPrefixes) -- RT-less, VRFID/Function-less, the same
-// "plain node reachability" shape NetworkGatewayReconciler.
-// applyBGPAdvertisements uses for its own VIP advertisements, and exactly
-// what ShardSID's and ShardAddress's own doc comments in datum-cloud/
-// network already promise. A no-op, not an error, when neither is set yet
-// (an operator who hasn't configured this node's shard identity yet has
-// nothing to advertise) or when no BGPRouter targets this node yet (the
-// BGPRouter watch added in SetupWithManager retries once one appears,
-// closing the same startup-race class NetworkGatewayReconciler hit before
-// commit 782c231).
+// covering both prefixes, in the route-target-less, VRFID-less plain
+// reachability shape the gateway's VIP advertisements use.
+//
+// A no-op rather than an error when neither address is set yet, or when no
+// BGPRouter targets this node yet: the BGPRouter watch retries once one
+// appears.
 func (r *NAT66ShardReconciler) applyShardAdvertisement(ctx context.Context, shard *bgpv1alpha1.NAT66Shard) error {
 	prefixes, err := shardAdvertisementPrefixes(shard)
 	if err != nil {
@@ -260,8 +224,8 @@ func (r *NAT66ShardReconciler) applyShardAdvertisement(ctx context.Context, shar
 }
 
 // withdrawShardAdvertisement deletes the BGPAdvertisement
-// applyShardAdvertisement creates for shardName, if any. Not an error if
-// it never existed (ShardSID was never set) or is already gone.
+// applyShardAdvertisement creates for shardName, if any. One that never existed
+// or is already gone is not an error.
 func withdrawShardAdvertisement(ctx context.Context, c client.Client, namespace, shardName string) error {
 	adv := &bgpv1alpha1.BGPAdvertisement{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: shardAdvertisementName(shardName)},
@@ -273,10 +237,8 @@ func withdrawShardAdvertisement(ctx context.Context, c client.Client, namespace,
 }
 
 // readyCondition computes the Ready condition from the datapath's current
-// attachment state. A nil Datapath (not expected in production --
-// cmd/galactic-nat66 always wires a real one -- but guarded against for
-// test/defensive-programming reasons the same way GatewayEngine's own
-// callers never pass nil) is treated as not attached, not as a panic.
+// attachment state. A nil datapath, not expected in production, is treated as
+// not attached rather than a panic.
 func (r *NAT66ShardReconciler) readyCondition() metav1.Condition {
 	if r.Datapath != nil && r.Datapath.Attached() {
 		return metav1.Condition{
@@ -294,14 +256,12 @@ func (r *NAT66ShardReconciler) readyCondition() metav1.Condition {
 	}
 }
 
-// SetupWithManager registers the NAT66ShardReconciler with the manager.
+// SetupWithManager registers the reconciler with the manager.
 //
-// The BGPRouter watch below closes the same startup-race class
-// NetworkGatewayReconciler hit before commit 782c231: without it, a
-// NAT66Shard whose node's BGPRouter doesn't exist yet at first reconcile
-// would fail applyShardAdvertisement's routerNameForNode lookup once and
-// never get a second chance until some unrelated event happened to
-// trigger a fresh reconcile.
+// The BGPRouter watch closes a startup race: without it, a NAT66Shard whose
+// node's BGPRouter does not exist yet at first reconcile fails its router
+// lookup once and gets no second chance until an unrelated event triggers a
+// fresh reconcile.
 func (r *NAT66ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.NAT66Shard{}).
@@ -314,11 +274,9 @@ func (r *NAT66ShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// broadcastToShardRequests enqueues every NAT66Shard in namespace --
-// mirrors broadcastToGatewayRequests (networkgateway_controller.go) for
-// the same reason: a BGPRouter change might be the one this node's own
-// NAT66Shard was waiting on, and there is normally at most one NAT66Shard
-// per node anyway, so listing the whole namespace is cheap.
+// broadcastToShardRequests enqueues every NAT66Shard in namespace. A BGPRouter
+// change may be the one this node's shard was waiting on, and there is normally
+// at most one shard per node, so listing the namespace is cheap.
 func broadcastToShardRequests(ctx context.Context, c client.Client, namespace string) []ctrlreconcile.Request {
 	logger := log.FromContext(ctx)
 	shardList := &bgpv1alpha1.NAT66ShardList{}

--- a/internal/controller/networkgateway_controller.go
+++ b/internal/controller/networkgateway_controller.go
@@ -26,63 +26,47 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// GatewayEngine is the interface NetworkGatewayReconciler drives, satisfied
-// by *gateway.Engine in production and a fake in tests — the same
-// interface-seam pattern galacticruntime.RuntimeManager provides for
-// BGPRouterReconciler.
-//
-// Unlike an earlier, rejected design's identically-named
-// interface, there is no SetVRFLink: this engine has no kernel VRF/Geneve
-// dependency at all (design plan decision #4).
+// GatewayEngine is the interface NetworkGatewayReconciler drives, satisfied by
+// *gateway.Engine in production and a fake in tests. The engine has no kernel
+// VRF or Geneve dependency, so nothing here sets up a link.
 type GatewayEngine interface {
 	// Reconcile converges the engine's live state toward desired.
 	Reconcile(ctx context.Context, desired gateway.EngineState) (gateway.EngineStatus, error)
 
-	// DatapathGeneration returns the datapath's current generation
-	// counter. Must be captured before desired's NetworkRule CRDs are
-	// listed — see ReconcileOrphans's doc comment.
+	// DatapathGeneration returns the datapath's current generation counter. It
+	// must be captured before the NetworkRule CRDs are listed; see
+	// ReconcileOrphans.
 	DatapathGeneration() uint64
 
-	// ReconcileOrphans cleans up rule_table state left behind by a
-	// mid-reconcile crash — see gateway.Engine.ReconcileOrphans. cutoff
-	// must have been obtained from DatapathGeneration before desired's
-	// NetworkRule CRDs were listed.
+	// ReconcileOrphans removes rule_table state left behind by a mid-reconcile
+	// crash. cutoff must come from DatapathGeneration, read before desired's
+	// NetworkRule CRDs were listed, so an entry written during the listing
+	// survives.
 	ReconcileOrphans(ctx context.Context, desired gateway.EngineState, cutoff uint64) error
 
 	// Stop tears down every currently-active rule.
 	Stop(ctx context.Context) error
 }
 
-// NetworkGatewayReconciler reconciles the single NetworkGateway object for
-// this node (spec.targetRef.name == NodeName), mirroring BGPRouterReconciler's
-// "does real reconcile work" pattern — NetworkGateway is the node-scoped
-// root object, exactly like BGPRouter.
+// NetworkGatewayReconciler reconciles the single NetworkGateway object whose
+// spec.targetRef.name is this node. NetworkGateway is the node-scoped root
+// object, as BGPRouter is for the router.
 //
-// It does three things per reconcile:
+// Each pass does three things:
 //
 //  1. Assembles a gateway.EngineState from every accepted, non-deleting
-//     NetworkRule in this namespace — under DSR's anycast model (design
-//     plan §0) every gateway node in a PoP serves every accepted rule
-//     identically, with no primary/secondary distinction to gate on (an
-//     earlier, Full-NAT-era version of this reconciler excluded rules with
-//     no status.primaryNode assigned; that field and the active-passive
-//     model it implemented no longer exist) — resolving each backend's
-//     SRv6 uSID via buildBackendSIDIndex, and converges Engine toward it.
-//  2. Reconciles a BGPAdvertisement per rule per VIP address family. This
-//     reuses the BGP API's existing l2vpn/evpn Type-5 IP-Prefix
-//     advertisement path end-to-end unmodified. VRFID/Function are left
-//     unset: these advertisements need no SRv6 decap behavior of their
-//     own (deriveRD falls back to "routerID:0", a different RD per
-//     originating node — see the go/no-go anycast spike,
-//     internal/runtime/gobgp/anycast_spike_test.go — which is exactly
-//     what lets every gateway node's identical-prefix advertisement
-//     survive as an independent, non-competing route rather than one
-//     silently replacing another). No LocalPreference is set: unlike the
-//     removed Full-NAT design's primary/secondary local-pref split, every
-//     gateway node's route is equally preferred by construction — RD
-//     independence, not BGP preference, is what keeps every node's route
-//     alive over the iBGP/EVPN mesh.
-//  3. Runs Engine.ReconcileOrphans for crash recovery.
+//     NetworkRule in the namespace, resolving each backend's SRv6 uSID, and
+//     converges the engine toward it. Under the anycast model every gateway
+//     node in a PoP serves every accepted rule identically, so there is no
+//     primary or secondary node to gate on.
+//  2. Reconciles one BGPAdvertisement per rule per VIP address family, reusing
+//     the l2vpn/evpn Type-5 IP-Prefix path unmodified. VRFID and Function stay
+//     unset, since these advertisements need no SRv6 decap behavior, which
+//     gives each originating node a distinct route distinguisher. That
+//     distinctness, not BGP preference, is what keeps every node's
+//     identical-prefix advertisement alive as an independent route, so no
+//     local preference is set either.
+//  3. Runs ReconcileOrphans for crash recovery.
 type NetworkGatewayReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -96,18 +80,15 @@ const (
 	// converged and fully advertised node.
 	reasonEngineHealthy = "EngineHealthy"
 
-	// reasonAdvertisementFailed is the Ready condition reason for a node
-	// whose engine converged but which could not publish one or more of the
-	// BGPAdvertisements that make that convergence reachable — its own
-	// self-address route, or a rule's VIP route. Such a node serves
-	// nothing, so it must not report reasonEngineHealthy (#365).
+	// reasonAdvertisementFailed is the Ready reason for a node whose engine
+	// converged but which could not publish one or more of the
+	// BGPAdvertisements that make it reachable. Such a node serves nothing, so
+	// it must not report reasonEngineHealthy.
 	reasonAdvertisementFailed = "AdvertisementFailed"
 
-	// reasonTerminating is the Ready condition reason for a NetworkGateway
-	// that is being deleted, whether observed via a live object still
-	// carrying a DeletionTimestamp or reconstructed for the NotFound case
-	// where the object is already gone (see Reconcile's two
-	// withdrawNodeAdvertisements call sites).
+	// reasonTerminating is the Ready reason for a NetworkGateway being deleted,
+	// whether observed on a live object carrying a deletion timestamp or
+	// reconstructed for the case where the object is already gone.
 	reasonTerminating = "Terminating"
 )
 
@@ -118,31 +99,24 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	gw := &bgpv1alpha1.NetworkGateway{}
 	if err := r.Get(ctx, req.NamespacedName, gw); err != nil {
 		if apierrors.IsNotFound(err) {
-			// Every gateway node's process reconciles every NetworkGateway
-			// in the namespace (SetupWithManager has no predicate), so a
-			// sibling node's deletion reaches this reconciler too, and by
-			// the time we get here the deleted object can no longer be
-			// read to check whose it was. Ask instead whether *some*
-			// NetworkGateway still targets this node: if one does, this
-			// node's own object is untouched and its engine must keep
-			// running. Only stop when this node no longer has a
-			// NetworkGateway of its own -- otherwise one node's deletion
-			// tears down every other gateway node's data plane too (#364).
+			// Every gateway node's process reconciles every NetworkGateway in
+			// the namespace, so a sibling node's deletion reaches this
+			// reconciler too, and the deleted object can no longer be read to
+			// see whose it was. Ask instead whether some NetworkGateway still
+			// targets this node: if one does, this node is untouched and its
+			// engine must keep running. Stopping otherwise would let one
+			// node's deletion tear down every other gateway node's data
+			// plane.
 			//
-			// req.Name is the departed NetworkGateway's own name, which by
-			// this repo's own convention (every NetworkGateway fixture and
-			// deployment overlay) is always that node's node name -- the
-			// same identity applyBGPAdvertisements/publishSelfAddress
-			// already used to name every advertisement it created. This is
-			// the reachable path for #406: without a finalizer on
-			// NetworkGateway (there is none), this reconciler never
-			// observes a live object with a deletion timestamp for a node
-			// that has already left -- the object is simply gone by the
-			// time any process's Get runs, on whichever node's process
-			// happens to handle the event. Withdrawing here, keyed on
-			// req.Name rather than r.NodeName, is what makes that node's
-			// own advertisements go away even though its own process is
-			// the one most likely already gone.
+			// req.Name is the departed NetworkGateway's name, which by
+			// convention is that node's name, the same identity
+			// applyBGPAdvertisements names every advertisement with. NetworkGateway carries no finalizer, so this
+			// reconciler never observes a live object with a deletion
+			// timestamp for a node that has left: the object is gone by the
+			// time any Get runs. Withdrawing here, keyed on req.Name rather
+			// than r.NodeName, is what makes a departed node's
+			// advertisements go away even though its own process is the one
+			// most likely already gone.
 			withdrawErr := withdrawNodeAdvertisements(ctx, r.Client, req.Namespace, req.Name)
 			if withdrawErr != nil {
 				logger.Error(withdrawErr, "withdraw BGPAdvertisements for departed gateway node", "node", req.Name)
@@ -163,24 +137,18 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("get NetworkGateway %s: %w", req.NamespacedName, err)
 	}
 
-	// Node check: skip gateways that don't target this node, mirroring
-	// BGPRouterReconciler/internal/reconcile.Reconciler.BuildDesiredRouter's
-	// own targetRef.Name check.
+	// Skip gateways that do not target this node.
 	if gw.Spec.TargetRef.Name != r.NodeName {
 		return ctrl.Result{}, nil
 	}
 
 	if !gw.DeletionTimestamp.IsZero() {
-		// Withdrawn before Engine.Stop, not after: the reverse order would
-		// leave a window where this node's forwarding state is already
-		// gone but BGP still advertises it as a valid destination -- the
-		// exact blackhole #406 reports, just moved one step earlier
-		// instead of eliminated. This branch is not known to be reachable
-		// today (NetworkGateway carries no finalizer, so a deletion
-		// ordinarily removes the object before any Get here observes a
-		// live DeletionTimestamp -- see the NotFound branch above, which
-		// is), but it costs nothing to keep it correct in case a finalizer
-		// is added later or another controller races this Get.
+		// Withdrawn before Engine.Stop, not after: the reverse order leaves a
+		// window where this node's forwarding state is gone while BGP still
+		// advertises it as a valid destination. This branch is not known to be
+		// reachable while NetworkGateway carries no finalizer, since a
+		// deletion removes the object before any Get here sees a live deletion
+		// timestamp, but it costs nothing to keep correct.
 		withdrawErr := withdrawNodeAdvertisements(ctx, r.Client, gw.Namespace, gw.Name)
 		if withdrawErr != nil {
 			logger.Error(withdrawErr, "withdraw BGPAdvertisements for terminating NetworkGateway",
@@ -202,12 +170,10 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, withdrawErr
 	}
 
-	// Advertisement failures are collected rather than returned on the spot:
-	// the rest of the pass still runs (one bad rule must not stop the
-	// others), then they are reported on the object as
-	// reasonAdvertisementFailed and returned, so controller-runtime retries
-	// with backoff instead of leaving a node that advertised nothing
-	// claiming EngineHealthy (#365).
+	// Advertisement failures are collected rather than returned on the spot, so
+	// one bad rule does not stop the others. They are then reported on the
+	// object and returned, so controller-runtime retries with backoff instead
+	// of leaving a node that advertised nothing claiming to be healthy.
 	var advErrs []error
 
 	// Crash-safety ordering contract (see GatewayEngine.ReconcileOrphans):
@@ -239,11 +205,9 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	for i := range ruleList.Items {
 		rule := &ruleList.Items[i]
 		if !rule.DeletionTimestamp.IsZero() {
-			// Being torn down: exclude from desired state immediately so
-			// this node's rule_table state converges towards "gone"
-			// without waiting on NetworkRuleReconciler's finalizer to
-			// finish the BGP-withdrawal step first (see that reconciler's
-			// doc comment on why the two aren't cross-node-synchronized).
+			// Being torn down: excluded from desired state immediately, so
+			// this node's rule_table converges toward gone without waiting on
+			// NetworkRuleReconciler's finalizer to finish withdrawing BGP.
 			continue
 		}
 		if !meta.IsStatusConditionTrue(rule.Status.Conditions, bgpv1alpha1.ConditionTypeAccepted) {
@@ -294,10 +258,9 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		logger.Error(updateErr, "update NetworkGateway status")
 	}
 
-	// Crash recovery (see GatewayEngine.ReconcileOrphans): a failed sweep
-	// leaves orphaned rule_table state behind until some later pass
-	// succeeds, so it is returned for retry too, after the status write
-	// above so the failure is still visible on the object.
+	// Crash recovery. A failed sweep leaves orphaned rule_table state behind
+	// until a later pass succeeds, so it is returned for retry, after the
+	// status write above so the failure stays visible on the object.
 	if err := r.Engine.ReconcileOrphans(ctx, desired, cutoff); err != nil {
 		logger.Error(err, "reconcile orphaned rule_table state")
 		return ctrl.Result{}, errors.Join(advErr, fmt.Errorf("reconcile orphaned rule_table state: %w", err))
@@ -306,10 +269,10 @@ func (r *NetworkGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, advErr
 }
 
-// readyConditionFor computes the Ready condition for a completed pass:
-// engine health first, then advertisement failures — a node whose engine
-// converged but whose routes never reached BGP serves no traffic, so it
-// must not report reasonEngineHealthy (#365).
+// readyConditionFor computes the Ready condition for a completed pass: engine
+// health first, then advertisement failures. A node whose engine converged but
+// whose routes never reached BGP serves no traffic, so it must not report
+// reasonEngineHealthy.
 func readyConditionFor(status gateway.EngineStatus, advErr error) metav1.Condition {
 	switch {
 	case !status.Healthy:
@@ -331,9 +294,8 @@ func readyConditionFor(status gateway.EngineStatus, advErr error) metav1.Conditi
 }
 
 // buildDesiredRule converts rule into a gateway.DesiredRule, resolving each
-// backend's SRv6 uSID via sidIndex (design plan decision #5) — there is no
-// kernel VRF/FIB dependency here at all (decision #4), unlike an earlier,
-// rejected design's identically-named function.
+// backend's SRv6 uSID through sidIndex. There is no kernel VRF or FIB
+// dependency.
 func buildDesiredRule(
 	rule *bgpv1alpha1.NetworkRule, sidIndex *backendSIDIndex,
 ) (gateway.DesiredRule, error) {
@@ -373,19 +335,16 @@ func buildDesiredRule(
 }
 
 // routerNameForNode returns the name of the BGPRouter whose targetRef.name
-// matches this node, or "" if none exists yet. Thin wrapper around the
-// package-level routerNameForNode, kept as a method so existing call sites
-// and tests don't need to change.
+// matches this node, or "" if none exists yet. A method wrapper around the
+// package-level function of the same name.
 func (r *NetworkGatewayReconciler) routerNameForNode(ctx context.Context, namespace string) (string, error) {
 	return routerNameForNode(ctx, r.Client, namespace, r.NodeName)
 }
 
 // routerNameForNode returns the name of the BGPRouter whose targetRef.name
-// matches nodeName, or "" if none exists yet. Extracted as a free function
-// (originally a NetworkGatewayReconciler method only) so
-// NAT66ShardReconciler's own shard-SID advertisement (nat66shard_controller.go)
-// can resolve the same "which BGPRouter is mine" lookup without either
-// duplicating it or reaching into a sibling reconciler's method set.
+// matches nodeName, or "" if none exists yet. A free function so
+// NAT66ShardReconciler can resolve the same "which BGPRouter is mine" lookup
+// without duplicating it or reaching into another reconciler's method set.
 func routerNameForNode(ctx context.Context, c client.Client, namespace, nodeName string) (string, error) {
 	list := &bgpv1alpha1.BGPRouterList{}
 	if err := c.List(ctx, list,
@@ -400,31 +359,24 @@ func routerNameForNode(ctx context.Context, c client.Client, namespace, nodeName
 	return list.Items[0].Name, nil
 }
 
-// applyBGPAdvertisements reconciles the BGPAdvertisement object(s) for a
-// single rule — one per non-empty VIP address family, name-qualified by
-// r.NodeName. The node qualifier is required, not cosmetic: this reconciler
-// runs once per gateway node, and under DSR's anycast model every gateway
-// node advertises every accepted rule it holds identically (see this file's
-// package doc comment) — without the node qualifier, every gateway node in
-// a namespace would compute the exact same name for the same rule and race
-// to create/update a single shared object, the same AlreadyExists failure
-// mode the removed Full-NAT/primary-secondary design already hit live.
+// applyBGPAdvertisements reconciles the BGPAdvertisements for a single rule,
+// one per non-empty VIP address family, with names qualified by r.NodeName.
 //
-// No LocalPreference is set on these advertisements: unlike that removed
-// design (which split PrimaryLocalPref/SecondaryLocalPref to pick one
-// "best" node), every gateway node's route here is equally preferred by
-// construction — each one gets its own distinct Route Distinguisher
-// (paths.go's deriveRD, RFC 4364 §4.3.2), which is what keeps every node's
-// advertisement alive as an independent, non-competing route rather than
-// BGP collapsing them to a single best path (see the go/no-go anycast
-// spike, internal/runtime/gobgp/anycast_spike_test.go).
+// The node qualifier is required. This reconciler runs once per gateway node,
+// and under the anycast model every gateway node advertises every accepted
+// rule identically, so without it every node in a namespace would compute the
+// same name for the same rule and race to own one shared object.
 //
-// Every object created or touched here is also labeled with
-// networkRuleLabel (backfilled on existing objects too), which is what lets
-// networkrule_controller.go's teardown find every advertisement this rule
-// ever caused across every gateway node — including one for a node that
-// has since left the namespace — without depending on this naming
-// convention at all; see networkRuleLabel's doc comment.
+// No local preference is set. Every gateway node's route is equally preferred
+// by construction, because each gets its own route distinguisher, which is what
+// keeps the advertisements alive as independent routes instead of BGP
+// collapsing them to a single best path.
+//
+// Every object created or touched here is labeled with networkRuleLabel,
+// backfilled on existing objects too. That label is what lets rule teardown
+// find every advertisement a rule ever caused on any gateway node, including
+// one that has since left the namespace, without depending on this naming
+// convention.
 func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 	ctx context.Context, rule *bgpv1alpha1.NetworkRule, desired gateway.DesiredRule, routerName string,
 ) error {
@@ -444,13 +396,10 @@ func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 			continue
 		}
 		name := rule.Name + "-" + r.NodeName + "-" + g.suffix
-		// This advertisement is built as l2vpn/evpn regardless of the VIP's
-		// own IPv4/IPv6 family — see this reconciler's doc comment for why
-		// (plain ipv4/ipv6-unicast BGPAdvertisements are never actually
-		// originated by the runtime). The per-family split still matters
-		// because a single EVPN IP-Prefix route's own Prefix field is
-		// single-family (see internal/runtime/gobgp/paths.go's
-		// gatewayForPrefix), so a dual-stack rule needs two advertisements.
+		// Built as l2vpn/evpn whatever the VIP's own family, since the runtime
+		// never originates plain unicast advertisements. The per-family split
+		// still matters because one EVPN IP-Prefix route's Prefix field is
+		// single-family, so a dual-stack rule needs two advertisements.
 
 		prefixes := make([]bgpv1alpha1.Prefix, len(g.prefixes))
 		for i, p := range g.prefixes {
@@ -486,10 +435,8 @@ func (r *NetworkGatewayReconciler) applyBGPAdvertisements(
 		}
 
 		advCopy := adv.DeepCopy()
-		// Backfills networkRuleLabel on an advertisement created before this
-		// label existed, so teardown's label-selector List (see
-		// networkrule_controller.go's reconcileDelete) finds it too — self-
-		// healing, not just a create-time concern.
+		// Backfill networkRuleLabel on an advertisement created before the
+		// label existed, so teardown's label-selector list finds it too.
 		if advCopy.Labels == nil {
 			advCopy.Labels = map[string]string{}
 		}
@@ -527,23 +474,15 @@ func (r *NetworkGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return ruleToGatewayRequests(ctx, r.Client, obj)
 			}),
 		).
-		// buildBackendSIDIndex (via buildDesiredRule) resolves each rule's
-		// backend uSID from BGPRouter/BGPAdvertisement/BGPVRFInstance, but
-		// none of those were ever watched -- only NetworkRule/NetworkGateway
-		// themselves. A backend whose owning BGPAdvertisement doesn't exist
-		// yet at reconcile time (a real, observed startup race: this
-		// reconciler's own initial reconcile can run before
-		// NetworkRuleReconciler/galactic-router have created and
-		// re-reconciled it) permanently fails that rule with "no
-		// BGPAdvertisement owned by VPC ... found" -- buildDesiredRule's
-		// error is logged and the rule is skipped, not requeued, and
-		// nothing the reconciler *does* watch ever changes afterward, so
-		// the rule stays broken until something unrelated (a NetworkRule
-		// edit, a pod restart) happens to trigger another reconcile. These
-		// three watches close that gap the same way NetworkRule's own
-		// watch does: broadcast to every NetworkGateway in the namespace,
-		// since any of them could be the one whose backend resolution was
-		// waiting on this exact object.
+		// Backend uSIDs resolve from BGPRouter, BGPAdvertisement, and
+		// BGPVRFInstance, so all three must be watched. A backend whose owning
+		// BGPAdvertisement does not exist yet at reconcile time, a real
+		// startup race, fails that rule with "no BGPAdvertisement owned by VPC
+		// ... found": the error is logged and the rule skipped rather than
+		// requeued, so without these watches nothing would trigger another
+		// reconcile and the rule would stay broken until an unrelated event.
+		// Each broadcasts to every NetworkGateway in the namespace, since any
+		// of them could be the one waiting on this object.
 		Watches(&bgpv1alpha1.BGPRouter{}, handler.EnqueueRequestsFromMapFunc(
 			func(ctx context.Context, obj client.Object) []ctrlreconcile.Request {
 				return broadcastToGatewayRequests(ctx, r.Client, obj.GetNamespace(), "BGPRouter", obj.GetName())
@@ -563,13 +502,11 @@ func (r *NetworkGatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// ruleToGatewayRequests maps a NetworkRule change to every NetworkGateway
-// in its namespace. Unlike peerToRouterRequests (which targets exactly the
-// BGPPeer's own routerRef), a NetworkRule carries no gatewayRef — the
-// Active-Active BGP model means every gateway node in a rule's PoP
-// (namespace, in this containerlab-style one-PoP-per-cluster deployment)
-// must re-evaluate its own local-pref and engine state whenever any rule
-// changes, so this is an intentional broadcast rather than a missing index.
+// ruleToGatewayRequests maps a NetworkRule change to every NetworkGateway in
+// its namespace. A NetworkRule carries no gatewayRef, and under the
+// Active-Active model every gateway node in the rule's PoP must re-evaluate its
+// own engine state whenever any rule changes, so the broadcast is intentional
+// rather than a missing index.
 func ruleToGatewayRequests(ctx context.Context, c client.Client, obj client.Object) []ctrlreconcile.Request {
 	rule, ok := obj.(*bgpv1alpha1.NetworkRule)
 	if !ok {
@@ -579,10 +516,9 @@ func ruleToGatewayRequests(ctx context.Context, c client.Client, obj client.Obje
 }
 
 // broadcastToGatewayRequests lists every NetworkGateway in namespace and
-// returns a reconcile request for each — the shared primitive
-// ruleToGatewayRequests and SetupWithManager's BGPRouter/BGPAdvertisement/
-// BGPVRFInstance watches all build on. sourceKind/sourceName are for the
-// list-failure log line only.
+// returns a reconcile request for each. It is the primitive the NetworkRule,
+// BGPRouter, BGPAdvertisement, and BGPVRFInstance watches all build on.
+// sourceKind and sourceName appear only in the list-failure log line.
 func broadcastToGatewayRequests(
 	ctx context.Context, c client.Client, namespace, sourceKind, sourceName string,
 ) []ctrlreconcile.Request {
@@ -603,8 +539,7 @@ func broadcastToGatewayRequests(
 }
 
 // gatewayNodeNames returns the targetRef.name of every NetworkGateway in
-// namespace — the pool of gateway nodes for this PoP that
-// gateway.AssignPrimaryNode chooses from.
+// namespace, the pool of gateway nodes for this PoP.
 func gatewayNodeNames(ctx context.Context, c client.Client, namespace string) ([]string, error) {
 	list := &bgpv1alpha1.NetworkGatewayList{}
 	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
@@ -618,10 +553,9 @@ func gatewayNodeNames(ctx context.Context, c client.Client, namespace string) ([
 }
 
 // isGatewayNode reports whether nodeName is one of namespace's registered
-// gateway nodes. NetworkRuleReconciler uses this to scope its per-object
-// lifecycle work (finalizer, primary_node assignment) to gateway-role nodes
-// only — every other node's galactic-router process leaves NetworkRule
-// objects alone.
+// gateway nodes. NetworkRuleReconciler uses it to scope its per-object
+// lifecycle work to gateway-role nodes, so every other node's router process
+// leaves NetworkRule objects alone.
 func isGatewayNode(ctx context.Context, c client.Client, namespace, nodeName string) (bool, error) {
 	names, err := gatewayNodeNames(ctx, c, namespace)
 	if err != nil {
@@ -635,42 +569,24 @@ func isGatewayNode(ctx context.Context, c client.Client, namespace, nodeName str
 	return false, nil
 }
 
-// withdrawNodeAdvertisements deletes every BGPAdvertisement that gateway
-// node nodeName created in namespace: every per-rule, per-address-family
-// route it advertised (named "<rule>-<node>-v4"/"-v6" -- see
-// applyBGPAdvertisements). An earlier, Full-NAT-era version of this
-// function also withdrew a "<node>-selfaddr" self-address route
-// (publishSelfAddress); DSR's anycast model has no self-address to
-// publish at all (no gateway node rewrites addresses, so none needs its
-// own reachable SNAT source advertised — see this file's package doc
-// comment), so that name pattern no longer applies here.
+// withdrawNodeAdvertisements deletes every BGPAdvertisement that gateway node
+// nodeName created in namespace: each per-rule, per-address-family route it
+// advertised, found by the "<rule>-<node>-v4"/"-v6" names applyBGPAdvertisements
+// gives them.
 //
-// This is issue #367's teardown fix in reverse. That fix
-// (networkRuleLabel, networkrule_controller.go's reconcileDelete)
-// withdraws every advertisement a *rule* caused, no matter which node
-// created it, discovered by List + label selector rather than
-// reconstructed names because the namespace's *current* gateway-node
-// membership no longer includes a node that has since left. The same
-// blind spot exists here in the other direction: a rule's own
-// advertisement is name-qualified by the node that created it, but
-// nothing lists "every rule this node ever advertised" the way
-// networkRuleLabel lists "every node that ever advertised this rule" --
-// especially once the rule itself has been deleted and left no object to
-// enumerate backwards from. Selecting by NAME rather than by a new label
-// sidesteps that: it needs no rule object, live or deleted, and no label
-// backfill pass from a node that is gone by the time this runs -- the
-// exact self-healing gap issue #406's own "label backfill" note flags for
-// networkRuleLabel would otherwise repeat here for a brand new label.
+// It selects by name rather than by label, the mirror image of how rule
+// teardown works. That path lists every advertisement a rule caused, whatever
+// node made it, because the namespace's current gateway membership no longer
+// includes a node that has left. Here the gap runs the other way: nothing
+// enumerates every rule a node ever advertised, least of all once the rule
+// itself is deleted. Selecting by name needs no rule object, live or deleted,
+// and no label backfill from a node that is already gone.
 //
-// Called with the departing node's own identity, not r.NodeName: the
-// caller may be running on any surviving gateway node's process (every
-// gateway node's process reconciles every NetworkGateway in the
-// namespace, see Reconcile's NotFound branch), most likely because the
-// departing node's own process is already gone -- that is exactly why
-// its NetworkGateway object got deleted in the first place. Concurrent
-// callers across surviving nodes racing this same sweep for the same
-// departed node is expected and harmless: every delete here is
-// idempotent (not-found is not an error).
+// nodeName is the departing node's identity, not the caller's. The caller may
+// be any surviving gateway node's process, most likely because the departing
+// node's process is already gone, which is why its NetworkGateway was deleted.
+// Surviving nodes racing this same sweep is expected and harmless, since every
+// delete is idempotent.
 func withdrawNodeAdvertisements(ctx context.Context, c client.Client, namespace, nodeName string) error {
 	advList := &bgpv1alpha1.BGPAdvertisementList{}
 	if err := c.List(ctx, advList, client.InNamespace(namespace)); err != nil {

--- a/internal/controller/networkrule_controller.go
+++ b/internal/controller/networkrule_controller.go
@@ -24,55 +24,42 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// networkRuleFinalizer guards the design plan's Teardown Ordering on
-// NetworkRule deletion: BGP-route withdrawal must complete before
-// NAT/conntrack state is released — see reconcileDelete.
+// networkRuleFinalizer orders teardown on NetworkRule deletion: BGP-route
+// withdrawal must complete before NAT state is released. See reconcileDelete.
 const networkRuleFinalizer = "galactic.datum.net/networkrule-teardown"
 
-// networkRuleLabel is set to rule.Name on every BGPAdvertisement a
-// NetworkRule owns (one per gateway node per non-empty VIP address family —
-// see NetworkGatewayReconciler.applyBGPAdvertisements), so reconcileDelete
-// can discover all of them with a List + label selector instead of
-// reconstructing their names from the namespace's *current* gateway-node
-// membership. A node that was registered when the rule was created and has
-// since left would not appear in that reconstruction, leaving its
-// advertisement never found and never withdrawn — see issue #367.
+// networkRuleLabel is set to the rule's name on every BGPAdvertisement it owns,
+// one per gateway node per non-empty VIP address family, so teardown can find
+// them all with a label selector rather than reconstructing their names from the
+// namespace's current gateway-node membership. A node registered when the rule
+// was created and since departed would not appear in that reconstruction,
+// leaving its advertisement never withdrawn.
 const networkRuleLabel = "galactic.datum.net/network-rule"
 
-// NetworkRuleReconciler owns two pieces of NetworkRule per-object lifecycle
-// that NetworkGatewayReconciler's aggregate, List-driven reconcile loop is
-// the wrong place for:
+// NetworkRuleReconciler owns the per-object NetworkRule lifecycle that
+// NetworkGatewayReconciler's aggregate, list-driven loop is the wrong place
+// for: setting the Accepted condition once gateway nodes exist, and the
+// finalizer-guarded teardown ordering on deletion.
 //
-//   - primary_node assignment, exactly once, at creation (assignPrimaryNode)
-//     — guarded so a later reconcile never recomputes it (see
-//     gateway.AssignPrimaryNode's doc comment for why recomputing would
-//     cause an avoidable traffic flap).
-//   - the finalizer-guarded Teardown Ordering on deletion (reconcileDelete).
+// That is a deliberate divergence from the no-op reconcilers elsewhere here,
+// which exist only as watch sources. Those objects have no per-object lifecycle
+// state of their own, while the finalizer's ordering guarantee is inherently a
+// per-object invariant that must be enforced from that object's own Reconcile
+// rather than reconstructed from a list whenever something else changes.
 //
-// This deliberately diverges from BGPPeerReconciler's "no-op Reconcile,
-// just a watch source" pattern: BGPPeer has no per-object lifecycle state
-// of its own to own (its parent BGPRouter does all the work), but
-// primary_node's immutability guarantee and the finalizer's ordering
-// guarantee are inherently *per-NetworkRule-object* invariants that must be
-// enforced from that object's own Reconcile call, not reconstructed from a
-// List every time some other object changes.
-//
-// Both pieces are safe to run from every gateway node's galactic-router
-// process (see isGatewayNode) without leader election (none exists
-// anywhere in this codebase) because they are either idempotent (finalizer
-// add/remove, BGPAdvertisement delete) or a pure function of inputs every
-// gateway node observes identically (gateway.AssignPrimaryNode).
+// Both jobs are safe to run from every gateway node's process without leader
+// election, none existing anywhere in this codebase, because they are
+// idempotent.
 type NetworkRuleReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	NodeName string
 }
 
-// Reconcile reconciles a single NetworkRule's finalizer and primary_node
-// assignment. Engine convergence and BGPAdvertisement wiring for accepted
-// rules happen in NetworkGatewayReconciler, which watches NetworkRule and
-// re-lists on every change (see ruleToGatewayRequests) — this reconciler
-// never touches the gateway engine directly.
+// Reconcile reconciles one NetworkRule's finalizer and Accepted condition.
+// Engine convergence and advertisement wiring for accepted rules happen in
+// NetworkGatewayReconciler, which watches NetworkRule and re-lists on every
+// change, so this reconciler never touches the gateway engine.
 func (r *NetworkRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	rule := &bgpv1alpha1.NetworkRule{}
 	if err := r.Get(ctx, req.NamespacedName, rule); err != nil {
@@ -109,27 +96,14 @@ func (r *NetworkRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-// updateAcceptedCondition ensures the Accepted condition is set once
-// gateway nodes exist for this namespace. An earlier, Full-NAT-era version
-// of this method (assignPrimaryNode) also computed and pinned
-// status.primaryNode exactly once, via gateway.AssignPrimaryNode — DSR's
-// anycast model has no primary/secondary node to assign at all (every
-// gateway node serves every accepted rule identically, see
-// networkgateway_controller.go's package doc comment), so that field and
-// function no longer exist; this method keeps only the half of the old
-// logic that's still meaningful.
+// updateAcceptedCondition sets the Accepted condition once gateway nodes exist
+// for this namespace.
 //
-// This is what networkrule_webhook.go's authorize doc comment promises
-// happens here: "the Accepted condition on the NetworkRule itself is set
-// by the future NetworkRule controller once the object has passed
-// admission and been persisted" (a validating webhook can't write to the
-// status of a request it hasn't admitted yet). Without it,
-// NetworkGatewayReconciler's own Accepted gate on its rule-gathering loop
-// would exclude every rule from every gateway node's vip_table and never
-// create its BGPAdvertisement, forever — since no
-// ValidatingWebhookConfiguration is deployed in this repo to set it any
-// other way (config/webhook/ doesn't exist yet -- see the NetworkRule
-// admission webhook's own known-gap note).
+// The admission webhook cannot do it: a validating webhook cannot write to the
+// status of a request it has not yet admitted. Without this, the gate
+// NetworkGatewayReconciler applies while gathering rules would exclude every
+// rule from every gateway node and never create its advertisement, since
+// nothing else in this repo sets the condition.
 func (r *NetworkRuleReconciler) updateAcceptedCondition(ctx context.Context, rule *bgpv1alpha1.NetworkRule) error {
 	nodes, err := gatewayNodeNames(ctx, r.Client, rule.Namespace)
 	if err != nil {
@@ -138,11 +112,10 @@ func (r *NetworkRuleReconciler) updateAcceptedCondition(ctx context.Context, rul
 
 	ruleCopy := rule.DeepCopy()
 	if len(nodes) == 0 {
-		// No gateway nodes registered yet for this PoP. Surface this via
-		// the Accepted condition rather than silently doing nothing — the
-		// NetworkGateway watch (see gatewayToRuleRequests) re-queues this
-		// rule as soon as a gateway node registers, so it is not parked
-		// here until the next periodic resync.
+		// No gateway nodes registered for this PoP yet. Surfaced on the
+		// Accepted condition rather than silently skipped. The NetworkGateway
+		// watch re-queues this rule as soon as a node registers, so it is not
+		// parked here until the next periodic resync.
 		setRuleCondition(ruleCopy, metav1.Condition{
 			Type:    bgpv1alpha1.ConditionTypeAccepted,
 			Status:  metav1.ConditionFalse,
@@ -164,25 +137,21 @@ func (r *NetworkRuleReconciler) updateAcceptedCondition(ctx context.Context, rul
 	return r.Status().Update(ctx, ruleCopy)
 }
 
-// reconcileDelete performs the design plan's Teardown Ordering on
-// NetworkRule deletion:
+// reconcileDelete orders teardown on NetworkRule deletion:
 //
-//  1. Withdraw the BGP route(s) — delete this rule's BGPAdvertisement
-//     object(s) — before touching NAT/conntrack state. Removing NAT state
-//     first while the route is still advertised risks blackholing in-flight
-//     flows through a translation that no longer exists.
-//  2. Release NAT/conntrack state. STUBBED (gateway.QuotaEnforcer) — this
-//     call site is real and wired, the implementation behind it is not.
+//  1. Withdraw the BGP routes, by deleting this rule's BGPAdvertisements,
+//     before touching NAT state. Removing that state while the route is still
+//     advertised risks blackholing in-flight flows through a translation that
+//     no longer exists.
+//  2. Release NAT and conntrack state. The call site is real and wired; the
+//     implementation behind it is a no-op.
 //
-// Step 3 (rule_table row removal) is node-local and is performed
-// independently by each gateway node's own NetworkGatewayReconciler /
-// internal/gateway.Engine, which excludes a deleting rule from its desired
-// state immediately (see that reconciler's rule-gathering loop) rather than
-// waiting on this finalizer — coordinating "both gateway nodes have
-// finished their own rule_table teardown" before releasing the finalizer
-// would need a cross-node protocol the design plan does not specify, so
-// this reconciler does not attempt one; the finalizer here only orders
-// step 1 before step 2, on this reconciler's own timeline.
+// Removing the datapath's own rule rows is node-local and done independently by
+// each gateway node, which drops a deleting rule from its desired state
+// immediately rather than waiting on this finalizer. Coordinating "every
+// gateway node has finished" before releasing the finalizer would need a
+// cross-node protocol that does not exist, so this only orders step 1 before
+// step 2 on this reconciler's own timeline.
 func (r *NetworkRuleReconciler) reconcileDelete(
 	ctx context.Context, rule *bgpv1alpha1.NetworkRule,
 ) (ctrl.Result, error) {
@@ -192,11 +161,10 @@ func (r *NetworkRuleReconciler) reconcileDelete(
 		return ctrl.Result{}, nil
 	}
 
-	// Listed by networkRuleLabel rather than reconstructed from the
-	// namespace's current gateway-node membership (as a name-based lookup
-	// would have to be) — this finds every advertisement this rule ever
-	// caused to be created, including ones for a node that has since left
-	// the namespace. See networkRuleLabel's doc comment and issue #367.
+	// Listed by label rather than reconstructed from the namespace's current
+	// gateway-node membership, which a name-based lookup would need. This finds
+	// every advertisement the rule ever caused, including one for a node that
+	// has since left.
 	advList := &bgpv1alpha1.BGPAdvertisementList{}
 	if err := r.List(ctx, advList,
 		client.InNamespace(rule.Namespace),
@@ -212,10 +180,9 @@ func (r *NetworkRuleReconciler) reconcileDelete(
 		}
 	}
 
-	// TODO(edge-gateway): this calls the real, wired gateway.QuotaEnforcer
-	// interface, but with NoopQuotaEnforcer behind it — see that
-	// interface's doc comment for why real per-tenant conntrack/NAT quota
-	// release is deferred to Phase E.
+	// TODO(edge-gateway): the QuotaEnforcer interface is real and wired, but
+	// the implementation behind it here is a no-op. Real per-tenant quota
+	// release is deferred.
 	if err := (gateway.NoopQuotaEnforcer{}).Release(ctx, rule.Namespace+"/"+rule.Name); err != nil {
 		return ctrl.Result{}, fmt.Errorf("release NAT/conntrack state for NetworkRule %s/%s: %w",
 			rule.Namespace, rule.Name, err)
@@ -232,14 +199,12 @@ func (r *NetworkRuleReconciler) reconcileDelete(
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager registers the NetworkRuleReconciler with the manager.
+// SetupWithManager registers the reconciler with the manager.
 //
-// The NetworkGateway watch is the mirror image of
-// NetworkGatewayReconciler's NetworkRule watch: both of this reconciler's
-// jobs (isGatewayNode gating in Reconcile, primary-node assignment in
-// assignPrimaryNode) are functions of the namespace's gateway-node pool, so
-// a rule must be re-examined whenever that pool changes rather than waiting
-// on its own periodic resync.
+// The NetworkGateway watch is the mirror of NetworkGatewayReconciler's
+// NetworkRule watch: this reconciler's work depends on the namespace's
+// gateway-node pool, so a rule must be re-examined whenever that pool changes
+// rather than waiting on its own periodic resync.
 func (r *NetworkRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.NetworkRule{}).
@@ -253,14 +218,12 @@ func (r *NetworkRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // gatewayToRuleRequests maps a NetworkGateway change to every NetworkRule in
-// its namespace — the inverse of ruleToGatewayRequests, and a deliberate
-// broadcast for the same reason: a NetworkRule carries no gatewayRef, and
-// every rule's Accepted condition and primary-node assignment depend on the
-// namespace's whole gateway-node pool (see assignPrimaryNode). Without this,
-// a rule created before any gateway node registered stays parked at
-// Accepted=False — and therefore excluded from NetworkGatewayReconciler's
-// rule-gathering loop — until the informer's periodic resync (10 hours by
-// default).
+// its namespace, the inverse of ruleToGatewayRequests and a deliberate
+// broadcast for the same reason: a NetworkRule carries no gateway reference,
+// and its Accepted condition depends on the whole gateway-node pool. Without
+// it, a rule created before any gateway node registered stays unaccepted, and
+// so excluded from every node's rule gathering, until the informer's periodic
+// resync hours later.
 func gatewayToRuleRequests(ctx context.Context, c client.Client, obj client.Object) []ctrlreconcile.Request {
 	gw, ok := obj.(*bgpv1alpha1.NetworkGateway)
 	if !ok {

--- a/internal/controller/peer_events.go
+++ b/internal/controller/peer_events.go
@@ -18,34 +18,28 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// Event Reason values PeerStateEventEmitter raises. Exported as constants
-// (rather than inline literals) so callers — and this package's own tests —
-// have one shared spelling to filter/assert on, e.g.
-// `kubectl get events --field-selector reason=SessionDown`.
+// Event reason values this emitter raises, named so callers and tests share one
+// spelling to filter and assert on.
 const (
 	ReasonSessionEstablished = "SessionEstablished"
 	ReasonSessionDown        = "SessionDown"
 )
 
-// peerEventQueueSize bounds PeerStateEventEmitter's internal queue. It's
-// arbitrary but generous relative to how often real peer flaps happen; once
-// full, ObservePeerStateChange drops the transition (logging it) rather than
-// blocking, since it runs synchronously on the reporting runtime's own
-// peer-event watcher goroutine — see PeerStateEventEmitter's doc comment.
+// peerEventQueueSize bounds the emitter's internal queue: generous relative to
+// how often real flaps happen. Once full, an observed transition is dropped and
+// logged rather than blocking, since observation runs synchronously on the
+// reporting runtime's own watcher goroutine.
 const peerEventQueueSize = 64
 
-// PeerStateEventEmitter turns real-time BGP peer FSM transitions
-// (model.PeerStateChange, as reported by a RouterRuntime's own peer-event
-// watcher — see internal/runtime/gobgp/peer_monitor.go) into Kubernetes
-// Events on the corresponding BGPPeer object. It implements
-// model.PeerStateObserver and manager.Runnable, so the controller-runtime
-// manager owns its worker goroutine's lifecycle the same way it owns every
-// reconciler — see docs/plans/router-bgp-peer-session-events.md.
+// PeerStateEventEmitter turns real-time peer FSM transitions, as reported by a
+// runtime's own watcher, into Kubernetes events on the corresponding BGPPeer.
+// It is both an observer and a manager runnable, so the manager owns its worker
+// goroutine's lifecycle the way it owns every reconciler.
 //
-// This is deliberately independent of BGPRouterReconciler's periodic
-// (peerStatusRequeue) BGPPeer.Status update: that keeps the CRD's status
-// current on a poll; this reacts to each transition immediately, including
-// ones that revert between two polls and would otherwise leave no trace.
+// It is deliberately independent of the reconciler's periodic status update:
+// that keeps the CRD current on a poll, while this reacts to each transition
+// immediately, including ones that revert between polls and would otherwise
+// leave no trace.
 type PeerStateEventEmitter struct {
 	Client   client.Client
 	Recorder events.EventRecorder
@@ -53,9 +47,8 @@ type PeerStateEventEmitter struct {
 	queue chan model.PeerStateChange
 }
 
-// NewPeerStateEventEmitter returns a PeerStateEventEmitter ready to be
-// registered with a manager (mgr.Add) and passed to
-// gobgp.NewRuntimeFactory as a model.PeerStateObserver.
+// NewPeerStateEventEmitter returns an emitter ready to be registered with a
+// manager and passed to the runtime factory as an observer.
 func NewPeerStateEventEmitter(c client.Client, recorder events.EventRecorder) *PeerStateEventEmitter {
 	return &PeerStateEventEmitter{
 		Client:   c,
@@ -64,10 +57,9 @@ func NewPeerStateEventEmitter(c client.Client, recorder events.EventRecorder) *P
 	}
 }
 
-// ObservePeerStateChange implements model.PeerStateObserver. It must never
-// block — see the type doc comment — so it only enqueues change for Start's
-// worker loop to process, dropping (and logging) it if the queue is ever
-// full rather than stalling the calling runtime's session convergence.
+// ObservePeerStateChange enqueues change for the worker loop. It must never
+// block, so a full queue drops and logs the change rather than stalling the
+// calling runtime's session convergence.
 func (e *PeerStateEventEmitter) ObservePeerStateChange(change model.PeerStateChange) {
 	select {
 	case e.queue <- change:
@@ -117,9 +109,8 @@ func (e *PeerStateEventEmitter) emit(ctx context.Context, change model.PeerState
 		if normalizeIP(peer.Spec.Address) != normalizeIP(change.Address) {
 			continue
 		}
-		// action mirrors reason: this emitter only reports an observed
-		// transition, it doesn't itself take a distinct "action" the
-		// EventsV1 Action field would otherwise describe.
+		// The action mirrors the reason: this emitter reports an observed
+		// transition rather than taking a distinct action of its own.
 		e.Recorder.Eventf(peer, nil, eventType, reason, reason, "%s", message)
 		return
 	}
@@ -127,13 +118,12 @@ func (e *PeerStateEventEmitter) emit(ctx context.Context, change model.PeerState
 		"router", change.RouterKey, "peer", change.Address)
 }
 
-// peerStateEventDetails reports the Event fields for change, and false when
-// change isn't one of the transitions this emitter surfaces. Only crossing
-// into or out of Established is reported: every other FSM hop (Idle,
-// Connect, Active, OpenSent, OpenConfirm cycling while a session has never
-// reached Established, e.g. initial connection setup or backoff) is normal
-// and would otherwise flood `kubectl get events` for any peer that simply
-// isn't up yet.
+// peerStateEventDetails reports the event fields for change, and false when
+// change is not a transition this emitter surfaces.
+//
+// Only crossing into or out of Established is reported. Every other FSM hop
+// while a session has never come up is normal, and reporting them would flood
+// the event stream for any peer that simply is not up yet.
 func peerStateEventDetails(change model.PeerStateChange) (eventType, reason, message string, ok bool) {
 	switch {
 	case change.To == model.BGPPeerStateEstablished:

--- a/internal/controller/servicevipbinding_controller.go
+++ b/internal/controller/servicevipbinding_controller.go
@@ -24,39 +24,30 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// serviceVIPBindingFinalizer guards ServiceVIPBinding teardown: the
-// veth/tap-specific unbind (vip.Unbind, or the translation table's
-// Unregister calls) must complete before the object is actually removed
-// from etcd, mirroring networkRuleFinalizer's identical ordering purpose
-// on NetworkRule.
+// serviceVIPBindingFinalizer guards teardown: the veth or tap unbind must
+// complete before the object is removed from etcd.
 const serviceVIPBindingFinalizer = "galactic.datum.net/servicevipbinding-teardown"
 
-// ipProtoTCP/ipProtoUDP are the wire protocol numbers (IANA) matching
-// usid.c's USID_IPPROTO_TCP/USID_IPPROTO_UDP constants -- the only two
-// protocols vip_xlat_table's rewrite path ever applies to.
+// ipProtoTCP and ipProtoUDP are the IANA wire protocol numbers matching the
+// datapath's own constants, the only two protocols vip_xlat_table's rewrite
+// path applies to.
 const (
 	ipProtoTCP = uint8(6)
 	ipProtoUDP = uint8(17)
 )
 
-// vipBindFn/vipUnbindFn/vipVerifyFn are package-level overridable indirections
-// onto internal/plumbing/vip's Bind/Unbind/Verify -- the same pattern
-// internal/plumbing/ebpf/attach.go uses (routeListFn/linkByIndexFn/
-// preflightCheckFn/filterPriorityFn) so tests can exercise the
-// EgressKindVeth branch's control flow without CAP_NET_ADMIN or a real
-// netlink socket. Production code never reassigns these; vip.go itself is
-// untouched.
+// vipBindFn, vipUnbindFn, and vipVerifyFn indirect internal/plumbing/vip so
+// tests can exercise the veth branch without CAP_NET_ADMIN or a real netlink
+// socket. Production never reassigns them.
 var (
 	vipBindFn   = vip.Bind
 	vipUnbindFn = vip.Unbind
 	vipVerifyFn = vip.Verify
 )
 
-// VIPTranslationTable is the interface ServiceVIPBindingReconciler drives
-// for both EgressKindVeth and EgressKindTap bindings (see
-// registerVIPTranslation), satisfied by *vipxlatmap.VipXlatTable in
-// production and a fake in tests -- the same interface-seam pattern
-// GatewayEngine (networkgateway_controller.go) provides for *gateway.Engine.
+// VIPTranslationTable is the interface ServiceVIPBindingReconciler drives for
+// both egress kinds, satisfied by *vipxlatmap.VipXlatTable in production and a
+// fake in tests.
 type VIPTranslationTable interface {
 	RegisterIngress(block uint64, argument uint16, proto uint8,
 		vipAddr net.IP, vipPort uint16, backendAddr net.IP, backendPort uint16) error
@@ -67,56 +58,42 @@ type VIPTranslationTable interface {
 }
 
 // ServiceVIPBindingReconciler reconciles ServiceVIPBinding objects targeting
-// this node (spec.targetRef.name == NodeName) -- the backend-side half of
-// the DSR/Maglev gateway redesign (see ServiceVIPBinding's own doc
-// comment). It branches on Spec.EgressKind exactly like usid.c's own
-// vrf_table egress_kind field does, but both branches now converge on the
-// same delivery mechanism:
+// this node. It branches on Spec.EgressKind the way the datapath's vrf_table
+// egress_kind field does, but both branches converge on the same delivery
+// mechanism:
 //
-//   - EgressKindTap calls VIPTranslationTable's Register/Unregister methods
-//     (vip_xlat_table's two independent rows -- see
-//     internal/plumbing/ebpf/vipxlatmap's package doc comment), after
-//     resolving this node's own uSID Block and the tenant VRF's Argument
-//     via resolveVIPBindingContext.
-//   - EgressKindVeth does the *same* vip_xlat_table registration (see
-//     registerVIPTranslation), plus internal/plumbing/vip.Bind/Unbind/Verify.
+//   - EgressKindTap registers vip_xlat_table's two rows, after resolving this
+//     node's uSID Block and the tenant VRF's Argument.
+//   - EgressKindVeth registers the same rows, and additionally binds the VIP in
+//     the root namespace through internal/plumbing/vip.
 //
-// # Why veth needs vip_xlat_table too, not just vip.Bind
+// # Why veth needs vip_xlat_table too, not just the bind
 //
-// vip.Bind only assigns the VIP to a plain dummy interface in the node's
-// *root* network namespace -- not enslaved to any tenant VRF (see
-// internal/plumbing/vip's own doc comment). But a DSR-forwarded ingress
-// packet is decapsulated by usid_ingress and delivered into the owning
-// tenant's *own* VRF routing table, which has no route to an address that
-// only exists on a root-namespace interface outside that VRF entirely.
-// Found live in containerlab: a NetworkRule's VIP reported fully
-// Advertised/Ready, the edge datapath's own metrics showed it matching and
-// forwarding every packet with zero drops, and the connection still never
-// completed -- traced to exactly this: iad-worker's own vrf60 routing
-// table had a route for the backend pod's real address but none at all for
-// the VIP. vip_xlat_table's ingress row rewrites the packet's destination
-// from VIP to the backend's real, already-routed address *before* that VRF
-// lookup happens (usid.c's own comment on this step: "translate the inner
-// packet's destination before the FIB lookup ... so the lookup resolves
-// against the tenant's real, routed address") -- exactly the missing
-// piece, and usid_ingress applies it unconditionally whenever a matching
-// vip_xlat_table row exists, regardless of egress_kind; only the control
-// plane was ever kind-gated. vip.Bind is kept alongside it for veth (not
-// replaced): it still gives the node itself a locally-verifiable answer on
-// the VIP (see vip.Verify), which registerVIPTranslation alone would not.
+// Binding assigns the VIP to a dummy interface in the node's root namespace,
+// enslaved to no tenant VRF. A DSR-forwarded ingress packet is decapsulated and
+// delivered into the owning tenant's VRF routing table, which has no route to an
+// address that exists only outside that VRF. The symptom is a VIP that reports
+// fully advertised and ready, with the edge datapath matching and forwarding
+// every packet and no drops, while the connection never completes.
 //
-// VIPTranslationTable is nil-safe for tests that never reconcile a live
-// binding: a nil table only matters once one actually is, at which point
-// it fails with a clear, actionable error rather than a nil-pointer panic.
+// The ingress row rewrites the destination from VIP to the backend's real,
+// already-routed address before that lookup happens. usid_ingress applies it
+// whenever a matching row exists, whatever the egress kind; only the control
+// plane was ever kind-gated. The bind is kept alongside it for veth rather than
+// replaced, because it still gives the node a locally verifiable answer on the
+// VIP.
+//
+// VIPTranslationTable may be nil for tests that never reconcile a live binding.
+// A nil table matters only once one is, at which point it fails with a clear
+// error rather than a nil-pointer panic.
 type ServiceVIPBindingReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
 	NodeName string
 
-	// VIPTranslationTable is the kernel-map handle both EgressKindVeth and
-	// EgressKindTap now drive (see the type doc comment above). See its own
-	// nil-safety contract there.
+	// VIPTranslationTable is the kernel-map handle both egress kinds drive. See
+	// the type doc comment for its nil-safety contract.
 	VIPTranslationTable VIPTranslationTable
 }
 
@@ -152,11 +129,10 @@ func (r *ServiceVIPBindingReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return ctrl.Result{}, nil
 }
 
-// reconcileBind applies binding's desired bind/translation state and
-// records the outcome on Status.Conditions[Bound], mirroring
-// networkrule_controller.go's own condition-update style (status update
-// happens regardless of success/failure, and the bind/register error, if
-// any, is returned afterward so the controller-runtime requeues it).
+// reconcileBind applies binding's desired bind and translation state and records
+// the outcome on the Bound condition. The status update happens whether or not
+// the bind succeeded, and the error is returned afterward so controller-runtime
+// requeues.
 func (r *ServiceVIPBindingReconciler) reconcileBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
 	bindErr := r.applyBind(ctx, binding)
 
@@ -184,10 +160,9 @@ func (r *ServiceVIPBindingReconciler) reconcileBind(ctx context.Context, binding
 	return nil
 }
 
-// applyBind performs the actual veth or tap binding for binding, branching
-// on Spec.EgressKind. Both kinds now register the same vip_xlat_table rows
-// (see registerVIPTranslation and the type doc comment above); veth
-// additionally does the root-namespace vip.Bind/Verify.
+// applyBind performs the veth or tap binding for binding, branching on
+// Spec.EgressKind. Both kinds register the same vip_xlat_table rows; veth
+// additionally binds and verifies the VIP in the root namespace.
 func (r *ServiceVIPBindingReconciler) applyBind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
 	switch binding.Spec.EgressKind {
 	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
@@ -209,11 +184,9 @@ func (r *ServiceVIPBindingReconciler) applyBind(ctx context.Context, binding *bg
 	}
 }
 
-// registerVIPTranslation registers both vip_xlat_table rows (ingress and
-// egress) for binding, after resolving this node's own uSID Block and the
-// owning tenant VRF's Argument (resolveVIPBindingContext). Shared by both
-// EgressKindVeth and EgressKindTap -- see ServiceVIPBindingReconciler's own
-// doc comment for why veth needs this too, not just tap.
+// registerVIPTranslation registers both vip_xlat_table rows for binding, after
+// resolving this node's uSID Block and the owning tenant VRF's Argument. Shared
+// by both egress kinds; see the type doc comment for why veth needs it too.
 func (r *ServiceVIPBindingReconciler) registerVIPTranslation(
 	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
 ) error {
@@ -260,12 +233,9 @@ func (r *ServiceVIPBindingReconciler) registerVIPTranslation(
 	return nil
 }
 
-// reconcileDelete performs the finalizer-guarded unbind/unregister on
-// ServiceVIPBinding deletion, mirroring networkrule_controller.go's
-// reconcileDelete pattern: the finalizer is only removed once the
-// underlying unbind/unregister has actually succeeded, so a failure here
-// blocks deletion (and is retried) rather than silently leaking kernel/host
-// state.
+// reconcileDelete performs the finalizer-guarded unbind on deletion. The
+// finalizer is removed only once the unbind has succeeded, so a failure blocks
+// deletion and is retried rather than silently leaking kernel state.
 func (r *ServiceVIPBindingReconciler) reconcileDelete(
 	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
 ) (ctrl.Result, error) {
@@ -286,13 +256,11 @@ func (r *ServiceVIPBindingReconciler) reconcileDelete(
 	return ctrl.Result{}, nil
 }
 
-// applyUnbind performs the actual veth or tap unbind for binding, branching
-// on Spec.EgressKind. Both kinds now unregister the same vip_xlat_table
-// rows (see unregisterVIPTranslation); veth additionally does the
-// root-namespace vip.Unbind. For veth, both are attempted even if one
-// fails, and any errors are joined -- mirroring unregisterVIPTranslation's
-// own "attempt every candidate even if one fails" convention -- so a
-// failure in one mechanism never silently skips tearing down the other.
+// applyUnbind performs the veth or tap unbind for binding, branching on
+// Spec.EgressKind. Both kinds unregister the same vip_xlat_table rows; veth
+// additionally unbinds in the root namespace. For veth both are attempted even
+// if one fails, and the errors are joined, so a failure in one never skips
+// tearing down the other.
 func (r *ServiceVIPBindingReconciler) applyUnbind(ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding) error {
 	switch binding.Spec.EgressKind {
 	case bgpv1alpha1.ServiceVIPBindingEgressKindVeth:
@@ -313,14 +281,10 @@ func (r *ServiceVIPBindingReconciler) applyUnbind(ctx context.Context, binding *
 	}
 }
 
-// unregisterVIPTranslation removes both vip_xlat_table rows for binding.
-// Shared by both EgressKindVeth and EgressKindTap -- see
-// ServiceVIPBindingReconciler's own doc comment. Both directions are
-// attempted even if resolving the VRF context or the first Unregister call
-// fails, and any errors are joined together -- mirroring
-// usidmap.VRFTable.Reconcile's own "attempt every candidate even if one
-// fails" convention -- so a partial failure never silently leaves the
-// other row behind unregistered.
+// unregisterVIPTranslation removes both vip_xlat_table rows for binding. Shared
+// by both egress kinds. Both directions are attempted even if resolving the VRF
+// context or the first removal fails, and the errors are joined, so a partial
+// failure never leaves the other row behind.
 func (r *ServiceVIPBindingReconciler) unregisterVIPTranslation(
 	ctx context.Context, binding *bgpv1alpha1.ServiceVIPBinding,
 ) error {
@@ -371,47 +335,31 @@ func ipProtocolNumber(proto bgpv1alpha1.NetworkRuleProtocol) (uint8, error) {
 	}
 }
 
-// resolveVIPBindingContext resolves this node's own uSID Block (from its
-// BGPRouter's SRv6Locator) and the owning tenant VRF's Argument (from the
-// BGPVRFInstance whose VRFID is associated with a BGPAdvertisement whose
-// advertised prefix contains backendAddr) -- the (block, argument) pair
-// vip_xlat_table's key needs (usid.c's struct vip_xlat_key), for a
-// tap-kind ServiceVIPBinding on this node.
+// resolveVIPBindingContext resolves the (block, argument) pair vip_xlat_table's
+// key needs for a binding on this node: the Block from this node's BGPRouter
+// locator, and the Argument from the BGPVRFInstance whose advertised prefix
+// contains backendAddr.
 //
-// # A documented ambiguity (no VPCRef/VRFRef field on ServiceVIPBinding)
+// # A documented ambiguity
 //
-// ServiceVIPBinding carries no VPCRef or VRFRef field of its own (see its
-// own doc comment and internal/controller/usidresolver.go's identical
-// concern for NetworkRule backends) -- the writer that is expected to
-// eventually populate ServiceVIPBinding objects (a future extension of
-// NetworkRuleReconciler, out of this reconciler's scope) has direct access
-// to the owning NetworkRule's VPCRef at creation time, but that identity is
-// not carried onto the ServiceVIPBinding object itself today. Absent that
-// field, this function resolves ownership the same way
-// usidresolver.go's backendSIDIndex already does for NetworkRule backends:
-// by matching BackendAddress against this node's own BGPVRFInstances'
-// advertised prefixes (reusing buildBackendSIDIndex directly rather than
-// re-listing the same CRDs) -- restricted to VRFs whose BGPVRFInstance
-// actually targets *this node's* own BGPRouter, since a tap binding's VRF
-// context is always local to the node it was written for.
+// ServiceVIPBinding carries no VPC or VRF reference of its own. The writer that
+// creates these objects has the owning rule's VPC reference at creation time,
+// but does not record it here. Absent that field, ownership is resolved by
+// matching backendAddr against the advertised prefixes of BGPVRFInstances
+// targeting this node's own BGPRouter, since a binding's VRF context is always
+// local to the node it was written for.
 //
-// This resolution is unambiguous as long as no two VRFs on this same node
-// advertise overlapping prefixes that both contain backendAddr (e.g. two
-// tenants independently choosing the same ULA range) -- exactly the
-// scenario backendSIDIndex.verifyTenantOwnership already exists to guard
-// against elsewhere, but that guard needs a known vpcRef to check
-// ownership *against*, which this function does not have. When more than
-// one candidate VRF matches, this function fails closed (an explicit
-// error) rather than guessing, on the same reasoning
-// verifyTenantOwnership's own doc comment gives: silently picking one
-// candidate over another risks translating a backend's traffic into the
-// wrong tenant's VRF, not merely an inconvenience.
+// That is unambiguous only while no two VRFs on this node advertise overlapping
+// prefixes containing backendAddr, such as two tenants choosing the same ULA
+// range. The ownership guard used elsewhere needs a known VPC reference to check
+// against, which this function does not have, so when more than one candidate
+// matches it fails with an explicit error rather than guessing: picking one
+// would translate a backend's traffic into the wrong tenant's VRF.
 //
-// TODO(dsr-maglev): once ServiceVIPBinding gains a VPCRef/VRFRef field (or
-// the writer encodes the resolved (block, argument) directly on the
-// object), replace this address-containment heuristic with a direct
-// lookup -- see crdnames.BGPVRFInstanceName(vpc, nodeName) for the
-// deterministic name that lookup would use.
+// TODO(dsr-maglev): once ServiceVIPBinding carries a VPC or VRF reference, or
+// the writer records the resolved (block, argument) on the object, replace this
+// address-containment heuristic with a direct lookup by
+// crdnames.BGPVRFInstanceName.
 func resolveVIPBindingContext(
 	ctx context.Context, c client.Client, namespace, nodeName string, backendAddr netip.Addr,
 ) (block uint64, argument uint16, err error) {
@@ -492,10 +440,9 @@ func resolveVIPBindingContext(
 	}
 }
 
-// vrfInstanceTargetsRouter reports whether vrf's RouterTarget (RouterRef or
-// RouterSelector) resolves to router -- mirroring routing.go's
-// enqueueRoutersForTarget matching logic, but as a boolean test against one
-// already-known router rather than a List-driven fan-out.
+// vrfInstanceTargetsRouter reports whether vrf's router target, by reference or
+// selector, resolves to router. The same matching the watch fan-out does, as a
+// boolean test against one known router rather than a list.
 func vrfInstanceTargetsRouter(vrf *bgpv1alpha1.BGPVRFInstance, router *bgpv1alpha1.BGPRouter) bool {
 	if vrf.Spec.RouterRef != nil {
 		return vrf.Spec.RouterRef.Name == router.Name
@@ -513,11 +460,9 @@ func vrfInstanceTargetsRouter(vrf *bgpv1alpha1.BGPVRFInstance, router *bgpv1alph
 	return false
 }
 
-// SetupWithManager registers the ServiceVIPBindingReconciler with the
-// manager. ServiceVIPBinding is a leaf CRD written by another controller
-// and consumed only here -- no additional watch is needed beyond the
-// object itself, unlike NetworkRuleReconciler's NetworkGateway watch
-// (which reacts to a namespace-wide gateway-node pool changing).
+// SetupWithManager registers the reconciler with the manager. ServiceVIPBinding
+// is a leaf CRD written outside this repo and consumed only here, so no watch
+// beyond the object itself is needed.
 func (r *ServiceVIPBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bgpv1alpha1.ServiceVIPBinding{}).

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -36,11 +36,9 @@ func setRouterCondition(router *bgpv1alpha1.BGPRouter, condition metav1.Conditio
 	meta.SetStatusCondition(&router.Status.Conditions, condition)
 }
 
-// setPeerReadyCondition updates the Ready condition based on the current BGP
-// FSM state, following the same semantics as the reference implementation in
-// the BGP API (BGPPeerStatus.updatePeerConditions). Ready is True only when
-// sessionState == Established; False otherwise with Reason set to the FSM
-// state (for Idle, the idleReason argument is used).
+// setPeerReadyCondition updates the Ready condition from the current FSM state.
+// Ready is true only when the session is Established, and false otherwise with
+// the reason set to the FSM state; for Idle, idleReason is used instead.
 func setPeerReadyCondition(peer *bgpv1alpha1.BGPPeer, state bgpv1alpha1.BGPPeerState, idleReason string) {
 	peer.Status.SessionState = state
 	peer.Status.ObservedGeneration = peer.Generation
@@ -102,49 +100,40 @@ func setVRFInstanceCondition(vrf *bgpv1alpha1.BGPVRFInstance, condition metav1.C
 	meta.SetStatusCondition(&vrf.Status.Conditions, condition)
 }
 
-// ConditionNPTv6Configured reports whether a BGPVRFInstance's own
-// Spec.NPTv6 field (when set) parses into a valid RFC 6296 mapping —
-// locally defined here (rather than added to the network module's own
-// vrf_types.go, which this workstream does not own) since generic
-// Conditions is exactly the extension point BGPVRFInstanceStatus already
-// exposes for this. It reflects config validity only, not live eBPF
-// datapath state: the process that actually registers/reconciles
-// nptv6_table entries (gc.SweepEBPFNPTv6Table, run from
-// internal/installer.Run inside the CNI "run" container) has no access
-// back to this CRD's status from there — see that function's own doc
-// comment for why eBPF map access is confined to that container.
+// ConditionNPTv6Configured reports whether a BGPVRFInstance's NPTv6 field, when
+// set, parses into a valid mapping. It is defined here rather than in the API
+// module this workstream does not own, generic conditions being exactly the
+// extension point the status already exposes.
+//
+// It reflects config validity only, never live datapath state: the process that
+// registers those map entries runs in a different container with no access back
+// to this CRD's status.
 const ConditionNPTv6Configured = "NPTv6Configured"
 
-// setGatewayCondition sets or updates a condition on NetworkGateway.
-// ConditionTypeReady (reused from peer_types.go, not redeclared) is the
-// only condition type NetworkGateway currently uses.
+// setGatewayCondition sets or updates a condition on a NetworkGateway. Ready is
+// the only type it currently uses.
 func setGatewayCondition(gw *bgpv1alpha1.NetworkGateway, condition metav1.Condition) {
 	condition.ObservedGeneration = gw.Generation
 	meta.SetStatusCondition(&gw.Status.Conditions, condition)
 }
 
-// setBindingCondition sets or updates a condition on ServiceVIPBinding.
-// bgpv1alpha1.ConditionTypeBound (vipbinding_types.go) is the only
-// condition type ServiceVIPBinding uses.
+// setBindingCondition sets or updates a condition on a ServiceVIPBinding. Bound
+// is the only type it uses.
 func setBindingCondition(binding *bgpv1alpha1.ServiceVIPBinding, condition metav1.Condition) {
 	condition.ObservedGeneration = binding.Generation
 	meta.SetStatusCondition(&binding.Status.Conditions, condition)
 }
 
-// setRuleCondition sets or updates a condition on NetworkRule.
-// ConditionTypeReady and ConditionTypeAccepted (both reused from
-// peer_types.go) are the condition types NetworkRule uses — Accepted per
-// the admission-webhook ownership check (internal/webhook), Ready per the
-// engine's own convergence result for that rule.
+// setRuleCondition sets or updates a condition on a NetworkRule. It uses two
+// types: Accepted, from the admission ownership check, and Ready, from the
+// engine's convergence result for that rule.
 func setRuleCondition(rule *bgpv1alpha1.NetworkRule, condition metav1.Condition) {
 	condition.ObservedGeneration = rule.Generation
 	meta.SetStatusCondition(&rule.Status.Conditions, condition)
 }
 
-// setNAT66ShardCondition sets or updates a condition on NAT66Shard.
-// ConditionTypeReady (reused from peer_types.go, not redeclared) is the
-// only condition type NAT66Shard currently uses — mirrors
-// setGatewayCondition's identical shape for NetworkGateway.
+// setNAT66ShardCondition sets or updates a condition on a NAT66Shard. Ready is
+// the only type it currently uses.
 func setNAT66ShardCondition(shard *bgpv1alpha1.NAT66Shard, condition metav1.Condition) {
 	condition.ObservedGeneration = shard.Generation
 	meta.SetStatusCondition(&shard.Status.Conditions, condition)

--- a/internal/controller/usidresolver.go
+++ b/internal/controller/usidresolver.go
@@ -16,45 +16,28 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// backendSIDIndex resolves a NetworkRule backend's address to the SRv6 uSID
-// of the worker node it is reachable through, by listing BGPAdvertisement,
-// BGPRouter, and BGPVRFInstance CRDs directly and matching by prefix
-// containment — then confirming tenant ownership of the match (see
-// verifyTenantOwnership) before trusting it.
+// backendSIDIndex resolves a NetworkRule backend's address to the SRv6 uSID of
+// the worker node it is reachable through, by listing BGPAdvertisement,
+// BGPRouter, and BGPVRFInstance CRDs and matching by prefix containment, then
+// confirming tenant ownership of the match before trusting it.
 //
-// This is a genuinely new problem an earlier, rejected design never
-// had to solve: that design tunneled every rule's traffic to a static
-// per-tenant Geneve peer, so it never needed to know which worker node any
-// individual backend Pod actually lived on. This design pushes an SRv6
-// outer header addressed to that worker node directly (design plan
-// decision #5), so it must resolve one.
-//
-// There is no exported "IP -> uSID" query anywhere in this codebase today
-// (internal/runtime/gobgp/monitor.go decodes EVPN Prefix-SID attributes
-// purely internally, only to drive local kernel route installation).
-// Rather than embed a second GoBGP speaker or add one, this mirrors
-// internal/reconcile/reconcile.go's resolveSRv6SID: combine a matching
-// BGPAdvertisement's VRFID/Function with its BGPRouter's SRv6Locator/NodeID
-// via srv6.ComputeSID. internal/cnibgp/bgp.go's buildAdvertisementSpec is
-// the producer side of that same data — one BGPAdvertisement per VPC
-// attachment's pod subnet(s), VRFID/Function always set — so every backend
-// Pod address a NetworkRule could plausibly name is covered by exactly the
-// same CRDs this reads.
+// No exported "address to uSID" query exists in this codebase: the router
+// decodes EVPN attributes internally, only to drive local route installation.
+// Rather than add a second BGP speaker, this mirrors the reconciler's own SID
+// resolution, combining a matching advertisement's VRFID and function with its
+// router's locator and node ID. The CNI publish path is the producer side of
+// exactly that data, one advertisement per attachment's pod subnets with both
+// fields always set, so every backend address a rule could name is covered by
+// the same CRDs.
 //
 // Tenant ownership, not address containment alone, is what makes a match
-// trustworthy: BGPAdvertisement carries no VPCRef field of its own to
-// disambiguate against, so two tenants advertising overlapping (e.g.
-// colliding ULA) address space would otherwise resolve to whichever
-// advertisement the list happened to return first — silently routing a
-// packet into the wrong tenant's VRF, not just an ambiguous-but-harmless
-// pick. verifyTenantOwnership closes this the same way NPTv6 and the NAT66
-// shard tier resolve tenant identity elsewhere in this design: from VRF
-// context, never from the address alone. It costs no new CRD field —
-// crdnames.BGPVRFInstanceName(vpc, nodeName) is already the deterministic
-// name galactic-bgp writes a tenant's own BGPVRFInstance under (see
-// internal/cnibgp/bgp.go), so a candidate match's (router, VRFID) pair can
-// be cross-checked directly against the one BGPVRFInstance the calling
-// NetworkRule's own VPCRef actually owns on that router's node.
+// trustworthy. BGPAdvertisement carries no tenant reference of its own, so two
+// tenants advertising overlapping address space would otherwise resolve to
+// whichever advertisement the list returned first, routing a packet into the
+// wrong tenant's VRF rather than merely picking ambiguously. The check costs no
+// new CRD field: a tenant's BGPVRFInstance already has a deterministic name, so
+// a candidate's (router, VRFID) pair can be cross-checked against the one
+// instance the calling rule's tenant owns on that router's node.
 type backendSIDIndex struct {
 	routers      map[string]*bgpv1alpha1.BGPRouter
 	advs         []*bgpv1alpha1.BGPAdvertisement
@@ -62,12 +45,11 @@ type backendSIDIndex struct {
 }
 
 // buildBackendSIDIndex lists every BGPRouter, BGPAdvertisement, and
-// BGPVRFInstance in namespace once, so resolving N backends across a
-// reconcile costs one triple of List calls rather than N. Advertisements
-// with no VRFID/Function set are excluded up front — those carry no SRv6
-// decap behavior of their own (see NetworkGatewayReconciler's own
-// VIP-preference advertisements, which are exactly that shape) and can
-// never be a backend's location.
+// BGPVRFInstance in namespace once, so resolving many backends across a
+// reconcile costs one set of list calls rather than one per backend.
+//
+// Advertisements with no VRFID or function set are excluded up front: those
+// carry no SRv6 decap behavior and can never be a backend's location.
 func buildBackendSIDIndex(ctx context.Context, c client.Client, namespace string) (*backendSIDIndex, error) {
 	routerList := &bgpv1alpha1.BGPRouterList{}
 	if err := c.List(ctx, routerList, client.InNamespace(namespace)); err != nil {
@@ -102,31 +84,27 @@ func buildBackendSIDIndex(ctx context.Context, c client.Client, namespace string
 	return &backendSIDIndex{routers: routers, advs: advs, vrfInstances: vrfInstances}, nil
 }
 
-// verifyTenantOwnership reports whether adv (matched against addr by prefix
-// containment) actually belongs to vpcRef on router's own node, rather than
-// to some other tenant whose advertised prefix happens to contain addr too.
+// verifyTenantOwnership reports whether adv, matched against an address by
+// prefix containment, actually belongs to vpcRef on router's node rather than
+// to another tenant whose advertised prefix happens to contain that address
+// too.
 //
-// galactic-bgp names a tenant's BGPVRFInstance deterministically —
-// crdnames.BGPVRFInstanceName(vpc, nodeName) — and that VRFID is what a
-// BGPAdvertisement's own VRFID must equal for the advertisement to have
-// been originated on vpcRef's behalf on this node. A mismatch (or a
-// missing BGPVRFInstance altogether) means adv belongs to a different
-// tenant that happens to share router's node and, for a colliding-ULA
-// backend address, possibly the same prefix — fail closed rather than
-// trust it.
+// A tenant's BGPVRFInstance is named deterministically, and its VRFID is what
+// an advertisement's VRFID must equal for that advertisement to have been
+// originated on the tenant's behalf on this node. A mismatch, or a missing
+// instance, means the advertisement belongs to a different tenant sharing the
+// node and possibly the prefix, so this fails closed.
 func (idx *backendSIDIndex) verifyTenantOwnership(vpcRef string, router *bgpv1alpha1.BGPRouter, vrfID int32) bool {
 	vrfName := crdnames.BGPVRFInstanceName(vpcRef, router.Spec.TargetRef.Name)
 	vrf, ok := idx.vrfInstances[vrfName]
 	return ok && vrf.Spec.VRFID == vrfID
 }
 
-// resolveUSID returns the SRv6 uSID of the worker node addr (a backend
-// Pod's address, belonging to vpcRef) is reachable through, per the
-// matching strategy documented on backendSIDIndex. vpcRef scopes the match
-// to advertisements this specific tenant's own BGPVRFInstance actually
-// owns (verifyTenantOwnership) — a prefix-containment hit alone is never
-// sufficient, so two tenants with colliding backend address space can
-// never resolve into each other's VRF.
+// resolveUSID returns the SRv6 uSID of the worker node the backend address addr,
+// belonging to vpcRef, is reachable through. vpcRef scopes the match to
+// advertisements that tenant's own BGPVRFInstance owns: a prefix-containment hit
+// alone is never sufficient, so two tenants with colliding address space cannot
+// resolve into each other's VRF.
 func (idx *backendSIDIndex) resolveUSID(addr netip.Addr, vpcRef string) (netip.Addr, error) {
 	for _, adv := range idx.advs {
 		router, ok := idx.routers[adv.Spec.RouterRef.Name]

--- a/internal/crdnames/crdnames.go
+++ b/internal/crdnames/crdnames.go
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package crdnames is the shared vocabulary for naming and annotating the
-// BGPVRFInstance/BGPAdvertisement CRDs a VPC attachment's chain of plugins
+// BGPVRFInstance and BGPAdvertisement CRDs a VPC attachment's chain of plugins
 // cooperate on: galactic-bgp writes them, galactic-ipam's deallocation path
-// (until its own local marker-file persistence lands) reads the subnet
-// annotations back, and galactic-router's GC controller reads the netns
-// annotation to decide liveness. Kept as one small leaf package — imported
-// by internal/cni, internal/cnitap, internal/cniipam, and internal/cnibgp —
-// so none of those need to import each other just to agree on a name.
+// reads the subnet annotations back, and galactic-router's GC reads the netns
+// annotation to decide liveness. It is a leaf package so none of those need to
+// import each other just to agree on a name.
 package crdnames
 
 import (
@@ -22,95 +20,80 @@ import (
 )
 
 // AnnotationAllocatedSubnetIPv6 is the BGPAdvertisement annotation key prefix
-// holding the allocated IPv6 pod subnet CIDR (the /96) for a container ID.
-// The full key appends a truncated container ID; see SubnetKeyIPv6.
+// holding a container's allocated IPv6 pod subnet CIDR. The full key appends a
+// truncated container ID; see SubnetKeyIPv6.
 const AnnotationAllocatedSubnetIPv6 = "galactic.datum.net/allocated-subnet-ipv6"
 
 // AnnotationAllocatedSubnetIPv4 is the BGPAdvertisement annotation key prefix
-// holding the allocated IPv4 pod address (the /32) for a container ID, when
-// the attachment is dual-stack. The full key appends a truncated container
-// ID; see SubnetKeyIPv4.
+// holding a container's allocated IPv4 pod address, when the attachment is
+// dual-stack. The full key appends a truncated container ID; see
+// SubnetKeyIPv4.
 const AnnotationAllocatedSubnetIPv4 = "galactic.datum.net/allocated-subnet-ipv4"
 
-// AnnotationNetNS is the BGPAdvertisement annotation key prefix holding the
-// CNI-provided network namespace path for a container ID. The GC controller
-// checks whether this exact path still exists to decide if the container is
-// still live — it cannot reconstruct the path from the container ID alone,
-// since netns bind-mounts are named by the runtime's own convention (e.g.
-// containerd's "cni-<uuid>"), which is unrelated to the container ID. The
-// full key appends a truncated container ID; see NetNSKey.
+// AnnotationNetNS is the BGPAdvertisement annotation key prefix holding a
+// container's CNI-provided network namespace path. GC checks whether that exact
+// path still exists to decide whether the container is live, and cannot
+// reconstruct it from the container ID, since netns bind mounts are named by
+// the runtime's own convention. The full key appends a truncated container ID;
+// see NetNSKey.
 const AnnotationNetNS = "galactic.datum.net/netns"
 
-// AnnotationIngressHostIfindex and AnnotationIngressHostMAC are the
-// BGPAdvertisement annotations the ingress sidecar records the two facts
-// about its own pod that the host side of its return path needs, and that
-// only the sidecar can read.
+// AnnotationIngressHostIfindex and AnnotationIngressHostMAC carry the two facts
+// about an ingress sidecar's own pod that the host side of its return path
+// needs, and that only the sidecar can read.
 //
-// A reply for a sidecar gateway address has to be redirected into the pod
-// that holds it, which means the host needs the ifindex of the host-side
-// end of that pod's netns-crossing veth, and the pod-side MAC to address
-// the frame to. Both are trivially readable from inside the pod (the
-// primary interface's peer index and its own hardware address) and not
-// readable from outside it without entering the namespace, which needs
-// CAP_SYS_ADMIN -- a privilege the node agent deliberately does not carry
-// (its container drops ALL and adds only BPF, NET_ADMIN and NET_RAW).
+// A reply for a sidecar gateway address must be redirected into the pod holding
+// it, so the host needs the ifindex of the host-side end of that pod's veth and
+// the pod-side MAC to address the frame to. Both are trivial to read from
+// inside the pod and unreadable from outside without entering the namespace,
+// which needs CAP_SYS_ADMIN, a privilege the node agent deliberately does not
+// carry.
 //
-// So the side that can see them publishes them, rather than the side that
-// cannot being given the privilege to go and look. Recorded on the
-// advertisement the sidecar already creates for this address, keyed the
-// same way, so there is one object describing one return path.
+// The side that can see them publishes them, on the advertisement the sidecar
+// already creates for this address, so one object describes one return path.
 const (
 	AnnotationIngressHostIfindex = "galactic.datum.net/ingress-host-ifindex"
 	AnnotationIngressHostMAC     = "galactic.datum.net/ingress-host-mac"
 )
 
-// AnnotationNoAddressing marks a BGPAdvertisement whose spec.prefixes is
-// empty by design — the attachment's config carries no "ipam" block, so no
-// address was ever requested for it (a VM managing its own addressing is a
-// supported case; see internal/cnitap). Unlike the annotations above, this
-// one is not keyed per container ID: every container attaching under the
-// same VPCAttachment shares the same master-plugin config, so they always
-// agree on whether addressing was requested, and the value only needs to
-// reflect the most recent ADD.
+// AnnotationNoAddressing marks a BGPAdvertisement whose spec.prefixes is empty
+// by design, because the attachment's config carries no "ipam" block and no
+// address was ever requested. A VM managing its own addressing is a supported
+// case.
 //
-// Without this, an empty spec.prefixes cannot be told apart from one whose
-// addressing silently failed to arrive (#342) — the same failure #327 closed
-// for the case where a stale config caused it. Set to
-// AnnotationNoAddressingValue whenever publishBGPState runs with a nil
-// *cniipam.IPAMResult, cleared otherwise.
+// Without it, an empty spec.prefixes is indistinguishable from addressing that
+// failed to arrive. Set to AnnotationNoAddressingValue whenever the publish
+// path runs with no IPAM result, cleared otherwise.
+//
+// Not keyed per container ID, unlike the annotations above: every container
+// under one VPCAttachment shares the master plugin's config, so they always
+// agree on whether addressing was requested.
 const AnnotationNoAddressing = "galactic.datum.net/no-addressing"
 
-// AnnotationNoAddressingValue is the only value AnnotationNoAddressing is
-// ever set to — a named constant instead of a literal "true" purely so
-// callers and tests share one spelling.
+// AnnotationNoAddressingValue is the only value AnnotationNoAddressing is set
+// to. Named so callers and tests share one spelling.
 const AnnotationNoAddressingValue = "true"
 
-// AnnotationSID is the per-pod EndpointSlice annotation key holding the
-// computed SRv6 uSID (see internal/plumbing/srv6.ComputeSID) that routes
-// traffic to this pod's VRF — human-readable detail, matching the
-// annotation-based pattern used elsewhere in this package. Not present when
-// this node's BGPRouter has no SRv6Locator/nodeID configured (see
-// registerEBPFDatapath's own skip case in internal/cnibgp/bgp.go).
+// AnnotationSID is the per-pod EndpointSlice annotation holding the computed
+// SRv6 uSID that routes traffic to this pod's VRF. Human-readable detail, and
+// absent when this node's BGPRouter has no SRv6 locator or node ID
+// configured.
 const AnnotationSID = "galactic.datum.net/srv6-sid"
 
-// LabelTenantID is the per-pod EndpointSlice label carrying the same value
-// as TenantIdentifier(vpc, vpcAttachment) — the discovery mechanism the HTTP
-// ingress extension server watches/indexes on to find the EndpointSlices for
-// a given VPC attachment. A label, not only an annotation, because
-// annotations aren't selectable in a k8s List/Watch call.
+// LabelTenantID is the per-pod EndpointSlice label carrying the
+// TenantIdentifier value, which is how the HTTP ingress extension server finds
+// the EndpointSlices for a VPC attachment. A label rather than only an
+// annotation, because annotations are not selectable in a List or Watch.
 const LabelTenantID = "galactic.datum.net/tenant-id"
 
-// AnnotationTenantID is the per-pod EndpointSlice annotation carrying the
-// same TenantIdentifier(vpc, vpcAttachment) value as LabelTenantID —
-// human-readable detail alongside the label that actually drives discovery.
+// AnnotationTenantID is the per-pod EndpointSlice annotation carrying the same
+// TenantIdentifier value as LabelTenantID, as human-readable detail alongside
+// the label that drives discovery.
 const AnnotationTenantID = LabelTenantID
 
-// containerIDLen is the number of characters used from a container ID in
-// annotation keys. Kubernetes limits the name part of an annotation key to
-// 63 bytes. The longest prefix sharing this constant is
-// "allocated-subnet-ipv6." (or "-ipv4."), both 22 bytes, leaving 41 bytes for
-// the container ID suffix — shorter prefixes ("netns.") just leave more room
-// than they need.
+// containerIDLen is how many characters of a container ID appear in an
+// annotation key. Kubernetes limits the name part of an annotation key to 63
+// bytes, and the longest prefix here is 22 bytes, leaving 41 for the suffix.
 const containerIDLen = 41
 
 // truncate returns id, shortened to containerIDLen characters if longer.
@@ -142,9 +125,10 @@ func NetNSKey(containerID string) string {
 // nameSegmentHashLen is the number of hex characters kept from the SHA-256 fallback.
 const nameSegmentHashLen = 12
 
-// nameSegment renders a base62 identifier as the lowercase hex value it encodes, since
-// metadata.name must be a lowercase RFC 1123 subdomain and base62 turns uppercase at 36.
-// Input that is not valid base62 is hashed under an "x" prefix no hex encoding can produce.
+// nameSegment renders a base62 identifier as the lowercase hex it encodes,
+// since metadata.name must be a lowercase RFC 1123 subdomain and base62 turns
+// uppercase at 36. Input that is not valid base62 is hashed under an "x" prefix
+// no hex encoding can produce.
 func nameSegment(id string) string {
 	if encoded, err := intf.Base62ToHex(id); err == nil && encoded != "" {
 		return encoded
@@ -158,131 +142,104 @@ func VPCSegment(vpc string) string {
 	return nameSegment(vpc)
 }
 
-// IngressAttachment is the synthetic vpcAttachment segment the ingress
-// sidecar publishes its own per-VPC gateway address under. A sidecar has no
-// real VPCAttachment -- it is not a tenant workload and no CNI ADD ever runs
-// for it -- but BGPAdvertisementName needs a middle segment, and one fixed
-// value keeps the name deterministic and one-per-(VPC, node).
+// IngressAttachment is the synthetic vpcAttachment segment the ingress sidecar
+// publishes its per-VPC gateway address under. A sidecar has no real
+// VPCAttachment, since no CNI ADD ever runs for it, but BGPAdvertisementName
+// needs a middle segment, and one fixed value keeps the name deterministic and
+// one per (VPC, node).
 //
-// Defined here, in the package that owns every CRD name, rather than in
-// internal/ingresssidecar which writes these advertisements: the host side
-// (internal/installer's sidecar return path) has to *recognize* them, and
-// two independently-maintained copies of the same literal is exactly how
-// that recognition silently stops matching.
+// It lives here, in the package that owns every CRD name, rather than in the
+// sidecar that writes these advertisements, because the host side has to
+// recognise them, and two copies of the same literal is how that recognition
+// silently stops matching.
 const IngressAttachment = "ingress"
 
-// IngressAdvertisementSegment is the middle name segment of every
-// BGPAdvertisement the ingress sidecar publishes, i.e. what
-// BGPAdvertisementName renders IngressAttachment as. Exported so a reader
-// can identify a sidecar's own gateway advertisement among the ones this
-// node originates, without re-deriving the encoding.
+// IngressAdvertisementSegment returns the middle name segment of every
+// BGPAdvertisement the ingress sidecar publishes, that is, what
+// BGPAdvertisementName renders IngressAttachment as. Exported so a reader can
+// identify a sidecar's gateway advertisement without re-deriving the
+// encoding.
 func IngressAdvertisementSegment() string {
 	return nameSegment(IngressAttachment)
 }
 
-// BGPVRFInstanceName returns the deterministic name for a BGPVRFInstance.
-// This is keyed by (vpc, node): the underlying kernel VRF is shared by every
-// attachment (pod or VM) on this VPC on this node (see internal/plumbing/vrf
-// and internal/plumbing/intf's GenerateInterfaceNameVRF), so every attachment
-// on the same VPC/node must resolve to the same BGPVRFInstance rather than
-// creating its own.
+// BGPVRFInstanceName returns the deterministic name for a BGPVRFInstance,
+// keyed by (vpc, node). The kernel VRF is shared by every attachment, pod or
+// VM, on this VPC on this node, so they must all resolve to the same
+// BGPVRFInstance rather than each creating one.
 func BGPVRFInstanceName(vpc, nodeName string) string {
 	return fmt.Sprintf("%s-%s", VPCSegment(vpc), nodeName)
 }
 
-// BGPAdvertisementName returns the deterministic name for a
-// BGPAdvertisement. Keyed by (vpc, vpcAttachment, node) -- node included for
-// the same reason BGPVRFInstanceName needs it (see that function's own
-// doc comment): a VPCAttachment identifies one logical attachment, but
-// nothing about that guarantees it is unique per *node* -- a multi-replica
-// Deployment scheduled across several nodes is the ordinary case, not an
-// edge case, and every replica's CNI ADD shares the very same VPCAttachment
-// identity from the CNI config on its own node.
+// BGPAdvertisementName returns the deterministic name for a BGPAdvertisement,
+// keyed by (vpc, vpcAttachment, node).
 //
-// Before node was part of this key, every node with a live attachment to
-// the same VPCAttachment raced to CreateOrUpdate the *same* BGPAdvertisement
-// object: each write clobbered the previous node's RouterRef/prefixes
-// wholesale, so only the last writer's node was ever actually advertised —
-// every other node's own attachment silently vanished from BGP the moment
-// a second node's ADD ran: a second node's attachment to a VPC that already
-// had one elsewhere would overwrite the first's BGPAdvertisement, and from
-// that point on BGP would advertise only the second node's SID for both —
-// traffic destined for the first node's own local pod would get redirected
-// to the second node's own uSID SID instead of ever being delivered
-// locally, and the second node's own egress_route_table registration for
-// its "own" prefix would then collide with itself for the same underlying
-// reason (two attachments, one shared key, one winner). This is also why
-// VRF-level address overlap across nodes must be tolerated, not prevented:
-// two nodes are allowed to each
-// have their own local traffic to/from the same VPC, and neither one's
-// BGPAdvertisement is allowed to silently displace the other's.
+// The node segment is required. A VPCAttachment identifies one logical
+// attachment but is not unique per node: a multi-replica Deployment spread
+// across nodes is ordinary, and every replica's CNI ADD carries the same
+// VPCAttachment identity. Without node in the key, every node with a live
+// attachment races to write one shared object, each write replacing the
+// previous node's router reference and prefixes, so only the last writer is
+// advertised. Traffic for the first node's local pod is then redirected to the
+// second node's SID instead of delivered locally, and the second node's egress
+// route registration collides with itself for the same reason.
 //
-// All three segments are encoded by nameSegment (the VPC one identically to
-// BGPVRFInstanceName); node is included raw, unencoded, matching
-// BGPVRFInstanceName's own convention.
+// This is also why VRF-level address overlap across nodes is tolerated rather
+// than prevented: two nodes may each carry local traffic for the same VPC, and
+// neither advertisement may displace the other.
+//
+// All three segments pass through nameSegment except node, which is included
+// raw, matching BGPVRFInstanceName.
 func BGPAdvertisementName(vpc, vpcAttachment, nodeName string) string {
 	return fmt.Sprintf("%s-%s-%s", VPCSegment(vpc), nameSegment(vpcAttachment), nodeName)
 }
 
-// vipNameReplacer sanitizes an IP address for use inside a Kubernetes
-// object name (RFC 1123 DNS subdomain: lowercase alphanumeric, '-', '.'
-// only) -- ':' (every IPv6 address) and '.' (every IPv4 address, and the
-// zone-id separator on a link-local IPv6 address) are not valid there.
+// vipNameReplacer sanitizes an IP address for use inside a Kubernetes object
+// name, which must be an RFC 1123 DNS subdomain. Neither ':' nor '.' is valid
+// there.
 var vipNameReplacer = strings.NewReplacer(":", "-", ".", "-")
 
-// ServiceVIPBindingName returns the deterministic name for a
-// ServiceVIPBinding: one binding per (node, VIP, protocol, port) tuple.
-// Prefixed by nodeName (always alphanumeric) rather than the sanitized
-// address directly, so an IPv6 address's leading "::" never produces a
-// name starting with '-' (invalid for a Kubernetes object name).
+// ServiceVIPBindingName returns the deterministic name for a ServiceVIPBinding,
+// one per (node, VIP, protocol, port). It leads with nodeName, which is always
+// alphanumeric, so an IPv6 address's leading "::" never produces a name
+// starting with '-'.
 func ServiceVIPBindingName(nodeName, vip string, port int32, proto string) string {
 	return fmt.Sprintf("%s-%s-%s-%d", nodeName, vipNameReplacer.Replace(vip), proto, port)
 }
 
-// TenantIdentifier returns the deterministic value used to identify a VPC
-// attachment across the EndpointSlice discovery surface (LabelTenantID/
-// AnnotationTenantID) — a plain (vpc, vpcAttachment) join, deliberately
-// *not* run through nameSegment like BGPVRFInstanceName/BGPAdvertisementName
-// are. Those two build a Kubernetes object *name*, which must be a
-// lowercase RFC 1123 subdomain and so needs nameSegment's hex-safe encoding;
-// this builds a label/annotation *value*, which permits uppercase and has
-// no such constraint. Staying unencoded matters for a second reason: a
-// consumer recovering the original vpc from this value only has to split on
-// the first "-", which works because vpc/vpcAttachment are both base62
-// ([0-9a-zA-Z]) and therefore never contain that separator themselves —
-// nameSegment's hex encoding would make that split unrecoverable back to
-// the original vpc.
+// TenantIdentifier returns the value identifying a VPC attachment across the
+// EndpointSlice discovery surface: a plain (vpc, vpcAttachment) join, not run
+// through nameSegment.
+//
+// Those that are encoded build an object name, which must be a lowercase RFC
+// 1123 subdomain; this builds a label and annotation value, which permits
+// uppercase. Staying unencoded also keeps it reversible: a consumer recovers
+// the original vpc by splitting on the first "-", which works because both
+// halves are base62 and so never contain the separator. Hex encoding would make
+// that split unrecoverable.
 func TenantIdentifier(vpc, vpcAttachment string) string {
 	return fmt.Sprintf("%s-%s", vpc, vpcAttachment)
 }
 
 // EndpointSliceName returns the deterministic name for the per-pod
-// discoveryv1.EndpointSlice published by galactic-bgp — a trivial
-// passthrough of the pod's own name (EndpointSlices are 1:1 with a pod, one
-// per namespace), centralized here like every other name in this package so
-// callers never spell the convention out themselves.
+// EndpointSlice galactic-bgp publishes, a passthrough of the pod's own name
+// since slices are one per pod. Centralized here like every other name in this
+// package, so callers never spell the convention out themselves.
 func EndpointSliceName(podName string) string {
 	return podName
 }
 
-// ParseTenantIdentifier splits a TenantIdentifier(vpc, vpcAttachment) value
-// back into its vpc and vpcAttachment components. This is the ingress
-// sidecar's (#855) only way to recover vpc — the value the kernel-side VRF
-// primitives are actually keyed by, per docs/plans/855-ingress-sidecar-vpc-
-// backend-connectivity.md §1/§2 — since neither LabelTenantID nor
-// AnnotationTenantID carries vpc on its own, only the combined identifier.
+// ParseTenantIdentifier splits a TenantIdentifier value back into its vpc and
+// vpcAttachment components. It is the ingress sidecar's only way to recover
+// vpc, the value the kernel-side VRF primitives are keyed by, since neither the
+// label nor the annotation carries vpc on its own.
 //
-// The split is unambiguous: both components are non-empty base62 strings
-// ([0-9a-zA-Z], see internal/cnimaster.IsValidBase62) and base62 never
-// contains "-", so vpc can never itself contain the separator
-// TenantIdentifier joins the two halves with. This is a stronger guarantee
-// than internal/gc's vpcFromVRFName has to work with — that one recovers vpc
-// from a zero-padded, lossy kernel interface name and has to tolerate
-// stripping leading zeros; this recovers it from the same unpadded string
-// TenantIdentifier itself produced, so there is nothing lossy to correct
-// for.
+// The split is unambiguous: both components are non-empty base62 strings, and
+// base62 never contains "-", so vpc can never contain the separator the two
+// halves are joined with. Nothing is lossy here, unlike recovering vpc from a
+// zero-padded kernel interface name.
 //
-// Returns ok=false if id contains no "-" or either resulting half is empty.
+// ok is false when id contains no "-" or either half is empty.
 func ParseTenantIdentifier(id string) (vpc, vpcAttachment string, ok bool) {
 	vpc, vpcAttachment, found := strings.Cut(id, "-")
 	if !found || vpc == "" || vpcAttachment == "" {

--- a/internal/gateway/datapath.go
+++ b/internal/gateway/datapath.go
@@ -6,62 +6,45 @@ package gateway
 
 import "context"
 
-// Datapath is the engine's interface onto the actual Maglev/DSR
-// load-balancing dataplane for one DesiredRule. GoBGP, via
-// galactic-router's existing embedding, owns all BGP speaking; no BGP
-// speaker lives in this interface's implementations at all. Unlike this
-// engine's Full-NAT predecessor, there is no Active-Active BGP
-// primary/secondary model here either — DSR's anycast model means every
-// gateway node advertises and serves every rule identically (see doc.go).
+// Datapath is the engine's interface onto the Maglev load-balancing dataplane
+// for one rule. No BGP speaker lives in any implementation of it; the router
+// owns all BGP speaking. There is no primary or secondary node either: under
+// the anycast model every gateway node advertises and serves every rule
+// identically.
 //
-// KernelDatapath (kerneldatapath.go) is the real implementation, backed by
-// internal/plumbing/ebpf/edgemap's VIPTable API onto a loaded
-// internal/plumbing/ebpf/edgeprog.EdgedsrObjects. Unlike an earlier,
-// rejected design's identically-named interface, there is no
-// lpmOverrides parameter here at all: that existed solely to work around a
-// LoxiLB-internal routing-engine self-collision bug, and this design has
-// no internal routing engine of its own for a return packet to collide
-// with (DSR never sees a return packet at all — see doc.go). NoopDatapath
-// remains available for tests and any caller not yet wired to a loaded,
-// attached edgeprog program.
+// KernelDatapath is the real implementation, backed by the map layer over a
+// loaded edge program. NoopDatapath is available for tests and for a caller not
+// yet wired to a loaded, attached program.
 type Datapath interface {
 	// ApplyRule programs (or reprograms) rule's ingress Maglev/DSR
 	// load-balancing state.
 	ApplyRule(ctx context.Context, rule DesiredRule) error
 
-	// RemoveRule tears down vip_table state for the rule identified by
-	// key. The caller (the future NetworkRule controller) must withdraw
-	// the rule's BGP route before calling this, never after — removing
-	// load-balancing state first while the route is still advertised
-	// risks blackholing in-flight flows that would otherwise still
-	// resolve to a live backend.
+	// RemoveRule tears down vip_table state for the rule identified by key.
+	// The caller must withdraw the rule's BGP route before calling this, never
+	// after: removing load-balancing state while the route is still advertised
+	// risks blackholing in-flight flows that would still resolve to a live
+	// backend.
 	RemoveRule(ctx context.Context, key string) error
 
-	// Generation returns a snapshot of the datapath's own monotonic
-	// clock, for crash-recovery purposes. Callers intending to call
-	// ReconcileOrphans must capture this immediately *before* listing the
-	// NetworkRule CRDs that become that call's live set — see
-	// internal/plumbing/ebpf/edgemap's VIPTable.Generation doc comment
-	// for why the ordering matters.
+	// Generation returns a snapshot of the datapath's monotonic clock, for
+	// crash recovery. A caller intending to call ReconcileOrphans must read it
+	// immediately before listing the CRDs that become that call's live set.
 	Generation() uint64
 
-	// ReconcileOrphans removes vip_table state whose owning rule is
-	// absent from live and was written before cutoff — the datapath-level
-	// half of Engine.ReconcileOrphans (recovery.go).
+	// ReconcileOrphans removes vip_table state whose owning rule is absent from
+	// live and was written before cutoff.
 	ReconcileOrphans(ctx context.Context, live []DesiredRule, cutoff uint64) error
 }
 
-// QuotaEnforcer is the engine's interface onto per-tenant vip_table quota
-// enforcement, called once per rule per convergence pass so a misbehaving
-// tenant's rules can be capped before they exhaust shared eBPF map capacity
-// on its assigned gateway node.
+// QuotaEnforcer is the engine's interface onto per-tenant vip_table quota,
+// called once per rule per convergence pass, so a misbehaving tenant's rules
+// are capped before they exhaust the shared map's capacity on its gateway node.
 //
-// NodeQuotaEnforcer (quota.go) is the real implementation: a coarse,
-// node-level admission cap (max rules per tenant, max total vip_table
-// entries), not per-flow rate limiting — see that type's doc comment for
-// why the latter needs live traffic data to calibrate sensible thresholds
-// against, which this repo does not have yet. NoopQuotaEnforcer remains
-// available for tests and always reports quota as available.
+// NodeQuotaEnforcer is the real implementation: a coarse node-level admission
+// cap on rules per tenant and total entries, not per-flow rate limiting, which
+// would need live traffic data to calibrate against. NoopQuotaEnforcer always
+// reports quota as available.
 type QuotaEnforcer interface {
 	// CheckAndReserve reports whether rule is within its per-tenant quota
 	// and, if so, reserves the resources ApplyRule is about to consume.
@@ -73,18 +56,15 @@ type QuotaEnforcer interface {
 }
 
 // TelemetryEmitter is the engine's interface onto telemetry for events only
-// knowable at Engine's own call sites — currently, rule applications
-// rejected before ever reaching the datapath (e.g. QuotaEnforcer denials).
+// knowable at the engine's own call sites, currently rule applications rejected
+// before reaching the datapath.
 //
-// PrometheusTelemetryEmitter (telemetry.go) is the real implementation --
-// vip_table's own per-packet counters are exposed separately by
-// internal/plumbing/ebpf/edgemetrics's pull-based Collector; see both
-// types' doc comments for the full split. NoopTelemetryEmitter remains
-// available for tests and drops every call on the floor.
+// PrometheusTelemetryEmitter is the real implementation. The datapath's
+// per-packet counters are exposed separately by a pull-based collector.
+// NoopTelemetryEmitter drops every call.
 type TelemetryEmitter interface {
-	// RuleApplied is called after a successful Datapath.ApplyRule, so a
-	// caller can emit primary/secondary advertisement state and NAT/
-	// conntrack counters for the rule.
+	// RuleApplied is called after a rule is successfully applied, so a caller
+	// can emit advertisement state and counters for it.
 	RuleApplied(ctx context.Context, rule DesiredRule)
 
 	// RuleRemoved is called after a successful teardown of key.
@@ -95,10 +75,8 @@ type TelemetryEmitter interface {
 	DropObserved(ctx context.Context, key string, reason string)
 }
 
-// NoopDatapath is a placeholder Datapath implementation for tests and any
-// caller not yet wired to a loaded, attached edgeprog program —
-// KernelDatapath (kerneldatapath.go) is the real implementation; see
-// Datapath's doc comment.
+// NoopDatapath is a placeholder for tests and for a caller not yet wired to a
+// loaded, attached program.
 type NoopDatapath struct{}
 
 func (NoopDatapath) ApplyRule(context.Context, DesiredRule) error { return nil }
@@ -108,9 +86,7 @@ func (NoopDatapath) ReconcileOrphans(context.Context, []DesiredRule, uint64) err
 	return nil
 }
 
-// NoopQuotaEnforcer is the TODO-marked placeholder QuotaEnforcer
-// implementation. It always reports quota as available — see
-// QuotaEnforcer's doc comment for why real enforcement is deferred.
+// NoopQuotaEnforcer always reports quota as available.
 type NoopQuotaEnforcer struct{}
 
 // CheckAndReserve always allows the rule.
@@ -123,9 +99,7 @@ func (NoopQuotaEnforcer) Release(context.Context, string) error {
 	return nil
 }
 
-// NoopTelemetryEmitter is the TODO-marked placeholder TelemetryEmitter
-// implementation. It drops every call — see TelemetryEmitter's doc
-// comment for why the real implementation is deferred.
+// NoopTelemetryEmitter drops every call.
 type NoopTelemetryEmitter struct{}
 
 // RuleApplied is a no-op.

--- a/internal/gateway/diff.go
+++ b/internal/gateway/diff.go
@@ -6,17 +6,15 @@ package gateway
 
 import "sort"
 
-// diffRuleKeys compares the currently-active rule keys against the desired
-// EngineState and returns which keys need to be (re)applied and which need
-// to be removed. A key present in both sets is always returned in toApply
-// (Engine.Reconcile applies unconditionally rather than trying to diff
-// individual field changes — matching GoBGPRuntime's own "re-apply the
-// whole desired set" convergence style) — toApply/toRemove partition the
-// *key space*, not "changed vs. unchanged".
+// diffRuleKeys compares the currently active rule keys against the desired state
+// and returns which need applying and which removing.
 //
-// Both returned slices are sorted for deterministic iteration order (log
-// output, test assertions) — desired/active are Go maps, whose iteration
-// order is intentionally randomized.
+// A key present in both is always returned in toApply: the engine applies
+// unconditionally rather than diffing individual field changes. The two slices
+// partition the key space, not changed against unchanged.
+//
+// Both are sorted, for deterministic log output and test assertions, the inputs
+// being maps whose iteration order is randomized.
 func diffRuleKeys(active map[string]DesiredRule, desired map[string]DesiredRule) (toApply, toRemove []string) {
 	for key := range desired {
 		toApply = append(toApply, key)

--- a/internal/gateway/doc.go
+++ b/internal/gateway/doc.go
@@ -2,54 +2,34 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package gateway implements the in-process edge Maglev/DSR (Direct Server
-// Return) load-balancing gateway engine. One Engine runs per gateway-role
-// node (one process, one NetworkGateway object), converging the set of
-// accepted network.datumapis.com/v1alpha1 NetworkRule resources for that
-// node into calls against a pluggable Datapath (datapath.go).
+// Package gateway implements the in-process edge Maglev direct-server-return
+// load-balancing engine. One Engine runs per gateway-role node, converging that
+// node's accepted NetworkRule resources into calls against a pluggable
+// Datapath.
 //
-// This package backs onto internal/plumbing/ebpf/edgeprog's XDP program
-// directly: no tunnel, no per-tenant provisioning, and — because the outer
-// SRv6 header is pushed straight from the program's own vip_table (resolved
-// via internal/plumbing/ebpf/edgemap) rather than a kernel VRF route — no
-// VRF dependency.
+// It backs onto the edge XDP program directly: no tunnel, no per-tenant
+// provisioning, and no VRF dependency, since the outer SRv6 header is pushed
+// from the program's own vip_table rather than a kernel route.
 //
-// This is also a pivot away from this package's own earlier, Full-NAT
-// (DNAT+SNAT) design: that design needed an Active-Active BGP model
-// (placement.go/localpref.go, both since deleted) because only one gateway
-// node at a time could hold a given rule's translation/conntrack state.
-// Maglev/DSR has no such state — every gateway node computes the identical
-// consistent-hash backend assignment for the identical (VIP, backend list)
-// input (internal/maglev's own doc comment), so every gateway node in a PoP
-// serves every rule identically under anycast/ECMP, with no primary/
-// secondary distinction and no BGP local-preference to carry. See
-// edgedsr.c's own header comment for the full packet-path rationale.
+// There is no primary or secondary gateway node and no BGP local preference to
+// carry. Every node computes the same consistent-hash backend assignment from
+// the same VIP and backend list, so every node in a PoP serves every rule
+// identically under anycast.
 //
-//   - engine.go: Engine, the mutex-guarded convergence loop, mirroring
-//     internal/runtime/gobgp's GoBGPRuntime shape ("apply everything in
-//     desired, remove everything not in desired" rather than a
-//     field-level diff, so a partial previous failure self-heals on the
-//     next Reconcile).
-//   - types.go: DesiredRule/DesiredBackend/EngineState/EngineStatus, the
-//     engine's own representation of a NetworkRule, assembled by the
-//     future NetworkGateway/NetworkRule controllers. DesiredBackend
-//     implements internal/maglev.Backend directly (see its Key() method).
-//   - datapath.go: the Datapath/QuotaEnforcer/TelemetryEmitter interfaces
-//     Engine calls through. KernelDatapath (kerneldatapath.go) is the
-//     real Datapath implementation: it builds an internal/maglev.Table
-//     over each rule's backend set and flattens it into the fixed-size
-//     arrays internal/plumbing/ebpf/edgemap's VIPTable expects, backed by
-//     a loaded internal/plumbing/ebpf/edgeprog.EdgedsrObjects (loading/
-//     attaching that object to an interface is
-//     internal/plumbing/ebpf/edgeattach's job, called from
-//     cmd/galactic-gateway's own startup, not from anywhere in this
-//     package). QuotaEnforcer/TelemetryEmitter have real implementations
-//     (quota.go/telemetry.go); Noop variants remain for tests.
-//   - recovery.go: Engine.ReconcileOrphans, the crash-recovery pass for a
-//     process that died mid-reconcile — delegates directly to
-//     edgemap.VIPTable.Reconcile's own Generation-cutoff mechanism (see
-//     that package's doc comment), since vip_table state (not a kernel
-//     interface) is the only thing this design can leak on a crash.
-//   - diff.go: diffRuleKeys, the pure key-set diff both Reconcile and
-//     ReconcileOrphans build on.
+//   - engine.go: Engine, the mutex-guarded convergence loop. It applies
+//     everything in desired state and removes everything absent from it, rather
+//     than diffing field by field, so a partial previous failure self-heals on
+//     the next pass.
+//   - types.go: the engine's own representation of a rule and its backends,
+//     assembled by the reconcilers.
+//   - datapath.go: the Datapath, QuotaEnforcer, and TelemetryEmitter interfaces
+//     Engine calls through. KernelDatapath is the real implementation: it builds
+//     a Maglev table over each rule's backend set and flattens it into the
+//     fixed-size arrays the map layer expects. Loading and attaching the program
+//     happens at process startup, not here. The other two interfaces have real
+//     implementations, with no-op variants kept for tests.
+//   - recovery.go: the crash-recovery pass for a process that died
+//     mid-reconcile, delegating to the map layer's generation cutoff, since
+//     map state is the only thing this design can leak on a crash.
+//   - diff.go: the pure key-set diff both reconcile paths build on.
 package gateway

--- a/internal/gateway/engine.go
+++ b/internal/gateway/engine.go
@@ -11,15 +11,10 @@ import (
 	"sync"
 )
 
-// Engine is the in-process gateway engine running on one gateway node,
-// mirroring internal/runtime/gobgp's GoBGPRuntime shape: a mutex-protected
-// map of currently-active state, converged towards a desired state on each
-// Reconcile call.
-//
-// Unlike an earlier, rejected design's identically-named type,
-// Engine holds no VRF/Geneve state at all — no vrfLinkNames map, no
-// SetVRFLink method — because this datapath has no VRF dependency (see
-// doc.go).
+// Engine is the in-process gateway engine on one gateway node: a
+// mutex-protected map of currently active state, converged toward a desired
+// state on each Reconcile. It holds no VRF state, this datapath having no VRF
+// dependency.
 type Engine struct {
 	mu     sync.Mutex
 	active map[string]DesiredRule
@@ -29,11 +24,9 @@ type Engine struct {
 	telemetry TelemetryEmitter
 }
 
-// NewEngine returns an Engine wired to the given Datapath, QuotaEnforcer,
-// and TelemetryEmitter implementations. Production callers pass
-// KernelDatapath (kerneldatapath.go), NoopQuotaEnforcer{}, and
-// NoopTelemetryEmitter{} until those interfaces' real implementations
-// land; tests pass fakes.
+// NewEngine returns an Engine wired to the given implementations. Production
+// callers pass the kernel datapath and the real quota and telemetry
+// implementations; tests pass fakes.
 func NewEngine(datapath Datapath, quota QuotaEnforcer, telemetry TelemetryEmitter) *Engine {
 	return &Engine{
 		active:    make(map[string]DesiredRule),
@@ -43,19 +36,15 @@ func NewEngine(datapath Datapath, quota QuotaEnforcer, telemetry TelemetryEmitte
 	}
 }
 
-// Reconcile converges the engine's live state toward desired: every rule in
-// desired.Rules is (re-)applied via Datapath.ApplyRule, and every rule no
-// longer present in desired.Rules but still active is torn down via
-// Datapath.RemoveRule (the caller must already have withdrawn its BGP
-// route before it ever disappears from desired — see Datapath.RemoveRule's
-// doc comment).
+// Reconcile converges live state toward desired: every rule in desired is
+// re-applied, and every rule still active but no longer in desired is torn
+// down. The caller must already have withdrawn a rule's BGP route before it
+// disappears from desired.
 //
-// Reconcile is intentionally "apply everything in desired, remove
-// everything not in desired" rather than a fine-grained field-level diff —
-// matching GoBGPRuntime.Apply's own convergence style — so a partial
-// previous failure (e.g. the process crashed between two rules) always
-// self-heals on the next call rather than requiring the caller to track
-// what succeeded.
+// It applies everything in desired and removes everything not in it, rather
+// than diffing field by field, so a partial previous failure, such as a crash
+// between two rules, self-heals on the next call instead of requiring the
+// caller to track what succeeded.
 func (e *Engine) Reconcile(ctx context.Context, desired EngineState) (EngineStatus, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -104,9 +93,8 @@ func (e *Engine) Status(context.Context) (EngineStatus, error) {
 	return EngineStatus{Healthy: true, Rules: statuses}, nil
 }
 
-// Stop tears down every currently-active rule. The caller must already
-// have withdrawn BGP routes for every rule before calling this, exactly as
-// for an individual rule removal via Reconcile.
+// Stop tears down every currently active rule. The caller must already have
+// withdrawn BGP routes for every one, exactly as for an individual removal.
 func (e *Engine) Stop(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -126,11 +114,9 @@ func (e *Engine) Stop(ctx context.Context) error {
 	return firstErr
 }
 
-// DatapathGeneration returns a snapshot of the underlying Datapath's
-// monotonic clock. Callers intending to call ReconcileOrphans must invoke
-// this *before* listing the NetworkRule CRDs that will become that call's
-// live set — see Datapath.Generation's doc comment for why the ordering
-// matters, and recovery.go for the full crash-recovery contract.
+// DatapathGeneration returns a snapshot of the underlying datapath's monotonic
+// clock. A caller intending to call ReconcileOrphans must read it before
+// listing the CRDs that become that call's live set.
 func (e *Engine) DatapathGeneration() uint64 {
 	return e.datapath.Generation()
 }
@@ -167,8 +153,8 @@ func (e *Engine) applyRuleLocked(ctx context.Context, rule DesiredRule) error {
 // Caller must hold e.mu.
 func (e *Engine) removeRuleLocked(ctx context.Context, key string) error {
 	// Quota is released even when datapath removal fails, so a reservation
-	// cannot outlive the rule; Release is a no-op for an already-released
-	// key, so the caller's next retry stays correct.
+	// cannot outlive the rule. Release is a no-op for an already-released key,
+	// so a retry stays correct.
 	dpErr := e.datapath.RemoveRule(ctx, key)
 	if dpErr != nil {
 		dpErr = fmt.Errorf("remove datapath rule %s: %w", key, dpErr)

--- a/internal/gateway/kerneldatapath.go
+++ b/internal/gateway/kerneldatapath.go
@@ -16,13 +16,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
 )
 
-// protoNumber maps a NetworkRuleSpec.Protocol string ("tcp"/"udp") to the
-// IANA protocol number edgedsr.c's vip_key.proto expects. There is no
-// generated/shared constant for this: network.datumapis.com/v1alpha1's
-// NetworkRuleProtocol enum is a string type for CRD readability, and
-// edgeprog's wire format is the numeric IPPROTO_* value edgedsr.c already
-// reads directly off the packet — this is the one place those two
-// representations need to be reconciled.
+// protoNumber maps a rule's protocol string to the IANA number the datapath's
+// key expects. There is no shared constant: the CRD enum is a string for
+// readability while the wire format is the numeric value read off the packet,
+// and this is the one place the two representations meet.
 func protoNumber(protocol string) (uint8, error) {
 	switch protocol {
 	case "tcp":
@@ -34,10 +31,9 @@ func protoNumber(protocol string) (uint8, error) {
 	}
 }
 
-// vipKeysForRule returns the vip_table keys ApplyRule registers for rule --
-// one per VIPAddress, since edgedsr.c's vip_table is keyed by (proto, VIP
-// port, VIP address) with the backend list and Maglev table identical
-// across every VIP a rule owns.
+// vipKeysForRule returns the vip_table keys ApplyRule registers for rule, one
+// per VIP address, the map being keyed by protocol, port, and address with the
+// backend list and Maglev table identical across every VIP a rule owns.
 func vipKeysForRule(rule DesiredRule) ([]edgemap.VIPKey, error) {
 	proto, err := protoNumber(rule.Protocol)
 	if err != nil {
@@ -50,24 +46,18 @@ func vipKeysForRule(rule DesiredRule) ([]edgemap.VIPKey, error) {
 	return keys, nil
 }
 
-// buildMaglevTable builds the ordered backend list and flattened Maglev
-// lookup table Register expects from rule.Backends, via
-// internal/maglev.Table:
+// buildMaglevTable builds the ordered backend list and the flattened Maglev
+// lookup table Register expects from rule.Backends:
 //
-//  1. Reject up front if rule.Backends exceeds edgemap.MaxBackends -- this
-//     shouldn't happen given NetworkRuleSpec.Backends' own CRD
-//     MaxItems=64, but a silently truncated or overflowed backend array is
-//     worse than a clear error here.
-//  2. Build a maglev.Table over rule.Backends (each DesiredBackend already
-//     implements maglev.Backend via its Key() method — see that method's
-//     doc comment for the address:port convention chosen).
-//  3. table.Backends() returns the backend set sorted by Key(); that sort
-//     order becomes each backend's index into the returned backends slice
-//     (and therefore into vip_value's own fixed-size Backends array).
-//  4. For each of the table's EDGE_MAGLEV_TABLE_SIZE slots, table.Lookup
-//     resolves the assigned backend, translated back to its index via a
-//     Key()->index map built from the same sorted list in the previous
-//     step.
+//  1. Reject up front when the backend count exceeds the cap. The CRD already
+//     bounds it, but a silently truncated array is worse than a clear error.
+//  2. Build a Maglev table over the backends, each of which supplies its own
+//     key.
+//  3. The table returns its backend set sorted by key, and that order becomes
+//     each backend's index into the returned slice, and so into the map value's
+//     fixed-size array.
+//  4. For each slot, resolve the assigned backend and translate it back to its
+//     index through a key-to-index map built from the same sorted list.
 func buildMaglevTable(rule DesiredRule) ([]edgemap.Backend, [edgemap.MaglevTableSize]byte, error) {
 	var maglevTable [edgemap.MaglevTableSize]byte
 
@@ -104,36 +94,26 @@ func buildMaglevTable(rule DesiredRule) ([]edgemap.Backend, [edgemap.MaglevTable
 	return backends, maglevTable, nil
 }
 
-// KernelDatapath is the real Datapath implementation, backed by
-// internal/plumbing/ebpf/edgemap's VIPTable API onto a loaded
-// internal/plumbing/ebpf/edgeprog.EdgedsrObjects. It assumes the compiled
-// program is already loaded and attached to the gateway node's public
-// interface by the time ApplyRule is first called — that attach lifecycle
-// is internal/plumbing/ebpf/edgeattach's job and cmd/galactic-gateway's own
-// startup sequence's, not this package's. NoopDatapath remains available
-// for tests and any caller not yet wired to a loaded program.
+// KernelDatapath is the real Datapath implementation, backed by the map layer
+// over a loaded edge program. It assumes the program is already loaded and
+// attached to the node's public interface by the time ApplyRule is first
+// called; that lifecycle belongs to the attach package and process startup.
 type KernelDatapath struct {
 	mu       sync.Mutex
 	vipTable *edgemap.VIPTable
 
-	// vipKeysByName maps a DesiredRule.Key to the vip_table keys currently
-	// registered for it, so RemoveRule (which the Datapath interface only
-	// passes a bare key string, not the full DesiredRule) knows what to
-	// unregister, and so ApplyRule can prune a key a rule dropped since
-	// its last apply (e.g. a VIP removed from spec.vipAddresses) without
-	// needing the caller to have tracked that itself.
+	// vipKeysByName maps a rule's key to the vip_table keys currently registered
+	// for it, so RemoveRule, which receives only a key string, knows what to
+	// unregister, and ApplyRule can prune a key the rule dropped since its last
+	// apply without the caller having tracked it.
 	vipKeysByName map[string][]edgemap.VIPKey
 }
 
-// NewKernelDatapath constructs a KernelDatapath and writes encapSrc into
-// encap_config_table once, immediately -- encapSrc is this gateway node's
-// own plain SRv6-reachable address (NetworkGatewayStatus.SRv6Address),
-// stable for the life of the process, so there is no per-rule or
-// per-reconcile path that ever needs to rewrite it again. Unlike the
-// Full-NAT predecessor's gw_config (gwAddr), this is never a NAT/SNAT
-// source and never needs to match anything on a return path -- DSR has no
-// return path through this node at all (see edgedsr.c's own header
-// comment).
+// NewKernelDatapath constructs a KernelDatapath and writes encapSrc into the
+// encapsulation config once, immediately. encapSrc is this node's plain
+// SRv6-reachable address, stable for the life of the process, so nothing per
+// rule or per reconcile ever rewrites it. It is never a translation source and
+// has no return-path significance.
 func NewKernelDatapath(objs *edgeprog.EdgedsrObjects, encapSrc netip.Addr) (*KernelDatapath, error) {
 	if !encapSrc.Is6() || encapSrc.Is4In6() {
 		return nil, fmt.Errorf("kerneldatapath: encap source address %s is not a native IPv6 address", encapSrc)
@@ -150,9 +130,9 @@ func NewKernelDatapath(objs *edgeprog.EdgedsrObjects, encapSrc netip.Addr) (*Ker
 	}, nil
 }
 
-// ApplyRule registers vip_table entries for rule (one per VIPAddress,
-// sharing rule.Backends' Maglev table), replacing whatever this rule had
-// registered previously and pruning any key it no longer owns.
+// ApplyRule registers vip_table entries for rule, one per VIP address sharing
+// its Maglev table, replacing whatever the rule had registered before and
+// pruning any key it no longer owns.
 func (d *KernelDatapath) ApplyRule(_ context.Context, rule DesiredRule) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -170,7 +150,7 @@ func (d *KernelDatapath) ApplyRule(_ context.Context, rule DesiredRule) error {
 	for i, key := range keys {
 		if err := d.vipTable.Register(key, backends, maglevTable); err != nil {
 			// Record the keys that did land, alongside the ones this rule
-			// already owned (the prune below has not run yet), so
+			// already owned, the prune below not having run yet, so
 			// RemoveRule can still find every live entry.
 			for _, written := range keys[:i] {
 				if !slices.Contains(d.vipKeysByName[rule.Key], written) {
@@ -219,19 +199,17 @@ func (d *KernelDatapath) Generation() uint64 {
 	return d.vipTable.Generation()
 }
 
-// ReconcileOrphans removes vip_table entries whose key is not implied by
-// any rule in live and was written before cutoff -- see
-// edgemap.VIPTable.Reconcile's identical contract, which this delegates to
-// directly.
+// ReconcileOrphans removes vip_table entries whose key is not implied by any
+// rule in live and was written before cutoff, delegating to the map layer's
+// reconcile.
 func (d *KernelDatapath) ReconcileOrphans(_ context.Context, live []DesiredRule, cutoff uint64) error {
 	liveKeys := make(map[edgemap.VIPKey]struct{})
 	for _, rule := range live {
 		keys, err := vipKeysForRule(rule)
 		if err != nil {
-			// A rule with an unsupported protocol never got registered
-			// by ApplyRule in the first place, so it can't own any
-			// vip_table entry to spare here either; skip rather than
-			// fail the whole orphan sweep over one bad rule.
+			// A rule with an unsupported protocol was never registered, so
+			// it owns no entry to spare here. Skip rather than fail the
+			// whole sweep over one bad rule.
 			continue
 		}
 		for _, k := range keys {

--- a/internal/gateway/quota.go
+++ b/internal/gateway/quota.go
@@ -11,71 +11,55 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgemap"
 )
 
-// Default limits for NodeQuotaEnforcer. Both are coarse, node-level
-// admission caps, not bandwidth or per-flow rate limits -- see that
-// type's doc comment for why the latter is deliberately out of scope
-// here.
+// Default limits for NodeQuotaEnforcer. Both are coarse, node-level admission
+// caps, not bandwidth or per-flow rate limits.
 const (
-	// DefaultMaxRulesPerTenant bounds how many NetworkRules a single
-	// VPCRef may have registered on one gateway node at once. A
-	// NetworkRule may carry up to 8 VIPAddresses (network.datumapis.com/
-	// v1alpha1's NetworkRuleSpec.VIPAddresses MaxItems), so this also
-	// bounds one tenant's worst-case vip_table footprint to
-	// DefaultMaxRulesPerTenant*8 entries.
+	// DefaultMaxRulesPerTenant bounds how many rules one tenant may have
+	// registered on a gateway node at once. A rule may carry up to eight VIP
+	// addresses, so this also bounds a tenant's worst-case map footprint to
+	// eight times this value.
 	DefaultMaxRulesPerTenant = 64
 
-	// DefaultMaxRuleTableEntries is the node-wide ceiling across every
-	// tenant, defaulting to edgemap.MaxVIPTableEntries (vip_table's own
-	// map capacity) -- once desired state would fill the map,
-	// bpf_map_update_elem starts failing mid-reconcile with no clean way
-	// to roll back a partial apply, so this must be enforced before
-	// ApplyRule is ever called, at CheckAndReserve time.
+	// DefaultMaxRuleTableEntries is the node-wide ceiling across every tenant,
+	// defaulting to the map's own capacity. Once desired state would fill the
+	// map, writes start failing mid-reconcile with no clean way to roll back a
+	// partial apply, so this must be enforced before any rule is applied.
 	DefaultMaxRuleTableEntries = edgemap.MaxVIPTableEntries
 )
 
-// NodeQuotaEnforcer is a real (not stubbed) QuotaEnforcer implementation,
-// enforcing two coarse, node-level admission caps entirely from
-// control-plane state Engine already holds — no eBPF map read required:
+// NodeQuotaEnforcer enforces two coarse, node-level admission caps entirely
+// from control-plane state the engine already holds, with no map read:
 //
-//  1. MaxRulesPerTenant: no single VPCRef may register more than this many
-//     NetworkRules on this gateway node at once.
-//  2. MaxRuleTableEntries: the total vip_table rows every tenant's rules
-//     would occupy together (one row per VIPAddress, see
-//     kerneldatapath.go's vipKeysForRule) may not exceed vip_table's own
-//     fixed map capacity.
+//  1. No single tenant may register more than MaxRulesPerTenant rules on this
+//     node at once.
+//  2. The total map rows every tenant's rules would occupy, one per VIP
+//     address, may not exceed MaxRuleTableEntries.
 //
-// What this deliberately does NOT do: per-flow or per-tenant packet/byte
-// rate limiting. vip_table's key carries no tenant dimension (a VIP is
-// globally unique, so it doesn't need one either), so there is no cheap
-// way to attribute an individual flow back to a tenant without adding a
-// field that changes the packet-path key layout; and a meaningful
-// bandwidth/packet-rate quota needs a time-windowed rate, not the
-// cumulative, never-reset Packets/Bytes counters vip_table carries (a
-// long-lived, healthy, popular rule will always eventually cross any
-// static cumulative threshold — that isn't misbehavior, that's success).
-// Real rate-based enforcement needs live traffic data to calibrate
-// sensible thresholds against, which this repo does not have yet — see
-// docs/agents/ARCHITECTURE-GATEWAY.md. This type is the enforceable subset
-// buildable without that data.
+// It deliberately does no per-flow or per-tenant rate limiting. The map's key
+// carries no tenant dimension, a VIP being globally unique, so attributing a
+// flow back to a tenant would mean changing the packet-path key layout. A
+// meaningful rate quota also needs a time-windowed rate rather than the
+// cumulative, never-reset counters the map carries: a long-lived, popular rule
+// eventually crosses any static cumulative threshold, which is success rather
+// than misbehavior. Calibrating real thresholds needs live traffic data this
+// repo does not have. This is the enforceable subset buildable without it.
 type NodeQuotaEnforcer struct {
 	mu sync.Mutex
 
 	maxRulesPerTenant   int
 	maxRuleTableEntries int
 
-	// tenantRuleCount/totalEntries are the enforcer's own bookkeeping of
-	// what it has reserved — not read back from vip_table itself, so
-	// CheckAndReserve/Release stay correct even before ApplyRule has run
-	// (a new rule has no vip_table row yet to read counters from).
+	// tenantRuleCount and totalEntries are the enforcer's own record of what it
+	// has reserved, not read back from the map, so reserve and release stay
+	// correct before a rule has been applied and has any row to read.
 	tenantRuleCount map[string]int
 	ruleTenant      map[string]string
 	ruleEntries     map[string]int
 	totalEntries    int
 }
 
-// NewNodeQuotaEnforcer returns a NodeQuotaEnforcer with the given limits.
-// Use DefaultMaxRulesPerTenant/DefaultMaxRuleTableEntries for production
-// defaults.
+// NewNodeQuotaEnforcer returns a NodeQuotaEnforcer with the given limits. Use
+// the package defaults in production.
 func NewNodeQuotaEnforcer(maxRulesPerTenant, maxRuleTableEntries int) *NodeQuotaEnforcer {
 	return &NodeQuotaEnforcer{
 		maxRulesPerTenant:   maxRulesPerTenant,
@@ -87,11 +71,10 @@ func NewNodeQuotaEnforcer(maxRulesPerTenant, maxRuleTableEntries int) *NodeQuota
 }
 
 // CheckAndReserve reports whether rule fits within both limits and, if so,
-// reserves its vip_table footprint. Idempotent for a rule.Key already
-// reserved: re-checking (or changing) an already-active rule's VIP count
-// never double-counts it against either limit — required because
-// Engine.Reconcile calls this for every desired rule on every reconcile
-// pass, not just new ones (see Engine.Reconcile's own doc comment).
+// reserves its map footprint. Idempotent for a key already reserved:
+// re-checking, or changing, an active rule's VIP count never double-counts it.
+// That is required because the engine calls this for every desired rule on
+// every pass, not only for new ones.
 func (e *NodeQuotaEnforcer) CheckAndReserve(_ context.Context, rule DesiredRule) (bool, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -110,10 +93,9 @@ func (e *NodeQuotaEnforcer) CheckAndReserve(_ context.Context, rule DesiredRule)
 	if !alreadyReserved {
 		tenantCount++
 	} else if prevTenant != rule.VPCRef {
-		// VPCRef changed for an existing rule.Key -- shouldn't happen in
-		// practice (NetworkRuleSpec.VPCRef is not mutated in place by any
-		// caller in this codebase), but guard against under/over-counting
-		// either tenant bucket if it ever does.
+		// The tenant changed for an existing rule key. That should not
+		// happen, no caller mutating a rule's tenant in place, but guard
+		// against miscounting either bucket if it ever does.
 		tenantCount++
 	}
 	if tenantCount > e.maxRulesPerTenant {
@@ -141,9 +123,8 @@ func (e *NodeQuotaEnforcer) CheckAndReserve(_ context.Context, rule DesiredRule)
 	return true, nil
 }
 
-// Release frees the reservation held for key, if any. Not an error if key
-// was never reserved (e.g. CheckAndReserve denied it, or it was never
-// called for this key at all).
+// Release frees the reservation held for key, if any. A key that was never
+// reserved is not an error.
 func (e *NodeQuotaEnforcer) Release(_ context.Context, key string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/internal/gateway/recovery.go
+++ b/internal/gateway/recovery.go
@@ -9,29 +9,22 @@ import (
 	"fmt"
 )
 
-// ReconcileOrphans identifies and cleans up vip_table state left behind
-// by a gateway engine process that crashed mid-reconcile.
+// ReconcileOrphans cleans up vip_table state left behind by a gateway engine
+// process that crashed mid-reconcile.
 //
-// Unlike an earlier, rejected design's identically-named method
-// (which scanned live Geneve interfaces against a desired VNI set), this
-// design has no kernel interface state of its own to leak — the only
-// thing a crashed process can leave behind is a vip_table row with no
-// corresponding NetworkRule left to reconcile it against. That is exactly
-// what internal/plumbing/ebpf/edgemap.VIPTable.Reconcile's own
-// Generation-cutoff mechanism already handles, so this method is a thin,
-// correctly-ordered wrapper around Datapath.ReconcileOrphans rather than a
-// second, independent orphan-detection mechanism.
+// This design has no kernel interface state of its own to leak: the only thing a
+// crashed process can leave behind is a map row with no rule left to reconcile
+// it against, which the map layer's generation cutoff already handles. So this
+// is a correctly ordered wrapper around the datapath's own orphan sweep rather
+// than a second detection mechanism.
 //
-// cutoff must have been captured via Engine.DatapathGeneration *before*
-// desired's NetworkRule CRDs were listed — an entry written after that
-// snapshot but before this call runs is a legitimate fresh Register this
-// method must not race, not an orphan (see
-// internal/plumbing/ebpf/edgemap's VIPTable.Generation doc comment for
-// the same ordering contract at the map layer).
+// cutoff must have been read before desired's CRDs were listed. An entry written
+// after that snapshot but before this call is a legitimate fresh registration
+// this must not race, not an orphan.
 //
-// Unlike Reconcile, ReconcileOrphans does not rely on Engine's in-memory
-// active map — that map is empty immediately after a crash/restart, which
-// is exactly the situation this method exists to recover from.
+// Unlike Reconcile, it does not rely on the engine's in-memory active map: that
+// map is empty immediately after a restart, which is exactly the situation this
+// exists to recover from.
 func (e *Engine) ReconcileOrphans(ctx context.Context, desired EngineState, cutoff uint64) error {
 	live := make([]DesiredRule, 0, len(desired.Rules))
 	for _, rule := range desired.Rules {

--- a/internal/gateway/telemetry.go
+++ b/internal/gateway/telemetry.go
@@ -16,21 +16,14 @@ const telemetryNamespace = "galactic_edge"
 // shared across every metric below that carries one.
 const labelRule = "rule"
 
-// PrometheusTelemetryEmitter is a real (not stubbed) TelemetryEmitter,
-// covering the one thing only knowable at Engine's own call sites -- not
-// re-derivable from a live scrape of vip_table state, which
-// internal/plumbing/ebpf/edgemetrics's Collector already exposes separately
-// (packets/bytes/dropped_packets/last_seen_ns per rule, same
-// pull-at-scrape-time pattern as internal/plumbing/ebpf/metrics's Collector
-// for the SRv6 uSID datapath): rule applications rejected before ever
-// reaching the datapath (e.g. QuotaEnforcer denials). These never touch
-// vip_table at all, so vip_table's own DroppedPackets counter (a strictly
-// datapath-level, per-packet count) cannot see them.
+// PrometheusTelemetryEmitter covers the one thing only knowable at the engine's
+// own call sites: rule applications rejected before reaching the datapath, such
+// as a quota denial. Those never touch the map at all, so its own drop counter,
+// a strictly per-packet datapath count, cannot see them.
 //
-// Unlike this engine's Full-NAT predecessor, there is no primary/secondary
-// placement gauge here: DSR's anycast model means every gateway node
-// serves every rule identically, so there is no per-rule placement state
-// left to report (see doc.go).
+// Everything re-derivable from live map state is exposed separately by the
+// metrics collector at scrape time instead. There is no per-rule placement
+// gauge, every gateway node serving every rule identically under anycast.
 type PrometheusTelemetryEmitter struct {
 	controlPlaneDrops *prometheus.CounterVec
 }
@@ -49,20 +42,16 @@ func NewPrometheusTelemetryEmitter() *PrometheusTelemetryEmitter {
 	}
 }
 
-// MustRegister registers every metric this type owns against reg. Panics
-// on a duplicate registration, matching prometheus.Registerer.MustRegister's
-// own documented behavior -- callers only ever do this once per process,
-// at startup, same convention as internal/plumbing/ebpf/metrics's
-// EventCounters.MustRegister.
+// MustRegister registers every metric this type owns against reg, panicking on
+// a duplicate as the underlying registry does. Callers do this once per process,
+// at startup.
 func (e *PrometheusTelemetryEmitter) MustRegister(reg prometheus.Registerer) {
 	reg.MustRegister(e.controlPlaneDrops)
 }
 
-// RuleApplied is a no-op: unlike this engine's Full-NAT predecessor, there
-// is no per-rule primary/secondary placement fact left to record here (see
-// this type's doc comment). Kept as a method (rather than removed) to
-// satisfy the TelemetryEmitter interface, and as the natural place for any
-// future call-site-only fact this engine learns.
+// RuleApplied is a no-op: there is no per-rule placement fact left to record.
+// It is kept to satisfy the interface, and as the natural place for any future
+// call-site-only fact this engine learns.
 func (e *PrometheusTelemetryEmitter) RuleApplied(context.Context, DesiredRule) {}
 
 // RuleRemoved is a no-op, for the same reason as RuleApplied.

--- a/internal/gateway/types.go
+++ b/internal/gateway/types.go
@@ -9,51 +9,40 @@ import (
 	"net/netip"
 )
 
-// DesiredBackend is a single backend endpoint a rule load-balances to,
-// mirroring network.datumapis.com/v1alpha1's NetworkRuleBackend plus one
-// field the CRD does not itself carry: USID, the SRv6 uSID of the worker
-// node this backend is reachable through. The controller building
-// DesiredRule resolves USID the same way any other cross-node SRv6
-// destination is resolved (srv6.ComputeSID over the backend's BGPRouter/
-// BGPAdvertisement — see internal/reconcile/reconcile.go's
-// resolveSRv6SID), never by parsing it out of a packet.
+// DesiredBackend is one backend endpoint a rule load-balances to. It mirrors
+// the CRD's backend plus one field the CRD does not carry: the SRv6 uSID of the
+// worker node the backend is reachable through. The controller resolves that
+// the way any other cross-node SRv6 destination is resolved, from the backend's
+// router and advertisement, never by parsing a packet.
 type DesiredBackend struct {
 	Address netip.Addr
 	Port    uint16
 	USID    netip.Addr
 }
 
-// Key implements internal/maglev.Backend. address:port (the backend's own
-// Pod address and port) is the chosen convention: it is stable across
-// reconciles for the life of the backend, unique within one rule's backend
-// set (two backends sharing an address:port would be indistinguishable
-// targets anyway), and does not change if the backend's USID changes
-// (its owning worker node's SRv6 path moving does not make it a
-// *different* backend for Maglev's consistent-hash purposes). See
-// kerneldatapath.go's buildMaglevTable for how this is used.
+// Key implements maglev.Backend. The address and port are the chosen
+// convention: stable across reconciles for the backend's life, unique within one
+// rule's backend set, since two backends sharing them would be
+// indistinguishable targets anyway, and unchanged if the backend's uSID changes.
+// Its worker node's SRv6 path moving does not make it a different backend for
+// consistent-hashing purposes.
 func (b DesiredBackend) Key() string {
 	return fmt.Sprintf("%s:%d", b.Address, b.Port)
 }
 
-// DesiredRule is the engine's internal representation of one NetworkRule,
-// assembled by the future NetworkGateway/NetworkRule controllers from the
-// NetworkRule CRD. Unlike an earlier, rejected design's identically-named
-// type, there is no VNI or VRFTableID here at all: this engine has no VRF/
-// Geneve dependency (see doc.go). Unlike this engine's own Full-NAT
-// predecessor, there is no primary/secondary placement field here either —
-// DSR's anycast model means every gateway node serves every rule
-// identically, with no BGP local-preference distinction to carry (see
-// doc.go).
+// DesiredRule is the engine's representation of one NetworkRule, assembled by
+// the reconcilers from the CRD. There is no tunnel identifier or VRF table here,
+// this engine having no VRF dependency, and no placement field either, every
+// gateway node serving every rule identically under anycast.
 type DesiredRule struct {
 	// Key uniquely identifies the rule (namespace/name of the source
 	// NetworkRule), used as the map key in Engine's convergence pass.
 	Key string
 
-	// VPCRef/VPCAttachmentRef are opaque tenant identifiers, carried
-	// through for telemetry labeling and admission-webhook auditing —
-	// this engine's datapath itself never needs them (a VIP is globally
-	// unique by construction, so no tenant dimension is needed to
-	// disambiguate ingress traffic; see edgeprog's doc comment).
+	// VPCRef and VPCAttachmentRef are opaque tenant identifiers, carried for
+	// telemetry labels and admission auditing. The datapath never needs them: a
+	// VIP is globally unique, so no tenant dimension disambiguates ingress
+	// traffic.
 	VPCRef           string
 	VPCAttachmentRef string
 
@@ -67,11 +56,10 @@ type DesiredRule struct {
 	Backends []DesiredBackend
 }
 
-// EngineState is the full desired state for one gateway node's Engine,
-// assembled by the NetworkGateway controller from every accepted
-// NetworkRule in the node's PoP — every gateway node in the PoP serves
-// every rule identically under DSR's anycast model, so there is no
-// primary/secondary subset to distinguish here.
+// EngineState is the full desired state for one gateway node's engine,
+// assembled from every accepted rule in the node's PoP. Every node in the PoP
+// serves every rule identically under anycast, so there is no subset to
+// distinguish here.
 type EngineState struct {
 	// Rules is keyed by DesiredRule.Key.
 	Rules map[string]DesiredRule

--- a/internal/gc/gc.go
+++ b/internal/gc/gc.go
@@ -28,9 +28,9 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// annotationNetNS is the annotation key prefix used by the CNI plugin
-// to store the netns path it was invoked with, keyed by container ID.
-// This is the liveness signal GC uses — see cni.netnsAnnotationKey.
+// annotationNetNS is the annotation key prefix the CNI plugin uses to record
+// the netns path it was invoked with, keyed by container ID. It is the
+// liveness signal GC reads.
 const annotationNetNS = "galactic.datum.net/netns"
 
 // OrphanedCRD represents a BGP CRD that appears to be orphaned because its
@@ -46,14 +46,12 @@ type OrphanedCRD struct {
 type CleanupResult struct {
 	OrphanedCRDsRemoved int
 	OrphanedVRFsRemoved int
-	// EBPFVRFEntriesRemoved counts stale eBPF uSID datapath vrf_table map
-	// entries removed by SweepEBPFVRFTable -- a distinct kind of resource
-	// from OrphanedVRFsRemoved's kernel VRF *interfaces* above (Milestone
-	// 7.3).
+	// EBPFVRFEntriesRemoved counts stale eBPF vrf_table map entries removed by
+	// SweepEBPFVRFTable, a different resource from the kernel VRF interfaces
+	// OrphanedVRFsRemoved counts.
 	EBPFVRFEntriesRemoved int
 	// EBPFVRFEntriesRegistered counts vrf_table entries SweepEBPFVRFTable
-	// (re-)registered for a live BGPVRFInstance CRD that had no
-	// corresponding vrf_table row -- see its repair-loop doc comment.
+	// re-registered for a live BGPVRFInstance CRD that had no matching row.
 	EBPFVRFEntriesRegistered int
 	// EBPFNPTv6EntriesRemoved counts stale eBPF uSID datapath nptv6_table
 	// map entries removed by SweepEBPFNPTv6Table.
@@ -61,35 +59,32 @@ type CleanupResult struct {
 	Errors                  int
 }
 
-// vrfNameRegex matches the deterministic VRF interface name pattern used by
-// Galactic. The template is "G%09sV" where %09s is the base62 VPC — the
-// kernel VRF is shared by every attachment on this VPC on this node, so
-// unlike the host/guest veth templates it carries no VPCAttachment segment.
-// Base62 includes digits and letters.
+// vrfNameRegex matches the deterministic VRF interface name Galactic
+// generates, "G%09sV", where the padded field is the base62 VPC. The kernel
+// VRF is shared by every attachment on this VPC on this node, so unlike the
+// host and guest veth templates it carries no VPCAttachment segment.
 var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})V$`)
 
-// legacyVRFNameRegex matches the VRF interface name Galactic generated before
-// the VRF became per-VPC: the template was "G%09s%03sV", carrying the same
-// VPCAttachment segment the host/guest veth names still do (14 chars). A node
-// upgraded in place keeps whatever VRFs it created under the old template, and
-// those interfaces hold a routing table ID and its routes for as long as they
-// survive — so collection has to recognise them, map them to the same VPC the
-// current name would yield, and reclaim them once nothing references that VPC.
+// legacyVRFNameRegex matches the VRF interface name generated before the VRF
+// became per-VPC: "G%09s%03sV", carrying the VPCAttachment segment the veth
+// names still do. A node upgraded in place keeps whatever VRFs it created
+// under that template, and each holds a routing table ID and its routes for as
+// long as it survives, so collection has to recognise them, map them to the
+// same VPC the current name would yield, and reclaim them.
 //
-// This is deliberately a collection-only concern: nothing creates these names
-// any more, and the removal path must NOT resolve one back through
-// intf.GenerateInterfaceNameVRF (see vpcFromVRFName and RemoveOrphanedVRFs).
+// Collection only. Nothing creates these names, and the removal path must not
+// resolve one back through intf.GenerateInterfaceNameVRF; see vpcFromVRFName
+// and RemoveOrphanedVRFs.
 var legacyVRFNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})[A-Za-z0-9]{3}V$`)
 
-// routerNamesForNode returns the names of every BGPRouter in the namespace
-// whose TargetRef points at nodeName. BGPAdvertisement/BGPVRFInstance CRDs
-// are namespace-scoped, not node-scoped — a namespace can hold CRDs created
-// by routers on other nodes (e.g. the default and rr roles both
-// watch the same namespace in the containerlab lab), and this node's local
-// kernel/filesystem state (VRFs, /var/run/netns) can only ever confirm or
-// deny liveness for containers that actually ran here. Callers must use this
-// to skip CRDs belonging to other nodes entirely, rather than risk deleting
-// another node's live resources because they look orphaned from here.
+// routerNamesForNode returns the names of every BGPRouter in namespace whose
+// TargetRef points at nodeName.
+//
+// BGPAdvertisement and BGPVRFInstance CRDs are namespace-scoped, not
+// node-scoped, so a namespace can hold CRDs created by routers on other nodes,
+// while this node's kernel and filesystem state can only confirm liveness for
+// containers that ran here. Callers must use this to skip other nodes' CRDs
+// rather than delete live resources that merely look orphaned from here.
 func routerNamesForNode(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) (map[string]struct{}, error) {
@@ -104,11 +99,10 @@ func routerNamesForNode(
 	return names, nil
 }
 
-// routersForNode is routerNamesForNode's fuller sibling: it keeps the full
-// BGPRouter object (keyed by name) rather than just membership, for
-// callers that need more than the name -- SweepEBPFVRFTable (Milestone
-// 7.3) needs each router's Spec.SRv6Locator to derive the eBPF uSID Block
-// its BGPVRFInstances resolve into.
+// routersForNode is routerNamesForNode's fuller sibling, keeping each
+// BGPRouter object keyed by name rather than just its membership.
+// SweepEBPFVRFTable needs each router's Spec.SRv6Locator to derive the uSID
+// Block its BGPVRFInstances resolve into.
 func routersForNode(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) (map[string]bgpv1alpha1.BGPRouter, error) {
@@ -126,21 +120,19 @@ func routersForNode(
 	return routers, nil
 }
 
-// vpcFromName extracts the VPC segment from a "vpc-suffix" CRD name —
-// BGPAdvertisement's vpc-vpcAttachment (crdnames.BGPAdvertisementName) or
-// BGPVRFInstance's vpc-node (crdnames.BGPVRFInstanceName). The base62 VPC
-// value itself never contains '-', so the first segment is always
-// unambiguous regardless of what the suffix contains — including a node
-// name that itself contains '-' (e.g. "dfw-worker-control").
+// vpcFromName extracts the VPC segment from a "vpc-suffix" CRD name, either a
+// BGPAdvertisement's vpc-vpcAttachment or a BGPVRFInstance's vpc-node. The
+// base62 VPC never contains '-', so the first segment is unambiguous whatever
+// the suffix holds, including a node name that itself contains '-'.
 func vpcFromName(name string) string {
 	vpc, _, _ := strings.Cut(name, "-")
 	return vpc
 }
 
 // vpcKeys returns every form a VPC may appear as in a CRD name: the value
-// itself, plus its encoded form (crdnames.VPCSegment). CRD names written
-// before the encoding change carry the raw base62 VPC, which is also what a
-// kernel VRF name yields, so both have to join for as long as either exists.
+// itself, plus its encoded form. CRD names written before the encoding change
+// carry the raw base62 VPC, which is also what a kernel VRF name yields, so
+// both must match for as long as either exists.
 func vpcKeys(vpc string) []string {
 	encoded := crdnames.VPCSegment(vpc)
 	if encoded == vpc {
@@ -167,24 +159,20 @@ func vpcInSet(set map[string]struct{}, vpc string) bool {
 }
 
 // CollectOrphanedCRDs scans BGPAdvertisement and BGPVRFInstance CRDs owned by
-// nodeName's BGPRouter(s) in the given namespace and returns those whose
-// associated container(s)/attachment(s) no longer exist on this node.
+// nodeName's BGPRouters in namespace and returns those whose containers or
+// attachments no longer exist on this node.
 //
-// A CRD is considered orphaned when:
-//   - It is a BGPAdvertisement targeting one of nodeName's BGPRouters, with
-//     at least one netns annotation, and NONE of the recorded paths exist
-//     under /var/run/netns. A vpc/vpcAttachment is shared across every pod
-//     that has ever attached to it on this node (pod churn adds a new
-//     annotation entry without removing old ones — see cmdDel in
-//     internal/cni/ops_del.go), so the object is only orphaned once every
-//     container that ever referenced it is gone, not just one.
-//   - It is a BGPVRFInstance (named vpc-node — crdnames.BGPVRFInstanceName —
-//     shared by every attachment on this VPC on this node, unlike the 1:1
-//     BGPAdvertisement) whose VPC has no surviving BGPAdvertisement: every
-//     BGPAdvertisement whose name's vpc segment matches is either orphaned
-//     or absent entirely. A BGPAdvertisement this pass could not determine
-//     the liveness of (no netns annotations at all) counts as surviving,
-//     not orphaned — GC must never guess a shared VRF is safe to reclaim.
+// A CRD is orphaned when:
+//   - It is a BGPAdvertisement with at least one netns annotation, and none of
+//     the recorded paths exist under /var/run/netns. An attachment is shared
+//     by every pod that has ever attached to it on this node, and pod churn
+//     adds annotations without removing old ones, so the object is orphaned
+//     only once every container that referenced it is gone.
+//   - It is a BGPVRFInstance, shared by every attachment on this VPC on this
+//     node, whose VPC has no surviving BGPAdvertisement. A BGPAdvertisement
+//     whose liveness this pass cannot determine, having no netns annotations,
+//     counts as surviving: GC must never guess that a shared VRF is safe to
+//     reclaim.
 func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]OrphanedCRD, error) {
 	routerNames, err := routerNamesForNode(ctx, k8s, namespace, nodeName)
 	if err != nil {
@@ -197,10 +185,10 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 	}
 
 	var orphaned []OrphanedCRD
-	// vpcSurvives records every VPC (attachments owned by this node's
-	// router(s) only) with at least one BGPAdvertisement that is live, or
-	// whose liveness could not be determined — the shared BGPVRFInstance for
-	// that VPC must not be touched while any of these remain.
+	// vpcSurvives records every VPC, among attachments owned by this node's
+	// routers, with at least one BGPAdvertisement that is live or whose
+	// liveness could not be determined. That VPC's shared BGPVRFInstance must
+	// not be touched while any of these remain.
 	vpcSurvives := make(map[string]struct{})
 
 	for _, adv := range advList.Items {
@@ -212,9 +200,8 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 
 		netnsPaths := collectNetNSPaths(&adv)
 		if len(netnsPaths) == 0 {
-			// No netns annotations — skip (might be legacy or manually
-			// created). We cannot determine if it is orphaned, so its VPC
-			// must be treated as surviving.
+			// No netns annotations, so liveness is unknown. Its VPC counts as
+			// surviving.
 			addVPC(vpcSurvives, vpc)
 			continue
 		}
@@ -248,12 +235,10 @@ func CollectOrphanedCRDs(ctx context.Context, k8s client.Client, namespace, node
 		})
 	}
 
-	// A BGPVRFInstance is orphaned only once every attachment on its VPC —
-	// not just one — is gone, since it's shared by all of them. This counts
-	// across every BGPAdvertisement for the VPC rather than aliasing 1:1 off
-	// a single BGPAdvertisement's name, the way the two used to share an
-	// identical vpc-vpcattachment name before BGPVRFInstance moved to
-	// vpc-node naming.
+	// A BGPVRFInstance is shared by every attachment on its VPC, so it is
+	// orphaned only once all of them are gone. This counts across every
+	// BGPAdvertisement for the VPC rather than aliasing off a single one's
+	// name.
 	vrfList := &bgpv1alpha1.BGPVRFInstanceList{}
 	if err := k8s.List(ctx, vrfList, client.InNamespace(namespace)); err != nil {
 		return nil, fmt.Errorf("list BGPVRFInstances: %w", err)
@@ -325,36 +310,23 @@ func RemoveOrphanedCRDs(ctx context.Context, k8s client.Client, orphans []Orphan
 }
 
 // activeVPCsFromEndpointSlices returns every VPC named by an EndpointSlice
-// carrying crdnames.LabelTenantID, cluster-wide — the same label
-// internal/ingresssidecar's own controller watches (hasTenantLabel in
-// internal/ingresssidecar/controller.go) to decide it needs a local VRF for
-// that VPC, entirely independent of any BGPAdvertisement/BGPVRFInstance CRD.
+// carrying crdnames.LabelTenantID, cluster-wide. It is the same label the
+// ingress sidecar watches to decide it needs a local VRF for that VPC,
+// independent of any BGPAdvertisement or BGPVRFInstance CRD.
 //
-// SweepEBPFVRFTable already exempts that sidecar's own eBPF vrf_table
-// entries by their reserved uformat.BlockMax block (see that function's own
-// doc comment on the ingress sidecar's BlockMax exemption: without it,
-// every entry the sidecar registers is invisible to the CRD-built live set
-// and gets reaped as an orphan on the very next sweep). This is the same
-// exemption at the kernel-VRF-interface layer instead,
-// needed because CollectOrphanedVRFs runs inside galactic-router
-// (cmd/galactic-router), which — deliberately, per SweepEBPFVRFTable's own
-// doc comment on why that sweep runs inside galactic-cni instead — has
-// neither the /sys/fs/bpf hostPath mount nor CAP_BPF to read vrf_table
-// itself. Found live: without this, ensureEgressDatapath's own VRF for a
-// real tenant VPC (created for the sidecar's own outbound routing, sharing
-// that VPC's identifier with — but never advertised by — any real CNI
-// attachment) gets reaped as orphaned on this sweep's very next tick,
-// stranding EnsureRoute with "no VRF interface found" on every subsequent
-// reconcile.
+// Without this, a VRF the sidecar created for its own outbound routing, which
+// no CNI attachment ever advertises, is reaped as orphaned on the next sweep
+// and every later reconcile fails to find a VRF interface. SweepEBPFVRFTable
+// makes the equivalent exemption one layer down, at the eBPF map, by reserving
+// a block; this is the kernel-interface layer, which needs its own because
+// CollectOrphanedVRFs runs inside galactic-router, which has neither the
+// /sys/fs/bpf mount nor CAP_BPF to read that map.
 //
-// Deliberately not scoped to this node, unlike the BGPAdvertisement check
-// above: an EndpointSlice carries no node affinity to filter on, so the
-// conservative direction is to err toward not reaping — a VPC claimed by
-// some other node's ingress sidecar is not this function's call to make,
-// the same way an unrelated node's BGPAdvertisement already isn't allowed
-// to vouch for a *different* node's VRF, just inverted (there, cross-node
-// claims are excluded to avoid a false "still alive"; here, they're
-// included to avoid a false "orphaned").
+// Not scoped to this node, unlike the BGPAdvertisement check above: an
+// EndpointSlice carries no node affinity to filter on, so the conservative
+// direction is to err away from reaping. A cross-node BGPAdvertisement is
+// excluded to avoid a false "still alive"; a cross-node EndpointSlice is
+// included to avoid a false "orphaned".
 func activeVPCsFromEndpointSlices(ctx context.Context, k8s client.Client) (map[string]struct{}, error) {
 	sliceList := &discoveryv1.EndpointSliceList{}
 	if err := k8s.List(ctx, sliceList, client.HasLabels{crdnames.LabelTenantID}); err != nil {
@@ -372,31 +344,22 @@ func activeVPCsFromEndpointSlices(ctx context.Context, k8s client.Client) (map[s
 	return vpcs, nil
 }
 
-// CollectOrphanedVRFs scans all VRF interfaces on this node and returns the
-// names of VRFs whose VPC has no surviving BGPAdvertisement CRD owned by
-// nodeName's BGPRouter(s) in the given namespace, and no ingress-sidecar
-// EndpointSlice claiming it either (see activeVPCsFromEndpointSlices).
+// CollectOrphanedVRFs scans the VRF interfaces on this node and returns those
+// whose VPC has no surviving BGPAdvertisement owned by nodeName's BGPRouters in
+// namespace, and no ingress-sidecar EndpointSlice claiming it.
 //
-// A VRF is considered orphaned when:
-//   - Its interface name matches the Galactic VRF naming pattern — either the
-//     current per-VPC name or the legacy pre-rename name that carried a
-//     VPCAttachment segment, both of which resolve to the same VPC (see
-//     vpcFromVRFName). A node upgraded in place still carries the latter, and
-//     they must be reclaimed too rather than stranding a routing table ID and
-//     its routes forever.
-//   - No BGPAdvertisement owned by this node (name's vpc segment matches,
-//     RouterRef pointing at one of nodeName's BGPRouters) exists for its
-//     VPC. The VRF is shared by every attachment on this VPC on this node
-//     (crdnames.BGPVRFInstanceName), so any one surviving BGPAdvertisement
-//     for the VPC — regardless of which vpcAttachment it names — keeps it
-//     alive, not just a single exact-name match. Other nodes sharing this
-//     namespace may coincidentally reuse the same VPC for their own,
-//     unrelated attachment — only this node's own BGPAdvertisements can
-//     vouch for a local VRF.
-//   - No EndpointSlice claims the VPC either, per
-//     activeVPCsFromEndpointSlices's own doc comment — internal/ingresssidecar
-//     creates and owns its own VRF for a VPC entirely independent of any
-//     BGPAdvertisement, and this sweep has no other way to see that claim.
+// A VRF is orphaned when:
+//   - Its name matches the current per-VPC pattern or the legacy pattern that
+//     carried a VPCAttachment segment. Both resolve to the same VPC. A node
+//     upgraded in place still carries legacy names, and leaving them behind
+//     strands a routing table ID and its routes forever.
+//   - No BGPAdvertisement owned by this node exists for its VPC. The VRF is
+//     shared by every attachment on this VPC on this node, so any one
+//     surviving BGPAdvertisement for the VPC keeps it alive, whichever
+//     attachment it names. Only this node's own advertisements can vouch for
+//     a local VRF, since another node may reuse the same VPC for an unrelated
+//     attachment.
+//   - No EndpointSlice claims the VPC, per activeVPCsFromEndpointSlices.
 func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, nodeName string) ([]string, error) {
 	vrfs, err := vrf.ListVRFLinks()
 	if err != nil {
@@ -447,26 +410,25 @@ func CollectOrphanedVRFs(ctx context.Context, k8s client.Client, namespace, node
 	return orphaned, nil
 }
 
-// RemoveOrphanedVRFs deletes the given orphaned VRF interfaces from the
-// kernel. Errors are logged but do not abort the cleanup — best-effort
-// semantics.
+// RemoveOrphanedVRFs deletes the named orphaned VRF interfaces from the
+// kernel. Errors are logged rather than returned; cleanup is best effort and
+// continues past a failure.
 func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 	result := CleanupResult{}
 
 	for _, name := range vrfNames {
-		// We need the vpc to call vrf.Delete. Parse the name back to get it —
-		// deliberately with parseVRFName, not vpcFromVRFName: vrf.Delete
-		// rebuilds the current "G%09sV" interface name from the VPC, so a
-		// legacy "G%09s%03sV" interface resolved that way would be looked up
-		// under a name that does not exist and silently reported as removed.
+		// Parse the name back to the VPC that vrf.Delete needs. Deliberately
+		// parseVRFName, not vpcFromVRFName: vrf.Delete rebuilds the current
+		// "G%09sV" name from the VPC, so a legacy interface resolved that way
+		// would be looked up under a name that does not exist and silently
+		// reported as removed.
 		vpc, ok := parseVRFName(name)
 		if !ok {
-			// Not a current-shape name — this is where a legacy VRF collected
-			// by vpcFromVRFName lands. Delete the interface we actually
-			// observed, by name, but flush its routing table first — the
-			// same order vrf.Delete uses — so this path leaves behind the
-			// same state as the one above rather than leaning on Add's own
-			// flush-on-reuse to clean up a table this path skipped (#343).
+			// Not a current-shape name, so this is where a legacy VRF lands.
+			// Delete the interface actually observed, by name, flushing its
+			// routing table first in the same order vrf.Delete uses, so this
+			// path leaves the same state behind rather than leaning on Add's
+			// flush-on-reuse to clean up a table it skipped.
 			link, err := netlink.LinkByName(name)
 			if err != nil {
 				// Already gone — not an error.
@@ -480,11 +442,9 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 					continue
 				}
 			} else {
-				// CollectOrphanedVRFs only ever collects names from
-				// vrf.ListVRFLinks, which filters to *netlink.Vrf — this
-				// branch means the interface changed kind between that scan
-				// and this delete. Nothing to flush; fall through and
-				// remove whatever is there now.
+				// Names are only ever collected from vrf.ListVRFLinks, which
+				// filters to VRF links, so this means the interface changed
+				// kind between that scan and this delete. Nothing to flush.
 				slog.Warn("GC: orphaned VRF name no longer resolves to a VRF interface, skipping flush",
 					"name", name)
 			}
@@ -512,29 +472,21 @@ func RemoveOrphanedVRFs(vrfNames []string) CleanupResult {
 	return result
 }
 
-// SweepEBPFVRFTable removes eBPF uSID datapath vrf_table map entries whose
-// (Block, Argument) key no longer corresponds to a live BGPVRFInstance CRD
-// owned by nodeName's BGPRouter(s) (design plan §5.3; Milestone 7.3).
-// Unlike RunGC's CRD/kernel-VRF sweep above, this deliberately does NOT run
-// from galactic-router's existing GC controller (internal/controller/
-// gc_controller.go): the pinned vrf_table map only exists inside
-// galactic-cni's "run" container, which has the /sys/fs/bpf hostPath mount
-// and CAP_BPF (Milestone 3.1) that galactic-router's own DaemonSet does
-// not and, for this alone, should not need. internal/installer.Run calls
-// this directly on its own ticker instead -- see that package's doc
-// comment for the full reasoning. The RBAC galactic-cni's ServiceAccount
-// already has (get/list bgprouters; get/list/...  bgpvrfinstances, see
-// config/galactic-cni/rbac.yaml) is exactly what this function needs, so no
-// permission change was required to place it there.
+// SweepEBPFVRFTable removes eBPF vrf_table entries whose (Block, Argument) key
+// no longer matches a live BGPVRFInstance CRD owned by nodeName's BGPRouters,
+// and re-registers entries a live CRD expects but the map lacks. pinDir is the
+// bpffs directory holding the pinned map.
 //
-// A pin directory this process can't confirm exists -- either genuinely
-// absent (the "run" container's eBPF datapath hasn't finished loading yet)
-// or inaccessible (e.g. /sys/fs/bpf's own restrictive mode denying a
-// non-root stat, which the production "run" container never hits since it
-// runs as root, design plan §9) -- is treated as "nothing to do this
-// tick," not an error; any stat failure here means there's no pinned
-// datapath this process can reach right now, and it isn't this function's
-// job to diagnose why.
+// It runs from internal/installer.Run's ticker rather than galactic-router's GC
+// controller because the pinned map exists only inside galactic-cni's run
+// container, which has the /sys/fs/bpf hostPath mount and CAP_BPF that
+// galactic-router does not need and should not have. The RBAC galactic-cni
+// already holds covers everything this reads.
+//
+// A pin directory this process cannot confirm exists, whether genuinely absent
+// because the datapath has not finished loading or merely inaccessible, means
+// there is no reachable datapath this tick. That is treated as nothing to do,
+// not an error.
 func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeName, pinDir string) CleanupResult {
 	result := CleanupResult{}
 
@@ -550,11 +502,8 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	}
 	defer func() { _ = closer.Close() }()
 
-	// Capture the cutoff *before* listing BGPVRFInstance CRDs below --
-	// VRFTable.Generation's own doc comment and doc.go's
-	// "plugin-binary-vs-run-container race" section explain why the
-	// ordering matters: a Register landing between this line and the List
-	// call below must survive this sweep.
+	// Capture the cutoff before listing CRDs below, so a Register landing
+	// between here and the List survives this sweep.
 	cutoff := reg.VRF.Generation()
 
 	routers, err := routersForNode(ctx, k8s, namespace, nodeName)
@@ -564,16 +513,13 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 		return result
 	}
 	if len(routers) == 0 {
-		// A node with any live eBPF-registered attachment at all necessarily
-		// has a BGPRouter targeting it -- registerEBPFDatapath requires one
-		// to run at all (internal/cnibgp/bgp.go). Finding none here is
-		// indistinguishable from a transient listing/cache hiccup or the
-		// router having just been renamed/recreated, so it must not be
-		// treated the same as "genuinely zero live attachments": doing so
-		// would fold every entry into the below-cutoff, absent-from-live
-		// case and wipe the entire vrf_table -- every pod on this node --
-		// on what may just be one bad tick. Skip this sweep instead; the
-		// next tick tries again once router listing is reliable again.
+		// A node with any live eBPF-registered attachment necessarily has a
+		// BGPRouter targeting it, since registerEBPFDatapath requires one.
+		// Finding none is indistinguishable from a transient listing hiccup or
+		// a router just renamed, so it must not read as "genuinely nothing is
+		// live": that would fold every entry into the stale case and wipe the
+		// whole vrf_table, and every pod on this node with it, on one bad
+		// tick. Skip and retry next tick instead.
 		slog.Warn("GC: no BGPRouter found for node during eBPF vrf_table sweep, skipping reconcile this tick",
 			"nodeName", nodeName)
 		return result
@@ -587,11 +533,10 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	}
 
 	live := make(map[usidmap.VRFKey]struct{}, len(vrfInstList.Items))
-	// liveCRDNames tracks, for every CRD-derived key above, the
-	// BGPVRFInstance name it came from -- the registration-repair step
-	// below needs the name back (to re-derive vrfTableID/egressKind via
-	// resolveVRFKernelState) but Reconcile only needs the key, so this
-	// stays a separate map rather than changing live's value type.
+	// liveCRDNames tracks the BGPVRFInstance name each key came from. The
+	// repair step below needs the name back to re-derive vrfTableID and
+	// egressKind, while Reconcile needs only the key, so this stays separate
+	// rather than widening live's value type.
 	liveCRDNames := make(map[usidmap.VRFKey]string, len(vrfInstList.Items))
 	for _, inst := range vrfInstList.Items {
 		if inst.Spec.RouterRef == nil {
@@ -616,11 +561,9 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 				"vrfInstance", inst.Name, "router", router.Name, "locator", router.Spec.SRv6Locator, "err", err)
 			continue
 		}
-		// inst.Spec.VRFID is the real, allocated Argument value directly
-		// (Milestone 6.1) -- no derivation needed. Guard the int32->uint16
-		// narrowing explicitly rather than trusting an external CRD value
-		// (a boundary this GC sweep does not otherwise validate) to
-		// already be in range.
+		// Spec.VRFID is the allocated Argument value directly. Guard the
+		// int32 to uint16 narrowing explicitly rather than trust an external
+		// CRD value this sweep does not otherwise validate.
 		if inst.Spec.VRFID < int32(uformat.ArgumentMin) || inst.Spec.VRFID > int32(uformat.ArgumentMax) {
 			slog.Warn("GC: skipping BGPVRFInstance with out-of-range VRFID during eBPF sweep",
 				"vrfInstance", inst.Name, "vrfID", inst.Spec.VRFID)
@@ -631,20 +574,14 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 		liveCRDNames[key] = inst.Name
 	}
 
-	// internal/ingresssidecar registers its own vrf_table entries under
-	// uformat.BlockMax -- a block deliberately reserved so it can never
-	// collide with a real BGPRouter locator (see that package's
-	// ingressSidecarBlock doc comment) -- and owns their entire lifecycle
-	// itself (ensureEgressDatapath/removeEgressDatapath), independent of
-	// any BGPVRFInstance CRD. Without this, every entry it ever registers
-	// is invisible to the CRD-built live set above and gets reaped as an
-	// orphan on this sweep's very next tick: with nothing preserving them,
-	// vrf_table would sit permanently empty for that sidecar's entries
-	// while ifindex_vrf_table (which this sweep never touches) kept
-	// holding the same entries, silently blackholing that sidecar's own
-	// outbound connections to VPC backends. Preserve every entry in that
-	// block unconditionally, the same way an entry with a live CRD is
-	// preserved.
+	// The ingress sidecar registers its own vrf_table entries under a reserved
+	// block that can never collide with a real BGPRouter locator, and owns
+	// their whole lifecycle independent of any BGPVRFInstance CRD. Without
+	// this exemption they are invisible to the CRD-built live set and reaped
+	// on the next tick, leaving vrf_table empty for those entries while
+	// ifindex_vrf_table, which this sweep never touches, still holds them, and
+	// silently blackholing the sidecar's outbound connections. Preserve every
+	// entry in that block unconditionally.
 	existing, err := reg.VRF.List()
 	if err != nil {
 		slog.Error("GC: failed to list eBPF vrf_table for sweep", "err", err)
@@ -659,15 +596,12 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 		}
 	}
 
-	// Repair vrf_table entries that a live BGPVRFInstance CRD expects but
-	// vrf_table does not currently have -- most notably attach.Load's own
-	// incompatible-map-schema reload (see its doc comment), which wipes
-	// every pinned map, including vrf_table, and leaves nothing behind for
-	// a *pre-existing* attachment to repopulate from: registerEBPFDatapath
-	// only ever runs once, at CNI ADD time, and nothing re-invokes it for
-	// an attachment that already succeeded. Reconcile above only ever
-	// deletes; this is vrf_table's only self-healing path for an entry
-	// that a live CRD says should exist but doesn't.
+	// Repair entries a live BGPVRFInstance expects but vrf_table lacks. An
+	// incompatible-schema reload wipes every pinned map, and nothing
+	// repopulates a pre-existing attachment: registerEBPFDatapath runs once,
+	// at CNI ADD, and is never re-invoked for an attachment that already
+	// succeeded. Reconcile above only deletes, so this is vrf_table's only
+	// self-healing path.
 	for key, instName := range liveCRDNames {
 		if _, ok := existingKeys[key]; ok {
 			continue // already present -- Reconcile above is what handles this one
@@ -680,10 +614,9 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 			continue
 		}
 		if !ok {
-			// No matching kernel VRF interface exists right now -- e.g. the
-			// attachment's own teardown is in flight, or the CNI ADD that
-			// will create it hasn't run yet. Nothing to repopulate from;
-			// leave it missing for this tick.
+			// No matching kernel VRF interface right now, because teardown is
+			// in flight or the CNI ADD that creates it has not run. Nothing
+			// to repopulate from this tick.
 			continue
 		}
 		if err := reg.VRF.Register(key.Block, key.Argument, vrfTableID, egressKind); err != nil {
@@ -711,48 +644,36 @@ func SweepEBPFVRFTable(ctx context.Context, k8s client.Client, namespace, nodeNa
 	return result
 }
 
-// listVRFLinksFn/listAllLinksFn indirect the two netlink calls
-// resolveVRFKernelState needs, so tests can substitute fabricated
-// *netlink.Vrf/netlink.Link values -- plain structs needing no real kernel
-// VRF interface or CAP_NET_ADMIN -- the same way attach.go's
-// preflightCheckFn lets tests substitute a kernel-touching call it makes.
+// listVRFLinksFn and listAllLinksFn indirect the netlink calls
+// resolveVRFKernelState makes, so tests can substitute fabricated links
+// needing no real VRF interface or CAP_NET_ADMIN.
 var (
 	listVRFLinksFn = vrf.ListVRFLinks
 	listAllLinksFn = netlink.LinkList
 )
 
-// resolveVRFKernelState recovers the (Linux VRF routing table id, egress
-// kind) a live BGPVRFInstance named instName should register in vrf_table,
-// by matching it against a real, currently existing kernel VRF interface.
-// SweepEBPFVRFTable uses this to repair an entry vrf_table is missing for a
-// still-live CRD (see that function's own doc comment on the repair loop).
+// resolveVRFKernelState recovers the Linux VRF routing table ID and egress
+// kind that a live BGPVRFInstance named instName should register in vrf_table,
+// by matching it against a kernel VRF interface that currently exists.
+// SweepEBPFVRFTable uses it to repair a missing entry.
 //
-// instName alone doesn't carry vrfTableID or egressKind -- BGPVRFInstance's
-// Spec has neither field, only RouterRef/VRFID/route targets -- so this
-// goes the other way: list every real kernel VRF interface (an ordinary,
-// independently-persisted kernel object, unaffected by an eBPF map wipe),
-// and check whether re-deriving its own CRD name -- via
-// crdnames.BGPVRFInstanceName, the exact forward computation the CNI ADD
-// path used to name instName in the first place -- reproduces instName.
-// vpcKeys accepts both the current (nameSegment-encoded) and legacy (raw)
-// CRD name shapes, the same as CollectOrphanedVRFs already does when going
-// in the opposite direction (kernel VRF -> live VPC set).
+// instName carries neither value, and BGPVRFInstance's Spec has no field for
+// either, so this works backwards: it lists every kernel VRF interface, an
+// ordinary kernel object unaffected by an eBPF map wipe, and checks whether
+// re-deriving its CRD name reproduces instName. Both the current and legacy
+// CRD name shapes are accepted.
 //
-// ok is false, not an error, when no matching kernel VRF interface exists
-// right now -- the ordinary case for a BGPVRFInstance whose attachment has
-// already been torn down (there is nothing left to repopulate an entry
-// from; Reconcile's own stale-entry sweep, not this function, is what
-// eventually removes its CRD).
+// ok is false, not an error, when no matching interface exists, the ordinary
+// case for a BGPVRFInstance whose attachment is already torn down: there is
+// nothing to repopulate an entry from, and Reconcile is what eventually
+// removes the CRD.
 //
-// The egress kind is read off whichever interface is currently enslaved to
-// the matched VRF: a "tuntap" link (internal/cnitap's tap-mode attachment)
-// yields EgressKindTap, anything else (ordinarily a "veth" link) yields
-// EgressKindVeth -- the same veth/tap distinction registerEBPFDatapath's
-// own egressKindForInterfaceType makes from the CNI config's interface
-// type, just read back from the kernel instead of from that config, which
-// this call site does not have. A VRF with no enslaved interface at all
-// (a narrow, transient window) falls back to EgressKindVeth, vrf_table's
-// own zero value and by far the common case.
+// The egress kind is read off whichever interface is enslaved to the matched
+// VRF. A tuntap link yields EgressKindTap and anything else EgressKindVeth,
+// the same distinction the CNI ADD path makes from its config, read back from
+// the kernel because this call site has no config. A VRF with nothing enslaved
+// yet falls back to EgressKindVeth, the common case and vrf_table's zero
+// value.
 func resolveVRFKernelState(nodeName, instName string) (vrfTableID uint32, egressKind uint32, ok bool, err error) {
 	links, err := listVRFLinksFn()
 	if err != nil {
@@ -797,30 +718,21 @@ func resolveVRFKernelState(nodeName, instName string) (vrfTableID uint32, egress
 	return match.Table, kind, true, nil
 }
 
-// SweepEBPFNPTv6Table registers/reconciles the eBPF uSID datapath's
-// nptv6_table map (internal/plumbing/ebpf/nptv6map) against every live
-// BGPVRFInstance CRD's own Spec.NPTv6 field, owned by nodeName's
-// BGPRouter(s).
+// SweepEBPFNPTv6Table reconciles the eBPF nptv6_table map against the NPTv6
+// field of every live BGPVRFInstance CRD owned by nodeName's BGPRouters in
+// namespace. pinDir is the bpffs directory holding the pinned map.
 //
-// Unlike SweepEBPFVRFTable (whose vrf_table registration happens at CNI ADD
-// time via internal/cnibgp's registerEBPFDatapath, and this function only
-// reconciles stale entries away), this function is nptv6_table's *only*
-// writer: nothing registers an NPTv6 mapping at CNI ADD time at all (the CNI
-// ADD path has no per-attachment notion of NPTv6 -- it is a per-VRF, not
-// per-attachment, config field). Every currently-live mapping is therefore
-// (re-)registered here, on the same tick that also reconciles stale ones
-// away -- see internal/plumbing/ebpf/nptv6map/doc.go's "no Generation/
-// monotonic-clock kernel field" section for why a single, sequential writer
-// (this function, never raced by a second writer) makes that safe without
-// vrf_table's own kernel-persisted generation field.
+// Unlike SweepEBPFVRFTable, which only reaps entries the CNI ADD path
+// registered, this is nptv6_table's only writer: NPTv6 is a per-VRF field with
+// no per-attachment counterpart, so nothing registers a mapping at ADD time.
+// Every live mapping is therefore re-registered on the same tick that reaps
+// stale ones. Being the sole writer is what makes that safe without the
+// kernel-persisted generation field vrf_table relies on.
 //
-// Runs from the same place as SweepEBPFVRFTable
-// (internal/installer.Run's ebpfGCSweepTicker), for the identical reason:
-// the pinned nptv6_table map only exists inside that container -- see
-// SweepEBPFVRFTable's own doc comment for the full reasoning (galactic-router's
-// own DaemonSet has no /sys/fs/bpf mount or CAP_BPF, so the BGPVRFInstance
-// controller-runtime reconciler cannot open this map directly regardless of
-// how it validates the CRD's own NPTv6 field).
+// It runs alongside SweepEBPFVRFTable, from the same ticker and for the same
+// reason: the pinned map exists only in the container with the /sys/fs/bpf
+// mount and CAP_BPF, so the BGPVRFInstance reconciler cannot open it whatever
+// it does with the CRD field.
 func SweepEBPFNPTv6Table(ctx context.Context, k8s client.Client, namespace, nodeName, pinDir string) CleanupResult {
 	result := CleanupResult{}
 
@@ -836,11 +748,9 @@ func SweepEBPFNPTv6Table(ctx context.Context, k8s client.Client, namespace, node
 	}
 	defer func() { _ = closer.Close() }()
 
-	// Capture the cutoff *before* listing BGPVRFInstance CRDs and
-	// (re-)registering their live mappings below -- every entry this same
-	// call registers therefore stamps a generation >= cutoff, and Reconcile
-	// keeps it regardless (it is also always in live directly). See
-	// nptv6map/doc.go for why this table has no second writer to race.
+	// Capture the cutoff before listing CRDs and re-registering their mappings
+	// below, so every entry this call registers stamps a generation at or
+	// above it and Reconcile keeps it.
 	cutoff := table.Generation()
 
 	routers, err := routersForNode(ctx, k8s, namespace, nodeName)
@@ -850,9 +760,8 @@ func SweepEBPFNPTv6Table(ctx context.Context, k8s client.Client, namespace, node
 		return result
 	}
 	if len(routers) == 0 {
-		// See SweepEBPFVRFTable's own identical guard for why zero routers
-		// found is treated as "skip this tick," not "genuinely nothing is
-		// live."
+		// Zero routers found means skip this tick, not "nothing is live". See
+		// SweepEBPFVRFTable's identical guard.
 		slog.Warn("GC: no BGPRouter found for node during eBPF nptv6_table sweep, skipping reconcile this tick",
 			"nodeName", nodeName)
 		return result
@@ -923,9 +832,9 @@ func SweepEBPFNPTv6Table(ctx context.Context, k8s client.Client, namespace, node
 	return result
 }
 
-// buildNPTv6Mapping converts a BGPVRFInstanceSpec's NPTv6 field (validated
-// only as parseable CIDRs here; nptv6.Mapping.Adjustment/Register perform
-// the fuller RFC 6296 range validation) into an internal/plumbing/nptv6.Mapping.
+// buildNPTv6Mapping converts a BGPVRFInstanceSpec's NPTv6 field into an
+// nptv6.Mapping. It checks only that the CIDRs parse; nptv6.Mapping performs
+// the fuller RFC 6296 range validation.
 func buildNPTv6Mapping(spec *bgpv1alpha1.NPTv6Spec) (nptv6.Mapping, error) {
 	_, ula, err := net.ParseCIDR(spec.ULAPrefix)
 	if err != nil {
@@ -938,10 +847,9 @@ func buildNPTv6Mapping(spec *bgpv1alpha1.NPTv6Spec) (nptv6.Mapping, error) {
 	return nptv6.Mapping{ULAPrefix: ula, PublicPrefix: pub}, nil
 }
 
-// RunGC performs a full garbage collection pass: removes orphaned BGP CRDs
-// and orphaned VRF interfaces. Returns a summary of what was cleaned up.
-// nodeName scopes the pass to CRDs owned by this node's BGPRouter(s) — see
-// routerNamesForNode.
+// RunGC performs a full garbage collection pass, removing orphaned BGP CRDs
+// and orphaned VRF interfaces, and returns a summary of what it cleaned up.
+// nodeName scopes the pass to CRDs owned by this node's BGPRouters.
 func RunGC(ctx context.Context, k8s client.Client, namespace, nodeName string) CleanupResult {
 	var result CleanupResult
 
@@ -979,11 +887,10 @@ func RunGC(ctx context.Context, k8s client.Client, namespace, nodeName string) C
 	return result
 }
 
-// collectNetNSPaths extracts every (containerID, netnsPath) pair recorded on
-// a BGPAdvertisement's netns annotations — one per container that has ever
-// attached to this vpc/vpcAttachment on this node. Pod churn adds a new
-// annotation entry without removing old ones (see cmdDel in
-// internal/cni/ops_del.go), so an object can carry several.
+// collectNetNSPaths extracts every (containerID, netnsPath) pair recorded on a
+// BGPAdvertisement's netns annotations, one per container that has ever
+// attached to this attachment on this node. Pod churn adds entries without
+// removing old ones, so an object can carry several.
 func collectNetNSPaths(adv *bgpv1alpha1.BGPAdvertisement) map[string]string {
 	paths := make(map[string]string)
 	if adv.Annotations == nil {
@@ -999,13 +906,12 @@ func collectNetNSPaths(adv *bgpv1alpha1.BGPAdvertisement) map[string]string {
 	return paths
 }
 
-// parseVRFName extracts the base62-encoded VPC and VPCAttachment from a
-// Galactic VRF interface name. Returns the parsed values and whether the
-// name matched the expected pattern.
+// parseVRFName extracts the base62 VPC from a Galactic VRF interface name,
+// reporting whether the name matched the current pattern.
 //
-// The interface name template ("G%09s%03sV") zero-pads the base62 components,
-// but BGP CRD names use the raw (unpadded) base62 values. parseVRFName strips
-// leading zeros so the returned values match the CRD naming convention.
+// The interface name template zero-pads its base62 components while BGP CRD
+// names use the raw values, so leading zeros are stripped to match the CRD
+// naming convention.
 func parseVRFName(name string) (vpc string, ok bool) {
 	// The template is "G%09sV" — 1 + 9 + 1 = 11 characters. But base62
 	// encoding can produce mixed alphanumeric, so we need a regex approach.
@@ -1018,18 +924,16 @@ func parseVRFName(name string) (vpc string, ok bool) {
 	return strings.TrimLeft(matches[1], "0"), true
 }
 
-// vpcFromVRFName resolves the VPC that a kernel VRF interface belongs to,
-// accepting both the current per-VPC name (parseVRFName) and the legacy
-// pre-rename name (legacyVRFNameRegex). Both shapes carry the same base62 VPC
-// in the same leading position, so a legacy VRF resolves to exactly the VPC
-// its BGPAdvertisements are named after and is judged against them like any
-// other.
+// vpcFromVRFName resolves the VPC a kernel VRF interface belongs to, accepting
+// both the current per-VPC name and the legacy pre-rename name. Both carry the
+// same base62 VPC in the same leading position, so a legacy VRF resolves to
+// exactly the VPC its BGPAdvertisements are named after.
 //
-// Only CollectOrphanedVRFs uses this. RemoveOrphanedVRFs deliberately keeps
-// using parseVRFName: it deletes a resolved VPC via vrf.Delete, which rebuilds
-// the *current* interface name from that VPC and so would silently no-op
-// against a legacy interface. Leaving a legacy name unresolved there routes it
-// into the by-name fallback, which deletes the interface actually observed.
+// Only CollectOrphanedVRFs uses this. RemoveOrphanedVRFs keeps parseVRFName,
+// because it deletes through vrf.Delete, which rebuilds the current interface
+// name from the VPC and would silently no-op against a legacy interface.
+// Leaving a legacy name unresolved there routes it into the by-name fallback,
+// which deletes the interface actually observed.
 func vpcFromVRFName(name string) (vpc string, ok bool) {
 	if vpc, ok := parseVRFName(name); ok {
 		return vpc, true

--- a/internal/gc/netns.go
+++ b/internal/gc/netns.go
@@ -13,14 +13,12 @@ import (
 
 const netnsPath = "/var/run/netns"
 
-// NetNSExists checks whether the network namespace at the given path (as
-// recorded by the CNI plugin at ADD time — see cni.netnsAnnotationKey) is
-// still present on this node.
+// NetNSExists reports whether the network namespace at netnsPathStr, as recorded
+// by the CNI plugin at ADD time, is still present on this node.
 //
-// This cannot be reconstructed from a container ID: netns bind-mounts are
-// named by the container runtime's own convention (e.g. containerd's
-// "cni-<uuid>"), which has no relationship to the container ID the CNI
-// plugin receives. The exact path used at ADD time must be recorded and
+// The path cannot be reconstructed from a container ID: namespace bind mounts
+// are named by the runtime's own convention, which bears no relationship to the
+// ID the plugin receives. The exact path used at ADD must be recorded and
 // checked verbatim.
 func NetNSExists(netnsPathStr string) bool {
 	if netnsPathStr == "" {

--- a/internal/hostconf/hostconf.go
+++ b/internal/hostconf/hostconf.go
@@ -2,26 +2,21 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package hostconf reads node-local settings (node name, kubeconfig,
-// namespace, log file/level) from the static per-node CNI conflist written
-// once by internal/installer.Bootstrap. Every binary in the galactic CNI
-// plugin chain needs this same lookup, so it lives here rather than being
-// duplicated per binary — internal/cni and internal/installer both used to
-// carry their own near-identical copy, hardcoded to match a single plugin
-// type ("galactic-cni").
+// Package hostconf reads node-local settings, the node name, kubeconfig,
+// namespace, and log file and level, from the static per-node CNI conflist
+// written once by the installer. Every binary in the plugin chain needs the
+// same lookup, so it lives here rather than being duplicated per binary.
 //
-// The static conflist is not the per-attachment chain conflist the CNI
-// runtime execs each plugin with (that one carries vpc/vpcattachment and is
-// templated per VPCAttachment by the external companion operator) — it
-// exists solely so any binary in the chain can find node-level settings by
-// reading a well-known path off disk, independent of how it was actually
-// invoked. Bootstrap only ever writes one entry, typed PluginType, so every
-// caller in this repo passes that same constant.
+// That static conflist is not the per-attachment conflist the CNI runtime execs
+// each plugin with, which carries the VPC identifiers and is templated per
+// attachment by an external operator. It exists so any binary in the chain can
+// find node-level settings at a well-known path, whatever it was invoked as.
+// The installer writes exactly one entry, typed PluginType, which every caller
+// here passes.
 //
-// It also carries RejectMovedIPAMKeys, the guard every master plugin runs
-// over that per-attachment config — shared here for the same reason Load
-// is, so the two master plugins cannot drift apart on which keys they
-// refuse.
+// It also carries RejectMovedIPAMKeys, the guard every master plugin runs over
+// the per-attachment config, shared here for the same reason: so the two master
+// plugins cannot drift apart on which keys they refuse.
 package hostconf
 
 import (
@@ -41,18 +36,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PluginType is the "type" value Bootstrap always writes into the static
-// conflist's single plugin entry. It names galactic-cni, the installer that
-// actually authors this file, not any particular master plugin — veth, tap,
-// and bgp all read this same value regardless of which binary is actually
-// reading it. Every caller in the chain passes this to Load.
+// PluginType is the "type" value the installer writes into the static
+// conflist's single entry. It names the installer that authors the file, not
+// any particular master plugin, so every binary in the chain passes it to
+// Load.
 const PluginType = "galactic-cni"
 
-// BGPPluginType is the "type" value a conflist entry must carry for
-// galactic-bgp, the chained plugin that publishes BGP/SRv6/eBPF state after
-// a master plugin (galactic-veth/galactic-tap) creates the interface. Both
-// master plugins check for its presence in their own attachment's conflist
-// before doing any other work — see VerifyChainIncludes.
+// BGPPluginType is the "type" a conflist entry must carry for the chained
+// plugin that publishes BGP, SRv6, and eBPF state after a master plugin creates
+// the interface. Both master plugins check for its presence in their own
+// attachment's conflist before doing any other work.
 const BGPPluginType = "galactic-bgp"
 
 // HostConf holds node-local settings read from the static per-node conflist
@@ -64,30 +57,22 @@ type HostConf struct {
 	LogFile    string `json:"log_file"`
 	LogLevel   string `json:"log_level,omitempty"`
 
-	// NAT66ShardSIDs is the comma-separated NAT66 shard SID list --
-	// see config.EnvCNINAT66ShardSIDs's own doc comment. Written by
-	// internal/installer.Bootstrap from its own env, read by
-	// internal/cnibgp the same way every other field here is: a CNI
+	// NAT66ShardSIDs is the comma-separated NAT66 shard SID list, written by
+	// the installer from its own environment and read by the BGP plugin: a CNI
 	// plugin's exec environment carries none of this on its own.
 	NAT66ShardSIDs string `json:"nat66_shard_sids,omitempty"`
 
-	// EBPFInterfaces is the comma-separated interface list
-	// config.EnvCNIEBPFInterfaces would otherwise carry -- see that env
-	// var's own doc comment. Written by internal/installer.Bootstrap
-	// from its own env/auto-detection (an init container sharing its
-	// pod's env with the long-running "run" container, which is why
-	// attach.ResolveInterfaces' env-var override already works
-	// correctly there today), for exactly the same reason NAT66ShardSIDs
-	// above is: internal/cnibgp -- invoked per-pod by the CNI runtime,
-	// not a long-lived process with configurable env -- never sees
-	// GALACTIC_CNI_EBPF_INTERFACES on its own, and silently falls back
-	// to attach.ResolveInterfaces' own auto-detection instead, which is
-	// wrong on any node where the interface actually carrying the
-	// default IPv6 route (e.g. Cilium's own uplink) isn't the fabric
-	// interface -- found live, this exact gap produced a plausible but
-	// wrong public_uplink_table entry (internal/plumbing/ebpf/prog/
-	// usid.c's DSR-reply redirect) that had nothing to do with that
-	// mechanism's own correctness.
+	// EBPFInterfaces is the comma-separated interface list, written by the
+	// installer from its own environment or auto-detection. The installer runs
+	// as an init container sharing its pod's environment with the long-running
+	// one, so its detection is correct there.
+	//
+	// The BGP plugin, invoked per pod by the CNI runtime rather than being a
+	// long-lived process with configurable environment, would otherwise never
+	// see the setting and would silently fall back to its own auto-detection.
+	// That is wrong on any node where the interface carrying the default IPv6
+	// route is not the fabric interface, and produces a plausible but wrong
+	// uplink entry for the DSR reply redirect.
 	EBPFInterfaces string `json:"ebpf_interfaces,omitempty"`
 }
 
@@ -98,10 +83,10 @@ type conflistEnvelope struct {
 	Plugins    []json.RawMessage `json:"plugins"`
 }
 
-// Load reads and parses the conflist at filePath and returns the HostConf
-// carried by whichever plugin entry's "type" matches one of acceptedTypes.
-// Returns an error wrapping fs.ErrNotExist (checkable via errors.Is) when
-// filePath does not exist, so tolerant callers can fall back to defaults.
+// Load reads and parses the conflist at filePath and returns the HostConf from
+// whichever plugin entry's type matches one of acceptedTypes. A missing file
+// returns an error wrapping fs.ErrNotExist, so a tolerant caller can fall back
+// to defaults.
 func Load(filePath string, acceptedTypes ...string) (*HostConf, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
@@ -137,20 +122,15 @@ func Load(filePath string, acceptedTypes ...string) (*HostConf, error) {
 	return nil, fmt.Errorf("conflist at %q does not contain a plugin with type in %v", filePath, acceptedTypes)
 }
 
-// VerifyChainIncludes parses configJSON as a CNI NetConfList — the same
-// {"plugins":[{"type":...}, ...]} envelope Load already parses, here read
-// from a NetworkAttachmentDefinition's own spec.config rather than a file —
-// and reports a CNI error (code 7) naming expectedType if no entry's "type"
-// field equals it anywhere in the list.
+// VerifyChainIncludes parses configJSON as a CNI plugin list, the same envelope
+// Load parses but read from an attachment definition rather than a file, and
+// returns a CNI error naming expectedType if no entry's type equals it.
 //
-// Presence-only, not position-aware: a conflist that names expectedType out
-// of order is a separate authoring bug this does not catch. Presence is
-// what issue #331 asks for ("attach fails when the chain is incomplete")
-// and is the cheapest check that catches the actual failure mode reported
-// there — a stale/hand-edited conflist that drops the entry entirely. A
-// conflist with no "plugins" key at all (the pre-#305 flat single-plugin
-// shape) has zero entries to match and fails the same way a conflist
-// missing just the galactic-bgp entry does.
+// Presence only, not position: a conflist naming expectedType out of order is a
+// separate authoring bug this does not catch. Presence is the cheapest check
+// that catches the real failure, a stale or hand-edited conflist that drops the
+// entry. A conflist with no plugin list at all has zero entries to match and
+// fails the same way.
 func VerifyChainIncludes(configJSON []byte, expectedType string) error {
 	var env conflistEnvelope
 	if err := json.Unmarshal(configJSON, &env); err != nil {
@@ -176,11 +156,11 @@ func VerifyChainIncludes(configJSON []byte, expectedType string) error {
 	}
 }
 
-// movedIPAMKeys holds exactly the addressing keys that used to sit at the
-// top level of a master plugin's config and now live inside its "ipam"
-// block. Every field is a json.RawMessage so presence is all that is
-// decoded: a wrong-typed value must still be reported as present rather
-// than failing the decode, and no value here is ever read.
+// movedIPAMKeys holds exactly the addressing keys that once sat at the top
+// level of a master plugin's config and now live inside its "ipam" block. Every
+// field is a raw message so only presence is decoded: a wrong-typed value must
+// still report as present rather than failing the decode, and no value is ever
+// read.
 type movedIPAMKeys struct {
 	IPv6Subnet      json.RawMessage `json:"ipv6_subnet"`
 	IPv4Subnet      json.RawMessage `json:"ipv4_subnet"`
@@ -188,22 +168,20 @@ type movedIPAMKeys struct {
 	StaticIP        json.RawMessage `json:"static_ip"`
 }
 
-// RejectMovedIPAMKeys reports a CNI validation error (code 7) when data
-// carries any of the moved addressing keys at the top level of a master
-// plugin's config.
+// RejectMovedIPAMKeys returns a CNI validation error when data carries any of
+// the moved addressing keys at the top level of a master plugin's config.
 //
 // Whether a master plugin allocates addresses at all is decided purely by
-// whether the "ipam" block is present. encoding/json drops unknown fields,
-// so a config still written against the old flat shape parses cleanly, the
-// pod attaches with a working interface and no addresses, and its
-// BGPAdvertisement is created advertising nothing — no error, no warning.
-// Guessing wrong about a pod's addressing is worse than refusing to attach
-// it, so the keys are refused by name instead.
+// whether the "ipam" block is present, and JSON decoding drops unknown fields.
+// A config written against the old flat shape therefore parses cleanly, the pod
+// attaches with a working interface and no addresses, and its advertisement is
+// created advertising nothing, with no error or warning. Guessing wrong about a
+// pod's addressing is worse than refusing to attach it.
 func RejectMovedIPAMKeys(data []byte) error {
 	var moved movedIPAMKeys
-	// A decode error here is the caller's own to report: every master
-	// plugin unmarshals the same bytes into its full config first, so
-	// malformed JSON has already been rejected with its own message.
+	// A decode error is the caller's to report: every master plugin unmarshals
+	// the same bytes into its full config first, so malformed JSON has already
+	// been rejected with its own message.
 	if err := json.Unmarshal(data, &moved); err != nil {
 		return nil
 	}
@@ -247,13 +225,11 @@ func detectScheme() *runtime.Scheme {
 	return scheme
 }
 
-// DetectNodeNameFromAPI queries the Kubernetes API and matches the node's
-// InternalIP addresses against local interface addresses. Returns the first
-// matching node name, or empty string with no error if detection fails
-// (allowing callers to fall through to other resolution methods). Used as a
-// fallback by any binary's config resolution when the static conflist is
-// missing or doesn't carry a node name (e.g. hostPath mount issues in
-// container-based test environments like Kind).
+// DetectNodeNameFromAPI queries the Kubernetes API and matches nodes' internal
+// addresses against local interface addresses, returning the first match. It
+// returns "" with no error when detection fails, so callers can fall through to
+// other methods. Used when the static conflist is missing or carries no node
+// name.
 func DetectNodeNameFromAPI() (string, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {

--- a/internal/hostgw/hostgw.go
+++ b/internal/hostgw/hostgw.go
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package hostgw configures the host-side gateway address and VRF-table
-// pod-subnet route for a VPC attachment's allocated IPAM addresses.
+// Package hostgw configures the host-side gateway address and the VRF-table
+// pod-subnet route for a VPC attachment's allocated addresses.
 //
-// This is kernel-interface work (netlink address/route/neighbor
-// manipulation on the interface a master plugin — galactic-veth,
-// galactic-tap — itself created), not BGP/SRv6/eBPF publish, so it
-// lives here rather than in internal/cnibgp: once galactic-bgp became its
-// own chain-invoked plugin (a separate process, invoked after the master
-// has already printed its own result), it no longer has any interface to
-// configure — "zero kernel-interface dependency" is the whole reason that
-// split was worth doing in the first place. Both master plugins call this
-// directly, before building their own CNI result; galactic-bgp reads
-// whatever addresses ended up in prevResult and never touches the kernel
-// interface at all.
+// This is kernel-interface work on the interface a master plugin created, not
+// BGP or eBPF publishing, so it lives here rather than in the BGP plugin. That
+// plugin is a separate process invoked after the master has printed its result,
+// and having no interface to configure is the whole point of the split. Both
+// master plugins call this directly before building their result; the BGP
+// plugin reads whatever addresses ended up in the previous result and never
+// touches the interface.
 package hostgw
 
 import (
@@ -32,46 +28,38 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// ConfigureHostGateway assigns each configured family's gateway address as a
-// host address (/128 for IPv6, /32 for IPv4 on veth) on this attachment's
-// own host-side interface (veth or tap) and installs an explicit pod-subnet
-// route for that family into the (now VPC-shared, not per-attachment) VRF
-// table. IPv4 is skipped entirely when the attachment is IPv6-only.
+// ConfigureHostGateway assigns each configured family's gateway address on this
+// attachment's host-side interface and installs an explicit pod-subnet route
+// for that family into the VPC's shared VRF table. IPv4 is skipped entirely on
+// an IPv6-only attachment.
 //
-// The gateway address is deliberately kept on this attachment's own link
-// rather than the shared VRF device, even though the VRF/table are shared
-// by every attachment on this VPC on this node (internal/plumbing/vrf) —
-// this was tried and reverted (see git history): IPv6 NDP resolution for an
-// address only works on links that address is actually configured on
-// (or has an explicit proxy-neighbor entry for); unlike IPv4's proxy_arp,
-// enabling net.ipv6.conf.*.proxy_ndp does not make the kernel auto-answer
-// for an address it can merely *route* to via another interface. Since a
-// VRF master device and its enslaved links are still separate link-layer
-// segments to NDP, a gateway address bound only to the VRF device is
-// invisible to Neighbor Solicitations arriving on any one attachment's own
-// veth/tap, and every guest's default-route NDP resolution fails outright.
-// Each attachment has its own distinct gateway address anyway (from its own
-// IPAM subnet), so there's no actual duplication to avoid by centralizing
-// it — keeping it per-attachment is both correct and no more wasteful.
+// The gateway address stays on the attachment's own link rather than the shared
+// VRF device. IPv6 neighbor resolution for an address only works on links that
+// address is configured on, or that carry an explicit proxy entry: unlike
+// IPv4's proxy ARP, enabling proxy NDP does not make the kernel answer for an
+// address it can merely route to through another interface. A VRF master and
+// its enslaved links are separate segments to NDP, so an address bound only to
+// the VRF device is invisible to solicitations arriving on any attachment's own
+// link, and every guest's default-route resolution fails. Each attachment has
+// its own gateway address from its own subnet anyway, so nothing is duplicated
+// by keeping it per attachment.
 //
-// Using a full-length gateway address (not the pod subnet mask) prevents the
-// kernel from auto-creating a subnet-router anycast entry in the VRF local
-// table. When the pod address equals the subnet network address the anycast
-// absorbs seg6local-decapped inner packets before they reach the guest
-// interface. The explicit subnet route replaces the one the kernel would
-// have created from the wider mask.
+// A full-length gateway address, rather than the pod subnet mask, keeps the
+// kernel from auto-creating a subnet-router anycast entry in the VRF's local
+// table. Where the pod address equals the subnet's network address, that
+// anycast absorbs decapsulated inner packets before they reach the guest. The
+// explicit subnet route replaces the connected route the wider mask would have
+// produced.
 //
-// For tap interfaces, the IPv4 gateway is instead assigned as a /25 so the
-// address reported on the interface reflects a real subnet (VM guests expect
-// this). That reintroduces the wider-mask hazard described above, so the
-// address is added with IFA_F_NOPREFIXROUTE: the kernel skips auto-creating
-// the connected /25 route entirely, leaving the explicit pod-subnet route
-// below as the only thing that governs delivery to this VM's address.
+// A tap interface instead gets its IPv4 gateway as a /25, so the address on the
+// interface reflects a real subnet as VM guests expect. That reintroduces the
+// wider-mask hazard, so the address is added with the no-prefix-route flag: the
+// kernel skips the connected route entirely, leaving the explicit pod-subnet
+// route as the only thing governing delivery.
 //
-// guestHWAddr is the guest-side veth's MAC address, used to prime a
-// permanent neighbor table entry for the pod's own address (see
-// installGatewayNeighbor). It is nil for tap attachments, which have no
-// separate guest-side link in this netns to resolve a MAC from.
+// guestHWAddr is the guest-side veth's MAC, used to prime a permanent neighbor
+// entry for the pod's address. It is nil for a tap, which has no guest-side
+// link in this namespace to read a MAC from.
 func ConfigureHostGateway(vpc, vpcAttachment string, res *cniipam.IPAMResult, guestHWAddr net.HardwareAddr) error {
 	if res == nil {
 		return nil
@@ -119,19 +107,16 @@ func ConfigureHostGateway(vpc, vpcAttachment string, res *cniipam.IPAMResult, gu
 	return nil
 }
 
-// installGatewayNeighbor installs a permanent neighbor table entry mapping
-// podIP to guestHWAddr on hostLink.
+// installGatewayNeighbor installs a permanent neighbor entry mapping podIP to
+// guestHWAddr on hostLink for the given family.
 //
-// The eBPF uSID ingress datapath (internal/plumbing/ebpf/prog/usid.c)
-// decapsulates SRv6 traffic and calls bpf_fib_lookup() to resolve the
-// egress path for the inner packet, then redirects it straight to the
-// resolved neighbor — entirely in-kernel, never touching the normal
-// forwarding stack. bpf_fib_lookup() does not itself trigger ARP/NDP
-// resolution the way ordinary kernel packet forwarding does, so without a
-// pre-existing neighbor table entry it fails with BPF_FIB_LKUP_RET_NO_NEIGH
-// and the datapath drops the packet. A permanent entry (installed once, at
-// CNI ADD, using the guest veth's own known MAC) means this resolution
-// never depends on dynamic ARP/NDP at all.
+// The uSID ingress datapath decapsulates traffic, resolves the inner packet's
+// egress with bpf_fib_lookup, and redirects straight to the resolved neighbor,
+// never touching the normal forwarding stack. That lookup does not trigger
+// neighbor resolution the way ordinary forwarding does, so without an existing
+// entry it fails and the datapath drops the packet. A permanent entry installed
+// once at CNI ADD, from the guest veth's known MAC, removes that dependency
+// entirely.
 func installGatewayNeighbor(hostLink netlink.Link, podIP net.IP, family int, guestHWAddr net.HardwareAddr) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    hostLink.Attrs().Index,
@@ -147,12 +132,10 @@ func installGatewayNeighbor(hostLink netlink.Link, podIP net.IP, family int, gue
 	return nil
 }
 
-// ipv4GatewayAddrParams returns the IPv4 gateway mask and netlink address
-// flags to use for hostLink. Tap interfaces get a /25 (so the address
-// reported on the interface reflects a real subnet) with
-// IFA_F_NOPREFIXROUTE, which stops the kernel from auto-creating a connected
-// route for the wider mask. Veth interfaces keep the plain /32 host address
-// with no flags.
+// ipv4GatewayAddrParams returns the IPv4 gateway mask and address flags for
+// hostLink. A tap gets a /25, so the address reflects a real subnet, with the
+// no-prefix-route flag stopping the kernel creating a connected route for that
+// wider mask. A veth keeps a plain host address with no flags.
 func ipv4GatewayAddrParams(hostLink netlink.Link) (net.IPMask, int) {
 	if _, isTap := hostLink.(*netlink.Tuntap); isTap {
 		return net.CIDRMask(25, 32), unix.IFA_F_NOPREFIXROUTE
@@ -160,11 +143,8 @@ func ipv4GatewayAddrParams(hostLink netlink.Link) (net.IPMask, int) {
 	return net.CIDRMask(32, 32), 0
 }
 
-// installGatewayAddress assigns gwNet as an address on hostLink (this
-// attachment's own host-side interface — see ConfigureHostGateway's doc
-// comment for why not the shared VRF device). Idempotent: EEXIST from a
-// prior attempt having already installed the identical address is not an
-// error.
+// installGatewayAddress assigns gwNet on hostLink with addrFlags. Idempotent:
+// an identical address already installed by a prior attempt is not an error.
 func installGatewayAddress(hostLink netlink.Link, gwNet *net.IPNet, addrFlags int) error {
 	if err := netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: gwNet, Flags: addrFlags}); err != nil {
 		if !errors.Is(err, syscall.EEXIST) {
@@ -174,11 +154,10 @@ func installGatewayAddress(hostLink netlink.Link, gwNet *net.IPNet, addrFlags in
 	return nil
 }
 
-// installPodSubnetRoute installs an explicit route to subnet, into the given
-// VRF table, pointing at hostLink (this attachment's own host-side
-// interface), for one address family. Idempotent: an existing matching
-// route is left alone, and a conflicting one returns an error rather than
-// being overwritten.
+// installPodSubnetRoute installs an explicit route to subnet in the given VRF
+// table, pointing at hostLink, for one address family. Idempotent: a matching
+// route is left alone, and a conflicting one is an error rather than being
+// overwritten.
 func installPodSubnetRoute(hostLink netlink.Link, subnet *net.IPNet, family, tableID int) error {
 	desiredRoute := &netlink.Route{
 		Dst:       subnet,
@@ -219,9 +198,8 @@ func installPodSubnetRoute(hostLink netlink.Link, subnet *net.IPNet, family, tab
 	return nil
 }
 
-// routeConflicts reports whether an existing route conflicts with the desired
-// pod-subnet route. A conflict occurs when the destination matches but the
-// gateway or link index differs.
+// routeConflicts reports whether existing conflicts with the desired
+// pod-subnet route: the destination matches but the gateway or link differs.
 func routeConflicts(existing, desired *netlink.Route) bool {
 	if existing.Dst == nil || desired.Dst == nil {
 		return false

--- a/internal/hostgw/tapneigh.go
+++ b/internal/hostgw/tapneigh.go
@@ -17,13 +17,12 @@ import (
 )
 
 const (
-	// neighSolicitDialTimeout bounds the solicit Dial. A guest that is not
-	// answering yet is the common case (the VM may not have booted), and
-	// the next reconcile retries, so this stays short.
+	// neighSolicitDialTimeout bounds the solicit dial. A guest not answering
+	// yet is the common case, the VM may not have booted, and the next
+	// reconcile retries, so this stays short.
 	neighSolicitDialTimeout = 500 * time.Millisecond
-	// neighResolveTimeout bounds the poll for a solicited entry to appear.
-	// A live guest answers in well under a millisecond; this is headroom,
-	// not an expected wait.
+	// neighResolveTimeout bounds the poll for a solicited entry to appear. A
+	// live guest answers in well under a millisecond; this is headroom.
 	neighResolveTimeout = 1 * time.Second
 	neighPollInterval   = 50 * time.Millisecond
 	// discardPort is soliciting traffic's destination. Nothing needs to
@@ -31,39 +30,32 @@ const (
 	discardPort = "9"
 )
 
-// EnsureTapGuestNeighbors resolves the neighbor entry for every VM/unikernel
-// guest behind a tap attachment on this node, so usid_ingress can deliver
-// decapsulated traffic to it.
+// EnsureTapGuestNeighbors resolves the neighbor entry for every guest behind a
+// tap attachment on this node, so usid_ingress can deliver decapsulated traffic
+// to it. It returns how many were resolved and how many are still pending.
 //
-// The bug this fixes: usid_ingress's step 8 calls bpf_fib_lookup, which does
-// not itself trigger ARP/NDP the way ordinary kernel forwarding does, so an
-// unresolved neighbor returns BPF_FIB_LKUP_RET_NO_NEIGH and the packet is
-// dropped (see installGatewayNeighbor's doc comment). For a veth attachment
-// ConfigureHostGateway primes a permanent entry at CNI ADD from the guest
-// veth's own known MAC. A tap has no guest-side link in this netns to read a
-// MAC from -- internal/cni/tap creates a bare Tuntap and the guest picks its
-// own address, so guestHWAddr is nil there and no entry was ever installed.
-// Measured on us-central-1-staging-lab: 20 injected packets, 20 decapsulated,
-// 20 dropped on fib_no_neigh.
+// bpf_fib_lookup does not trigger NDP the way ordinary forwarding does, so an
+// unresolved neighbor makes it return NO_NEIGH and the packet is dropped. For a
+// veth the CNI primes a permanent entry at ADD from the guest end's known MAC.
+// A tap has no guest-side link in this namespace to read a MAC from, the guest
+// picking its own address, so no entry was ever installed and every packet
+// dropped.
 //
 // So resolve it the only way available, by asking the guest. This deliberately
-// does not install a NUD_PERMANENT entry the way the veth path does: the host
-// never learns a tap guest's MAC authoritatively, and a permanent entry
-// holding a stale one after a guest reboots with a new MAC is worse than
-// having none, since nothing would ever correct it. A dynamically resolved
-// entry is what bpf_fib_lookup needs (any NUD_VALID state satisfies it),
-// the kernel refreshes it from the guest's own advertisements, and this
-// function re-solicits whenever it has fallen out of the cache.
+// does not install a permanent entry the way the veth path does: the host never
+// learns a tap guest's MAC authoritatively, and a permanent entry holding a
+// stale one after a guest reboots is worse than none, since nothing would
+// correct it. A dynamically resolved entry is what the lookup needs, any valid
+// state satisfying it, the kernel refreshes it from the guest's own
+// advertisements, and this re-solicits whenever it falls out of the cache.
 //
-// Everything it needs comes from kernel state, so nothing has to be persisted
-// at ADD time and a guest that boots long after its CNI ADD is picked up on a
-// later pass: for each tap enslaved to a VPC VRF, the guest prefixes are the
-// routes in that VRF's table pointing at the tap, which is exactly what
-// installPodSubnetRoute put there.
+// Everything needed comes from kernel state, so nothing is persisted at ADD
+// time and a guest that boots long after its ADD is picked up on a later pass:
+// for each tap enslaved to a VPC VRF, the guest prefixes are the routes in that
+// VRF's table pointing at the tap.
 //
-// Errors are per-attachment and never abort the sweep: one guest that is down
-// must not stop the others being resolved. Returns the number resolved and
-// still-unresolved, for the caller to log or export.
+// Errors are per attachment and never abort the sweep: one guest that is down
+// must not stop the others.
 func EnsureTapGuestNeighbors() (resolved, pending int) {
 	links, err := netlink.LinkList()
 	if err != nil {
@@ -110,15 +102,13 @@ func EnsureTapGuestNeighbors() (resolved, pending int) {
 }
 
 // guestAddrsForTap returns the guest addresses reachable out this tap, read
-// back from the pod-subnet routes installPodSubnetRoute installed in the
-// VPC VRF's own table. Both families, since the same NO_NEIGH drop applies
-// to each; only the IPv6 side has been observed in the wild.
+// back from the pod-subnet routes in the VPC VRF's own table. Both families,
+// since the same drop applies to each.
 //
-// The filtering is the whole job. A VPC VRF's table carries several routes
-// per tap and only one of them names a guest, so an unfiltered sweep spends
-// its time soliciting addresses that can never answer. Measured on
-// us-central-1-staging-lab with three real guests, it found 32 candidates
-// and blocked for 32 seconds a pass. What the table actually holds:
+// The filtering is the whole job. A VRF's table carries several routes per tap
+// and only one names a guest, so an unfiltered sweep spends its time soliciting
+// addresses that can never answer, which on a node with a few guests means
+// dozens of candidates and tens of seconds a pass. What the table holds:
 //
 //	local fd20:0:2::1 dev <tap> proto kernel metric 0     <- host's own gateway addr
 //	fd20:0:2::1 dev <tap> proto kernel metric 256         <- its connected route
@@ -126,11 +116,11 @@ func EnsureTapGuestNeighbors() (resolved, pending int) {
 //	anycast fe80:: dev <tap> proto kernel metric 0
 //	fe80::/64 dev <tap> proto kernel metric 256
 //
-// So: only unicast routes this component installed itself. RTPROT_KERNEL
-// excludes everything the kernel derived from an address assignment, which
-// is the gateway address and the link-local pair; RTN_UNICAST excludes the
-// local and anycast entries; and link-local or multicast destinations are
-// skipped outright, since a guest is never addressed by one here.
+// So: only unicast routes this component installed itself. Excluding
+// kernel-derived routes drops the gateway address and the link-local pair,
+// requiring unicast drops the local and anycast entries, and link-local or
+// multicast destinations are skipped outright, a guest never being addressed by
+// one here.
 func guestAddrsForTap(tableID, tapIndex int) []net.IP {
 	var out []net.IP
 	for _, family := range []int{netlink.FAMILY_V6, netlink.FAMILY_V4} {
@@ -156,9 +146,9 @@ func guestAddrsForTap(tableID, tapIndex int) []net.IP {
 	return out
 }
 
-// ensureNeighbor reports whether guest has a usable neighbor entry on the
-// tap, soliciting once and polling if it does not. ok is false with a nil
-// error when the guest simply has not answered.
+// ensureNeighbor reports whether guest has a usable neighbor entry on the tap,
+// soliciting once and polling if it does not. ok is false with a nil error when
+// the guest simply has not answered.
 func ensureNeighbor(vrfName string, tap *netlink.LinkAttrs, guest net.IP) (ok bool, err error) {
 	if mac, lerr := lookupNeighborMAC(tap.Index, guest); lerr != nil {
 		return false, lerr
@@ -185,9 +175,8 @@ func ensureNeighbor(vrfName string, tap *netlink.LinkAttrs, guest net.IP) (ok bo
 }
 
 // lookupNeighborMAC reads the neighbor cache for guest on linkIndex without
-// soliciting, accepting any entry that already carries a hardware address --
-// bpf_fib_lookup is satisfied by any NUD_VALID state, not REACHABLE alone,
-// so a STALE entry counts.
+// soliciting, accepting any entry that already carries a hardware address:
+// bpf_fib_lookup is satisfied by any valid state, so a stale entry counts.
 func lookupNeighborMAC(linkIndex int, guest net.IP) (net.HardwareAddr, error) {
 	family := netlink.FAMILY_V6
 	if guest.To4() != nil {
@@ -205,25 +194,22 @@ func lookupNeighborMAC(linkIndex int, guest net.IP) (net.HardwareAddr, error) {
 	return nil, nil
 }
 
-// solicitVRFNeighbor drives the kernel to resolve guest by sending it an
-// actual packet, bound to the VPC's VRF device.
+// solicitVRFNeighbor drives the kernel to resolve guest by sending it a real
+// packet, bound to the VPC's VRF device.
 //
-// The send itself mirrors internal/plumbing/ebpf/egressroutemap's own
-// solicitNeighbor, whose doc comment records why an administrative
-// NeighSet(NUD_NONE, NTF_USE) does not work here (verified against a live
-// veth: it parks the entry in NUD_INCOMPLETE and never carries it further)
-// while writing a real datagram resolves in well under a millisecond.
-// Nothing need listen on the far side; constructing and writing the packet
-// is what drives resolution, and its fate past this host's output path is
-// irrelevant.
+// The send mirrors the egress route map's own solicit, whose doc comment
+// records why an administrative neighbor update does not work here while
+// writing a real datagram resolves in well under a millisecond. Nothing need
+// listen on the far side; writing the packet is what drives resolution, and its
+// fate past this host's output path is irrelevant.
 //
-// The addition for taps is SO_BINDTODEVICE on the VRF. A guest address is
-// only routable in its VPC's own table, so an unbound socket would resolve
-// against the main table -- reaching the default route, or nothing -- and
+// The addition for taps is binding the socket to the VRF device. A guest
+// address is routable only in its VPC's table, so an unbound socket would
+// resolve against the main table, reaching the default route or nothing, and
 // solicit on the wrong interface or not at all.
 //
-// Every error is deliberately ignored: ensureNeighbor's poll is the only
-// judge of whether this worked.
+// Errors are ignored deliberately: the caller's poll is the only judge of
+// whether this worked.
 func solicitVRFNeighbor(vrfName string, guest net.IP) {
 	network := "udp6"
 	if guest.To4() != nil {

--- a/internal/ingresssidecar/backend.go
+++ b/internal/ingresssidecar/backend.go
@@ -17,29 +17,24 @@ import (
 	"go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// Backend is the kernel-facing interface Store converges VRF and SRv6
-// egress-route state against. kernelBackend (below) wires it to
-// internal/plumbing/vrf and internal/plumbing/srv6 directly — the same
-// primitives galactic-cni's own pod-attachment path uses; see §2 of the
-// plan for why this is "not new kernel-programming work." Tests use a fake.
+// Backend is the kernel-facing interface Store converges VRF and SRv6 egress
+// route state against. kernelBackend wires it to the same primitives the CNI
+// pod-attachment path uses; tests use a fake.
 type Backend interface {
 	// EnsureVRF creates (idempotently) the per-VPC Linux VRF device and
 	// returns its kernel routing table ID.
 	EnsureVRF(vpc string) (tableID uint32, err error)
-	// RemoveVRF tears down the per-VPC VRF device. Callers must only call
-	// this once no route for this VPC remains live or in its own grace
-	// period — see vrf.Delete's own doc comment on why deleting out from
-	// under a still-live sibling breaks it.
+	// RemoveVRF tears down the per-VPC VRF device. Callers must only call it
+	// once no route for this VPC remains live or in its grace period, since
+	// deleting out from under a live sibling breaks it.
 	RemoveVRF(vpc string) error
-	// EnsureRoute installs (idempotently — see srv6.RouteEgressAdd's use of
-	// netlink.RouteReplace) the seg6 ENCAP_RED route for prefix, toward
-	// sid, in tableID.
+	// EnsureRoute idempotently installs the encapsulating route for prefix,
+	// toward sid, in tableID.
 	EnsureRoute(prefix *net.IPNet, sid net.IP, tableID uint32) error
 	// RemoveRoute removes the route EnsureRoute installed.
 	RemoveRoute(prefix *net.IPNet, tableID uint32) error
-	// ListVRFs returns every Galactic per-VPC VRF device currently present
-	// on the host, resolved back to its owning VPC — the startup-inventory
-	// step (§9 item 2 of the plan; see Store.Inventory).
+	// ListVRFs returns every per-VPC VRF device present on the host, resolved
+	// back to its owning VPC, for the startup inventory.
 	ListVRFs() ([]VRFInfo, error)
 	// ListRoutes returns every seg6-encapsulated route currently installed
 	// in tableID — the route half of the same startup-inventory step.
@@ -62,9 +57,8 @@ type RouteInfo struct {
 // kernelBackend is the production Backend.
 type kernelBackend struct{}
 
-// NewKernelBackend returns the production Backend, wired to real kernel
-// state via internal/plumbing/vrf and internal/plumbing/srv6. Requires
-// CAP_NET_ADMIN — see §6 of the plan.
+// NewKernelBackend returns the production Backend, wired to real kernel state.
+// Requires CAP_NET_ADMIN.
 func NewKernelBackend() Backend { return kernelBackend{} }
 
 func (kernelBackend) EnsureVRF(vpc string) (uint32, error) {
@@ -75,12 +69,10 @@ func (kernelBackend) EnsureVRF(vpc string) (uint32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("resolve VRF table ID for vpc %s: %w", vpc, err)
 	}
-	// See ensureEgressDatapath's own doc comment (ebpfdatapath.go): without
-	// this, EnsureRoute's egress_route_table entries below have nothing in
-	// this pod's netns ever attached to read them. vpc is threaded through
-	// (not just tableID) so ensureEgressDatapath can also derive and assign
-	// this VPC's own return-path gateway address, when configured -- see
-	// ensureGatewayAddress in gatewayaddress.go.
+	// Without this, the egress route entries below have nothing attached in
+	// this pod's namespace to read them. vpc is threaded through, not just
+	// tableID, so this can also derive and assign the VPC's return-path gateway
+	// address when one is configured.
 	if err := ensureEgressDatapath(vpc, tableID); err != nil {
 		return 0, fmt.Errorf("attach eBPF egress datapath for vpc %s: %w", vpc, err)
 	}
@@ -92,9 +84,8 @@ func (kernelBackend) RemoveVRF(vpc string) error {
 	if err != nil {
 		return nil // VRF already gone — idempotent, matching vrf.Delete's own stance
 	}
-	// Torn down before vrf.Delete removes the interface below, while its
-	// ifindex can still be resolved — see removeEgressDatapath's own doc
-	// comment.
+	// Torn down before the interface is removed below, while its ifindex can
+	// still be resolved.
 	if err := removeEgressDatapath(tableID); err != nil {
 		return fmt.Errorf("detach eBPF egress datapath for vpc %s: %w", vpc, err)
 	}
@@ -108,10 +99,8 @@ func (kernelBackend) EnsureRoute(prefix *net.IPNet, sid net.IP, tableID uint32) 
 	if err := srv6.RouteEgressAdd(prefix, sid, tableID); err != nil {
 		return fmt.Errorf("install seg6 route for %s: %w", prefix, err)
 	}
-	// See ensureRedirectRoute's own doc comment (ebpfdatapath.go): without
-	// this, nothing ever routes this pod's own outbound traffic for prefix
-	// into the VRF interface egress_route_table's entry above was just
-	// registered against.
+	// Without this, nothing routes this pod's outbound traffic for prefix into
+	// the VRF interface the entry above was just registered against.
 	if err := ensureRedirectRoute(prefix, tableID); err != nil {
 		return fmt.Errorf("install main-table redirect route for %s: %w", prefix, err)
 	}
@@ -128,14 +117,12 @@ func (kernelBackend) RemoveRoute(prefix *net.IPNet, tableID uint32) error {
 	return nil
 }
 
-// vrfNameRegex matches the interface name intf.GenerateInterfaceNameVRF
-// produces for a VPC ("G%09sV" — 'G', 9 zero-padded base62 characters,
-// 'V'). Mirrors internal/gc's identically-purposed, unexported
-// vrfNameRegex; duplicated rather than imported since that package doesn't
-// export it, with the same zero-pad-stripping caveat its parseVRFName
-// documents (a vpc value that legitimately begins with '0' round-trips
-// lossily through the padded interface name — an existing, accepted
-// limitation this doesn't newly introduce).
+// vrfNameRegex matches the interface name generated for a VPC: a leading
+// letter, nine zero-padded base62 characters, and a trailing letter.
+//
+// Duplicated from the garbage collector rather than imported, that package not
+// exporting it, and carrying the same caveat: a VPC value legitimately
+// beginning with "0" round-trips lossily through the padded name.
 var vrfNameRegex = regexp.MustCompile(`^G([A-Za-z0-9]{9})V$`)
 
 func (kernelBackend) ListVRFs() ([]VRFInfo, error) {

--- a/internal/ingresssidecar/controller.go
+++ b/internal/ingresssidecar/controller.go
@@ -19,11 +19,9 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 )
 
-// Reconciler is the thin controller-runtime glue that turns EndpointSlice
-// watch events into Store.SetDesired calls — all the actual VRF/route
-// lifecycle logic lives in Store. Mirrors this repo's other CRD-to-desired-
-// state reconcilers (e.g. internal/controller.BGPAdvertisementReconciler)
-// in being a pure translation layer with no state of its own.
+// Reconciler is the controller-runtime glue turning EndpointSlice watch events
+// into desired-state updates on the Store, where all the actual VRF and route
+// lifecycle logic lives. A pure translation layer with no state of its own.
 type Reconciler struct {
 	client.Client
 	Store *Store
@@ -45,10 +43,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	desired, err := BuildDesiredRoute(slice)
 	if err != nil {
-		// Selected but malformed in a way retrying can't fix (a bad
-		// annotation isn't going to parse differently on the next attempt)
-		// -- log via the returned error (controller-runtime logs Reconcile
-		// errors itself) and drop it rather than requeue-looping forever.
+		// Selected but malformed in a way retrying cannot fix: a bad annotation
+		// will not parse differently next time. Log through the returned
+		// error, which controller-runtime logs itself, and drop it rather than
+		// requeue-loop forever.
 		ctrl.LoggerFrom(ctx).Error(err, "skipping malformed EndpointSlice", "endpointslice", req.String())
 		return ctrl.Result{}, nil
 	}
@@ -59,10 +57,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 // SetupWithManager registers the controller against mgr, watching every
-// EndpointSlice cluster-wide — per §3 of the plan, these land in each pod's
-// own namespace, not one fixed namespace, so the cache/watch must not be
-// namespace-scoped — filtered to only those carrying crdnames.LabelTenantID
-// (§3: "select by label presence").
+// EndpointSlice cluster-wide, since these land in each pod's own namespace
+// rather than one fixed namespace, and filtering to those carrying the tenant
+// label.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Client = mgr.GetClient()
 	return ctrl.NewControllerManagedBy(mgr).
@@ -75,15 +72,13 @@ func hasTenantLabel(obj client.Object) bool {
 	return ok
 }
 
-// RunSweeper blocks, calling store.Sweep on a fixed interval tick until ctx
-// is done — the periodic mechanism that actually acts on expired teardown
-// grace periods (see Store.Sweep's own doc comment for why this has to be
-// polling-driven rather than reactive: VRF-level teardown is an aggregate
-// condition over potentially many routes, not a single watched object's own
-// transition). Mirrors cmd/galactic-router's GC ticker goroutine in shape.
+// RunSweeper blocks, sweeping the store on a fixed interval until ctx is done.
+// It is what actually acts on expired teardown grace periods, and has to be
+// polling-driven rather than reactive: VRF teardown is an aggregate condition
+// over many routes, not one watched object's transition.
 //
-// Callers must not start this until SeedFromAPI and Store.Inventory have
-// both run — see Store.Inventory's own doc comment.
+// Callers must not start it until the API seed and the store's inventory pass
+// have both run.
 func RunSweeper(ctx context.Context, store *Store, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/internal/ingresssidecar/desired.go
+++ b/internal/ingresssidecar/desired.go
@@ -13,10 +13,9 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 )
 
-// IsSelected reports whether slice carries the label this sidecar watches
-// EndpointSlices through — presence of crdnames.LabelTenantID, per §3 of
-// the plan ("select by label presence, group by its value"). Used both as
-// the controller's watch predicate and by BuildDesiredRoute.
+// IsSelected reports whether slice carries the tenant label this sidecar watches
+// EndpointSlices through. Used both as the controller's watch predicate and by
+// BuildDesiredRoute.
 func IsSelected(slice *discoveryv1.EndpointSlice) bool {
 	if slice == nil {
 		return false
@@ -25,20 +24,18 @@ func IsSelected(slice *discoveryv1.EndpointSlice) bool {
 	return ok
 }
 
-// BuildDesiredRoute translates one EndpointSlice into the DesiredRoute this
-// sidecar should converge toward.
+// BuildDesiredRoute translates one EndpointSlice into the route this sidecar
+// should converge toward.
 //
-// Returns (nil, nil) — "nothing to do, not an error" — when slice isn't one
-// this sidecar owns (IsSelected is false) or hasn't picked up its SID
-// annotation yet: crdnames.AnnotationSID is only set once the pod's hosting
-// node's BGPRouter has SRv6Locator/NodeID configured (see that constant's
-// own doc comment), so a freshly-published EndpointSlice can legitimately
-// have the tenant label but no SID yet, pending a later update.
+// It returns nil with a nil error, meaning nothing to do rather than an error,
+// when the slice is not one this sidecar owns or has not picked up its SID
+// annotation yet. That annotation appears only once the pod's node has a locator
+// and node ID configured, so a freshly published slice can legitimately carry
+// the tenant label and no SID, pending a later update.
 //
-// Returns (nil, err) for a slice that IS selected but malformed in a way
-// that indicates a real problem worth logging — a bad tenant identifier, an
-// unparseable SID/address, or an unsupported (non-IPv6) AddressType, which
-// per §3 should never occur for these backends.
+// It returns an error for a slice that is selected but malformed in a way worth
+// logging: a bad tenant identifier, an unparseable SID or address, or a
+// non-IPv6 address type, which should never occur for these backends.
 func BuildDesiredRoute(slice *discoveryv1.EndpointSlice) (*DesiredRoute, error) {
 	if !IsSelected(slice) {
 		return nil, nil

--- a/internal/ingresssidecar/doc.go
+++ b/internal/ingresssidecar/doc.go
@@ -2,43 +2,35 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package ingresssidecar implements #855's ingress sidecar: the second
-// container in the shared Envoy Gateway fleet's pod, responsible only for
-// VPC backend connectivity — Linux VRF device + SRv6 seg6 encap route
-// lifecycle — never for xDS/EDS, health checking, or anything Envoy-facing.
-// See docs/plans/855-ingress-sidecar-vpc-backend-connectivity.md for the
-// full design; this doc comment only orients the code.
+// Package ingresssidecar implements the ingress sidecar: the second container
+// in the shared Envoy fleet's pod, responsible only for VPC backend
+// connectivity, meaning the Linux VRF device and SRv6 egress route lifecycle,
+// and never for xDS, health checking, or anything Envoy-facing.
 //
-// Desired state comes from a single source: a cluster-scoped watch on
-// discoveryv1.EndpointSlice objects published per pod by galactic-cni
-// (#854), selected by the crdnames.LabelTenantID label. That label's value
-// — TenantIdentifier(vpc, vpcAttachment) — is used only to decide *which*
-// slices this sidecar cares about; it is never the reconcile key for either
-// kernel resource this package manages, because the two are keyed at two
-// different granularities than the tenant label:
+// Desired state comes from one source: a cluster-scoped watch on EndpointSlice
+// objects published per pod by the CNI, selected by the tenant label. That
+// label's value decides only which slices this sidecar cares about; it is never
+// the reconcile key for either kernel resource, because the two are keyed at
+// different granularities than the label:
 //
-//   - VRF device: one per VPC (crdnames.ParseTenantIdentifier's vpc half),
-//     shared by every attachment of that VPC present on this node —
-//     matching the kernel VRF's identity everywhere else in this codebase
-//     (internal/plumbing/vrf).
-//   - SRv6 egress route: one per pod (per EndpointSlice) — pods of the same
-//     tenant on different nodes carry different SIDs, so there is no
-//     tenant-aggregate route to install.
+//   - VRF device: one per VPC, shared by every attachment of that VPC on this
+//     node, matching the kernel VRF's identity everywhere else in this
+//     codebase.
+//   - SRv6 egress route: one per pod, since pods of the same tenant on
+//     different nodes carry different SIDs and there is no tenant-aggregate
+//     route to install.
 //
 // Package layout:
 //
-//   - model.go — DesiredRoute, the one value this package's desired-state
-//     translation produces.
-//   - desired.go — BuildDesiredRoute: EndpointSlice → DesiredRoute.
-//   - backend.go — Backend, the kernel-facing interface Store converges
-//     against, and kernelBackend, its production implementation wired to
-//     internal/plumbing/vrf and internal/plumbing/srv6 directly.
-//   - store.go — Store: the mutex-protected, two-granularity, grace-period-
-//     aware reconciler at this package's core. Mirrors internal/gateway's
-//     Engine and internal/runtime/gobgp's GoBGPRuntime in shape.
-//   - metrics.go — Prometheus metrics (§6 of the plan).
-//   - controller.go — Reconciler: the thin controller-runtime glue that
-//     turns EndpointSlice watch events into Store.SetDesired calls, plus
-//     the startup-inventory and periodic-sweep wiring cmd/galactic-vrf's
-//     root.go drives.
+//   - model.go: DesiredRoute, the one value the desired-state translation
+//     produces.
+//   - desired.go: turning an EndpointSlice into a DesiredRoute.
+//   - backend.go: the kernel-facing interface Store converges against, and its
+//     production implementation.
+//   - store.go: the mutex-protected, two-granularity, grace-period-aware
+//     reconciler at this package's core.
+//   - metrics.go: Prometheus metrics.
+//   - controller.go: the controller-runtime glue turning watch events into
+//     desired-state updates, plus the startup inventory and periodic sweep
+//     wiring the binary drives.
 package ingresssidecar

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -26,60 +26,44 @@ import (
 )
 
 // ebpfPinDir is the bpffs directory this file's registrations read from and
-// attach against -- a package-level var, not a bare use of attach.PinDir,
-// so tests can override it the same way internal/plumbing/srv6's own
-// pinDir does. Production always uses attach.PinDir: this sidecar mounts
-// the same host /sys/fs/bpf hostPath (see its DaemonSet volume) that
-// galactic-cni's own control daemon already loads and pins usid_egress and
-// its maps under, so the pins this file opens are the very same
-// kernel-side objects, not a second, sidecar-private instance of them.
+// attach against. A package var so tests can override it. In production it is
+// attach.PinDir: this sidecar mounts the same host /sys/fs/bpf that the CNI
+// control daemon pins usid_egress and its maps under, so these are the same
+// kernel objects, not a private second copy.
 var ebpfPinDir = attach.PinDir
 
-// ingressSidecarBlock is the fixed, synthetic uSID Block this file uses for
-// every vrf_table/ifindex_vrf_table entry it registers, standing in for
-// the real, per-router bgp.srv6Locator-derived Block internal/cnibgp's own
-// registerEBPFDatapath uses for a genuine tenant CNI attachment.
+// ingressSidecarBlock is the fixed, synthetic uSID Block this file registers
+// every vrf_table and ifindex_vrf_table entry under, standing in for the real
+// locator-derived Block a genuine tenant CNI attachment uses.
 //
-// Why a synthetic value is correct here, not a shortcut: vrf_table's key
-// (block<<12 | argument) is consulted by usid_egress purely as a local,
-// opaque lookup into this *one node's* own vrf_table -- never embedded in
-// a packet, never interpreted by any other node (contrast the real,
-// wire-significant Block a genuine SID's outer header carries). Nothing
-// about correctness requires this sidecar's own entries to share the
-// node's real BGPRouter locator; they only need to (a) never collide with
-// a real (block, argument) pair internal/cnibgp might independently
-// register for some other tenant VPC's CNI attachment sharing this same
-// node, and (b) stay internally consistent between this file's own
-// ifindex_vrf_table and vrf_table writes.
+// A synthetic value is correct here because vrf_table's key is consulted by
+// usid_egress purely as a local lookup into this node's own map. It is never
+// put on the wire and never interpreted by another node, unlike the Block a
+// real SID's outer header carries. These entries only need to avoid colliding
+// with any (block, argument) pair the CNI path might register for a tenant VPC
+// on this same node, and to stay consistent between this file's own two map
+// writes.
 //
-// (a) is what this constant buys: uformat.BlockMax is the all-ones 48-bit
-// value -- as an IPv6 prefix, ffff:ffff:ffff::/48, a pattern no fabric
-// operator would plausibly assign as a real SRv6 locator (every real one
-// in this fleet today is a normal-looking GUA/ULA prefix, e.g.
-// 2607:ed40:8002::/48) -- so this file's entries occupy a corner of
-// vrf_table's keyspace no real CNI attachment's own (block, argument) pair
-// can ever land in, regardless of which argument/vrfID it was allocated.
-// Deliberately not derived from the VPC identifier or anything else
-// per-VPC: a single reserved Block, with per-VPC disambiguation left
-// entirely to argument (see argumentForTableID), is simpler and no less
-// collision-safe, since this whole Block is already carved out.
+// uformat.BlockMax buys the first: as a prefix it is ffff:ffff:ffff::/48, which
+// no operator would assign as a real locator, so these entries sit in a corner
+// of the keyspace no CNI attachment can reach whatever argument it was
+// allocated. One reserved Block with per-VPC disambiguation left to argument is
+// simpler than deriving a Block per VPC and no less collision-safe, since the
+// whole Block is already carved out.
 //
-// See internal/ingresssidecar's own package-level "no BGP runtime, CRD
-// scheme, or per-node identity" design constraint (cmd/galactic-vrf's
-// runCmd doc comment) for why this file cannot simply read a real
-// bgp.srv6Locator the way internal/cnibgp does.
+// This sidecar has no BGP runtime and no per-node identity, so it cannot read a
+// real locator the way the CNI path does.
 const ingressSidecarBlock = uformat.BlockMax
 
-// argumentForTableID derives this file's uSID Argument for vpc's VRF from
-// its own Linux kernel routing table ID, rather than allocating a separate
-// value: vrf.TableID(vpc) already guarantees node-local uniqueness per VPC
-// (that is its entire purpose), which is the only property Argument needs
-// here (see ingressSidecarBlock's own doc comment) -- so reusing it avoids
-// needing a second, redundant allocator. Fails if tableID does not fit in
-// Argument's 12-bit range: vrf.Add allocates table IDs starting from 1 and
-// counting up, so this is not expected to happen in any deployment with
-// anywhere near 4095 VPCs live on one node, but a silently wrapped/aliased
-// Argument would be a real cross-VPC datapath bug, not a safe fallback.
+// argumentForTableID derives the uSID Argument for a VPC's VRF from its Linux
+// routing table ID rather than allocating a separate value. The table ID is
+// already unique per VPC on this node, which is the only property Argument
+// needs here, so reusing it avoids a second allocator.
+//
+// Fails if tableID does not fit Argument's 12-bit range. Table IDs are
+// allocated from 1 upward, so this needs about 4095 live VPCs on one node, but
+// a silently aliased Argument would be a cross-VPC datapath bug rather than a
+// safe fallback.
 func argumentForTableID(tableID uint32) (uint16, error) {
 	if tableID < uint32(uformat.ArgumentMin) || tableID > uint32(uformat.ArgumentMax) {
 		return 0, fmt.Errorf(
@@ -89,12 +73,10 @@ func argumentForTableID(tableID uint32) (uint16, error) {
 	return uint16(tableID), nil
 }
 
-// vrfLinkForTable returns the kernel VRF link whose own routing table is
-// tableID -- the interface EnsureVRF already created for this table, found
-// by table id rather than by name since this file's callers (EnsureRoute,
-// EnsureEgressDatapath and their Remove counterparts) only ever carry a
-// tableID forward, not the vpc string it came from (mirroring Backend's
-// own EnsureRoute/RemoveRoute signatures).
+// vrfLinkForTable returns the kernel VRF link whose routing table is tableID,
+// the interface EnsureVRF already created. Found by table ID rather than by
+// name because this file's callers carry only a tableID forward, not the vpc
+// string it came from.
 func vrfLinkForTable(tableID uint32) (*netlink.Vrf, error) {
 	links, err := vrf.ListVRFLinks()
 	if err != nil {
@@ -108,31 +90,24 @@ func vrfLinkForTable(tableID uint32) (*netlink.Vrf, error) {
 	return nil, fmt.Errorf("no VRF interface found for table %d", tableID)
 }
 
-// egressVethNames derives this VPC's own veth pair names from tableID
-// alone -- ensureEgressDatapath/removeEgressDatapath only ever carry a
-// tableID forward, not the vpc string vrf.Add itself was keyed on
-// (vrfLinkForTable's own doc comment). Collision-free the same way
-// vrf.TableID(vpc) already is (that is its whole purpose), and
-// comfortably inside IFNAMSIZ: tableID fits uSID Argument's 12-bit range
-// (argumentForTableID's own check), so at most 4 decimal digits.
+// egressVethNames derives a VPC's veth pair names from tableID alone, since the
+// callers carry only a tableID forward. Collision-free because table IDs are
+// already unique per VPC on this node, and comfortably inside IFNAMSIZ, since a
+// table ID that fits Argument's 12-bit range is at most 4 decimal digits.
 func egressVethNames(tableID uint32) (inner, peer string) {
 	return fmt.Sprintf("ivs%d", tableID), fmt.Sprintf("ivp%d", tableID)
 }
 
-// ensureEgressVeth creates (or finds) the one real interface pair
-// usid_egress actually intercepts this VPC's traffic on: inner enslaved
-// into vrfLink itself, with a default route in vrfLink's own table
-// pointed at it, so every destination this VPC's egress_route_table might
-// ever match has somewhere real to go once the kernel's own vrf_xmit()
-// redoes its route lookup inside that table. peer -- left outside the
-// VRF, in this pod's main netns -- is where usid_egress actually attaches
-// (see ensureEgressDatapath's own doc comment for why the VRF's own
-// egress hook doesn't work for that).
+// ensureEgressVeth creates, or finds, the interface pair usid_egress
+// intercepts this VPC's traffic on. inner is enslaved into vrfLink with a
+// default route in that VRF's table pointed at it, so every destination
+// egress_route_table might match has somewhere real to go once the kernel
+// redoes its route lookup inside the VRF. peer stays outside the VRF, in the
+// pod's main namespace, and is where usid_egress actually attaches.
 //
-// Idempotent: LinkAdd against an already-existing name is treated as
-// already-done, and RouteReplace overwrites rather than errors on a
-// second call -- the same "safe on every SetDesired that ensures a VRF"
-// contract every other step in this file already has.
+// Idempotent: an existing name counts as already done, and the route is
+// replaced rather than added, so it is safe on every call that ensures a
+// VRF.
 func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, error) {
 	peerLink, err := netlink.LinkByName(peer)
 	if err != nil {
@@ -167,25 +142,16 @@ func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, e
 		return nil, fmt.Errorf("set %q up: %w", peer, err)
 	}
 
-	// The second, inner hop vrf_xmit() takes once a packet actually
-	// enters this VRF -- a route in the VRF's own table, not the main
-	// table ensureRedirectRoute installs, which otherwise has no route of
-	// its own to anywhere.
+	// The inner hop the kernel takes once a packet enters this VRF: a route in
+	// the VRF's own table, which otherwise has no route anywhere.
 	//
-	// Routed via the peer's own link-local address, deliberately not a
-	// bare on-link route (LinkIndex alone, no Gw): an on-link default
-	// forces the kernel to resolve a neighbor for the packet's own final
-	// destination before
-	// it ever reaches usid_egress's TC hook at all -- nothing answers
-	// that (there is no real host at an arbitrary destination this VRF's
-	// egress_route_table is about to rewrite), so the kernel gives up
-	// with "destination unreachable" and the packet never reaches the
-	// interface's qdisc, let alone the ingress filter on it. Routing via
-	// a gateway instead means the kernel only ever has to resolve *one*
-	// neighbor -- the peer, always present and always answerable, the
-	// same real ND exchange proven to complete in under a millisecond
-	// earlier in this investigation -- regardless of what the packet's
-	// own destination address is.
+	// Routed via the peer's link-local address rather than as a bare on-link
+	// route. An on-link default makes the kernel resolve a neighbor for the
+	// packet's final destination before it ever reaches usid_egress, and
+	// nothing answers for a destination egress_route_table is about to
+	// rewrite, so the kernel gives up and the packet never reaches the qdisc.
+	// A gateway route means only one neighbor is ever resolved, the peer,
+	// which is always present and always answers, whatever the destination.
 	peerLinkLocal, err := waitForLinkLocalAddr(peerLink)
 	if err != nil {
 		return nil, fmt.Errorf("wait for veth peer %q's own link-local address: %w", peer, err)
@@ -203,12 +169,10 @@ func ensureEgressVeth(vrfLink *netlink.Vrf, inner, peer string) (netlink.Link, e
 	return peerLink, nil
 }
 
-// waitForLinkLocalAddr returns link's own global-scope-eligible link-local
-// IPv6 address (kernel-assigned via SLAAC/EUI-64 the moment the link comes
-// up), polling briefly since that assignment happens asynchronously to
-// LinkSetUp returning -- confirmed live to normally already be present
-// within the first poll, this bound is headroom, not an expected steady-
-// state wait.
+// waitForLinkLocalAddr returns link's kernel-assigned link-local IPv6 address,
+// polling briefly because that assignment happens asynchronously to LinkSetUp
+// returning. The address is normally present on the first poll, so the bound is
+// headroom rather than an expected wait.
 func waitForLinkLocalAddr(link netlink.Link) (net.IP, error) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -228,20 +192,13 @@ func waitForLinkLocalAddr(link netlink.Link) (net.IP, error) {
 	}
 }
 
-// ensureNodeSourceAddress registers this node's own SRv6/underlay-facing
-// source address into node_src_addr_table, mirroring
-// internal/cnibgp's own registerNodeSourceAddress -- see
-// ensureEgressDatapath's own call site for why this sidecar cannot rely on
-// that copy alone having already run on this node. Idempotent and cheap
-// (one netlink query or one k8s list, one map write), safe to call on every
-// ensureEgressDatapath the same way srv6.ResolveNodeSourceAddress's own
-// per-node-constant result already tolerates being redone.
+// ensureNodeSourceAddress registers this node's underlay-facing SRv6 source
+// address into node_src_addr_table. Idempotent and cheap, so it is safe on
+// every call.
 //
-// Prefers a configured NodeSourceAddressResolver (SetNodeSourceAddressResolver)
-// over srv6.ResolveNodeSourceAddress's own local-netns auto-detection --
-// see that interface's own doc comment for why the latter resolves to the
-// wrong address (this pod's own ULA overlay IP, not this node's real one)
-// for every real deployment of this specific sidecar.
+// It prefers a resolver configured through SetNodeSourceAddressResolver over
+// local auto-detection, which in this sidecar resolves to the pod's own overlay
+// address rather than the node's real one.
 func ensureNodeSourceAddress() error {
 	var (
 		addr net.IP
@@ -263,64 +220,40 @@ func ensureNodeSourceAddress() error {
 	return nodeSrc.Set(addr)
 }
 
-// ensureEgressDatapath makes usid_egress's own VRF resolution
-// (ifindex_vrf_table -> vrf_table -> Linux VRF table id, usid.c's own
-// doc comment on usid_egress) resolve correctly for vpc's VRF interface,
-// then attaches usid_egress where it actually intercepts that VRF's
-// traffic -- the actual enforcement point that was entirely missing
-// before this file existed: EnsureRoute's egress_route_table entries had
-// nothing anywhere in this pod's netns ever attached to read them.
+// ensureEgressDatapath makes usid_egress's VRF resolution, from
+// ifindex_vrf_table through vrf_table to a Linux VRF table ID, resolve for
+// vpc's VRF, then attaches usid_egress where it intercepts that VRF's traffic.
+// Without it, EnsureRoute's egress_route_table entries have nothing attached in
+// this pod's namespace to read them.
 //
-// This used to attach directly to the VRF interface's own TC *egress*
-// hook (attach.AttachLocalEgress). That looked right -- the VRF is where
-// usid_egress's ifindex_vrf_table lookup needs a 1:1 ifindex<->VRF
-// mapping anyway, the same shape internal/cnibgp's own
-// registerEBPFDatapath relies on for a genuine tenant veth/tap attachment
-// -- but did not hold up: packet capture confirmed that a Linux VRF
-// master device's own TC egress hook never actually fires for traffic
-// routed through it, for any tenant, however
-// correctly every map involved is populated. internal/cnibgp's own
-// attachUsidEgress never attaches to a VRF at all; it attaches to a real
-// tenant veth's *ingress* hook from the host side, because that is where
-// the tenant's own egress traffic actually arrives. ensureEgressVeth
-// gives this file the equivalent of that real veth -- enslaved into the
-// VRF so vrf_xmit() has somewhere to send a packet once it resolves
-// there -- and this attaches the exact same way internal/cnibgp already
-// does, on its peer's ingress hook via attach.AttachEgress, not
-// attach.AttachLocalEgress.
+// The attachment goes on the peer end's ingress hook, not the VRF device's
+// egress hook. A VRF master device's TC egress hook never fires for traffic
+// routed through it, however correctly the maps are populated. The CNI path has
+// the same shape for a real tenant: it attaches to a veth's ingress hook from
+// the host side, because that is where the tenant's egress traffic arrives.
+// ensureEgressVeth supplies the equivalent veth here.
 //
-// Attaching on this pod's own shared eth0 instead, tempting since that is
-// where cilium ultimately hands the packet off, was considered and
-// rejected: eth0 is shared by every VPC this sidecar serves, and
-// ifindex_vrf_table can only carry one (block, argument) per ifindex -- a
-// single eth0 registration could resolve at most one of this pod's VPCs
-// correctly.
+// Attaching to the pod's shared eth0 instead does not work either: eth0 is
+// shared by every VPC this sidecar serves, and ifindex_vrf_table holds one
+// (block, argument) per ifindex, so a single registration could resolve at most
+// one VPC.
 //
-// Idempotent: every step here is a plain overwrite/replace operation,
-// safe to call on every SetDesired that ensures a VRF (a repeat call for
-// an already-provisioned VPC, e.g. after this sidecar's own restart, is a
-// no-op in effect).
+// tableID is the VPC's Linux routing table. vpc is used to derive that VPC's
+// return-path gateway address when one is configured.
 //
-// vpc (added alongside tableID, not derived from it) is used for exactly
-// one thing beyond this doc comment's own long-standing "vpc's VRF
-// interface" description: deriving vpc's own return-path gateway address,
-// when SetGatewayAddressAssignment has configured one -- see
-// ensureGatewayAddress in gatewayaddress.go.
+// Idempotent: every step is a replace, so a repeat call for an
+// already-provisioned VPC is in effect a no-op.
 func ensureEgressDatapath(vpc string, tableID uint32) error {
-	// node_src_addr_table is a per-node singleton, not per-VPC: usid_egress
-	// fails open (TC_ACT_UNSPEC, uncounted) on every encapsulation attempt
-	// until some caller sets it, and internal/cnibgp's own registration
-	// only ever runs as a side effect of a real tenant CNI ADD landing on
-	// this node -- something a node running only this sidecar's synthetic
-	// attachments, with no real tenant CNI attachment at all, never gets.
-	// An otherwise fully correct attachment (VRF, veth, ifindex_vrf_table,
-	// egress_route_table all resolving) can therefore silently produce no
-	// encapsulated traffic at all, traced to this exact gap. Non-fatal on
-	// failure, same as
-	// internal/cnibgp's own call site and for the identical reason --
-	// ResolveNodeSourceAddress needs a converged underlay default route,
-	// which this pod can transiently lack right after this sidecar itself
-	// restarts.
+	// node_src_addr_table is a per-node singleton, not per-VPC. usid_egress
+	// fails open, uncounted, on every encapsulation attempt until something
+	// sets it, and the CNI path only registers it as a side effect of a real
+	// tenant ADD landing on this node, which a node running only this
+	// sidecar's synthetic attachments never sees. An otherwise correct
+	// attachment then produces no encapsulated traffic at all.
+	//
+	// Non-fatal, as at the CNI call site and for the same reason: resolving
+	// the address needs a converged underlay default route, which this pod can
+	// transiently lack right after a restart.
 	if err := ensureNodeSourceAddress(); err != nil {
 		slog.Warn("ensureEgressDatapath: could not register this node's own SRv6 source address; "+
 			"egress routing will fail open until this succeeds", "err", err)
@@ -342,12 +275,10 @@ func ensureEgressDatapath(vpc string, tableID uint32) error {
 		return fmt.Errorf("ensure egress veth for VRF table %d: %w", tableID, err)
 	}
 
-	// Assigns this VPC's own return-path gateway address (if configured,
-	// see SetGatewayAddressAssignment) to inner -- the same VRF-slave veth
-	// just enslaved above. Non-fatal on failure, same stance as
-	// ensureNodeSourceAddress just above: a still-missing gateway address
-	// degrades the return path (or, unconfigured, is simply a no-op), it
-	// does not make the forward path this function exists for any worse.
+	// Assign this VPC's return-path gateway address, when one is configured,
+	// to the VRF-slave veth enslaved above. Non-fatal, like
+	// ensureNodeSourceAddress: a missing gateway address degrades the return
+	// path without making the forward path any worse.
 	if err := ensureGatewayAddress(vpc, inner); err != nil {
 		slog.Warn("ensureEgressDatapath: could not assign this VPC's own gateway address", "vpc", vpc, "err", err)
 	}
@@ -358,13 +289,10 @@ func ensureEgressDatapath(vpc string, tableID uint32) error {
 	}
 	defer func() { _ = closer.Close() }()
 
-	// EgressKindVeth: a don't-care here, not a real claim about this VRF
-	// device's own link type. EgressKind only steers usid_ingress's own
-	// step-9 redirect (usid.c's own doc comment on enum egress_kind), and
-	// usid_ingress is never attached anywhere in this pod's netns -- this
-	// sidecar has no ingress/decap side at all (its own package doc
-	// comment). usid_egress, the only program this file's registrations
-	// ever feed, never reads EgressKind.
+	// EgressKindVeth is a don't-care here, not a claim about this device's link
+	// type. EgressKind steers only usid_ingress's redirect, and usid_ingress is
+	// never attached in this pod's namespace, since this sidecar has no decap
+	// side. usid_egress never reads it.
 	if err := registry.VRF.Register(ingressSidecarBlock, argument, tableID, usidmap.EgressKindVeth); err != nil {
 		return fmt.Errorf("register eBPF vrf_table entry: %w", err)
 	}
@@ -375,10 +303,8 @@ func ensureEgressDatapath(vpc string, tableID uint32) error {
 	}
 	defer func() { _ = ifindexCloser.Close() }()
 
-	// Keyed by the veth peer's ifindex, not the VRF's own -- see this
-	// function's own doc comment for why usid_egress has to see this
-	// traffic arriving on that interface's ingress hook, not the VRF's
-	// egress.
+	// Keyed by the veth peer's ifindex, not the VRF's, because usid_egress has
+	// to see this traffic arrive on that interface's ingress hook.
 	if err := ifindexTable.Register(uint32(peerLink.Attrs().Index), ingressSidecarBlock, argument); err != nil {
 		return fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
 	}
@@ -395,21 +321,16 @@ func ensureEgressDatapath(vpc string, tableID uint32) error {
 	return nil
 }
 
-// removeEgressDatapath undoes ensureEgressDatapath's own registrations for
-// the VPC whose VRF table is tableID -- called before RemoveVRF deletes
-// the VRF interface itself (backend.go's RemoveVRF), while the veth
-// pair's own names can still be derived. Best-effort and idempotent,
-// matching every other teardown step in this package (Unregister is
-// already "absent is not an error"): every step is attempted even if an
-// earlier one failed, and every failure is joined and returned together,
-// rather than a first error aborting the rest of cleanup.
+// removeEgressDatapath undoes ensureEgressDatapath's registrations for the VPC
+// whose VRF table is tableID. It runs before RemoveVRF deletes the VRF
+// interface, while the veth names can still be derived.
 //
-// No explicit detach call for usid_egress: deleting the veth pair below
-// removes both ends and, with them, every qdisc/filter attached to
-// either -- the same "the interface going away is the detach" contract
-// internal/cnibgp's own teardown already relies on for its real tenant
-// veth (attachUsidEgress's own doc comment has no DetachEgress
-// counterpart at all).
+// Best-effort and idempotent: every step is attempted even if an earlier one
+// failed, and the failures are joined and returned together rather than the
+// first one aborting cleanup.
+//
+// usid_egress needs no explicit detach. Deleting the veth pair removes both
+// ends and every qdisc and filter on them.
 func removeEgressDatapath(tableID uint32) error {
 	argument, err := argumentForTableID(tableID)
 	if err != nil {
@@ -452,24 +373,18 @@ func removeEgressDatapath(tableID uint32) error {
 	return errors.Join(errs...)
 }
 
-// ensureRedirectRoute installs a plain (unencapsulated, no SEG6 involved)
-// host route for prefix into this pod's own main routing table, forwarding
-// out the VRF interface for tableID as a bare nexthop device -- no gateway
-// address, since a Linux VRF master device needs none: a route naming it
-// as LinkIndex alone re-dispatches the packet through that device's own
-// egress hook, which is exactly where ensureEgressDatapath already
-// attached usid_egress.
+// ensureRedirectRoute installs a plain host route for prefix into this pod's
+// main routing table, out the VRF interface for tableID as a bare nexthop
+// device. A VRF master device needs no gateway address: naming it as the link
+// re-dispatches the packet through that device, which is where usid_egress is
+// attached.
 //
-// This exists because nothing else pulls this pod's outbound traffic for
-// prefix off its ordinary default route: neither Envoy nor cilium has any
-// notion of this destination belonging to a VPC VRF (see this fix's own
-// design notes), so an unbound socket's normal FIB lookup would otherwise
-// resolve prefix via the default route out eth0 exactly like any other
-// "world" destination. A route this specific (EnsureRoute's own callers
-// always pass a /128 -- see DesiredRoute.Prefix) wins ordinary
-// longest-prefix-match over that default route without needing cilium to
-// know anything about the VPC address space, or Envoy to bind its sockets
-// to anything.
+// Nothing else pulls this pod's outbound traffic for prefix off its default
+// route. Neither Envoy nor the cluster CNI knows this destination belongs to a
+// VPC VRF, so an unbound socket's ordinary lookup would resolve prefix out eth0
+// like any other destination. Callers always pass a /128, so this route wins
+// longest-prefix match over the default without the CNI knowing anything about
+// VPC address space or Envoy binding its sockets to anything.
 func ensureRedirectRoute(prefix *net.IPNet, tableID uint32) error {
 	link, err := vrfLinkForTable(tableID)
 	if err != nil {
@@ -486,10 +401,9 @@ func ensureRedirectRoute(prefix *net.IPNet, tableID uint32) error {
 	return nil
 }
 
-// removeRedirectRoute removes the main-table redirect route ensureRedirectRoute
-// installed for prefix -- ensureRedirectRoute's own counterpart, mirroring
-// srv6.RouteMainDel's identical shape (a plain netlink.RouteDel by Dst and
-// Table alone, no LinkIndex needed to identify it).
+// removeRedirectRoute removes the main-table route ensureRedirectRoute
+// installed for prefix. Deleting by destination and table alone is enough to
+// identify it.
 func removeRedirectRoute(prefix *net.IPNet) error {
 	return netlink.RouteDel(&netlink.Route{
 		Dst:   prefix,

--- a/internal/ingresssidecar/gateway.go
+++ b/internal/ingresssidecar/gateway.go
@@ -24,51 +24,41 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// ingressVPCAttachment is the synthetic "vpcAttachment" segment
-// crdnames.BGPAdvertisementName needs a third argument for. This sidecar
-// has no real VPCAttachment of its own (that identity belongs to a CNI
-// attachment — see internal/cnibgp) — it uses this fixed, valid-base62
-// literal so its own advertisement's name still follows the established
-// (vpc, vpcAttachment, node) convention and can never collide with a real
-// CNI-derived attachment's own advertisement for the same (vpc, node),
-// which always shares this sidecar's own BGPVRFInstance (see
-// PublishGateway) but never its BGPAdvertisement.
+// ingressVPCAttachment is the synthetic attachment segment
+// crdnames.BGPAdvertisementName takes as its third argument. This sidecar has
+// no real VPCAttachment, that identity belonging to a CNI attachment, so a
+// fixed base62 literal keeps its advertisement name following the same
+// (vpc, attachment, node) convention while never colliding with a real
+// attachment's advertisement for the same VPC and node.
 //
-// Aliased to crdnames' own constant rather than repeating the literal: the
-// host side has to recognize the advertisements this writes (see
-// internal/installer's sidecar return path), so both ends must read the
-// same value or the recognition quietly stops matching.
+// Aliased to the shared constant rather than repeating the literal: the host
+// side has to recognise the advertisements this writes, so both ends must read
+// the same value or the recognition quietly stops matching.
 const ingressVPCAttachment = crdnames.IngressAttachment
 
-// ErrGatewayAddressNotProvisioned is returned by a GatewayAddressResolver
-// when this VPC has no local gateway address to advertise yet. Callers
-// (Store) treat this as "nothing to do yet", not a reconcile error — see
-// Store's own gateway-publish call site.
+// ErrGatewayAddressNotProvisioned is returned by a GatewayAddressResolver when
+// this VPC has no local gateway address to advertise yet. Callers treat it as
+// nothing to do, not a reconcile error.
 var ErrGatewayAddressNotProvisioned = errors.New("ingresssidecar: no gateway address provisioned for this VPC yet")
 
-// GatewayAddressResolver discovers this sidecar's own local address inside
-// a managed VPC's subnet — the source address Envoy's outbound connections
-// into that VPC use (see internal/plumbing/srv6.ResolveNodeSourceAddress's
-// doc comment for why the kernel, not this codebase, picks that address).
-// GatewayPublisher advertises whatever this returns so that a VPC backend's
-// reply traffic has an SRv6 route back to it.
+// GatewayAddressResolver discovers this sidecar's local address inside a
+// managed VPC's subnet: the source address Envoy's outbound connections into
+// that VPC use. GatewayPublisher advertises whatever it returns, so a backend's
+// reply traffic has an SRv6 route back.
 //
-// This interface deliberately does not create that address: provisioning
-// it (a veth-style attachment into the VPC, with its own IPAM allocation)
-// is a real, unimplemented gap — see docs/plans/855-return-path-gateway-
-// advertisement.md's "Not implemented here" section. NetlinkGatewayAddressResolver
-// only discovers an address some other mechanism already provisioned.
+// It does not create that address. Provisioning one, as an attachment into the
+// VPC with its own allocation, is a separate mechanism; this only discovers an
+// address something else already provisioned.
 type GatewayAddressResolver interface {
 	// ResolveGatewayAddress returns this node's own local address for vpc,
 	// or ErrGatewayAddressNotProvisioned (wrapped) if none exists yet.
 	ResolveGatewayAddress(vpc string) (net.IP, error)
 }
 
-// NetlinkGatewayAddressResolver is the production GatewayAddressResolver:
-// it looks for a global-scope IPv6 address on some interface enslaved to
-// vpc's own Linux VRF device (the same device internal/plumbing/vrf.Add
-// creates) — the shape a veth-style ingress attachment would take if one
-// exists. Requires CAP_NET_ADMIN, like internal/plumbing/vrf itself.
+// NetlinkGatewayAddressResolver is the production resolver: it looks for a
+// global-scope IPv6 address on an interface enslaved to the VPC's Linux VRF
+// device, the shape an attachment into the VPC would take. Requires
+// CAP_NET_ADMIN.
 type NetlinkGatewayAddressResolver struct{}
 
 // ResolveGatewayAddress implements GatewayAddressResolver.
@@ -103,28 +93,22 @@ func (NetlinkGatewayAddressResolver) ResolveGatewayAddress(vpc string) (net.IP, 
 		ErrGatewayAddressNotProvisioned, vrfName)
 }
 
-// GatewayPublisher advertises (and withdraws) this sidecar's own local
-// gateway address for a VPC via a BGPAdvertisement CRD, so that a backend
-// pod's reply traffic — addressed back to that gateway address — has an
-// SRv6 route to follow. Mirrors internal/cnibgp/bgp.go's own
-// BGPVRFInstance/BGPAdvertisement publish pattern (lookupBGPRouter,
-// allocateArgument, routeTarget, buildVRFInstanceSpec/buildAdvertisementSpec)
-// for a pod's own address; deliberately reimplemented here in miniature
-// rather than imported, since cnibgp's version is entangled with CNI-only
-// concerns (prevResult, IPAM, container-ID-keyed annotations, rollback
-// tracking) this sidecar has none of. Consolidating the two into one shared
-// package is a reasonable follow-up, not done here to avoid touching
-// cnibgp's existing, heavily-relied-upon publish path in the same change
-// that introduces this new caller.
+// GatewayPublisher advertises, and withdraws, this sidecar's local gateway
+// address for a VPC through a BGPAdvertisement, so a backend pod's reply
+// traffic addressed back to it has an SRv6 route to follow.
+//
+// It reimplements the CNI path's publish pattern in miniature rather than
+// importing it, since that version is entangled with CNI-only concerns this
+// sidecar has none of: previous results, IPAM, container-keyed annotations, and
+// rollback tracking. Consolidating the two is a reasonable follow-up.
 type GatewayPublisher interface {
 	// PublishGateway ensures a BGPAdvertisement exists for addr, the local
-	// gateway address for vpc, originated from this node's own BGPRouter.
-	// Idempotent: safe to call every time Store creates vpc's VRF.
+	// gateway address for vpc, originated from this node's BGPRouter.
+	// Idempotent.
 	PublishGateway(ctx context.Context, vpc string, addr net.IP) error
-	// WithdrawGateway removes the BGPAdvertisement PublishGateway created
-	// for vpc, if any. Never removes the (possibly shared) BGPVRFInstance
-	// PublishGateway reused or created — see its own doc comment for why
-	// that's galactic-router's GC controller's job, not this one's.
+	// WithdrawGateway removes the BGPAdvertisement PublishGateway created for
+	// vpc, if any. It never removes the possibly shared BGPVRFInstance, which
+	// is garbage collection's job.
 	WithdrawGateway(ctx context.Context, vpc string) error
 }
 
@@ -135,20 +119,17 @@ type k8sGatewayPublisher struct {
 	namespace string
 }
 
-// NewK8sGatewayPublisher returns a GatewayPublisher that reads/writes BGP
-// CRDs in namespace via c, attributing every advertisement it creates to
-// the BGPRouter targeting nodeName.
+// NewK8sGatewayPublisher returns a GatewayPublisher that reads and writes BGP
+// CRDs in namespace, attributing every advertisement to the BGPRouter targeting
+// nodeName.
 func NewK8sGatewayPublisher(c client.Client, nodeName, namespace string) GatewayPublisher {
 	return &k8sGatewayPublisher{client: c, nodeName: nodeName, namespace: namespace}
 }
 
 // gatewayBGPConfig is the subset of a matched BGPRouter's spec PublishGateway
-// needs — mirrors internal/cnibgp/bgp.go's own unexported bgpConfig, minus
-// the SRv6Locator/NodeID fields that caller doesn't need: unlike a pod's own
-// advertisement, this one never computes a SID directly (see
-// internal/reconcile.resolveSRv6SID, which derives it from the
-// BGPAdvertisement's own VRFID/Function plus the BGPRouter it targets, at
-// reconcile time, not here).
+// needs. It omits the locator and node ID, since this advertisement never
+// computes a SID: that is derived at reconcile time from the advertisement's
+// own VRFID and function plus the router it targets.
 type gatewayBGPConfig struct {
 	asNumber   int64
 	routerName string
@@ -176,12 +157,11 @@ func (p *k8sGatewayPublisher) lookupBGPRouter(ctx context.Context) (gatewayBGPCo
 	}
 }
 
-// vpcRouteTarget mirrors internal/cnibgp/bgp.go's own routeTarget: the RT in
-// "ASN:NN" format using the low 32 bits of the VPC identifier, so this
-// advertisement's community matches every other advertisement for the same
-// VPC (whichever node/attachment originated them) bit for bit — that
-// equality, not any shared code path, is what makes a receiving node's own
-// ImportRouteTargets pick this advertisement up.
+// vpcRouteTarget returns the route target in "ASN:NN" form from the low 32 bits
+// of the VPC identifier, so this advertisement's community matches every other
+// advertisement for the same VPC bit for bit, whichever node or attachment
+// originated it. That equality, not any shared code path, is what makes a
+// receiving node import it.
 func vpcRouteTarget(asNumber int64, vpc string) (string, error) {
 	vpcHex, err := intf.Base62ToHex(vpc)
 	if err != nil {
@@ -194,11 +174,9 @@ func vpcRouteTarget(asNumber int64, vpc string) (string, error) {
 	return fmt.Sprintf("%d:%d", asNumber, uint32(v)), nil
 }
 
-// allocateGatewayArgument mirrors internal/cnibgp/bgp.go's own
-// allocateArgument: the value already registered under vrfName if a
-// BGPVRFInstance by that name exists, otherwise the lowest value in
-// [uformat.ArgumentMin, uformat.ArgumentMax] not already used by routerName's
-// other BGPVRFInstances.
+// allocateGatewayArgument returns the Argument already registered under vrfName
+// if a BGPVRFInstance by that name exists, and otherwise the lowest value in
+// range not already used by routerName's other instances.
 func allocateGatewayArgument(
 	ctx context.Context, k8s client.Client, namespace, routerName, vrfName string,
 ) (int32, error) {
@@ -229,26 +207,22 @@ func allocateGatewayArgument(
 // under, and so the veth whose peer is this pod's way in from the host.
 const primaryPodInterface = "eth0"
 
-// podEntryPoint returns the ifindex, in the *host's* namespace, of the peer
-// of this pod's primary interface, plus that interface's own hardware
-// address.
+// podEntryPoint returns the ifindex, in the host's namespace, of the peer of
+// this pod's primary interface, plus that interface's hardware address.
 //
-// Read here, and published on the advertisement, because this is the only
-// side that can see it. For a veth the kernel reports the peer's index even
-// when the peer is in another namespace, so both values come out of one
-// ordinary link query with no extra privilege. Reading them from the host
-// instead would mean entering this namespace, which needs CAP_SYS_ADMIN --
-// see crdnames.AnnotationIngressHostIfindex.
+// Read here, and published on the advertisement, because this is the only side
+// that can see it. For a veth the kernel reports the peer's index even when the
+// peer is in another namespace, so both values come from one ordinary link query
+// with no extra privilege. Reading them from the host would mean entering this
+// namespace, which needs CAP_SYS_ADMIN.
 //
-// A missing primary interface is a real error rather than a skip: a pod
-// without one has no way in at all, so publishing a gateway address for it
-// would advertise a return path that cannot be completed.
-// podEntryPointFn is podEntryPoint, indirected so tests can supply a pod
-// that does not exist -- the same override pattern
-// internal/installer's newK8sClientFn and addrListFn use. There is no
-// primary interface in a unit test's own namespace, and the value this
-// reads is a plain kernel attribute rather than logic worth faking a
-// netlink server for.
+// A missing primary interface is an error rather than a skip: a pod without one
+// has no way in, so publishing a gateway address for it would advertise a
+// return path that cannot complete.
+//
+// podEntryPointFn indirects it so tests can supply a pod that does not exist.
+// There is no primary interface in a unit test's namespace, and the value read
+// is a plain kernel attribute rather than logic worth faking netlink for.
 var podEntryPointFn = podEntryPoint
 
 func podEntryPoint() (hostIfindex int, mac net.HardwareAddr, err error) {
@@ -278,12 +252,10 @@ func (p *k8sGatewayPublisher) PublishGateway(ctx context.Context, vpc string, ad
 		return err
 	}
 
-	// Same (vpc, node)-keyed BGPVRFInstance a real CNI attachment on this
-	// node would use (crdnames.BGPVRFInstanceName's own doc comment) —
-	// CreateOrUpdate here reuses one that already exists (a tenant pod
-	// sharing this node and VPC) rather than creating a competing entry, or
-	// creates one for the shared VRFID/route-target bookkeeping if none
-	// does yet.
+	// The same (vpc, node)-keyed BGPVRFInstance a real CNI attachment on this
+	// node would use. This reuses one that already exists, for a tenant pod
+	// sharing this node and VPC, rather than creating a competing entry, or
+	// creates one for the shared VRFID and route-target bookkeeping.
 	vrfName := crdnames.BGPVRFInstanceName(vpc, p.nodeName)
 	vrfID, err := allocateGatewayArgument(ctx, p.client, p.namespace, bgp.routerName, vrfName)
 	if err != nil {
@@ -309,12 +281,11 @@ func (p *k8sGatewayPublisher) PublishGateway(ctx context.Context, vpc string, ad
 		return fmt.Errorf("apply BGPVRFInstance %s: %w", vrfName, err)
 	}
 
-	// The two facts the host side of this return path needs and cannot read
-	// for itself -- see podEntryPoint. Resolved before the advertisement is
-	// written so an advertisement never exists without them: the host keys
-	// its route and neighbor off these, and one published without them
-	// would look like a return path that should work while nothing could
-	// complete it.
+	// The two facts the host side of this return path needs and cannot read for
+	// itself. Resolved before the advertisement is written so one never exists
+	// without them: the host keys its route and neighbor off these, and an
+	// advertisement published without them looks like a working return path
+	// that nothing can complete.
 	hostIfindex, mac, err := podEntryPointFn()
 	if err != nil {
 		return fmt.Errorf("resolve this pod's host-side entry point for vpc %s: %w", vpc, err)

--- a/internal/ingresssidecar/gatewayaddress.go
+++ b/internal/ingresssidecar/gatewayaddress.go
@@ -16,44 +16,25 @@ import (
 	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
-// gatewayAssignmentMu guards gatewayPrefix/gatewayNodeID -- the same
-// package-level-var-as-configuration-seam pattern internal/plumbing/srv6's
-// own pinDir and this package's own ebpfPinDir already use, chosen over
-// threading a new parameter through Backend/kernelBackend's existing
-// signatures (see SetGatewayAddressAssignment's own doc comment for why).
+// gatewayAssignmentMu guards gatewayPrefix and gatewayNodeID.
 var (
 	gatewayAssignmentMu sync.Mutex
 	gatewayPrefix       *net.IPNet
 	gatewayNodeID       string
 )
 
-// SetGatewayAddressAssignment enables ensureEgressDatapath to assign this
-// node's own deterministic return-path gateway address (see
-// DeriveGatewayAddress) to the VRF-slave veth it already creates for
-// usid_egress, for every VPC this sidecar subsequently reconciles a VRF
-// for. nodeID must be stable and unique per node (cmd/galactic-vrf passes
-// its own cfg.NodeName, the same identity GatewayPublisher already
-// attributes its BGPAdvertisements to) -- see DeriveGatewayAddress's own
-// doc comment for why an empty or shared nodeID would make every replica
-// of this sidecar collide on the identical address for a given VPC.
+// SetGatewayAddressAssignment enables assignment of this node's return-path
+// gateway address to the VRF-slave veth created for usid_egress, for every VPC
+// this sidecar reconciles a VRF for.
 //
-// prefix == nil (the default, never called) leaves address assignment
-// disabled entirely: ensureEgressDatapath's own call site no-ops, and
-// NetlinkGatewayAddressResolver keeps returning
-// ErrGatewayAddressNotProvisioned exactly as it does today -- this is
-// purely additive to the existing opt-in GatewayPublisher wiring, not a
-// replacement for it; both must be configured for the return path to
-// actually work end to end.
+// prefix is the reserved CIDR addresses are derived inside; nil disables
+// assignment, leaving NetlinkGatewayAddressResolver returning
+// ErrGatewayAddressNotProvisioned. nodeID must be stable and unique per node:
+// it is hashed into the address, so an empty or shared value makes every
+// replica derive the same address for a given VPC.
 //
-// A package-level setter rather than a new Backend/kernelBackend
-// constructor parameter: ensureEgressDatapath(vpc, tableID) is an
-// unexported function called from exactly one production site
-// (kernelBackend.EnsureVRF) with no vpc-scoped Backend state to carry this
-// through today, and adding a stateful field to kernelBackend (currently
-// the empty struct{} NewKernelBackend returns) to thread one optional,
-// process-wide value through every EnsureVRF call is more invasive than
-// this seam, for a value that is genuinely process-global (one node, one
-// prefix, one identity) exactly like ebpfPinDir already is.
+// The value is process-global (one node, one prefix, one identity) rather than
+// Backend state, so it is set here rather than threaded through EnsureVRF.
 func SetGatewayAddressAssignment(prefix *net.IPNet, nodeID string) {
 	gatewayAssignmentMu.Lock()
 	defer gatewayAssignmentMu.Unlock()
@@ -61,42 +42,31 @@ func SetGatewayAddressAssignment(prefix *net.IPNet, nodeID string) {
 	gatewayNodeID = nodeID
 }
 
-// gatewayAddressAssignment returns the currently configured prefix/nodeID
-// pair -- prefix == nil means disabled. Callers must not mutate the
-// returned *net.IPNet.
+// gatewayAddressAssignment returns the configured prefix and nodeID. A nil
+// prefix means assignment is disabled. Callers must not mutate the returned
+// *net.IPNet.
 func gatewayAddressAssignment() (*net.IPNet, string) {
 	gatewayAssignmentMu.Lock()
 	defer gatewayAssignmentMu.Unlock()
 	return gatewayPrefix, gatewayNodeID
 }
 
-// DeriveGatewayAddress deterministically computes this node's own
-// return-path gateway address for vpc inside prefix, a reserved,
-// byte-aligned IPv6 CIDR that is disjoint by construction from any tenant
-// address space -- see internal/config.VRFConfig's GatewayPrefix doc
-// comment for why it must never be carved out of, or derived from, a real
-// tenant VPC's own subnet: that space is allocated by a system this repo
-// has no visibility into (confirmed live: a real tenant address's own bit
-// layout does not match this repo's own internal/cni/ipam allocator), so
-// the only structural collision-safety guarantee available here is a
-// prefix that no tenant IPAM -- this repo's own or the external one --
-// is ever handed as a pool to allocate from in the first place.
+// DeriveGatewayAddress computes this node's return-path gateway address for
+// vpc inside prefix. The result depends only on its inputs, so any component
+// holding (prefix, vpc, nodeID) derives the same address without coordinating.
 //
-// The host bits (everything after prefix's own mask) are filled from
-// sha256(vpcHex + "|" + nodeID), truncated to fit -- collision-safe against
-// another VPC's own derived address, or another node's own address for the
-// same VPC, with overwhelming probability for any realistic (vpc, nodeID)
-// cardinality (a birthday bound over the mask's own free bit width), not
-// deterministically unique the way galactic-ipam's on-disk-marker
-// allocator is. That's an acceptable tradeoff here specifically because
-// nothing else ever contends for a specific value the way a live IPAM
-// allocation call does -- there is no "already claimed by someone else"
-// state to race against, only two independent hashes landing on the same
+// prefix must be a byte-aligned IPv6 CIDR with host bits left over, and must
+// be disjoint from every tenant VPC subnet. Tenant space is allocated by a
+// system outside this repo, so a prefix that no IPAM is ever handed as a pool
+// is the only collision guarantee available. vpc is base62-encoded; nodeID is
+// any caller-stable per-node identity. Returns the full 128-bit address, or an
+// error if prefix is unusable or vpc is not valid base62.
+//
+// Host bits come from sha256(vpcHex + "|" + nodeID) truncated to fit, so the
+// address is collision-safe with high probability rather than unique by
+// construction. Nothing contends for a specific value here, so there is no
+// "already claimed" state to race against, only two hashes landing on the same
 // bytes.
-//
-// vpc is base62-encoded (the same form crdnames/gateway.go's own
-// vpcRouteTarget already takes); nodeID is any caller-stable per-node
-// identity string (SetGatewayAddressAssignment's own doc comment).
 func DeriveGatewayAddress(prefix *net.IPNet, vpc, nodeID string) (net.IP, error) {
 	vpcHex, err := intf.Base62ToHex(vpc)
 	if err != nil {
@@ -130,19 +100,13 @@ func DeriveGatewayAddress(prefix *net.IPNet, vpc, nodeID string) (net.IP, error)
 	return addr, nil
 }
 
-// ensureGatewayAddress assigns this node's derived gateway address for vpc
-// (DeriveGatewayAddress) to the named interface -- ensureEgressDatapath's
-// own VRF-slave veth (ensureEgressVeth's inner end), already enslaved into
-// vpc's VRF for usid_egress's own attachment. Doing so is what lets
-// NetlinkGatewayAddressResolver (gateway.go) find a global-scope address
-// there with no further wiring: it already scans every interface enslaved
-// to a VPC's VRF for exactly this.
+// ensureGatewayAddress assigns vpc's derived gateway address to inner, the
+// VRF-slave veth end already enslaved into vpc's VRF. Placing it there is what
+// lets NetlinkGatewayAddressResolver find it, since that scans interfaces
+// enslaved to a VPC's VRF for a global-scope address.
 //
-// No-ops (returns nil) when address assignment isn't configured
-// (SetGatewayAddressAssignment never called) -- callers must treat that
-// identically to success, matching ensureNodeSourceAddress's own
-// non-fatal-on-not-yet-available stance just above it in
-// ensureEgressDatapath.
+// Returns nil when assignment is not configured. Callers must treat that as
+// success.
 func ensureGatewayAddress(vpc, inner string) error {
 	prefix, nodeID := gatewayAddressAssignment()
 	if prefix == nil {
@@ -159,9 +123,8 @@ func ensureGatewayAddress(vpc, inner string) error {
 		return fmt.Errorf("look up %q: %w", inner, err)
 	}
 
-	// /128, matching exactly what GatewayPublisher.PublishGateway
-	// advertises (gateway.go's own addr.String()+"/128") -- a host route,
-	// not a claim on prefix's own subnet as a whole.
+	// A host route, matching what GatewayPublisher.PublishGateway advertises,
+	// rather than a claim on the whole prefix.
 	nladdr := &netlink.Addr{IPNet: &net.IPNet{IP: addr, Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8)}}
 	if err := netlink.AddrReplace(link, nladdr); err != nil {
 		return fmt.Errorf("assign gateway address %s to %q: %w", addr, inner, err)
@@ -170,30 +133,20 @@ func ensureGatewayAddress(vpc, inner string) error {
 	return ensureGatewayVRFRoute(vpc, addr)
 }
 
-// ensureGatewayVRFRoute pulls traffic for this VPC's gateway address into
-// that VPC's VRF, by routing it at the VRF device in this namespace's main
-// table.
+// ensureGatewayVRFRoute pulls traffic for vpc's gateway address into that
+// VPC's VRF, by routing addr at the VRF device in the main table.
 //
-// Assigning the address above is not enough to receive on it. It lands on a
-// veth enslaved to the VPC's VRF, so it is local only within that VRF's own
-// table -- while a reply arriving from outside, redirected in by
-// usid_ingress on the host, lands on this pod's primary interface, which is
-// in no VRF at all. The input lookup then runs in the main table, finds
-// nothing local for the address, and the packet is dropped without being
-// counted anywhere: Ip6InReceives advances, Ip6InDelivers does not, and
-// neither Ip6InNoRoutes nor Ip6InAddrErrors moves. Measured exactly that
-// way before this existed.
+// Assigning the address is not enough to receive on it. It lands on a veth
+// enslaved to the VPC's VRF, so it is local only within that VRF's table,
+// while a reply redirected in by usid_ingress arrives on the pod's primary
+// interface, which is in no VRF. The input lookup then runs in the main table,
+// finds nothing local, and drops the packet silently: Ip6InReceives advances,
+// Ip6InDelivers does not, and no error counter moves.
 //
-// A route at the VRF device is the standard way across that boundary: the
-// VRF driver redirects the lookup into its own table, where the address is
-// local, and delivery proceeds. It is the same idiom the pod-subnet routes
-// this sidecar already installs use to reach a VPC at all, applied to the
-// one address the sidecar owns itself rather than to a remote prefix.
-//
-// In the main table deliberately, not the VRF's: a lookup that has already
-// entered the VRF's table finds the address local there and never needs
-// this, so putting it inside would be inert. The main table is where the
-// lookup that currently fails happens.
+// A route at the VRF device makes the VRF driver redirect the lookup into its
+// own table, where the address is local. It belongs in the main table, not the
+// VRF's: a lookup that already entered the VRF table finds the address without
+// it.
 func ensureGatewayVRFRoute(vpc string, addr net.IP) error {
 	vrfName := intf.GenerateInterfaceNameVRF(vpc)
 	vrfLink, err := netlink.LinkByName(vrfName)

--- a/internal/ingresssidecar/metrics.go
+++ b/internal/ingresssidecar/metrics.go
@@ -8,11 +8,9 @@ import "github.com/prometheus/client_golang/prometheus"
 
 const metricsNamespace = "galactic_ingress_sidecar"
 
-// Metrics is this sidecar's Prometheus surface — §6 of the plan: "active
-// VRF (per-VPC) count, active route (per-pod) count, reconcile error rate,
-// reconcile latency, teardown-grace-period queue depth for both." Mirrors
-// internal/gateway's PrometheusTelemetryEmitter in shape: build once via
-// NewMetrics, MustRegister once at startup, then pass into NewStore.
+// Metrics is this sidecar's Prometheus surface: active VRF and route counts,
+// reconcile error rate and latency, and teardown queue depth. Build it once,
+// register it once at startup, then pass it into the store.
 type Metrics struct {
 	VRFActive     prometheus.Gauge
 	RouteActive   prometheus.Gauge
@@ -60,10 +58,8 @@ func NewMetrics() *Metrics {
 	}
 }
 
-// MustRegister registers every metric this type owns against reg. Panics on
-// a duplicate registration — callers only ever do this once per process, at
-// startup, same convention as internal/gateway.PrometheusTelemetryEmitter's
-// own MustRegister.
+// MustRegister registers every metric this type owns against reg, panicking on
+// a duplicate. Callers do this once per process, at startup.
 func (m *Metrics) MustRegister(reg prometheus.Registerer) {
 	reg.MustRegister(m.VRFActive, m.RouteActive, m.VRFPending, m.RoutePending, m.ReconcileErrs, m.ReconcileTime)
 }

--- a/internal/ingresssidecar/model.go
+++ b/internal/ingresssidecar/model.go
@@ -6,21 +6,17 @@ package ingresssidecar
 
 import "net"
 
-// DesiredRoute is the desired SRv6 egress-route state for one pod, derived
-// from a single EndpointSlice — see BuildDesiredRoute. Store.SetDesired
-// keys each DesiredRoute by that EndpointSlice's own namespace/name; VPC is
-// the separate, coarser key its VRF device lifecycle rolls up to (see
-// Store's doc comment and §1 of the plan).
+// DesiredRoute is the desired SRv6 egress-route state for one pod, derived from
+// a single EndpointSlice. The store keys each by that slice's namespace and
+// name; VPC is the coarser key its VRF device lifecycle rolls up to.
 type DesiredRoute struct {
-	// VPC is the base62 VPC identifier this pod is attached to, recovered
-	// via crdnames.ParseTenantIdentifier — never the combined tenant
-	// identifier (vpc-vpcAttachment) itself, which is not a value any
-	// kernel-side primitive in this codebase accepts.
+	// VPC is the base62 VPC identifier this pod is attached to, recovered from
+	// the tenant identifier. Never the combined identifier itself, which no
+	// kernel-side primitive here accepts.
 	VPC string
-	// Prefix is the pod's own address as a host route (/128 for the
-	// IPv6-only backends this sidecar handles per §3 of the plan) — never a
-	// tenant/subnet aggregate, since none exists: SIDs vary per hosting
-	// node, so pods of the same tenant on different nodes need independent
+	// Prefix is the pod's own address as a host route, these backends being
+	// IPv6-only. Never a subnet aggregate, since none exists: SIDs vary per
+	// hosting node, so pods of one tenant on different nodes need independent
 	// routes even though they share a VPC.
 	Prefix *net.IPNet
 	// SID is the pod's own computed SRv6 uSID — the seg6 encap gateway

--- a/internal/ingresssidecar/nodesourceaddress.go
+++ b/internal/ingresssidecar/nodesourceaddress.go
@@ -15,29 +15,23 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// NodeSourceAddressResolver resolves this node's own real, globally-routable
-// underlay-facing address -- the address usid_egress's outer SRv6 header
-// must be sourced from for a reply to have any real-world path back to it.
+// NodeSourceAddressResolver resolves this node's globally routable
+// underlay-facing address, the address usid_egress's outer header must be
+// sourced from for a reply to have a real path back.
 //
-// ensureNodeSourceAddress's default (srv6.ResolveNodeSourceAddress) answers
-// this by auto-detecting the interface carrying the local default IPv6
-// route -- correct for galactic-cni, which runs in the host's own root
-// network namespace, where that really is the fabric uplink. It is wrong by
-// construction for this package: #855 deliberately runs this sidecar inside
-// Envoy's own pod netns (so SO_BINDTODEVICE resolves there), and *inside*
-// that netns the interface carrying the default route is the pod's own
-// Cilium-managed eth0 -- a ULA pod address drawn from the cluster's own
-// tenant pool (fd20::/20), not this node's real address at all. Confirmed
-// live: a captured outer SRv6 header's source matched this sidecar's own
-// pod IP bit for bit, and a ULA source is exactly the kind of thing a
-// competent network edge's own anti-spoofing/BCP38 filtering exists to
-// silently drop -- which is what happened, all the way through otherwise-
-// working global BGP transit to the destination.
+// The default resolver auto-detects the interface carrying the local default
+// IPv6 route. That is correct for a process in the host's root namespace, where
+// it really is the fabric uplink, and wrong by construction here: this sidecar
+// runs inside Envoy's pod namespace so socket binds resolve there, and inside
+// that namespace the default route belongs to the pod's cluster-managed
+// interface. Its address is a ULA drawn from the cluster's own pool, not this
+// node's address, and a ULA source is exactly what a competent network edge's
+// anti-spoofing filtering drops silently, after otherwise-working transit all
+// the way to the destination.
 //
-// This resolver answers the same question a different way: read it off a
-// BGPPeer this node's own galactic-router already maintains, rather than
-// guessing from local netns state that #855's own design makes unreliable
-// for this specific caller.
+// This resolver answers the same question differently, by reading the address
+// off a BGPPeer this node's router already maintains rather than guessing from
+// local namespace state that this deployment shape makes unreliable.
 type NodeSourceAddressResolver interface {
 	ResolveNodeSourceAddress() (net.IP, error)
 }
@@ -49,33 +43,26 @@ type k8sNodeSourceAddressResolver struct {
 	namespace string
 }
 
-// NewK8sNodeSourceAddressResolver returns a NodeSourceAddressResolver that
-// reads BGPPeer CRDs in namespace via c, looking for one targeting
-// nodeName's own BGPRouter.
+// NewK8sNodeSourceAddressResolver returns a resolver that reads BGPPeer CRDs in
+// namespace, looking for one targeting nodeName's own BGPRouter.
 func NewK8sNodeSourceAddressResolver(c client.Client, nodeName, namespace string) NodeSourceAddressResolver {
 	return &k8sNodeSourceAddressResolver{client: c, nodeName: nodeName, namespace: namespace}
 }
 
-// ResolveNodeSourceAddress implements NodeSourceAddressResolver.
+// ResolveNodeSourceAddress reads the local source address off a BGPPeer.
 //
-// A BGPPeer's own Spec.Address is the *remote* peer's address (its own doc
-// comment says so explicitly) -- Spec.UpdateSource is the local one: "the
-// local IP address ... used as the source for the BGP TCP session". Every
-// BGPPeer whose RouterRef names this node shares the same real answer here
-// (a node uses one consistent source address for all of its own sessions),
-// so the first one with a usable UpdateSource wins; nothing here needs them
-// to agree beyond that, and a node with none configured yet (BFD/session
-// still converging right after this sidecar's own restart) returns a plain
-// error for ensureNodeSourceAddress's own existing non-fatal-on-failure
-// handling to log and retry, matching every other resolver in this package.
+// A peer's address field is the remote peer's; the update source is the local
+// one, the address used as the source for the BGP session. Every peer whose
+// router reference names this node shares the same answer, a node using one
+// consistent source for all its sessions, so the first with a usable update
+// source wins. A node with none configured yet, its sessions still converging
+// after a restart, returns an error for the caller's existing non-fatal
+// handling to log and retry.
 //
-// context.Background() rather than a threaded ctx: ensureEgressDatapath's
-// entire call chain up through Backend.EnsureVRF carries no context
-// parameter today, and adding one is a much larger, cross-cutting signature
-// change for a call this package's own doc comments already describe as
-// cheap, idempotent, and safe to retry on the next reconcile -- not a
-// tradeoff worth making in the same change that fixes the actual address
-// bug. Revisit if EnsureVRF ever grows a context for an unrelated reason.
+// It uses a background context rather than a threaded one: the whole call chain
+// up through the VRF backend carries no context today, and adding one is a
+// cross-cutting signature change for a call that is cheap, idempotent, and
+// safe to retry on the next reconcile.
 func (r *k8sNodeSourceAddressResolver) ResolveNodeSourceAddress() (net.IP, error) {
 	ctx := context.Background()
 	peerList := &bgpv1alpha1.BGPPeerList{}
@@ -99,23 +86,19 @@ func (r *k8sNodeSourceAddressResolver) ResolveNodeSourceAddress() (net.IP, error
 		r.nodeName, r.namespace)
 }
 
-// nodeSourceAddressResolverMu guards nodeSourceAddressResolver -- the same
-// package-level-var-as-configuration-seam pattern gatewayAssignmentMu
-// (gatewayaddress.go) and gatewayPublisher (store.go) already use, for the
-// identical reason: ensureNodeSourceAddress is an unexported function
-// called from exactly one production site with no per-call state to thread
-// this through today.
+// nodeSourceAddressResolverMu guards nodeSourceAddressResolver, the same
+// configuration-seam pattern the other setters in this package use:
+// ensureNodeSourceAddress is called from one production site with no per-call
+// state to thread this through.
 var (
 	nodeSourceAddressResolverMu sync.Mutex
 	nodeSourceAddressResolver   NodeSourceAddressResolver
 )
 
 // SetNodeSourceAddressResolver configures ensureNodeSourceAddress to use r
-// instead of its default (srv6.ResolveNodeSourceAddress) -- see
-// NodeSourceAddressResolver's own doc comment for why the default is wrong
-// for this package's real deployment shape. r == nil (the default, until
-// cmd/galactic-vrf wires one) restores the old behavior; this is purely
-// additive, matching every other opt-in setter in this package.
+// instead of the default local auto-detection, which is wrong for this
+// package's deployment shape. A nil r, the default until startup wires one,
+// keeps the original behavior.
 func SetNodeSourceAddressResolver(r NodeSourceAddressResolver) {
 	nodeSourceAddressResolverMu.Lock()
 	defer nodeSourceAddressResolverMu.Unlock()

--- a/internal/ingresssidecar/seed.go
+++ b/internal/ingresssidecar/seed.go
@@ -17,34 +17,26 @@ import (
 	"go.datum.net/galactic/internal/crdnames"
 )
 
-// SeedFromAPI lists every EndpointSlice this sidecar selects on directly
-// from reader and applies each one's desired route to store synchronously,
-// via the same SetDesired path Reconciler itself uses.
+// SeedFromAPI lists every EndpointSlice this sidecar selects on, directly from
+// reader, and applies each one's desired route to store synchronously, through
+// the same path the reconciler uses.
 //
-// Call this once at startup, before Store.Inventory, passing
-// mgr.GetAPIReader() as reader — the manager's uncached reader, which talks
-// straight to the API server and is safe to use before mgr.Start. That
-// matters because it's what lets this run without depending on the
-// manager's informer cache or controller workqueue at all: Store.Inventory
-// used to be gated on mgr.GetCache().WaitForCacheSync(ctx) alone, on the
-// assumption that a synced cache implied every pre-existing EndpointSlice
-// had already gone through the controller's own Reconcile (and therefore
-// SetDesired). That assumption is false — WaitForCacheSync only guarantees
-// the informer's initial List landed in the cache; it says nothing about
-// whether the workqueue that same initial List fed into has been drained
-// by the controller's Reconcile loop yet. On a busy node at boot those two
-// things race: Inventory could observe a live pod's kernel route as
-// orphaned (routeKnownLocked found no tracked state for it yet) and seed it
-// under a synthetic "boot/..." key with its own grace period, independently
-// of the real key the delayed Reconcile eventually creates -- and once that
-// synthetic entry's grace elapsed, Sweep would delete the underlying kernel
-// route (routes are addressed by prefix+table, not by Store's map key) out
-// from under the still-live pod. SeedFromAPI closes that race by making
-// every live EndpointSlice's desired route visible to Store before
-// Inventory ever runs, independent of cache/queue timing entirely.
-// SetDesired is idempotent (EnsureVRF/EnsureRoute no-op once installed), so
-// the controller's own later, now-redundant Reconcile of the same objects
-// is harmless.
+// Call it once at startup, before the store's inventory pass, passing the
+// manager's uncached reader: that talks straight to the API server and is safe
+// to use before the manager starts.
+//
+// That is what removes the dependency on cache and workqueue timing. Waiting for
+// the cache to sync is not enough on its own: it guarantees the informer's
+// initial list landed in the cache, and says nothing about whether the workqueue
+// that list fed has been drained by the reconcile loop. On a busy node at boot
+// those race, and inventory can see a live pod's kernel route as orphaned,
+// seeding it under a synthetic key with its own grace period, independently of
+// the real key the delayed reconcile eventually creates. Once that synthetic
+// entry's grace elapses, the sweep deletes the underlying route, addressed by
+// prefix and table rather than by store key, out from under the live pod.
+//
+// Seeding first closes that race. Applying desired state is idempotent, so the
+// reconciler's later, now-redundant pass over the same objects is harmless.
 func SeedFromAPI(ctx context.Context, reader client.Reader, store *Store) error {
 	req, err := labels.NewRequirement(crdnames.LabelTenantID, selection.Exists, nil)
 	if err != nil {

--- a/internal/ingresssidecar/store.go
+++ b/internal/ingresssidecar/store.go
@@ -21,10 +21,9 @@ type routeState struct {
 	prefix    *net.IPNet
 	sid       net.IP
 	installed bool
-	// absentSince is the zero Time while this route is desired. SetDesired
-	// sets it the moment a nil desired value is first observed for this
-	// key, and clears it again if the route is reactivated before Sweep
-	// tears it down — see SetDesired and Sweep.
+	// absentSince is the zero Time while this route is desired. It is set the
+	// moment a nil desired value is first observed, and cleared again if the
+	// route is reactivated before Sweep tears it down.
 	absentSince time.Time
 }
 
@@ -32,39 +31,33 @@ type routeState struct {
 type vrfState struct {
 	tableID   uint32
 	installed bool
-	// absentSince is the zero Time while at least one route still
-	// references this VPC (installed or itself still within its own grace
-	// period — see Sweep). Only once every such route is gone does this
-	// VPC's own teardown grace period start.
+	// absentSince is the zero Time while at least one route still references
+	// this VPC, whether installed or itself within its grace period. Only once
+	// every such route is gone does this VPC's teardown clock start.
 	absentSince time.Time
-	// gatewayPublished is true once this VPC's return-path BGPAdvertisement
-	// has been published (see Store.publishGateway) — set at most once per
-	// VRF lifetime, alongside installed, so a transient resolve/publish
-	// failure retries on the next SetDesired for this VPC rather than being
-	// silently abandoned for the VRF's whole remaining lifetime.
+	// gatewayPublished is true once this VPC's return-path advertisement has
+	// been published. Set at most once per VRF lifetime, so a transient resolve
+	// or publish failure retries on the next SetDesired rather than being
+	// abandoned for the VRF's remaining lifetime.
 	gatewayPublished bool
 }
 
-// Store is the in-process desired/applied-state reconciler for this
-// sidecar's two granularities (§1 of the plan): route lifecycle keyed per
-// pod, VRF lifecycle keyed per VPC and rolled up from every route
-// referencing it. Mirrors internal/gateway's Engine and
-// internal/runtime/gobgp's GoBGPRuntime in shape — a mutex-protected map of
-// applied state, converged via Backend calls — except teardown here is
-// intentionally delayed by a grace period rather than applied synchronously
-// (§9 item 1 of the plan's teardown-race decision), so SetDesired/Sweep
-// replace a single Reconcile/Apply call: SetDesired applies "up" transitions
-// immediately and only starts a clock on "down" ones; Sweep is what actually
-// acts once that clock expires.
+// Store is the in-process desired-versus-applied reconciler for this sidecar's
+// two granularities: route lifecycle keyed per pod, and VRF lifecycle keyed per
+// VPC and rolled up from every route referencing it.
+//
+// Teardown is deliberately delayed by a grace period rather than applied
+// synchronously, which is why SetDesired and Sweep replace a single reconcile
+// call: SetDesired applies transitions up immediately and only starts a clock
+// on transitions down, and Sweep acts once that clock expires.
 type Store struct {
 	mu      sync.Mutex
 	backend Backend
 	grace   time.Duration
 	metrics *Metrics
 
-	// gatewayPublisher and gatewayResolver are both nil by default — see
-	// SetGatewayPublisher's doc comment for what enabling them does and why
-	// leaving them unset is a safe, fully backward-compatible no-op.
+	// gatewayPublisher and gatewayResolver are nil by default. See
+	// SetGatewayPublisher for what enabling them does.
 	gatewayPublisher GatewayPublisher
 	gatewayResolver  GatewayAddressResolver
 
@@ -72,10 +65,9 @@ type Store struct {
 	vrfs   map[string]*vrfState
 }
 
-// NewStore returns a Store that converges against backend, delaying
-// teardown of any route or VRF by grace after it drops out of desired
-// state. metrics may be nil (tests commonly pass nil; production callers
-// always pass a real *Metrics).
+// NewStore returns a Store that converges against backend, delaying teardown of
+// any route or VRF by grace after it leaves desired state. metrics may be nil,
+// as tests commonly pass.
 func NewStore(backend Backend, grace time.Duration, metrics *Metrics) *Store {
 	return &Store{
 		backend: backend,
@@ -86,21 +78,14 @@ func NewStore(backend Backend, grace time.Duration, metrics *Metrics) *Store {
 	}
 }
 
-// SetGatewayPublisher enables this Store to publish (and withdraw) a
-// return-path BGPAdvertisement for each VPC it manages a VRF for — see
-// GatewayPublisher/GatewayAddressResolver's own doc comments for the
-// mechanism and docs/plans/855-return-path-gateway-advertisement.md for why
-// it's needed: without it, a VPC backend's reply traffic has no SRv6 route
-// back to this node, confirmed live by packet capture (see that doc).
+// SetGatewayPublisher enables this Store to publish and withdraw a return-path
+// BGPAdvertisement for each VPC it manages a VRF for. Without one, a backend's
+// reply traffic has no SRv6 route back to this node.
 //
-// Both arguments default to nil (the zero Store), which is a fully inert,
-// backward-compatible no-op — every existing deployment of this sidecar
-// today has no gateway address provisioned for resolver to find anyway
-// (see GatewayAddressResolver's own doc comment on what provisioning it
-// still needs), so leaving this unset changes nothing about how Store
-// already behaves. Call this once, before the first SetDesired, from
-// cmd/galactic-vrf's own startup only when both a node identity and a real
-// resolver are actually configured.
+// Both arguments default to nil, which is fully inert: a deployment with no
+// gateway address provisioned has nothing for the resolver to find anyway. Call
+// this once, before the first SetDesired, and only when both a node identity
+// and a real resolver are configured.
 func (s *Store) SetGatewayPublisher(publisher GatewayPublisher, resolver GatewayAddressResolver) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -108,17 +93,15 @@ func (s *Store) SetGatewayPublisher(publisher GatewayPublisher, resolver Gateway
 	s.gatewayResolver = resolver
 }
 
-// publishGateway attempts to publish vpc's return-path gateway
-// advertisement once, the first time its VRF is created. Called with s.mu
-// already held (from SetDesired). A resolve failure because nothing has
-// provisioned a gateway address yet (ErrGatewayAddressNotProvisioned) is
-// logged at debug and left for the next SetDesired to retry — not a
-// reconcile error, since most deployments have no such provisioning
-// mechanism at all yet (see SetGatewayPublisher's doc comment). Any other
-// error is logged at warn and also left to retry, rather than failing the
-// route reconcile that triggered it — a missing return path degrades this
-// VPC's ingress traffic, it doesn't make it worse to also install the
-// forward-path route while it's unresolved.
+// publishGateway attempts to publish vpc's return-path advertisement once, the
+// first time its VRF is created. Called with s.mu held.
+//
+// A resolve failure because nothing has provisioned a gateway address yet is
+// logged at debug and left for the next SetDesired to retry, not treated as a
+// reconcile error. Any other error is logged at warn and likewise retried,
+// rather than failing the route reconcile that triggered it: a missing return
+// path degrades this VPC's ingress traffic, and withholding the forward-path
+// route as well would not improve it.
 func (s *Store) publishGateway(ctx context.Context, vpc string, v *vrfState) {
 	if s.gatewayPublisher == nil || s.gatewayResolver == nil || v.gatewayPublished {
 		return
@@ -139,13 +122,12 @@ func (s *Store) publishGateway(ctx context.Context, vpc string, v *vrfState) {
 	v.gatewayPublished = true
 }
 
-// withdrawGateway is publishGateway's teardown counterpart, called with
-// s.mu already held (from Sweep) once a VPC's VRF is actually about to be
-// removed. Best-effort: a failure here is logged, not propagated — it must
-// never block the kernel-side vrf.Delete that follows it, or a transient
-// k8s API error would leave a VPC's VRF permanently stuck mid-teardown.
-// galactic-router's GC controller reaps a BGPAdvertisement left behind by a
-// failed withdraw the same way it already reaps any other orphaned one.
+// withdrawGateway is publishGateway's counterpart, called with s.mu held once a
+// VPC's VRF is about to be removed. Best-effort: a failure is logged rather
+// than propagated, since it must never block the kernel-side delete that
+// follows, or a transient API error would leave a VRF stuck mid-teardown.
+// Garbage collection reaps an advertisement left behind by a failed withdraw
+// like any other orphan.
 func (s *Store) withdrawGateway(ctx context.Context, vpc string, v *vrfState) {
 	if s.gatewayPublisher == nil || !v.gatewayPublished {
 		return
@@ -155,17 +137,15 @@ func (s *Store) withdrawGateway(ctx context.Context, vpc string, v *vrfState) {
 	}
 }
 
-// SetDesired updates the desired state for the route identified by key —
-// an EndpointSlice's namespace/name (see Reconciler). desired == nil means
-// the EndpointSlice is gone or no longer selected (BuildDesiredRoute
-// returned nil for a not-yet-ready one, or the object was deleted): this
-// starts (or leaves running) that route's teardown grace period rather than
-// removing it immediately. desired != nil ensures the route's VRF and its
-// own seg6 route exist immediately — no delay on the way up, only on the
-// way down, the asymmetry §9 item 1 of the plan calls for. A route
-// reappearing before its own grace period elapses, or a VPC gaining a new
-// route before its VRF's grace period elapses, cancels that pending
-// teardown outright.
+// SetDesired updates the desired state for the route identified by key, an
+// EndpointSlice's namespace and name.
+//
+// A nil desired means the slice is gone or no longer selected, which starts, or
+// leaves running, that route's teardown grace period rather than removing it
+// immediately. A non-nil desired ensures the route's VRF and its own route
+// exist immediately: no delay on the way up, only on the way down. A route
+// reappearing before its grace period elapses, or a VPC gaining a new route
+// before its VRF's does, cancels the pending teardown outright.
 func (s *Store) SetDesired(ctx context.Context, key string, desired *DesiredRoute) (err error) {
 	if s.metrics != nil {
 		timer := prometheusTimer(s.metrics)
@@ -222,15 +202,16 @@ func (s *Store) SetDesired(ctx context.Context, key string, desired *DesiredRout
 	return nil
 }
 
-// Sweep advances every pending teardown whose grace period has elapsed as
-// of now, removing kernel state and forgetting it. Routes are processed
-// first; a VPC's own grace period only starts once Sweep observes no
-// remaining route — installed or still within its own grace — referencing
-// it, so the two timers can never overlap: a VPC is never torn down while
-// any of its routes still might come back. Call this periodically (see
-// RunSweeper), never reactively — VRF-level teardown is an aggregate
-// condition over potentially many routes, not a single watched object's own
-// transition.
+// Sweep advances every pending teardown whose grace period has elapsed as of
+// now, removing kernel state and forgetting it.
+//
+// Routes are processed first. A VPC's grace period only starts once Sweep
+// observes no remaining route referencing it, installed or still within its own
+// grace, so the two timers can never overlap and a VPC is never torn down while
+// one of its routes might still come back.
+//
+// Call this periodically, never reactively: VRF teardown is an aggregate
+// condition over many routes, not one watched object's transition.
 func (s *Store) Sweep(ctx context.Context, now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -297,23 +278,19 @@ func (s *Store) Sweep(ctx context.Context, now time.Time) {
 	}
 }
 
-// Inventory seeds Store with every Galactic-managed VRF device (and its
-// currently-installed seg6 routes) already present on the host at process
-// start — §9 item 2 of the plan's startup-reconcile-safety decision.
+// Inventory seeds Store with every managed VRF device, and its installed
+// routes, already present on the host at process start.
 //
-// Call this once, after every EndpointSlice existing at boot has already
-// been through SetDesired — see SeedFromAPI, which callers must run first
-// for exactly that reason (its own doc comment covers why
-// mgr.GetCache().WaitForCacheSync alone isn't sufficient here) — but before
-// the first Sweep runs. A VPC/route already known by that point is left
-// alone: SeedFromAPI's call already claimed it, so its absentSince is
-// already clear. Anything Inventory itself has to seed is, by construction,
-// missing that claim — either a VPC/pod truly orphaned while this sidecar
-// was down, or one whose EndpointSlice is itself gone/unready for some
-// other reason — so it's seeded with an ordinary grace period starting now
-// rather than torn down on sight (giving a slightly late EndpointSlice
-// update a chance to reclaim it) and rather than kept alive forever (the
-// pre-#377-revision failure mode this decision exists to avoid).
+// Call it once, after every EndpointSlice existing at boot has been through
+// SetDesired, and before the first Sweep. Anything already known by then is
+// left alone, its claim having been made by that seeding.
+//
+// Anything Inventory itself has to seed is by construction missing that claim:
+// either genuinely orphaned while this sidecar was down, or belonging to a slice
+// that is gone or unready for some other reason. Such state is seeded with an
+// ordinary grace period starting now, rather than torn down on sight, which
+// gives a slightly late update a chance to reclaim it, and rather than kept
+// alive forever.
 func (s *Store) Inventory(ctx context.Context, now time.Time) error {
 	infos, err := s.backend.ListVRFs()
 	if err != nil {
@@ -350,9 +327,9 @@ func (s *Store) Inventory(ctx context.Context, now time.Time) error {
 	return nil
 }
 
-// routeKnownLocked reports whether some already-tracked route shares vpc
-// and prefix with the given kernel route — i.e. it's not orphaned, a live
-// EndpointSlice already claims it. Callers must hold s.mu.
+// routeKnownLocked reports whether an already-tracked route shares vpc and
+// prefix with the given kernel route, meaning a live EndpointSlice claims it
+// and it is not orphaned. Callers must hold s.mu.
 func (s *Store) routeKnownLocked(vpc string, prefix *net.IPNet) bool {
 	for _, r := range s.routes {
 		if r.vpc == vpc && r.prefix.String() == prefix.String() {
@@ -368,9 +345,8 @@ func (s *Store) countError(kind string) {
 	}
 }
 
-// vrfActiveDelta and routeActiveDelta adjust the vrf_active/route_active
-// gauges by delta, no-oping if metrics weren't configured (tests commonly
-// pass nil — see NewStore).
+// vrfActiveDelta and routeActiveDelta adjust the active-count gauges by delta,
+// doing nothing when metrics were not configured.
 func (s *Store) vrfActiveDelta(delta float64) {
 	if s.metrics != nil {
 		s.metrics.VRFActive.Add(delta)

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -39,53 +39,41 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// ebpfHealthCheckInterval controls how often Run polls
-// internal/plumbing/ebpf/attach.Health once the eBPF datapath is running.
-// A package-level var (not a const) so tests can shrink it, the same
-// override pattern internal/plumbing/ebpf/attach/watch.go's
-// debounceInterval already uses.
+// ebpfHealthCheckInterval controls how often Run polls attach.Health once the
+// eBPF datapath is running. A var, not a const, so tests can shrink it.
 var ebpfHealthCheckInterval = 10 * time.Second
 
-// ebpfGCSweepInterval controls how often Run calls gc.SweepEBPFVRFTable
-// once the eBPF datapath is running. A package-level var, same override
-// pattern as ebpfHealthCheckInterval above -- matches galactic-router's
-// own GC controller's documented default period (docs/agents/
-// ARCHITECTURE-ROUTER.md: "ticker-driven, default every 5m").
+// ebpfGCSweepInterval controls how often Run runs the eBPF map GC sweeps once
+// the datapath is running. Matches galactic-router's own GC controller
+// period.
 var ebpfGCSweepInterval = 5 * time.Minute
 
-// radvReconcileInterval controls how often Run diffs the currently recorded
-// tap attachments (internal/plumbing/radv.ListAttachments) against the set
-// of running radv.RunActor goroutines, starting one for each newly recorded
-// attachment and canceling one for each attachment that has disappeared. A
-// package-level var, same override pattern as ebpfHealthCheckInterval
-// above. Kept short (unlike the RFC-sized intervals radv.RunActor itself
-// uses) since it only gates how fast a new attachment starts being served
-// at all -- a guest's own boot time dwarfs a couple of seconds either way.
+// radvReconcileInterval controls how often Run diffs the recorded tap
+// attachments against the running radv.RunActor goroutines, starting one for
+// each new attachment and canceling one for each that has gone. Kept short,
+// unlike the RFC-sized intervals the actors themselves use, because it only
+// gates how fast a new attachment starts being served, and a guest's boot time
+// dwarfs a few seconds.
 var radvReconcileInterval = 2 * time.Second
 
 // tapNeighReconcileInterval paces hostgw.EnsureTapGuestNeighbors. Far slower
-// than radv's own ticker: a resolved neighbor is refreshed by the kernel from
-// the guest's own advertisements, so this only has to notice one that has
-// aged out of the cache or a guest that has newly booted, and each pass costs
-// a solicit per unresolved guest.
+// than radv's ticker: the kernel refreshes a resolved neighbor from the guest's
+// own advertisements, so a pass only has to notice one that aged out or a guest
+// that just booted, and each pass costs a solicit per unresolved guest.
 var tapNeighReconcileInterval = 30 * time.Second
 
-// sidecarReturnReconcileInterval paces ensureSidecarReturnPath. Matched to
-// tapNeighReconcileInterval rather than the credential-refresh ticker
-// because what it installs points at a pod: an Envoy pod restart changes
-// the host-side veth and MAC the return route and neighbor name, and its
-// sidecar creates the VRF holding the gateway address some time after the
-// pod is scheduled. Each pass walks this node's network namespaces, so it
-// is not free enough for radv's cadence.
+// sidecarReturnReconcileInterval paces ensureSidecarReturnPath. Slower than
+// radv's ticker because each pass walks this node's network namespaces, and
+// faster than the credential refresh because what it installs points at a pod:
+// an Envoy restart changes the host-side veth and MAC the return route names,
+// and the sidecar creates the VRF holding the gateway address some time after
+// the pod is scheduled.
 var sidecarReturnReconcileInterval = 30 * time.Second
 
-// ebpfHealthServiceName is the gRPC health service name (see
-// grpc_health_v1.HealthServer) reporting the live status of the eBPF uSID
-// datapath specifically, separate from the overall (""), always-serving
-// status the credential-refresh/log-rotation loop reports -- so a BPF
-// datapath degradation (e.g. something external detaches the tc filter)
-// doesn't get conflated with, or masked by, the rest of this container's
-// unrelated responsibilities.
+// ebpfHealthServiceName is the gRPC health service name reporting the eBPF
+// uSID datapath's status, kept separate from the overall ("") always-serving
+// status so a datapath degradation is neither conflated with nor masked by this
+// container's unrelated responsibilities.
 const ebpfHealthServiceName = "ebpf-datapath"
 
 var (
@@ -134,10 +122,10 @@ func atomicWriteFile(destPath string, content []byte, mode os.FileMode) error {
 	return nil
 }
 
-// atomicCopyFile streams a file from srcPath to destPath atomically. It
-// copies via io.Copy rather than reading the whole source into memory
-// first, since binaries copied here (e.g. galactic-veth itself) run tens of
-// megabytes and the installer runs under a tight memory limit.
+// atomicCopyFile streams the file at srcPath to destPath atomically, creating
+// it with mode. It streams rather than buffering the whole source, since the
+// binaries copied here run to tens of megabytes and the installer has a tight
+// memory limit.
 func atomicCopyFile(srcPath, destPath string, mode os.FileMode) error {
 	src, err := os.Open(srcPath)
 	if err != nil {
@@ -181,11 +169,9 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
-	// bgpv1alpha1 registration is required for gc.SweepEBPFVRFTable's
-	// BGPRouter/BGPVRFInstance List calls (Milestone 7.3) -- newK8sClientFn
-	// below is shared with Bootstrap's plain Node lookup, which doesn't
-	// need it, but the client itself must know about every kind either
-	// caller lists.
+	// Registered for the BGPRouter and BGPVRFInstance lists the eBPF map
+	// sweeps make. The client is shared with Bootstrap's plain Node lookup,
+	// which does not need it, but must know every kind either caller lists.
 	_ = bgpv1alpha1.AddToScheme(scheme)
 }
 
@@ -202,24 +188,19 @@ var addrListFn = func(family int) ([]netlink.Addr, error) {
 	return netlink.AddrList(nil, family)
 }
 
-// ebpfStartFn loads, pins, and attaches the eBPF/TC-BPF uSID datapath, then
-// keeps its resolved interface set re-evaluated against netlink link/route
-// change events for the life of ctx (design plan
-// .local/plan-ebpf-xdp-usid-datapath.md §4.1, §4.4, §5.4; Milestones 3.1
-// and 3.2 of .local/implementation-plan-ebpf-xdp-usid-datapath.md). It is a
-// package-level override point -- like addrListFn and newK8sClientFn above
-// -- so tests can exercise Run's wiring without needing root, a real kernel
-// BPF stack, or a live network interface. The returned io.Closer is
-// internal/plumbing/ebpf/attach.StartWatching's *prog.UsidObjects in
-// production; Run keeps it open for the process lifetime and Closes it on
-// shutdown (see the attach package doc comment for why that does not
-// disrupt already-attached forwarding). Canceling ctx stops the background
-// netlink watch loop but does not, by itself, close the returned object.
+// ebpfStartFn loads, pins, and attaches the eBPF uSID datapath, then keeps its
+// resolved interface set re-evaluated against netlink link and route events for
+// the life of ctx. pinDir is the bpffs directory to pin into.
 //
-// The returned *attach.Watcher is Run's handle onto that background watch
-// loop -- wired into the ebpfHealthTicker case below so a failed health
-// check can nudge an out-of-band reconcile, and a watch loop that has
-// died is itself reported as unhealthy (ecv's review of #283).
+// It is a package-level override point so tests can exercise Run's wiring
+// without root, a kernel BPF stack, or a live interface. The returned io.Closer
+// is the loaded objects; Run holds it for the process lifetime and closes it on
+// shutdown, which does not disrupt already-attached forwarding. Canceling ctx
+// stops the watch loop but does not close the object.
+//
+// The returned *attach.Watcher is Run's handle on that watch loop, so a failed
+// health check can nudge an out-of-band reconcile and a watch loop that has
+// died is itself reported unhealthy.
 var ebpfStartFn = func(ctx context.Context, pinDir string) (io.Closer, []string, *attach.Watcher, error) {
 	return attach.StartWatching(ctx, pinDir)
 }
@@ -230,32 +211,23 @@ func resolveLogLevel() string {
 	return config.NormalizeLogLevel(os.Getenv(config.EnvLogLevel))
 }
 
-// resolveNAT66ShardSIDs reads GALACTIC_CNI_NAT66_SHARD_SIDS, the fabric-wide
-// NAT66 shard membership list -- see that env var's own doc comment. Unlike
-// resolveLogLevel's fallback, an unset/empty value has no default to
-// normalize to: it means no shard is configured yet, and is written into
-// the conflist verbatim (empty), not substituted for anything.
+// resolveNAT66ShardSIDs reads the fabric-wide NAT66 shard membership list from
+// the environment. An unset or empty value means no shard is configured yet and
+// is written into the conflist verbatim, with no default substituted.
 func resolveNAT66ShardSIDs() string {
 	return os.Getenv(config.EnvCNINAT66ShardSIDs)
 }
 
-// resolveEBPFInterfaces resolves the eBPF datapath's own interface list
-// (attach.ResolveInterfaces -- env override if GALACTIC_CNI_EBPF_INTERFACES
-// is set, auto-detected from the default IPv6 route otherwise) and joins
-// it for storage in the static conflist (HostConf.EBPFInterfaces), the
-// same "resolve once, in this init container's own real pod env, so a
-// per-pod CNI plugin invocation never has to" pattern
-// resolveNAT66ShardSIDs's own doc comment describes -- see that field's
-// doc comment in internal/hostconf for why a CNI plugin's own
-// auto-detection is unreliable in a way this container's isn't.
+// resolveEBPFInterfaces resolves the eBPF datapath's interface list, from the
+// environment override if set and auto-detected from the default IPv6 route
+// otherwise, and joins it for storage in the static conflist. Resolving it here,
+// in this container's real pod environment, saves every per-pod CNI invocation
+// from repeating an auto-detection that is less reliable there.
 //
-// A resolution failure here (e.g. no default IPv6 route yet and no env
-// override) is not fatal to Bootstrap: it writes an empty string, the
-// same "not yet known, caller falls back to its own auto-detection"
-// state the conflist field already has before this function existed at
-// all -- no worse than today, and self-heals whenever install-cni next
-// runs (a Bootstrap re-run, e.g. this DaemonSet pod restarting) with a
-// converged default route.
+// A resolution failure, such as no default IPv6 route and no override, is not
+// fatal: it writes an empty string, the same "not yet known, fall back to your
+// own detection" state the field already has, and self-heals the next time this
+// container runs with a converged route.
 func resolveEBPFInterfaces() string {
 	names, err := attach.ResolveInterfaces()
 	if err != nil {
@@ -267,10 +239,9 @@ func resolveEBPFInterfaces() string {
 	return strings.Join(names, ",")
 }
 
-// Bootstrap runs the CNI installation init container tasks:
-// 1. Copies binaries to the host.
-// 2. Performs a one-shot dual-stack node identity check.
-// 3. Templates the static conflist and initial kubeconfig.
+// Bootstrap runs the CNI installation init container tasks: it copies the
+// binaries to the host, performs a one-shot dual-stack node identity check, and
+// templates the static conflist and initial kubeconfig.
 func Bootstrap(ctx context.Context, nodeName string) error {
 	if nodeName == "" {
 		return errors.New("node name is required (or set GALACTIC_CNI_NODE_NAME)")
@@ -278,10 +249,9 @@ func Bootstrap(ctx context.Context, nodeName string) error {
 
 	slog.Info("Starting CNI installer bootstrap", "nodeName", nodeName)
 
-	// 1. Copy the CNI plugin chain's binaries to the host. Every binary in
-	// the chain ships in this same image and is staged here by this one
-	// init container, regardless of which master plugin(s) a given node's
-	// workloads actually use.
+	// Copy the CNI plugin chain's binaries to the host. Every binary in the
+	// chain ships in this image and is staged by this one init container,
+	// whichever master plugin a node's workloads use.
 	if err := os.MkdirAll(HostBinDir, 0755); err != nil {
 		return fmt.Errorf("create host CNI bin dir: %w", err)
 	}
@@ -442,8 +412,7 @@ users:
 }
 
 // ebpfDatapathState bundles what startEBPFDatapath resolves for Run to use
-// afterward (health polling, metrics, the GC sweep) -- a named type purely
-// to avoid a many-value return signature.
+// afterward: health polling, metrics, and the GC sweeps.
 type ebpfDatapathState struct {
 	objs      *prog.UsidObjects
 	ifaces    []string
@@ -453,13 +422,13 @@ type ebpfDatapathState struct {
 	nodeName  string
 }
 
-// startEBPFDatapath is Run's eBPF-datapath startup path, split out solely
-// to keep Run's own cyclomatic complexity within golangci-lint's gocyclo
-// budget -- behaviorally this is inlined exactly where it used to live. A
-// failure here (including a failed kernel preflight check, design plan §6)
-// is fatal: Run returns an error rather than falling back to a partial or
-// unsafe datapath state -- this is the only forwarding path, there is no
-// legacy path to fall back to.
+// startEBPFDatapath loads and attaches the eBPF datapath and returns the state
+// Run needs to poll and sweep it, plus the closer Run holds for the process
+// lifetime. Split out of Run to keep it within the gocyclo budget.
+//
+// A failure, including a failed kernel preflight check, is fatal. This is the
+// only forwarding path, so there is no partial or legacy state to fall back
+// to.
 func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathState, io.Closer, error) {
 	attach.SetHooks(m.Events.Hooks())
 
@@ -471,10 +440,9 @@ func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathSta
 
 	state := ebpfDatapathState{ifaces: ifaces, watcher: watcher}
 
-	// ebpfStartFn's io.Closer is *prog.UsidObjects in production (test
-	// fakes stand in a plain mock closer, which correctly leaves
-	// metrics/health/GC wiring inert below -- see installer_test.go's
-	// fakeDatapathCloser).
+	// The closer is the loaded objects in production. A test fake stands in a
+	// plain mock closer, which correctly leaves the metrics, health, and GC
+	// wiring below inert.
 	if objs, ok := datapath.(*prog.UsidObjects); ok {
 		state.objs = objs
 		if err := m.RegisterDatapathCollector(objs); err != nil {
@@ -482,11 +450,10 @@ func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathSta
 		}
 	}
 
-	// Best-effort setup for the eBPF vrf_table GC sweep (Milestone 7.3).
-	// A failure here is not fatal to Run -- unlike the datapath start
-	// above, GC is a background maintenance task, not a hard requirement
-	// for the datapath to forward traffic -- it just means this node's
-	// sweep ticker stays inert until the next restart.
+	// Best-effort setup for the eBPF map GC sweeps. Unlike the datapath start
+	// above, a failure is not fatal: GC is background maintenance, not a
+	// requirement for forwarding, so the sweep ticker just stays inert until
+	// the next restart.
 	if hostConf, err := hostconf.Load(HostConflist, hostconf.PluginType); err != nil {
 		slog.Warn("eBPF vrf_table GC sweep disabled: failed to load host conf", "err", err)
 	} else if k8sClient, err := newK8sClientFn(); err != nil {
@@ -498,10 +465,8 @@ func startEBPFDatapath(ctx context.Context, m *metrics.Metrics) (ebpfDatapathSta
 	return state, datapath, nil
 }
 
-// cleanupOldBinaryWrapper is Run's cleanupTimer case body, split out solely
-// to keep Run's own cyclomatic complexity within golangci-lint's gocyclo
-// budget -- same reasoning as startEBPFDatapath above; behaviorally this is
-// inlined exactly where it used to live.
+// cleanupOldBinaryWrapper removes the stale .bin wrapper file. Split out of
+// Run's select to keep it within the gocyclo budget.
 func cleanupOldBinaryWrapper() {
 	oldBinPath := filepath.Join(HostBinDir, "galactic-cni.bin")
 	if _, err := os.Stat(oldBinPath); err == nil {
@@ -513,13 +478,12 @@ func cleanupOldBinaryWrapper() {
 	}
 }
 
-// startTapNeighborSweep runs one hostgw.EnsureTapGuestNeighbors pass off
-// Run's own goroutine, dropping the tick when a previous pass is still in
-// flight. Split out of Run's select for the same reason startEBPFDatapath
-// was: to keep Run inside golangci-lint's gocyclo budget.
+// startTapNeighborSweep runs one hostgw.EnsureTapGuestNeighbors pass off Run's
+// goroutine, so a slow pass cannot hold the select loop.
 //
-// sem is a size-1 semaphore, so a slow pass delays nothing and never queues
-// a backlog of ticks behind itself.
+// sem is a size-1 semaphore: a tick arriving while a pass is still in flight is
+// dropped rather than queued, so freshness suffers instead of a backlog
+// building.
 func startTapNeighborSweep(sem chan struct{}) {
 	select {
 	case sem <- struct{}{}:
@@ -535,12 +499,12 @@ func startTapNeighborSweep(sem chan struct{}) {
 }
 
 // startSidecarReturnSweep runs one ensureSidecarReturnPath pass off Run's
-// own goroutine, for the same reason startTapNeighborSweep does: a pass
-// enters every network namespace on this node, and a node running a large
-// Envoy fleet must not hold the select loop long enough to starve the
-// credential refresh, GC sweeps and eBPF health check. The semaphore drops
-// a tick rather than queueing it when the previous pass is still running,
-// so a slow pass costs freshness rather than piling up goroutines.
+// goroutine. A pass enters every network namespace on this node, so on a node
+// running a large Envoy fleet it would otherwise starve the credential refresh,
+// GC sweeps, and health check.
+//
+// sem is a size-1 semaphore, dropping a tick rather than queueing it when the
+// previous pass is still running.
 func startSidecarReturnSweep(ctx context.Context, sem chan struct{}, st ebpfDatapathState) {
 	select {
 	case sem <- struct{}{}:
@@ -552,41 +516,29 @@ func startSidecarReturnSweep(ctx context.Context, sem chan struct{}, st ebpfData
 	}
 }
 
-// radvActorSet tracks the currently running radv.RunActor goroutines, keyed
-// by host interface name (radv.Record.HostInterface) -- Run's own local
-// state, reconciled against radv.ListAttachments on every
-// radvReconcileTicker tick (see reconcileRadvActors). The zero value is
-// ready to use.
+// radvActorSet tracks the running radv.RunActor goroutines, keyed by host
+// interface name. It is Run's local state, reconciled against the recorded
+// attachments on every tick. The zero value is ready to use.
 //
-// cancel is touched only from Run's own goroutine (reconcileRadvActors and
-// the radvActorFailed case below) -- deliberately not guarded by a mutex,
-// since keeping it single-owner is simpler than synchronizing concurrent
-// access from the actor goroutines themselves. Those goroutines instead
-// report a failed startup back onto failed, which Run's select loop drains
-// on its own turn.
+// cancel is touched only from Run's own goroutine and is deliberately
+// unguarded, since single ownership is simpler than synchronizing with the
+// actor goroutines. Those goroutines report a failed startup on failed
+// instead, which Run's select drains on its own turn.
 type radvActorSet struct {
 	cancel map[string]context.CancelFunc
 	failed chan string
 	wg     sync.WaitGroup
 }
 
-// reconcileRadvActors is Run's radvReconcileTicker case body -- also called
-// once before the loop starts, so attachments already recorded when this
-// daemon starts (e.g. a restart while VMs are still attached) are served
-// immediately rather than waiting out the first tick. Split into its own
-// function solely to keep Run's own cyclomatic complexity within
-// golangci-lint's gocyclo budget -- same reasoning as startEBPFDatapath
-// above.
+// reconcileRadvActors starts one radv.RunActor per newly recorded tap
+// attachment and cancels one for each attachment that has disappeared. It is
+// also called once before Run's loop starts, so attachments already recorded
+// when this daemon starts are served immediately.
 //
-// Starts one radv.RunActor per newly recorded attachment and cancels one
-// for each attachment that has disappeared since the last reconcile. A
-// listing failure here is never fatal to Run -- resending/soliciting is
-// best-effort maintenance for already-attached VM guests, not a
-// requirement for anything else this process does -- so already-running
-// actors are simply left alone until the next tick succeeds. An actor that
-// fails during startup (e.g. a transient interface lookup failure) reports
-// itself on actors.failed instead of silently leaving its map entry stuck
-// "running" forever -- see radvActorFailed.
+// A listing failure is never fatal. Resending and soliciting is best-effort
+// maintenance for already-attached guests, so running actors are left alone
+// until a tick succeeds. An actor that fails during startup reports itself on
+// actors.failed rather than leaving its map entry stuck as running.
 func reconcileRadvActors(ctx context.Context, actors *radvActorSet) {
 	records, err := radv.ListAttachments(radv.DefaultStateDir)
 	if err != nil {
@@ -596,11 +548,10 @@ func reconcileRadvActors(ctx context.Context, actors *radvActorSet) {
 
 	if actors.cancel == nil {
 		actors.cancel = make(map[string]context.CancelFunc)
-		// Buffered generously relative to any realistic node's tap
-		// attachment count, so a run of startup failures can't block an
-		// actor goroutine on this send -- radvActorFailed's own send is
-		// non-blocking besides, so a full channel only delays a retry
-		// rather than deadlocking anything.
+		// Buffered well past any realistic node's attachment count, so a run
+		// of startup failures cannot block an actor goroutine on this send.
+		// radvActorFailed sends non-blocking anyway, so a full channel only
+		// delays a retry.
 		actors.failed = make(chan string, 256)
 	}
 
@@ -638,60 +589,39 @@ func reconcileRadvActors(ctx context.Context, actors *radvActorSet) {
 	}
 }
 
-// radvActorFailed is Run's radvActors.failed case body: an actor that
-// couldn't even start (radv.RunActor returned a non-nil error, meaning it
-// never got past opening its Conn) reported itself here rather than
-// leaving reconcileRadvActors permanently convinced it's still running.
-// Clearing its map entry lets the next reconcile tick see the attachment
-// as unserved again and retry it. A delete on a key already gone (the
-// reconciler noticed the attachment itself disappeared in the meantime) is
-// a safe no-op.
+// radvActorFailed clears the map entry for an actor that could not start, so
+// the next reconcile sees the attachment as unserved and retries it. Without
+// it, reconcileRadvActors would stay convinced the actor is running. Deleting a
+// key that is already gone, because the attachment itself disappeared, is a
+// safe no-op.
 func radvActorFailed(actors *radvActorSet, iface string) {
 	delete(actors.cancel, iface)
 }
 
 // Run executes the CNI installer main container tasks:
-//  1. Loads/pins/attaches the eBPF/TC-BPF uSID datapath and keeps its
-//     attachment set re-evaluated against netlink link/route change events
-//     for the life of ctx (design plan §4.1, §4.4, §5.4; Milestones 3.1
-//     and 3.2 of .local/implementation-plan-ebpf-xdp-usid-datapath.md) --
-//     the only forwarding path. A failure here (including a failed kernel
-//     preflight check, design plan §6) is fatal: Run returns an error
-//     rather than falling back to a partial or unsafe datapath state.
-//     Once running, the netlink-driven re-attachment loop logs and retries
-//     its own failures rather than propagating them back into Run -- see
-//     internal/plumbing/ebpf/attach.Watch's doc comment. Datapath
-//     load/attach/detach events are counted via
-//     internal/plumbing/ebpf/metrics's EventCounters (Milestone 4), and
-//     live vrf_table/locator_table/drop_reasons state is exposed through
-//     the same metrics endpoint.
+//  1. Loads, pins, and attaches the eBPF uSID datapath and keeps its attachment
+//     set re-evaluated against netlink events for the life of ctx. This is the
+//     only forwarding path, so a failure here, including a failed kernel
+//     preflight check, is fatal. Once running, the re-attachment loop logs and
+//     retries its own failures instead of propagating them back into Run.
+//     Load, attach, and detach events are counted, and live map state is
+//     exposed on the same metrics endpoint.
 //  2. Serves Prometheus metrics on metricsPort.
-//  3. Sets up log rotation periodically.
-//  4. Starts a simple ServiceAccount token refresh ticker.
-//  5. Deferred cleanup of stale .bin wrapper file.
-//  6. Starts the gRPC health check server -- the overall ("") service
-//     always reports SERVING once the process is up (credential
-//     refresh/log rotation have no meaningful "unhealthy" state of their
-//     own); a separate ebpfHealthServiceName ("ebpf-datapath") service is
-//     polled on a ticker and reports the live result of
-//     internal/plumbing/ebpf/attach.Health -- exit criterion "health check
-//     fails correctly when the program is unloaded".
-//  7. Periodically sweeps stale vrf_table entries via gc.SweepEBPFVRFTable
-//     (design plan §5.3; Milestone 7.3), and registers/reconciles
-//     nptv6_table entries via gc.SweepEBPFNPTv6Table. Both run from here,
-//     not from galactic-router's existing GC controller
-//     (internal/controller/gc_controller.go), because the pinned maps
-//     only exist inside this container -- see gc.SweepEBPFVRFTable's own
-//     doc comment for the full reasoning.
-//  8. Runs one internal/plumbing/radv.RunActor goroutine per tap attachment
-//     galactic-tap has recorded (radv.ListAttachments), reconciled against
-//     that list on a short ticker (radvReconcileInterval). Each actor both
-//     resends an IPv6 Router Advertisement on a jittered schedule and
-//     replies to that guest's own Router Solicitations. This runs from
-//     here, not from galactic-tap's own cmdAdd, because a VM guest's boot
-//     almost always outlives that short-lived process -- see radv's own
-//     doc comment for the full reasoning. Unrelated to, and runs
-//     regardless of, the eBPF datapath above.
+//  3. Rotates logs periodically.
+//  4. Refreshes the ServiceAccount token on a ticker.
+//  5. Cleans up the stale .bin wrapper file.
+//  6. Serves gRPC health on grpcHealthPort. The overall ("") service always
+//     reports SERVING once the process is up, since credential refresh and log
+//     rotation have no meaningful unhealthy state; a separate
+//     ebpfHealthServiceName service reports the polled result of attach.Health.
+//  7. Sweeps stale vrf_table entries and reconciles nptv6_table entries on a
+//     ticker. Both run here rather than in galactic-router's GC controller
+//     because the pinned maps exist only inside this container.
+//  8. Runs one radv.RunActor per recorded tap attachment, reconciled on a short
+//     ticker. Each actor resends Router Advertisements on a jittered schedule
+//     and replies to that guest's solicitations. This runs here, not from
+//     galactic-tap's cmdAdd, because a guest's boot outlives that short-lived
+//     process. It is independent of the eBPF datapath and runs regardless.
 func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	slog.Info("Starting CNI installer run daemon", "grpcHealthPort", grpcHealthPort, "metricsPort", metricsPort)
 
@@ -709,10 +639,9 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 		}()
 	}
 
-	// This node's own uSID locator has to be locally resolvable before any
-	// same-node SRv6 egress route can be registered -- see
-	// ensureLocatorLocalRoute. Non-fatal, and retried on refreshTicker
-	// below, since the BGPRouter carrying the locator may not exist yet.
+	// This node's uSID locator must be locally resolvable before any same-node
+	// SRv6 egress route can be registered. Non-fatal and retried below, since
+	// the BGPRouter carrying the locator may not exist yet.
 	reconcileLocatorLocalRoute(ctx, ebpfState)
 
 	// Serve Prometheus metrics at the conventional /metrics scrape path.
@@ -768,28 +697,22 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	cleanupTimer := time.NewTimer(2 * time.Minute)
 	defer cleanupTimer.Stop()
 
-	// eBPF datapath health poll -- only meaningful once datapathObjs is
-	// set (eBPF datapath enabled and actually running); otherwise this
-	// fires harmlessly and does nothing every tick.
+	// Health poll, meaningful only once the datapath is running; otherwise it
+	// fires harmlessly and does nothing.
 	ebpfHealthTicker := time.NewTicker(ebpfHealthCheckInterval)
 	defer ebpfHealthTicker.Stop()
 	var ebpfLastHealthy = true // matches the initial SetServingStatus(SERVING) above
 
-	// eBPF vrf_table GC sweep (Milestone 7.3) -- only meaningful once
-	// gcK8sClient is set (eBPF datapath enabled and host conf/k8s client
-	// setup above succeeded); otherwise this fires harmlessly and does
-	// nothing every tick, same as the health poll above.
+	// eBPF map GC sweep, meaningful only once the Kubernetes client is set;
+	// otherwise it fires harmlessly, like the health poll above.
 	ebpfGCSweepTicker := time.NewTicker(ebpfGCSweepInterval)
 	defer ebpfGCSweepTicker.Stop()
 
-	// Router Advertisement serving for tap-attached VM guests (see
-	// internal/plumbing/radv's own doc comment) -- runs regardless of
-	// whether the eBPF datapath is enabled, since it has nothing to do with
-	// it. One radv.RunActor goroutine per currently recorded attachment
-	// (radvActorSet, reconciled on every radvReconcileTicker tick below)
-	// handles both the periodic resend and Router Solicitation replies for
-	// that attachment; reconciled once here too, so attachments already
-	// recorded when this daemon starts don't wait out the first tick.
+	// Router Advertisement serving for tap-attached guests, independent of the
+	// eBPF datapath. One actor per recorded attachment handles both the
+	// periodic resend and solicitation replies. Reconciled once here as well
+	// as on the ticker, so attachments already recorded at startup do not wait
+	// out the first tick.
 	radvActors := &radvActorSet{}
 	reconcileRadvActors(ctx, radvActors)
 	defer radvActors.wg.Wait()
@@ -829,9 +752,9 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 				rotateLogFile(logFileHostPath)
 			}
 
-			// Re-assert this node's uSID locator local route: picks up a
-			// BGPRouter created after startup, and restores the route if
-			// something flushed it.
+			// Re-assert the locator local route: this picks up a BGPRouter
+			// created after startup and restores the route if it was
+			// flushed.
 			reconcileLocatorLocalRoute(ctx, ebpfState)
 
 		case <-ebpfHealthTicker.C:
@@ -862,10 +785,8 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 			result := gc.SweepEBPFVRFTable(ctx, ebpfState.k8sClient, ebpfState.namespace, ebpfState.nodeName, attach.PinDir)
 			logEBPFVRFSweepResult(result)
 
-			// nptv6_table's own sweep: unlike vrf_table above, this is the
-			// map's *only* writer (see gc.SweepEBPFNPTv6Table's own doc
-			// comment) -- it both registers every currently-live NPTv6
-			// mapping and reconciles stale ones away on every tick.
+			// nptv6_table's sweep is its map's only writer, so it registers
+			// every live mapping as well as reaping stale ones.
 			nptv6Result := gc.SweepEBPFNPTv6Table(
 				ctx, ebpfState.k8sClient, ebpfState.namespace, ebpfState.nodeName, attach.PinDir)
 			if nptv6Result.EBPFNPTv6EntriesRemoved > 0 || nptv6Result.Errors > 0 {
@@ -877,31 +798,25 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 			reconcileRadvActors(ctx, radvActors)
 
 		case <-tapNeighTicker.C:
-			// Resolve each tap guest's neighbor entry, without which
-			// usid_ingress's own FIB lookup drops every decapsulated packet
-			// bound for it -- see hostgw.EnsureTapGuestNeighbors. Periodic,
-			// and not once at CNI ADD, for the same reason the radv actors
-			// above run here: a VM guest's boot almost always outlives the
-			// short-lived plugin process that attached it, so there is
-			// nothing to solicit yet at ADD time.
+			// Resolve each tap guest's neighbor entry, without which the
+			// datapath's FIB lookup drops every decapsulated packet bound for
+			// it. Periodic rather than once at CNI ADD, for the same reason
+			// the radv actors run here: a guest's boot outlives the
+			// short-lived plugin process, so there is nothing to solicit yet
+			// at ADD time.
 			//
-			// Off this loop's goroutine, and on a ticker of its own rather
-			// than radv's 2s one. Each unresolved guest costs a solicit plus
-			// up to neighResolveTimeout of polling, so a node whose guests
-			// are down would otherwise hold the select loop long past the
-			// next tick and starve the credential refresh, GC sweeps and
-			// eBPF health check with it -- measured at 32s a pass before the
-			// route filter was tightened. The semaphore drops a tick rather
-			// than queueing it when the previous pass is still running.
+			// Off this goroutine and on its own slower ticker. Each
+			// unresolved guest costs a solicit plus polling, so a node whose
+			// guests are down would hold the select loop past the next tick
+			// and starve the credential refresh, GC sweeps, and health check
+			// with it.
 			startTapNeighborSweep(tapNeighSem)
 
 		case <-sidecarReturnTicker.C:
-			// Install (and re-assert) the host side of the ingress
-			// sidecar's return path -- the routes, neighbors and uSID map
-			// entries a reply encapsulated toward this node's own SID needs
-			// in order to reach an Envoy pod's per-VPC sidecar VRF. See
-			// sidecarreturn.go's own file comment for why this cannot live
-			// in the sidecar itself.
+			// Install and re-assert the host side of the ingress sidecar's
+			// return path: the routes, neighbors, and uSID map entries a
+			// reply encapsulated toward this node's SID needs to reach an
+			// Envoy pod's per-VPC sidecar VRF.
 			startSidecarReturnSweep(ctx, sidecarReturnSem, ebpfState)
 
 		case iface := <-radvActors.failed:
@@ -910,12 +825,9 @@ func Run(ctx context.Context, grpcHealthPort, metricsPort int) error {
 	}
 }
 
-// logEBPFVRFSweepResult logs one gc.SweepEBPFVRFTable tick's result, if
-// there's anything worth logging -- split out of Run's own select loop
-// (rather than inlined there like every other ticker case) purely to keep
-// that branch out of Run's own cyclomatic complexity count, now that this
-// result carries a third field (EBPFVRFEntriesRegistered) alongside the
-// original two.
+// logEBPFVRFSweepResult logs one vrf_table sweep result when there is anything
+// worth logging. Split out of Run's select to keep it within the gocyclo
+// budget.
 func logEBPFVRFSweepResult(result gc.CleanupResult) {
 	if result.EBPFVRFEntriesRemoved > 0 || result.EBPFVRFEntriesRegistered > 0 || result.Errors > 0 {
 		slog.Info("eBPF vrf_table GC sweep complete",

--- a/internal/installer/locatorroute.go
+++ b/internal/installer/locatorroute.go
@@ -20,47 +20,38 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// ensureLocatorLocalRoute installs a local route for this node's own uSID
-// locator /64 -- the Block(48) + Node-ID(16) prefix from its BGPRouter --
-// into the kernel's local table, pointed at lo.
+// ensureLocatorLocalRoute installs a local route for this node's uSID locator
+// /64, the Block and Node-ID prefix from its BGPRouter, into the kernel's local
+// table pointed at loopback.
 //
-// This exists because a node has to be able to resolve a route to its *own*
-// SIDs. internal/plumbing/ebpf/egressroutemap's resolveLinkAndL2 calls
-// netlink.RouteGet(sid) once per registration to pick the egress interface
-// and next-hop MAC that usid_egress will then redirect to, and for a
-// same-node destination (an Envoy sidecar reaching a backend on its own
-// node) that SID belongs to this very node. Without a matching route,
-// RouteGet fails against the locator's own Null0 discard route with EINVAL,
-// registration fails, and same-node SRv6 encapsulation is never set up.
+// A node has to be able to resolve a route to its own SIDs. Egress route
+// registration resolves each SID once to pick the egress interface and next-hop
+// MAC the datapath then redirects to, and for a same-node destination, an Envoy
+// sidecar reaching a backend on its own node, that SID belongs to this node.
+// Without a matching route the lookup fails against the locator's own discard
+// route, registration fails, and same-node encapsulation is never set up.
 //
-// A route, deliberately, and not an address on a dummy interface -- which is
-// how this was previously satisfied. A locally-assigned global address is
-// published as a node address by cluster discovery, which lands it in every
-// KubeSpan peer's allowedIPs; KubeSpan's nftables chains then steer traffic
-// to it into the WireGuard policy table, where this datapath is not attached
-// (attach.ResolveInterfaces skips wireguard links) and could not parse it
-// anyway, a WireGuard interface being link-type RAW with no Ethernet header
-// for usid_ingress's first parse step. That silently blackholed every
-// inter-node SRv6 packet. Cluster discovery publishes addresses, not routes,
-// so a local route restores resolution without re-creating that.
+// A route, deliberately, and not an address on a dummy interface. A locally
+// assigned global address is published as a node address by cluster discovery,
+// which lands it in every mesh peer's allowed addresses, and the mesh's own
+// rules then steer traffic for it into a policy table where this datapath is
+// not attached and could not parse the packets anyway, the tunnel having no
+// Ethernet header for the first parse step. That silently blackholes every
+// inter-node encapsulated packet. Discovery publishes addresses, not routes.
 //
 // Covering the whole /64 rather than individual SIDs is what makes this
-// self-maintaining: every SID this node can compute shares that prefix, so
-// no per-VPC or per-Argument bookkeeping is needed, and a VPC whose Argument
-// nobody thought to configure resolves the same as any other. It cannot
-// shadow decapsulation either, because usid_ingress claims packets at tc
-// ingress before any FIB lookup runs.
+// self-maintaining: every SID this node can compute shares that prefix, so no
+// per-VPC bookkeeping is needed and a VPC nobody configured resolves like any
+// other. It cannot shadow decapsulation either, since usid_ingress claims
+// packets at tc ingress before any FIB lookup runs.
 //
-// Idempotent (RouteReplace), and safe to call repeatedly: Run invokes it at
-// startup and on its refresh ticker, so a BGPRouter that appears later, or a
-// route flushed out from under us, is picked up without a restart.
+// Idempotent and safe to call repeatedly, so a BGPRouter that appears later, or
+// a route flushed out from under it, is picked up without a restart.
 //
-// It also removes the routes it installed for a locator this node no longer
-// owns. RouteReplace alone cannot: a changed Block or Node-ID is a different
-// prefix, so the old route is left behind claiming address space this node
-// has given up, and nothing would ever retract it. Observed after moving a
-// node back to its cluster Block, which left both the new and the old /64
-// local on lo.
+// It also removes routes it installed for a locator this node no longer owns. A
+// replace alone cannot: a changed Block or Node-ID is a different prefix, so the
+// old route is left behind claiming address space this node gave up, and nothing
+// would retract it.
 func ensureLocatorLocalRoute(ctx context.Context, k8s client.Client, namespace, nodeName string) error {
 	if k8s == nil || nodeName == "" {
 		return nil // no node identity configured; nothing to resolve against
@@ -90,12 +81,11 @@ func ensureLocatorLocalRoute(ctx context.Context, k8s client.Client, namespace, 
 		return fmt.Errorf("install local route %s dev lo table local: %w", prefix, err)
 	}
 
-	// Deliberately only after a successful install, and only with a valid
-	// desired prefix in hand -- pruning against the zero Prefix would strip
-	// this node's working route every time the BGPRouter is briefly
-	// unreadable during bring-up. A prune failure is not the install
-	// failing: same-node resolution already works, a leftover only
-	// over-claims space, and the refresh ticker retries.
+	// Only after a successful install, and only with a valid desired prefix in
+	// hand: pruning against the zero prefix would strip this node's working
+	// route every time the BGPRouter is briefly unreadable during bring-up. A
+	// prune failure is not an install failure, since same-node resolution
+	// already works and a leftover only over-claims space.
 	if err := pruneStaleLocatorLocalRoutes(lo.Attrs().Index, prefix); err != nil {
 		slog.Warn("Could not remove stale uSID locator local routes; this node still "+
 			"claims a locator prefix it no longer owns", "keep", prefix.String(), "err", err)
@@ -128,17 +118,16 @@ func pruneStaleLocatorLocalRoutes(loIndex int, keep netip.Prefix) error {
 	return errors.Join(errs...)
 }
 
-// staleLocatorLocalRoute reports whether r is one of ensureLocatorLocalRoute's
-// own routes for a prefix other than keep.
+// staleLocatorLocalRoute reports whether r is one of this component's own
+// routes for a prefix other than keep.
 //
-// The filtering is the whole safety argument, because the local table is
-// mostly the kernel's and deleting from it wrongly would black-hole one of
-// this node's own addresses. Every entry the kernel derives from an assigned
-// address carries RTPROT_KERNEL and is a /128 host route; what this component
-// installs carries neither. So a candidate must be RTN_LOCAL on lo, not
-// RTPROT_KERNEL, and exactly a Block+Node-ID /64 -- the one length
-// ensureLocatorLocalRoute ever writes. A node's own loopback /128, ::1, and
-// anything on another link all fail that.
+// The filtering carries the safety argument, the local table being mostly the
+// kernel's and a wrong delete blackholing one of this node's own addresses.
+// Every entry the kernel derives from an assigned address is a kernel-protocol
+// /128 host route, and what this component installs is neither. So a candidate
+// must be a local route on loopback, not kernel-derived, and exactly a /64, the
+// one length ever written here. A loopback /128, ::1, and anything on another
+// link all fail that.
 func staleLocatorLocalRoute(r netlink.Route, loIndex int, keep netip.Prefix) bool {
 	if r.LinkIndex != loIndex || r.Table != unix.RT_TABLE_LOCAL {
 		return false
@@ -160,13 +149,11 @@ func staleLocatorLocalRoute(r netlink.Route, loIndex int, keep netip.Prefix) boo
 	return netip.PrefixFrom(got.Unmap(), ones) != keep
 }
 
-// nodeLocatorPrefix returns the Block(48)+Node-ID(16) /64 carved out of this
-// node's BGPRouter locator, or the zero Prefix when this node has no
-// BGPRouter or that router carries no SRv6 locator yet -- both ordinary
-// during bring-up, and neither an error.
-//
-// Matched on Spec.TargetRef.Name, the same way internal/cnibgp and
-// internal/ingresssidecar both find the router for a node.
+// nodeLocatorPrefix returns the /64 carved out of this node's BGPRouter
+// locator, or the zero Prefix when this node has no BGPRouter or that router
+// carries no locator yet. Both are ordinary during bring-up and neither is an
+// error. The router is matched on its target name, the same way every other
+// component here finds a node's router.
 func nodeLocatorPrefix(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) (netip.Prefix, error) {
@@ -205,9 +192,9 @@ func nodeLocatorPrefix(
 	return netip.Prefix{}, nil
 }
 
-// reconcileLocatorLocalRoute is Run's non-fatal wrapper: a missing or
-// not-yet-created BGPRouter, or a transient API error, must not stop the
-// installer daemon, and the refresh ticker retries on its own.
+// reconcileLocatorLocalRoute is Run's non-fatal wrapper: a missing BGPRouter or
+// a transient API error must not stop the installer daemon, and the refresh
+// ticker retries.
 func reconcileLocatorLocalRoute(ctx context.Context, st ebpfDatapathState) {
 	if err := ensureLocatorLocalRoute(ctx, st.k8sClient, st.namespace, st.nodeName); err != nil {
 		slog.Warn("Could not install this node's uSID locator local route; "+

--- a/internal/installer/sidecarreturn.go
+++ b/internal/installer/sidecarreturn.go
@@ -28,80 +28,62 @@ import (
 // The ingress sidecar's return path, host side.
 //
 // internal/ingresssidecar gives an Envoy pod one Linux VRF per tenant VPC
-// inside its *own* netns, and advertises a per-VPC gateway address into
-// EVPN so a backend's reply -- addressed back to that gateway address --
-// has an SRv6 route to follow (GatewayPublisher's doc comment). A remote
-// node duly encapsulates that reply toward this node's own SID for the
-// advertised Argument.
+// inside its own netns, and advertises a per-VPC gateway address into EVPN so a
+// backend's reply has an SRv6 route to follow. A remote node encapsulates that
+// reply toward this node's SID for the advertised Argument.
 //
-// Nothing on this node could take delivery of it. The sidecar registers
-// only what usid_egress reads, under a synthetic Block that usid_ingress
-// deliberately never matches (ingressSidecarBlock's doc comment), and it
-// cannot register the ingress side itself for two reasons that both come
-// down to which netns it is in: usid_ingress runs in the *host* netns,
-// while the sidecar's VRFs, their routing tables, and both ends of their
-// veth pairs are in the pod's, and a container in that pod cannot install
-// host-netns routes. So the receiving half has to live here, in the host
-// daemon, and this file is it.
+// The receiving half cannot live in the sidecar. usid_ingress runs in the host
+// netns, while the sidecar's VRFs, routing tables, and veth pairs are in the
+// pod's, and a container there cannot install host-netns routes. The sidecar
+// also registers only what usid_egress reads, under a synthetic Block
+// usid_ingress never matches.
 //
-// The split runs the other way too, which is why this reads annotations
-// rather than going to look. Pointing a reply at the right pod needs that
-// pod's host-side veth and MAC, and reading those from here means entering
-// its namespace: setns wants CAP_SYS_ADMIN, and this container drops ALL
-// and adds only BPF, NET_ADMIN and NET_RAW. The sidecar can read both from
-// inside with no privilege at all, so it publishes them on the
-// advertisement it already writes and this side consumes them. Each half
-// does the part it has the rights for.
+// This side reads annotations rather than going to look, for the mirror-image
+// reason. Pointing a reply at the right pod needs that pod's host-side veth and
+// MAC, and reading those from here means entering its namespace, which needs
+// CAP_SYS_ADMIN. This container drops ALL and adds only BPF, NET_ADMIN, and
+// NET_RAW. The sidecar reads both from inside with no privilege and publishes
+// them on the advertisement it already writes.
 //
-// What a decapsulated reply needs, and what this installs per advertised
-// sidecar gateway address:
+// Per advertised gateway address, a decapsulated reply needs:
 //
-//  1. locator_table + function_table entries for this node's own Block and
-//     Node-ID, so usid_ingress claims the packet at all rather than passing
-//     it to a stack that has no tunnel device to hand it to. A node hosting
-//     only sidecars has no CNI attachment, so nothing else ever writes
-//     these -- internal/cnibgp's registerEBPFDatapath, their only other
-//     writer, runs at CNI ADD.
-//  2. A vrf_table entry under this node's *real* Block, keyed on the
-//     Argument the advertisement was published with, pointing at a routing
-//     table this file owns, with EgressKindVeth so step 9 uses
-//     bpf_redirect_peer and crosses into the pod's netns.
-//  3. In that table, a route for the gateway address out the *host* side of
-//     the pod's netns-crossing veth, so step 8's bpf_fib_lookup resolves to
-//     an interface bpf_redirect_peer can cross.
-//  4. A permanent neighbor for that address on the same interface. As
-//     internal/hostgw's installGatewayNeighbor records, bpf_fib_lookup does
-//     not trigger NDP the way ordinary forwarding does, so an unresolved
-//     neighbor is BPF_FIB_LKUP_RET_NO_NEIGH and a silent drop.
+//  1. locator_table and function_table entries for this node's Block and
+//     Node-ID, so usid_ingress claims the packet rather than passing it to a
+//     stack with no tunnel device to hand it to. A node hosting only sidecars
+//     has no CNI attachment, so nothing else writes these.
+//  2. A vrf_table entry under this node's real Block, keyed on the Argument the
+//     advertisement was published with, pointing at a routing table this file
+//     owns, with EgressKindVeth so the redirect crosses into the pod's netns.
+//  3. In that table, a route for the gateway address out the host side of the
+//     pod's veth, so bpf_fib_lookup resolves to an interface
+//     bpf_redirect_peer can cross.
+//  4. A permanent neighbor for that address on the same interface, because
+//     bpf_fib_lookup does not trigger NDP and an unresolved neighbor is a
+//     silent drop.
 //
-// The Argument is the one subtlety worth stating plainly, because getting
-// it wrong is invisible. The sidecar's own vrf_table registrations key on
-// argumentForTableID -- its pod-netns table id -- while the advertisement,
-// and therefore the SID a remote node encapsulates toward, carries the
-// BGPVRFInstance VRFID. Those are different numbers for the same VPC. This
-// file keys on the advertised VRFID, since that is what actually arrives on
+// The Argument is the subtlety worth stating, because getting it wrong is
+// invisible. The sidecar keys its own vrf_table registrations on its pod-netns
+// table ID, while the advertisement, and so the SID a remote node encapsulates
+// toward, carries the BGPVRFInstance VRFID. Those are different numbers for the
+// same VPC. This file keys on the advertised VRFID, which is what arrives on
 // the wire.
 
 const (
-	// sidecarReturnTableBase is the first Linux routing table id this file
-	// allocates from, and sidecarReturnTableMax the last. A dedicated,
-	// documented range matters twice over: internal/plumbing/vrf's own
-	// allocator hands out table ids from 1 upward for real tenant VRFs, so
-	// anything low would eventually collide with one, and pruning below
-	// deletes whole tables, which must never be able to reach a table this
-	// file did not create.
+	// sidecarReturnTableBase and sidecarReturnTableMax bound the Linux routing
+	// table IDs this file allocates from. A dedicated range matters twice:
+	// tenant VRF table IDs are handed out from 1 upward, so anything low would
+	// eventually collide, and pruning deletes whole tables, which must never
+	// reach one this file did not create.
 	//
-	// The range is sized to hold one table per Argument
-	// ([ArgumentMin,ArgumentMax], 12 bits), which is the most sidecar VRFs
-	// a single node can ever have.
+	// Sized to hold one table per Argument, the most sidecar VRFs a node can
+	// have.
 	sidecarReturnTableBase = 0xF000
 	sidecarReturnTableMax  = sidecarReturnTableBase + uformat.ArgumentMax
 )
 
-// sidecarReturnTableID maps an advertised Argument to the routing table
-// this file keeps that VPC's return route in. One table per Argument rather
-// than one shared table so pruning a single withdrawn VPC cannot disturb
-// another's route.
+// sidecarReturnTableID maps an advertised Argument to the routing table holding
+// that VPC's return route. One table per Argument, so pruning a withdrawn VPC
+// cannot disturb another's route.
 func sidecarReturnTableID(vrfID uint16) (uint32, error) {
 	if vrfID < uformat.ArgumentMin || vrfID > uformat.ArgumentMax {
 		return 0, fmt.Errorf("sidecar return path: VRFID %d outside the valid Argument range [%#x,%#x]",
@@ -111,29 +93,27 @@ func sidecarReturnTableID(vrfID uint16) (uint32, error) {
 }
 
 // sidecarEndpoint is one gateway address this node's sidecar has advertised:
-// the Argument a remote node will have encoded into the SID it encapsulates
-// replies toward, plus where on this node that pod can be reached.
+// the Argument a remote node encodes into the SID it encapsulates replies
+// toward, plus where on this node that pod can be reached.
 type sidecarEndpoint struct {
 	advName string
 	addr    netip.Addr
 	vrfID   uint16
-	// hostIfindex is the ifindex, in this (host) namespace, of the peer of
-	// the pod's primary interface -- what bpf_redirect_peer has to target
-	// to enter that pod. hostMAC is the pod-side end's hardware address.
+	// hostIfindex is the ifindex, in the host namespace, of the peer of the
+	// pod's primary interface, which is what bpf_redirect_peer must target to
+	// enter that pod. hostMAC is the pod-side end's hardware address.
 	//
-	// Both come from the advertisement's own annotations rather than being
-	// discovered here, because only the sidecar can see them: reading them
-	// from this side means entering the pod's namespace, and setns needs
-	// CAP_SYS_ADMIN, which this container deliberately does not carry. See
-	// crdnames.AnnotationIngressHostIfindex.
+	// Both come from the advertisement's annotations rather than being
+	// discovered here, because reading them from this side means entering the
+	// pod's namespace, which needs a privilege this container does not
+	// carry.
 	hostIfindex int
 	hostMAC     net.HardwareAddr
 }
 
-// reconcileSidecarReturnPath is Run's non-fatal wrapper, matching
-// reconcileLocatorLocalRoute's contract: a node with no sidecar on it, a
-// not-yet-created BGPRouter, or a transient API error must never stop the
-// installer daemon, and the caller's ticker retries on its own.
+// reconcileSidecarReturnPath is Run's non-fatal wrapper. A node with no
+// sidecar, a not-yet-created BGPRouter, or a transient API error must never
+// stop the installer daemon, and the caller's ticker retries.
 func reconcileSidecarReturnPath(ctx context.Context, st ebpfDatapathState) {
 	if st.k8sClient == nil || st.nodeName == "" {
 		return
@@ -145,19 +125,18 @@ func reconcileSidecarReturnPath(ctx context.Context, st ebpfDatapathState) {
 }
 
 // ensureSidecarReturnPath brings the host side of every advertised sidecar
-// gateway address on this node up to date, and prunes what no longer
-// belongs. Idempotent, and safe on a node with no sidecar at all: with no
-// matching advertisement it installs nothing and only prunes.
+// gateway address on this node up to date and prunes what no longer belongs.
+// Idempotent, and safe on a node with no sidecar: with no matching
+// advertisement it installs nothing and only prunes.
 func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, nodeName string) error {
 	endpoints, err := sidecarGatewayEndpoints(ctx, k8s, namespace, nodeName)
 	if err != nil {
 		return err
 	}
 
-	// Prune first, and unconditionally: a withdrawn advertisement has to
-	// stop being routed here even on a node whose identity has since gone
-	// away, and pruning is the only step that is correct with an empty
-	// endpoint set.
+	// Prune first and unconditionally: a withdrawn advertisement must stop
+	// being routed here even on a node whose identity has gone away, and
+	// pruning is the only step that is correct with an empty endpoint set.
 	live := make(map[uint32]netip.Addr, len(endpoints))
 	for _, e := range endpoints {
 		if table, terr := sidecarReturnTableID(e.vrfID); terr == nil {
@@ -177,9 +156,9 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 		return err
 	}
 	if !ok {
-		// No SRv6 identity configured for this node yet. The sidecar's
-		// advertisements exist but nothing can be keyed off a Block we do
-		// not have; the ticker retries.
+		// No SRv6 identity for this node yet. The advertisements exist but
+		// nothing can be keyed off a Block we do not have; the ticker
+		// retries.
 		return nil
 	}
 
@@ -189,9 +168,9 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 	}
 	defer func() { _ = closer.Close() }()
 
-	// Per-node, not per-endpoint, and the reason a sidecar-only node needs
-	// this file at all: without them usid_ingress rejects every arriving
-	// uSID packet before it reaches any Argument-specific decision.
+	// Per-node, not per-endpoint, and the reason a sidecar-only node needs this
+	// file at all: without these, usid_ingress rejects every arriving uSID
+	// packet before reaching any Argument-specific decision.
 	if err := registry.Locator.Register(block, nodeID); err != nil {
 		return fmt.Errorf("register locator_table entry for the sidecar return path: %w", err)
 	}
@@ -202,9 +181,9 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 	var errs []error
 	for _, e := range endpoints {
 		if err := installSidecarReturn(registry, block, e); err != nil {
-			// Per-endpoint, and never fatal to the sweep: one Envoy pod
-			// still starting up must not stop another VPC's return path
-			// being installed.
+			// Per-endpoint and never fatal to the sweep: one Envoy pod still
+			// starting must not stop another VPC's return path from being
+			// installed.
 			errs = append(errs, fmt.Errorf("advertisement %s: %w", e.advName, err))
 		}
 	}
@@ -214,16 +193,15 @@ func ensureSidecarReturnPath(ctx context.Context, k8s client.Client, namespace, 
 	return nil
 }
 
-// installSidecarReturn wires up one endpoint: the route, the neighbor, and
-// the vrf_table entry that together point a decapsulated reply at the pod
-// holding that gateway address.
+// installSidecarReturn wires up one endpoint: the route, the neighbor, and the
+// vrf_table entry that together point a decapsulated reply at the pod holding
+// that gateway address.
 func installSidecarReturn(registry *usidmap.Registry, block uint64, e sidecarEndpoint) error {
-	// The interface the annotation names has to still exist here. It may
-	// not: the advertisement outlives any single Envoy pod, so between a
-	// pod being replaced and its sidecar re-publishing, this names the veth
-	// of a pod that is gone. Installing against a stale ifindex would put a
-	// route to a tenant address on whatever now holds that index, so this
-	// is checked rather than assumed.
+	// The interface the annotation names must still exist. The advertisement
+	// outlives any single Envoy pod, so between a pod being replaced and its
+	// sidecar republishing, this names a veth that is gone. Installing against
+	// a stale ifindex would put a route for a tenant address on whatever now
+	// holds that index.
 	if _, err := netlink.LinkByIndex(e.hostIfindex); err != nil {
 		return fmt.Errorf("host-side interface %d for gateway address %s is not present: %w",
 			e.hostIfindex, e.addr, err)
@@ -241,21 +219,21 @@ func installSidecarReturn(registry *usidmap.Registry, block uint64, e sidecarEnd
 		return err
 	}
 
-	// EgressKindVeth is a real claim here, not a don't-care: the interface
-	// the route above resolves to is one end of a veth pair whose peer is
-	// in the pod's netns, so step 9 must use bpf_redirect_peer to cross
-	// into it. Plain bpf_redirect would hand the packet to that interface's
-	// own egress in this netns and never reach the sidecar.
+	// EgressKindVeth is a real claim here, not a don't-care: the interface the
+	// route resolves to is one end of a veth pair whose peer is in the pod's
+	// netns, so the redirect must be bpf_redirect_peer. Plain bpf_redirect
+	// would hand the packet to that interface's egress in this netns and never
+	// reach the sidecar.
 	if err := registry.VRF.Register(block, e.vrfID, table, usidmap.EgressKindVeth); err != nil {
 		return fmt.Errorf("register vrf_table entry (block %#x, argument %d): %w", block, e.vrfID, err)
 	}
 	return nil
 }
 
-// ensureSidecarReturnRoute installs the /128 device route step 8's
-// bpf_fib_lookup resolves against, in this file's own table for that
-// Argument. RouteReplace so a pod that came back on a different host-side
-// veth is followed rather than duplicated.
+// ensureSidecarReturnRoute installs the /128 device route bpf_fib_lookup
+// resolves against, in this file's table for that Argument. Replaced rather
+// than added, so a pod that came back on a different host-side veth is followed
+// rather than duplicated.
 func ensureSidecarReturnRoute(table uint32, addr netip.Addr, hostIfindex int) error {
 	route := &netlink.Route{
 		Dst:       &net.IPNet{IP: addr.AsSlice(), Mask: net.CIDRMask(addr.BitLen(), addr.BitLen())},
@@ -269,11 +247,9 @@ func ensureSidecarReturnRoute(table uint32, addr netip.Addr, hostIfindex int) er
 }
 
 // ensureSidecarReturnNeighbor primes the neighbor entry bpf_fib_lookup needs
-// but will not resolve for itself. Permanent, unlike internal/hostgw's tap
-// sweep and for the opposite reason: the pod-side MAC here is read
-// authoritatively from the kernel rather than solicited, so a stale entry
-// is not a risk -- and if the pod is replaced, the next tick reads the new
-// MAC and RouteReplace/NeighSet overwrite this one.
+// but will not resolve itself. Permanent, unlike the tap sweep's entries: the
+// pod-side MAC is read authoritatively rather than solicited, so a stale entry
+// is not a risk, and a replaced pod is followed on the next tick.
 func ensureSidecarReturnNeighbor(addr netip.Addr, hostIfindex int, mac net.HardwareAddr) error {
 	neigh := &netlink.Neigh{
 		LinkIndex:    hostIfindex,
@@ -288,19 +264,18 @@ func ensureSidecarReturnNeighbor(addr netip.Addr, hostIfindex int, mac net.Hardw
 	return nil
 }
 
-// pruneSidecarReturnRoutes removes every route in this file's own table
-// range that live does not account for, so a withdrawn VPC stops being
-// routed into a pod that may since have been replaced by an unrelated one.
+// pruneSidecarReturnRoutes removes every route in this file's table range that
+// live does not account for, so a withdrawn VPC stops being routed into a pod
+// that may since have been replaced by an unrelated one.
 //
-// One listing across all tables, filtered down to the reserved range here,
-// rather than a listing per table: the range spans every possible Argument,
-// so per-table would be 4096 netlink round trips on every tick to find the
-// handful of routes that exist.
+// One listing across all tables, filtered to the reserved range, rather than one
+// per table: the range spans every possible Argument, so per-table would be
+// thousands of netlink round trips per tick to find a handful of routes.
 //
-// staleSidecarReturnRoute is the whole safety argument, and it is a pure
-// predicate so the cases it must not match can be enumerated in a test --
-// this deletes routes, and a range check that drifted from the constants
-// would delete somebody else's.
+// staleSidecarReturnRoute carries the safety argument, and is a pure predicate
+// so the cases it must not match can be enumerated in a test. This deletes
+// routes, and a range check that drifted from the constants would delete
+// someone else's.
 func pruneSidecarReturnRoutes(live map[uint32]netip.Addr) error {
 	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
 		&netlink.Route{Table: unix.RT_TABLE_UNSPEC}, netlink.RT_FILTER_TABLE)
@@ -322,13 +297,13 @@ func pruneSidecarReturnRoutes(live map[uint32]netip.Addr) error {
 	return errors.Join(errs...)
 }
 
-// staleSidecarReturnRoute reports whether r is a route this file installed
-// for an endpoint that live no longer accounts for.
+// staleSidecarReturnRoute reports whether r is a route this file installed for
+// an endpoint live no longer accounts for.
 //
-// Every condition here is a guard against deleting something else. The
-// table range is what confines this to tables this file allocates from; a
-// route with no destination, or one whose table holds the address live still
-// wants, is left alone.
+// Every condition guards against deleting something else. The table range
+// confines this to tables this file allocates from, and a route with no
+// destination, or whose table holds an address live still wants, is left
+// alone.
 func staleSidecarReturnRoute(r netlink.Route, live map[uint32]netip.Addr) bool {
 	if r.Table < sidecarReturnTableBase || r.Table > sidecarReturnTableMax {
 		return false
@@ -348,15 +323,14 @@ func staleSidecarReturnRoute(r netlink.Route, live map[uint32]netip.Addr) bool {
 }
 
 // sidecarGatewayEndpoints returns every gateway advertisement the ingress
-// sidecar on *this* node has published.
+// sidecar on this node has published.
 //
 // Identified by name rather than by shape. A sidecar's advertisement is a
-// single /128 with an Argument and End.DT46, which is also exactly what a
-// real CNI attachment publishes for a pod address -- and those must not be
-// touched here, since internal/cnibgp already registers a vrf_table entry
-// pointing at the pod's real host-netns VRF. The name is the only
-// discriminator that cannot confuse the two, which is why
-// crdnames.IngressAdvertisementSegment is exported for it.
+// single /128 with an Argument and End.DT46, which is exactly what a real CNI
+// attachment publishes for a pod address, and those must not be touched here,
+// since the CNI path already registers a vrf_table entry pointing at the pod's
+// host-netns VRF. The name is the only discriminator that cannot confuse the
+// two.
 func sidecarGatewayEndpoints(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) ([]sidecarEndpoint, error) {
@@ -380,10 +354,9 @@ func sidecarGatewayEndpoints(
 		}
 		hostIfindex, hostMAC, ok := ingressEntryPointAnnotations(a.Annotations)
 		if !ok {
-			// An advertisement from a sidecar that has not recorded its own
-			// entry point. Skipped rather than errored, and quietly: this is
-			// what an advertisement written by an older sidecar looks like,
-			// and it resolves itself the next time that sidecar republishes.
+			// An advertisement from a sidecar that has not recorded its entry
+			// point yet. Skipped quietly rather than errored: it resolves
+			// itself the next time that sidecar republishes.
 			slog.Debug("Sidecar gateway advertisement carries no host-side entry point yet",
 				"advertisement", a.Name)
 			continue
@@ -392,8 +365,8 @@ func sidecarGatewayEndpoints(
 			pref, err := netip.ParsePrefix(string(p))
 			if err != nil || !pref.Addr().Is6() || pref.Bits() != pref.Addr().BitLen() {
 				// A gateway address is always a single host route. Anything
-				// else is not something this return path knows how to point
-				// at a pod.
+				// else is not something this return path can point at a
+				// pod.
 				continue
 			}
 			out = append(out, sidecarEndpoint{
@@ -409,9 +382,9 @@ func sidecarGatewayEndpoints(
 }
 
 // isIngressAdvertisementName reports whether name is what
-// crdnames.BGPAdvertisementName renders for the ingress attachment on
-// nodeName. Matched from the end because a node name may itself contain the
-// separator, while the two leading segments never can.
+// crdnames.BGPAdvertisementName renders for the ingress attachment on nodeName.
+// Matched from the end, because a node name may contain the separator while the
+// two leading segments never can.
 func isIngressAdvertisementName(name, nodeName, segment string) bool {
 	rest, ok := strings.CutSuffix(name, "-"+nodeName)
 	if !ok {
@@ -424,10 +397,9 @@ func isIngressAdvertisementName(name, nodeName, segment string) bool {
 	return rest[idx+1:] == segment
 }
 
-// nodeLocatorIdentity returns the Block and Node-ID this node's own SIDs are
-// built from. ok is false, with a nil error, when this node has no SRv6
-// identity configured yet -- the same "nothing to do" case
-// nodeLocatorPrefix returns its zero Prefix for.
+// nodeLocatorIdentity returns the Block and Node-ID this node's SIDs are built
+// from. ok is false, with a nil error, when this node has no SRv6 identity
+// configured yet.
 func nodeLocatorIdentity(
 	ctx context.Context, k8s client.Client, namespace, nodeName string,
 ) (block uint64, nodeID uint16, ok bool, err error) {
@@ -438,9 +410,9 @@ func nodeLocatorIdentity(
 	if !prefix.IsValid() {
 		return 0, 0, false, nil
 	}
-	// Derived from the prefix nodeLocatorPrefix already assembled rather
-	// than re-read from the BGPRouter, so the two can never disagree about
-	// which locator this node owns.
+	// Derived from the prefix already assembled rather than re-read from the
+	// BGPRouter, so the two cannot disagree about which locator this node
+	// owns.
 	block, err = uformat.Block(prefix.Addr())
 	if err != nil {
 		return 0, 0, false, fmt.Errorf("derive uSID Block from node locator %s: %w", prefix, err)
@@ -452,14 +424,13 @@ func nodeLocatorIdentity(
 	return block, nodeID, true, nil
 }
 
-// ingressEntryPointAnnotations reads the host-side ifindex and MAC the
-// sidecar recorded on its own advertisement. ok is false when either is
-// absent or unusable, which the caller treats as "not published yet"
-// rather than as a failure.
+// ingressEntryPointAnnotations reads the host-side ifindex and MAC the sidecar
+// recorded on its advertisement. ok is false when either is absent or unusable,
+// which the caller treats as not yet published rather than as a failure.
 //
-// Both are validated rather than trusted. They come from another component
-// via the API server, and they are about to become a route and a permanent
-// neighbor for a tenant address: a zero or negative ifindex, or a malformed
+// Both are validated rather than trusted. They arrive from another component
+// through the API server and are about to become a route and a permanent
+// neighbor for a tenant address, so a zero or negative ifindex, or a malformed
 // hardware address, must not reach netlink.
 func ingressEntryPointAnnotations(annotations map[string]string) (int, net.HardwareAddr, bool) {
 	if annotations == nil {

--- a/internal/maglev/doc.go
+++ b/internal/maglev/doc.go
@@ -2,36 +2,27 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package maglev implements Google's Maglev consistent-hashing lookup table
-// (Eisenbrand et al., "Maglev: A Fast and Reliable Software Network Load
-// Balancer", NSDI 2016, §3.4). Every backend gets an independent
-// pseudo-random permutation of table slots (derived from two hashes of its
-// own key, never from any other backend's key or from table contents), and
-// slots are handed out round-robin over each backend's own permutation
-// until the table is full. Two properties fall out of that construction,
-// both load-bearing for how this package is used:
+// Package maglev implements the Maglev consistent-hashing lookup table.
 //
-//   - Given the identical backend set and the identical table size, every
-//     caller builds the byte-identical table — no coordination, no shared
-//     state, no RPC between callers. This is what makes it safe for every
-//     galactic-gateway node to independently compute the same backend
-//     assignment for the design's anycast/DSR forwarding model (see the
-//     design plan's §0): ECMP or BGP reconvergence can move a flow's
-//     packets to a different gateway node mid-connection, and that node
-//     still picks the identical backend, because it built the identical
-//     table from the identical (VIP, backend list) input.
-//   - Removing or adding one backend only reassigns approximately 1/N of
-//     the table's slots (N = backend count) rather than reshuffling
-//     everything, unlike a plain hash(key) % len(backends) scheme (see
-//     TestTable_DisruptionBound). This is the property that makes this
-//     package usable for both this repo's own consistent-hash use sites
-//     without sharing a ring between them: galactic-gateway's ingress
-//     backend-selection ring, and galactic-nat66's independent
-//     shard-placement ring (design plan §3.1) — conflating the two rings
-//     is explicitly not what this package is for; construct one *Table
-//     per ring.
+// Every backend gets an independent pseudo-random permutation of table slots,
+// derived from two hashes of its own key and never from another backend's key
+// or from table contents, and slots are handed out round-robin over each
+// backend's permutation until the table is full. Two properties follow, both
+// load-bearing here:
 //
-// This package is pure Go with no kernel/CRD dependency, mirroring
-// internal/plumbing/nptv6's identical split between pure computation and
-// whatever eBPF/CRD wiring consumes it.
+//   - Given the same backend set and table size, every caller builds the
+//     byte-identical table, with no coordination, shared state, or messaging
+//     between them. That is what lets every gateway node independently compute
+//     the same backend assignment under anycast forwarding: reconvergence can
+//     move a flow's packets to a different node mid-connection, and that node
+//     still picks the same backend, having built the same table from the same
+//     inputs.
+//   - Removing or adding one backend reassigns roughly one slot in N rather
+//     than reshuffling everything, unlike a plain modulo scheme. That is what
+//     makes this usable for both consistent-hash sites here without sharing a
+//     ring: the gateway's backend selection and the NAT66 tier's shard
+//     placement. Conflating those rings is explicitly not what this is for;
+//     construct one table per ring.
+//
+// Pure Go, with no kernel or CRD dependency.
 package maglev

--- a/internal/maglev/table.go
+++ b/internal/maglev/table.go
@@ -12,49 +12,43 @@ import (
 	"sort"
 )
 
-// Backend is one candidate a Table can assign lookup-table slots to. Key
-// must be stable and unique within one Table's backend set — it is the sole
-// input to both of a backend's permutation hashes (offsetSeed/skipSeed
-// below), so two backends sharing a Key would collide onto the identical
-// permutation and are not distinguishable by this package.
+// Backend is one candidate a Table can assign lookup slots to. Key must be
+// stable and unique within a Table's backend set: it is the sole input to both
+// of a backend's permutation hashes, so two backends sharing a Key collide onto
+// the same permutation and are indistinguishable here.
 type Backend interface {
 	Key() string
 }
 
-// offsetSeed/skipSeed are fixed salts distinguishing the two independent
-// hashes Maglev's permutation generation needs (the paper's h1/h2) from one
-// underlying hash function (fnv1a) applied to Key() + a different seed,
-// rather than requiring two unrelated hash algorithms.
+// offsetSeed and skipSeed are fixed salts distinguishing the two independent
+// hashes the permutation needs, derived from one hash function applied to the
+// key plus a different seed rather than two unrelated algorithms.
 const (
 	offsetSeed uint64 = 0xda7a5eed0ffce7e5
 	skipSeed   uint64 = 0x5eedda7a1ceb00c5
 )
 
-// Table is a Maglev consistent-hash lookup table over a fixed backend set.
-// See doc.go for the properties this construction gives: deterministic
-// given (backends, size), and a bounded (~1/N) disruption fraction on
-// backend-set changes.
+// Table is a Maglev consistent-hash lookup table over a fixed backend set. See
+// the package doc comment for the properties: deterministic given its inputs,
+// with a bounded disruption fraction when the backend set changes.
 type Table struct {
 	size     int
 	entries  []Backend
 	backends []Backend // sorted by Key(), for deterministic iteration/inspection
 }
 
-// New builds a Table assigning size lookup slots across backends. size must
-// be prime (see IsPrime) and, per the Maglev paper, at least 100x
-// len(backends) for the disruption-bound property to hold in practice — New
-// does not itself enforce the 100x guidance (a caller validating a small
-// fixed table against a handful of backends in a test is a legitimate use
-// that would otherwise be rejected), but does reject a size that cannot even
-// fit one slot per backend, and any non-prime size (the permutation-cycle
-// argument the paper's disruption bound rests on requires it).
+// New builds a Table assigning size lookup slots across backends.
 //
-// backends must be non-empty and every Key() unique; New returns an error
-// otherwise rather than silently building a degenerate table. The input
-// slice order does not affect the result — backends are sorted by Key()
-// internally, so every caller building a Table from the identical backend
-// set (regardless of the order each independently observed it in, e.g. from
-// unordered CRD list results) produces the byte-identical table.
+// size must be prime, which the disruption bound's permutation-cycle argument
+// requires, and the paper recommends at least 100 times the backend count for
+// that bound to hold in practice. New does not enforce the ratio, a small fixed
+// table in a test being a legitimate use, but does reject a size too small to
+// fit one slot per backend, and any non-prime size.
+//
+// backends must be non-empty with unique keys; anything else is an error rather
+// than a silently degenerate table. Input order does not matter, backends being
+// sorted by key internally, so every caller building from the same set produces
+// the byte-identical table whatever order it observed them in.
 func New(backends []Backend, size int) (*Table, error) {
 	if len(backends) == 0 {
 		return nil, errors.New("maglev: at least one backend is required")
@@ -80,10 +74,10 @@ func New(backends []Backend, size int) (*Table, error) {
 	return t, nil
 }
 
-// fill runs the paper's round-robin permutation-preference algorithm
-// (§3.4): each backend repeatedly proposes its next-preferred still-free
-// slot (computed lazily from its own offset/skip, never materializing a
-// full n-by-size permutation matrix) until every slot is claimed.
+// fill runs the round-robin permutation-preference algorithm: each backend
+// repeatedly proposes its next-preferred free slot, computed lazily from its
+// own offset and skip rather than materializing a full permutation matrix,
+// until every slot is claimed.
 func (t *Table) fill() {
 	n := len(t.backends)
 	offset := make([]uint64, n)
@@ -118,9 +112,8 @@ func (t *Table) fill() {
 	}
 }
 
-// Lookup returns the backend assigned to key's slot (key mod the table
-// size). Every Table built from the identical (backends, size) input
-// resolves the identical key to the identical backend — see doc.go.
+// Lookup returns the backend assigned to key's slot. Every Table built from the
+// same inputs resolves the same key to the same backend.
 func (t *Table) Lookup(key uint64) Backend {
 	return t.entries[key%uint64(t.size)]
 }
@@ -132,11 +125,10 @@ func (t *Table) Size() int { return t.size }
 // Key(). Callers must not mutate the returned slice.
 func (t *Table) Backends() []Backend { return t.backends }
 
-// IsPrime reports whether n is a prime number (n < 2 is never prime). Trial
-// division is intentionally used rather than a probabilistic test: table
-// sizes in this package's use are modest (tens of thousands at most, chosen
-// once per rule/shard-set change, not per packet), and correctness matters
-// more than the marginal speed of a Miller-Rabin implementation here.
+// IsPrime reports whether n is prime; anything below 2 is not. Trial division
+// rather than a probabilistic test: table sizes here are modest and chosen once
+// per rule change rather than per packet, so correctness matters more than the
+// marginal speed.
 func IsPrime(n int) bool {
 	if n < 2 {
 		return false
@@ -152,11 +144,9 @@ func IsPrime(n int) bool {
 	return true
 }
 
-// hashKey derives one of the two independent hash values Maglev's
-// permutation generation needs from a single fnv1a hash of key's own bytes
-// followed by seed's own 8 bytes — a different seed produces an
-// uncorrelated-in-practice second hash without depending on a second,
-// unrelated hash algorithm.
+// hashKey derives one of the two hash values the permutation needs, from a
+// single hash over the key's bytes followed by the seed's. A different seed
+// produces an uncorrelated second hash without a second algorithm.
 func hashKey(key string, seed uint64) uint64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(key))

--- a/internal/model/peer_events.go
+++ b/internal/model/peer_events.go
@@ -10,11 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// PeerStateChange is a single observed BGP peer FSM transition, reported by
-// a RouterRuntime's own peer-event watcher (e.g. internal/runtime/gobgp's
-// GoBGP-native WatchEvent/WatchPeer subscription) to a PeerStateObserver in
-// real time — independent of, and faster than, the periodic BGPPeer.Status
-// update driven by RuntimeManager.Status polling, which can miss a
+// PeerStateChange is one observed BGP peer FSM transition, reported by a
+// runtime's own watcher to an observer in real time. That is independent of, and
+// faster than, the periodic status update driven by polling, which can miss a
 // transition entirely if it reverts between two polls.
 type PeerStateChange struct {
 	// RouterKey identifies the BGPRouter this peer belongs to.
@@ -24,24 +22,22 @@ type PeerStateChange struct {
 	// PeerASN is the peer's autonomous system number, when known.
 	PeerASN int64
 	// From and To are the FSM states either side of this transition. From is
-	// BGPPeerStateIdle for the first transition observed for a peer, since
-	// the underlying watch API does not report a peer's prior state.
+	// Idle for the first transition observed for a peer, the underlying watch
+	// API not reporting a prior state.
 	From, To BGPPeerState
-	// DisconnectReason and DisconnectMessage describe why a session dropped
-	// out of Established, when the runtime supplies them. Both are empty for
-	// every other transition.
+	// DisconnectReason and DisconnectMessage describe why a session dropped out
+	// of Established, when the runtime supplies them. Both are empty for every
+	// other transition.
 	DisconnectReason  string
 	DisconnectMessage string
 	// Time is when the runtime observed this transition.
 	Time time.Time
 }
 
-// PeerStateObserver receives BGP peer FSM state transitions as a
-// RouterRuntime detects them. Implementations must not block:
-// ObservePeerStateChange is called synchronously on the runtime's own
-// peer-event watcher goroutine, so a slow or blocking implementation would
-// stall that runtime's session convergence for every peer it manages, not
-// just the one that just transitioned.
+// PeerStateObserver receives peer FSM transitions as a runtime detects them.
+// Implementations must not block: the callback runs synchronously on the
+// runtime's own watcher goroutine, so a slow one stalls that runtime's session
+// convergence for every peer it manages, not just the one that transitioned.
 type PeerStateObserver interface {
 	ObservePeerStateChange(PeerStateChange)
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -44,10 +44,8 @@ type DesiredRouter struct {
 	LocalASN        int64
 	RouterID        string
 	AddressFamilies []AddressFamily
-	// ListenPort is the per-router override of the TCP port GoBGP binds for
-	// incoming BGP connections, carried from BGPRouter.spec.listenPort. When
-	// nil, the runtime's process-wide default (GALACTIC_ROUTER_BGP_LISTEN_PORT)
-	// applies instead.
+	// ListenPort overrides, per router, the TCP port GoBGP binds for incoming
+	// connections. Nil means the process-wide default applies.
 	ListenPort     *int32
 	Peers          []DesiredPeer
 	VRFInstances   []DesiredVRFInstance
@@ -65,19 +63,16 @@ type DesiredPeer struct {
 	HoldTime        time.Duration
 	KeepaliveTime   time.Duration
 	AuthPassword    string
-	// UpdateSource is the per-peer override of the TCP source address for this
-	// session, carried from BGPPeer.spec.updateSource. When empty, the
-	// runtime's process-wide default (GALACTIC_ROUTER_BGP_LOCAL_ADDRESS)
-	// applies instead.
+	// UpdateSource overrides, per peer, the TCP source address for this session.
+	// Empty means the process-wide default applies.
 	UpdateSource string
 }
 
 // DesiredVRFInstance describes an L2VPN EVPN VRF to configure on the BGP router.
 type DesiredVRFInstance struct {
 	Name string
-	// VRFID is the 16-bit PoP-local VRF identifier (BGPVRFInstanceSpec.VRFID).
-	// The runtime derives the RFC 4364 Type 1 route distinguisher from it as
-	// "routerID:vrfID".
+	// VRFID is the 16-bit PoP-local VRF identifier. The runtime derives the route
+	// distinguisher from it as "routerID:vrfID".
 	VRFID              int32
 	ImportRouteTargets []string
 	ExportRouteTargets []string
@@ -93,17 +88,16 @@ type DesiredAdvertisement struct {
 	// NextHop is the BGP next-hop address placed in MpReachNLRI (node's transit-reachable
 	// IPv6 address). Required when AddressFamily is l2vpn/evpn.
 	NextHop string
-	// SRv6SID, when set, is placed in a BGP Prefix-SID path attribute (RFC 9252
-	// SRv6 L3 Service TLV) rather than NextHop or the EVPN route's own Gateway
-	// IP field — that field can't carry an IPv6 SID for an IPv4 prefix, since
-	// RFC 9136 requires it to share the prefix's own address family. Must be
-	// the End.DT46 SID for this VPC attachment so that receiving nodes install
-	// a seg6 encap route targeting the correct SRv6 decap instruction.
+	// SRv6SID, when set, goes in a BGP Prefix-SID path attribute rather than the
+	// next hop or the EVPN route's own gateway field, which cannot carry an IPv6
+	// SID for an IPv4 prefix, having to share the prefix's address family. It
+	// must be the End.DT46 SID for this attachment, so receiving nodes install
+	// an encapsulating route targeting the right decap instruction.
 	SRv6SID string
-	// VRFID is the 16-bit PoP-local VRF identifier carried from the BGPAdvertisement
-	// spec. The runtime derives the per-VRF route distinguisher as "routerID:vrfID" so
-	// that advertisements from different VRFs on the same router produce distinct NLRIs.
-	// When nil, the legacy "routerID:0" fallback is used.
+	// VRFID is the 16-bit PoP-local VRF identifier from the advertisement. The
+	// runtime derives the per-VRF route distinguisher from it, so advertisements
+	// from different VRFs on one router produce distinct NLRIs. Nil falls back
+	// to "routerID:0".
 	VRFID *int32
 }
 

--- a/internal/nadpatch/nadpatch.go
+++ b/internal/nadpatch/nadpatch.go
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nadpatch patches the NetworkAttachmentDefinition with the
-// deterministic host-side interface name a master plugin (galactic-veth,
-// galactic-tap) just created — shared since NAD annotation is identical
-// regardless of interface type.
+// Package nadpatch records, on a pod's network-attachment definition, the
+// deterministic host-side interface name a master plugin just created. Shared
+// between the master plugins, since the annotation is identical whichever
+// interface type was made.
 package nadpatch
 
 import (
@@ -23,9 +23,8 @@ import (
 	"go.datum.net/galactic/internal/hostconf"
 )
 
-// AnnotationHostInterface is the NAD annotation key that records the
-// deterministic host-side interface name created by the CNI plugin for
-// this VPC+VPCAttachment pair.
+// AnnotationHostInterface is the annotation key recording the deterministic
+// host-side interface name created for this VPC and attachment pair.
 const AnnotationHostInterface = "k8s.v1.cni.cncf.io/host-interface"
 
 // nadGVK is the GroupVersionKind for NetworkAttachmentDefinition.
@@ -35,10 +34,8 @@ var nadGVK = schema.GroupVersionKind{
 	Kind:    "NetworkAttachmentDefinition",
 }
 
-// ParsePodNamespace extracts the K8S_POD_NAMESPACE value from the CNI_ARGS
-// environment variable string passed as args.Args by Multus. Returns an
-// empty string when the value is not present (e.g. standalone CNI
-// invocation).
+// ParsePodNamespace extracts the pod namespace from the CNI arguments string
+// the runtime passes. Returns "" when absent, as in a standalone invocation.
 func ParsePodNamespace(cniArgs string) string {
 	for _, part := range strings.Split(cniArgs, ";") {
 		key, value, ok := strings.Cut(part, "=")
@@ -49,10 +46,8 @@ func ParsePodNamespace(cniArgs string) string {
 	return ""
 }
 
-// ParsePodName extracts the K8S_POD_NAME value from the CNI_ARGS
-// environment variable string passed as args.Args by Multus. Returns an
-// empty string when the value is not present (e.g. standalone CNI
-// invocation), same convention as ParsePodNamespace.
+// ParsePodName extracts the pod name from the CNI arguments string the runtime
+// passes. Returns "" when absent, as ParsePodNamespace does.
 func ParsePodName(cniArgs string) string {
 	for _, part := range strings.Split(cniArgs, ";") {
 		key, value, ok := strings.Cut(part, "=")
@@ -63,12 +58,12 @@ func ParsePodName(cniArgs string) string {
 	return ""
 }
 
-// AnnotateNAD patches the NetworkAttachmentDefinition with the host
-// interface name. The NAD is expected to already exist (created by the
-// external VPC operator before the CNI is invoked), so a not-found response
-// is a hard failure rather than something to tolerate. A conflict response
-// is the one case treated as non-fatal: it means the annotation was already
-// applied by a previous invocation.
+// AnnotateNAD patches the attachment definition with the host interface name.
+//
+// The definition is expected to already exist, created by the external VPC
+// operator before the CNI runs, so not-found is a hard failure. A conflict is
+// the one non-fatal case: it means a previous invocation already applied the
+// annotation.
 func AnnotateNAD(ctx context.Context, k8s client.Client, nadName, nadNamespace, hostInterface string) error {
 	if nadNamespace == "" {
 		return nil
@@ -98,17 +93,15 @@ func AnnotateNAD(ctx context.Context, k8s client.Client, nadName, nadNamespace, 
 	return nil
 }
 
-// VerifyChainComplete fetches nadName's NetworkAttachmentDefinition and
-// fails if its own spec.config does not chain expectedType anywhere in its
-// plugins list. A conflist that omits it — stale, hand-edited, or a bug in
-// the external operator that authors it — would otherwise let every plugin
-// that DOES run report ADD success, handing back a pod with a working
-// interface and no path to its VPC (issue #331).
+// VerifyChainComplete fetches the attachment definition and fails if its config
+// does not chain expectedType anywhere in its plugin list.
 //
-// nadNamespace == "" (no CNI_ARGS — a standalone/manual chain invocation,
-// not a real Multus-driven attach; see tests/e2e's TestCNITapInterface) is
-// treated as nothing to check, mirroring AnnotateNAD's own convention:
-// there is no NAD to read in that case.
+// A conflist that omits it, whether stale, hand-edited, or a bug in the operator
+// that authors it, would otherwise let every plugin that does run report success,
+// handing back a pod with a working interface and no path to its VPC.
+//
+// An empty nadNamespace, meaning no CNI arguments and so a manual rather than
+// runtime-driven attach, is nothing to check: there is no definition to read.
 func VerifyChainComplete(ctx context.Context, k8s client.Client, nadName, nadNamespace, expectedType string) error {
 	if nadNamespace == "" {
 		return nil

--- a/internal/plumbing/bond/bond.go
+++ b/internal/plumbing/bond/bond.go
@@ -2,27 +2,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package bond holds the pure, netlink-view-agnostic logic for recognizing
-// a Linux bonding master and enumerating its slave interfaces. It exists so
-// internal/plumbing/ebpf/attach (the CNI's TC-BPF ingress path, which
-// attaches to both a bond master and its slaves -- ingress tc/eBPF
-// classification on a bonded interface happens on the slaves, not the
-// master) and internal/plumbing/ebpf/edgeattach (the gateway's XDP path,
-// which must attach to the slaves only -- native-mode XDP cannot attach to
-// a bonding master at all, since bonding doesn't implement ndo_bpf) share
-// one implementation of "is this a bond, and if so what are its slaves"
-// instead of each maintaining its own copy. See
-// internal/plumbing/ebpf/edgeattach.ResolveTargets' own doc comment for the
-// more precise statement of why XDP can't rely on the bond master itself:
-// it isn't simply "bonding never implements ndo_bpf" on every kernel, but
-// attaching to the master is never something this codebase relies on
-// working either way.
+// Package bond holds the netlink-view-agnostic logic for recognizing a Linux
+// bonding master and enumerating its slaves.
 //
-// Each caller keeps its own package-level netlink override vars for
-// testability (matching the existing linkByNameFn/linkListFn pattern in
-// both packages above); this package takes plain netlink.Link/[]netlink.Link
-// values rather than function vars of its own, so it has no test-only
-// indirection to carry.
+// It exists so the two attach paths share one implementation of "is this a bond,
+// and if so what are its slaves". The TC-BPF ingress path attaches to both the
+// master and its slaves, ingress classification on a bond happening on the
+// slaves; the XDP path attaches to the slaves only, native XDP against a bonding
+// master being unreliable.
+//
+// Each caller keeps its own netlink override vars for testability, and this
+// package takes plain link values rather than function vars, so it carries no
+// test-only indirection.
 package bond
 
 import "github.com/vishvananda/netlink"
@@ -36,10 +27,9 @@ func IsMaster(link netlink.Link) bool {
 	return link.Type() == LinkType
 }
 
-// SlaveNames returns the names of every link in links enslaved to master
-// (i.e. whose MasterIndex, populated from netlink's IFLA_MASTER attribute,
-// equals master's own index), in whatever order links itself is in. Returns
-// nil if master has no slaves in links.
+// SlaveNames returns the names of every link in links enslaved to master,
+// meaning those whose master index equals master's own, in whatever order links
+// is in. Returns nil when master has no slaves there.
 func SlaveNames(master netlink.Link, links []netlink.Link) []string {
 	masterIndex := master.Attrs().Index
 	var slaves []string

--- a/internal/plumbing/doc.go
+++ b/internal/plumbing/doc.go
@@ -2,9 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package plumbing provides low-level kernel and network primitives shared
-// between the Galactic CNI plugin and agent. Sub-packages cover SRv6 endpoint
-// encoding and ingress routing (intf, srv6), Linux VRF lifecycle (vrf), and
-// interface sysctl configuration (sysctl). Functions that require CAP_NET_ADMIN
-// or a real kernel are not unit-tested; use the e2e suite for coverage.
+// Package plumbing provides the low-level kernel and network primitives the
+// galactic binaries share. It holds no code of its own; the sub-packages cover
+// SRv6 encoding and interface naming (intf, srv6), Linux VRF lifecycle (vrf),
+// interface sysctls (sysctl), bonding-master recognition (bond), loopback
+// address detection (loaddr), stateless prefix translation (nptv6), Router
+// Advertisements for tap-attached guests (radv), VIP binding on backend nodes
+// (vip), and the eBPF datapaths (ebpf).
+//
+// Anything requiring CAP_NET_ADMIN or a real kernel is not unit-tested; the
+// end-to-end suite covers it.
 package plumbing

--- a/internal/plumbing/ebpf/attach/attach.go
+++ b/internal/plumbing/ebpf/attach/attach.go
@@ -23,35 +23,27 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 )
 
-// PinDir is the default bpffs directory every usid_ingress map is pinned
-// under (design plan §4.4/§9: "All maps pinned under /sys/fs/bpf/galactic/
-// so a control-daemon restart does not require the datapath to stop
-// forwarding").
+// PinDir is the default bpffs directory every usid_ingress map is pinned under,
+// so a control-daemon restart does not stop the datapath forwarding.
 const PinDir = "/sys/fs/bpf/galactic"
 
-// filterName identifies this package's own TC-BPF ingress filter on an
-// interface, so re-attachment (across a container restart, or Watch's
-// netlink-driven re-attachment, Milestone 3.2) replaces the same filter
-// instead of stacking a duplicate.
+// filterName identifies this package's TC-BPF ingress filter on an interface,
+// so a re-attach replaces the same filter rather than stacking a duplicate.
 const filterName = "galactic_usid_ingress"
 
-// defaultFilterPriority is the tc priority attachOne uses when
-// config.EnvCNIEBPFFilterPriority is unset. Priority 1 is the highest
-// (lowest-numbered) priority tc allows; this has not been validated
-// against Cilium's own clsact priority on any specific version/datapath
-// mode -- see config.EnvCNIEBPFFilterPriority's doc comment. Override via
-// that env var if it collides.
+// defaultFilterPriority is the tc priority attachOne uses when no override is
+// set. Priority 1 is the highest tc allows, and has not been validated against
+// another CNI's clsact priority on any particular version. Override it through
+// the environment if it collides.
 const defaultFilterPriority = 1
 
-// filterPriorityFn resolves the tc priority attachOne attaches at. It is a
-// package-level override point (the same pattern interfaces.go's
-// routeListFn/linkByIndexFn use) so tests can exercise a non-default
-// priority without setting a real process environment variable.
+// filterPriorityFn resolves the tc priority attachOne attaches at. An override
+// point so tests can exercise a non-default priority without setting a real
+// environment variable.
 var filterPriorityFn = resolveFilterPriority
 
-// resolveFilterPriority reads config.EnvCNIEBPFFilterPriority, if set and a
-// valid uint16, as the tc priority to attach this package's ingress filter
-// at; otherwise it returns defaultFilterPriority.
+// resolveFilterPriority returns the configured tc priority when the environment
+// sets a valid uint16, and defaultFilterPriority otherwise.
 func resolveFilterPriority() uint16 {
 	if v := strings.TrimSpace(os.Getenv(config.EnvCNIEBPFFilterPriority)); v != "" {
 		if parsed, err := strconv.ParseUint(v, 10, 16); err == nil {
@@ -63,22 +55,20 @@ func resolveFilterPriority() uint16 {
 	return defaultFilterPriority
 }
 
-// preflightCheckFn is a package-level override point so tests can force the
-// preflight failure path without touching the real kernel -- the same
-// pattern preflight.CheckWith itself uses for Prober.
+// preflightCheckFn is an override point so tests can force the preflight
+// failure path without touching the real kernel.
 var preflightCheckFn = preflight.Check
 
-// Start runs the kernel preflight check (blocking on failure -- design plan
-// §6), loads and pins internal/plumbing/ebpf/prog's compiled usid_ingress
-// object under pinDir, resolves the interface set per §4.1, and attaches
-// the program to each resolved interface's ingress hook. On any failure the
-// returned *prog.UsidObjects is nil and any partially-loaded kernel objects
-// from this call are cleaned up -- there is no partial/unsafe fallback.
+// Start runs the kernel preflight check, loads and pins the compiled
+// usid_ingress object under pinDir, resolves the interface set, and attaches the
+// program to each resolved interface's ingress hook. It returns the loaded
+// objects and the interfaces actually attached to.
 //
-// On success, the caller owns the returned objects and the interfaces
-// actually attached to; the objects should be kept open for the life of the
-// process and Closed on shutdown (see the package doc comment for why that
-// is safe).
+// A preflight failure blocks. On any failure the returned objects are nil and
+// partially loaded kernel objects are cleaned up: there is no partial fallback.
+//
+// On success the caller owns the objects, which should stay open for the life of
+// the process and be closed on shutdown.
 func Start(pinDir string) (objs *prog.UsidObjects, ifaces []string, err error) {
 	objs, err = Load(pinDir)
 	if err != nil {
@@ -99,18 +89,14 @@ func Start(pinDir string) (objs *prog.UsidObjects, ifaces []string, err error) {
 	return objs, ifaces, nil
 }
 
-// Load runs the kernel preflight check (design plan §6, Milestone 2.3) and,
-// only if it passes, loads internal/plumbing/ebpf/prog's compiled object
-// with every map pinned under pinDir. A map already pinned there from a
-// previous process is reused as-is (its contents survive); a map with no
-// existing pin is created and pinned fresh. Load does not attach the
-// program to any interface -- call Attach (or use Start) for that.
+// Load runs the kernel preflight check and, only if it passes, loads the
+// compiled object with every map pinned under pinDir. A map already pinned there
+// by a previous process is reused with its contents intact; one with no pin is
+// created and pinned fresh. Load attaches nothing; call Attach or Start for
+// that.
 func Load(pinDir string) (objs *prog.UsidObjects, err error) {
-	// loadHook observes every return path below (design plan §9's "BPF
-	// program load/reload events and failures" metric; Milestone 4) via a
-	// single defer over the named return, rather than a call at each
-	// return statement -- so a future return path added here can't
-	// accidentally forget to report itself.
+	// A single defer over the named return observes every path below, so a
+	// return added later cannot forget to report itself.
 	defer func() { loadHook(err) }()
 
 	if err = preflightCheckFn(); err != nil {
@@ -134,13 +120,10 @@ func Load(pinDir string) (objs *prog.UsidObjects, err error) {
 		return nil, err
 	}
 
-	// Pin every map by name under pinDir (design plan §4.4: "All maps
-	// pinned"). usid.c's map definitions don't set a BTF `pinning`
-	// attribute themselves, so pinning is configured here at load time
-	// instead -- see github.com/cilium/ebpf's Map.newMapWithOptions:
-	// PinByName + MapOptions.PinPath together make LoadAndAssign reuse an
-	// existing pin if one exists at <pinDir>/<map name>, rather than
-	// always creating a fresh map.
+	// Pin every map by name under pinDir. The datapath's map definitions set
+	// no BTF pinning attribute, so pinning is configured here at load time:
+	// pin-by-name plus a pin path together make the load reuse an existing pin
+	// when one is present rather than always creating a fresh map.
 	for _, m := range spec.Maps {
 		m.Pinning = ebpf.PinByName
 	}
@@ -151,16 +134,12 @@ func Load(pinDir string) (objs *prog.UsidObjects, err error) {
 	}
 	loadErr := spec.LoadAndAssign(&loaded, opts)
 	if loadErr != nil && errors.Is(loadErr, ebpf.ErrMapIncompatible) {
-		// A pin left by a previous version of this program no longer
-		// matches the newly compiled map spec (e.g. a changed value
-		// struct size or max_entries) -- cilium/ebpf refuses to reuse it
-		// as-is. Every map here is control-plane-owned and reconstructable
-		// (usidmap.Register calls re-populate it from BGPVRFInstance/
-		// BGPRouter CRD state, and the GC controller sweeps anything
-		// stale), so recreating it from scratch on a schema mismatch is
-		// safe -- the alternative, leaving this fatal, would crashloop
-		// every node on the first such schema change until an operator
-		// manually deletes the stale pins under pinDir.
+		// A pin left by a previous version no longer matches the compiled map
+		// spec, after a changed value size or entry count, and cannot be
+		// reused. Every map here is control-plane-owned and reconstructable
+		// from CRD state, with GC sweeping anything stale, so recreating it is
+		// safe. Leaving this fatal would crashloop every node on the first
+		// schema change until an operator deleted the pins by hand.
 		slog.Warn("attach: pinned eBPF map incompatible with the newly compiled map spec, recreating "+
 			"(control-plane state will repopulate on the next CNI ADD/GC sweep)", "pinDir", pinDir, "err", loadErr)
 		if unpinErr := unpinIncompatibleMaps(spec, pinDir); unpinErr != nil {
@@ -180,17 +159,15 @@ func Load(pinDir string) (objs *prog.UsidObjects, err error) {
 		return nil, err
 	}
 
-	// Pin usid_egress too, alongside the maps above -- unlike usid_ingress
-	// (attached once per node, by this same long-running process, to a
-	// known interface name from a static env var), usid_egress attaches
-	// per-attachment, at CNI ADD time, to an interface that doesn't exist
-	// until that ADD creates it -- internal/cnibgp, a short-lived process
-	// with no other handle on this collection, needs to load this exact
-	// program by its pin to attach it. A stale pin from a previous
-	// process's Load is removed and replaced unconditionally: unlike a
-	// map, a program has no persistent state to preserve across the
-	// swap, so there's no reuse-vs-recreate decision to make the way
-	// unpinIncompatibleMaps has to make for maps.
+	// Pin usid_egress alongside the maps. usid_ingress is attached once per
+	// node by this long-running process to a known interface, while usid_egress
+	// attaches per attachment, at CNI ADD time, to an interface that does not
+	// exist until that ADD creates it. The short-lived plugin process has no
+	// other handle on this collection and loads the program by its pin.
+	//
+	// A stale pin is removed and replaced unconditionally: a program has no
+	// persistent state to preserve, so there is no reuse-or-recreate decision
+	// to make as there is for a map.
 	egressPinPath := filepath.Join(pinDir, UsidEgressPinName)
 	if rmErr := os.Remove(egressPinPath); rmErr != nil && !os.IsNotExist(rmErr) {
 		err = fmt.Errorf("attach: remove stale usid_egress pin: %w", rmErr)
@@ -204,20 +181,17 @@ func Load(pinDir string) (objs *prog.UsidObjects, err error) {
 	return &loaded, nil
 }
 
-// UsidEgressPinName is the bpffs filename usid_egress is pinned under,
-// alongside (but distinct from, so it can never collide with) every map
-// name under the same pinDir.
+// UsidEgressPinName is the bpffs filename usid_egress is pinned under, distinct
+// from every map name in the same directory so the two can never collide.
 const UsidEgressPinName = "usid_egress_prog"
 
-// unpinIncompatibleMaps removes the on-disk pin for every map spec.Maps
-// names, if one exists under pinDir -- called after LoadAndAssign fails
-// with ebpf.ErrMapIncompatible, so the immediately following retry creates
-// each map fresh instead of failing against the stale pin again. A map
-// with no existing pin (os.ErrNotExist from LoadPinnedMap) isn't an error
-// here: LoadAndAssign would have created that one fine on the first
-// attempt, so only the actually-incompatible pin(s) need clearing, but
-// clearing all of them unconditionally is simpler and equally safe since
-// every one of these maps is control-plane-reconstructable.
+// unpinIncompatibleMaps removes the on-disk pin for every map spec names, if one
+// exists under pinDir, so the retry that follows an incompatible-map load creates
+// each map fresh instead of failing against the stale pin again.
+//
+// A map with no existing pin is not an error: that one would have loaded fine.
+// Clearing all of them unconditionally is simpler and equally safe, since every
+// one is reconstructable from control-plane state.
 func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
 	var errs []error
 	for name := range spec.Maps {
@@ -238,15 +212,14 @@ func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
 	return errors.Join(errs...)
 }
 
-// Attach attaches program to the ingress hook of each named interface via a
-// clsact qdisc + direct-action BPF filter (design plan §4.1: "TC-BPF
-// (clsact qdisc, ingress)"), creating the clsact qdisc if it doesn't
-// already exist. Re-running Attach against an interface that already has
-// this package's filter replaces it (github.com/vishvananda/netlink's
-// FilterReplace) instead of stacking a duplicate, so repeated calls -- a
-// container restart, or Watch's netlink-driven re-attachment (Milestone
-// 3.2) -- are idempotent. Every interface is attempted even if one fails;
-// all failures are joined and returned together.
+// Attach attaches program to the ingress hook of each named interface, through a
+// clsact qdisc and a direct-action BPF filter, creating the qdisc if it does not
+// exist.
+//
+// Re-running against an interface that already carries this package's filter
+// replaces it rather than stacking a duplicate, so repeated calls are
+// idempotent. Every interface is attempted even if one fails, and the failures
+// are joined and returned together.
 func Attach(program *ebpf.Program, ifaceNames []string) error {
 	if program == nil {
 		return errors.New("attach: program is nil")
@@ -264,23 +237,20 @@ func Attach(program *ebpf.Program, ifaceNames []string) error {
 	return errors.Join(errs...)
 }
 
-// egressFilterName identifies usid_egress's own TC-BPF ingress filter,
-// mirroring filterName's identical "so a re-attach replaces the same
-// filter instead of stacking a duplicate" role for usid_ingress -- kept
-// as its own distinct constant even though the two programs never
-// target the same interface in practice (usid_ingress: the shared
-// uplink; usid_egress: each tenant's own host-side veth/tap).
+// egressFilterName identifies usid_egress's TC-BPF ingress filter, so a
+// re-attach replaces the same filter rather than stacking a duplicate. Its own
+// constant even though the two programs never target the same interface:
+// usid_ingress takes the shared uplink, usid_egress each tenant's host-side veth
+// or tap.
 const egressFilterName = "galactic_usid_egress"
 
-// AttachEgress attaches program (usid_egress, loaded via its own pin --
-// see Load's own doc comment for why) to ifaceName's ingress hook: the
-// tenant's own host-side veth/tap interface, per usid_egress's own doc
-// comment in usid.c for why that -- not the shared uplink usid_ingress
-// uses -- is the correct attach point. Thin wrapper around the same
-// attachOne/FilterReplace idempotency Attach already provides, just
-// under egressFilterName and for exactly one interface at a time (each
-// internal/cnibgp CNI ADD attaches its own single attachment's interface,
-// never a batch).
+// AttachEgress attaches program, usid_egress loaded from its pin, to ifaceName's
+// ingress hook. That interface is the tenant's own host-side veth or tap, not
+// the shared uplink usid_ingress uses, because that is where the tenant's egress
+// traffic arrives.
+//
+// A thin wrapper around the same idempotency Attach provides, for one interface
+// at a time, since each CNI ADD attaches only its own attachment's interface.
 func AttachEgress(program *ebpf.Program, ifaceName string) error {
 	if program == nil {
 		return errors.New("attach: program is nil")
@@ -288,13 +258,10 @@ func AttachEgress(program *ebpf.Program, ifaceName string) error {
 	return attachOne(program, ifaceName, egressFilterName, netlink.HANDLE_MIN_INGRESS)
 }
 
-// attachOne attaches program to one interface's TC hook (parent -- either
-// netlink.HANDLE_MIN_INGRESS or netlink.HANDLE_MIN_EGRESS) under the given
-// tc filter name. It is the single internal choke point every attach path
-// in this package goes through (Attach's loop above, AttachEgress above,
-// and Watch's netlink-driven reconcile in watch.go), so instrumenting it
-// here with attachHook (hooks.go, Milestone 4) observes every attach
-// attempt regardless of caller.
+// attachOne attaches program to one interface's TC hook, named by
+// tcFilterName and rooted at parent, either the ingress or egress handle. It is
+// the choke point every attach path in this package goes through, so
+// instrumenting it here observes every attempt whatever the caller.
 func attachOne(program *ebpf.Program, name, tcFilterName string, parent uint32) (err error) {
 	defer func() { attachHook(name, err) }()
 
@@ -328,16 +295,14 @@ func attachOne(program *ebpf.Program, name, tcFilterName string, parent uint32) 
 	return nil
 }
 
-// Detach removes this package's own TC-BPF ingress filter (identified by
-// filterName) from each named interface, without touching the interface's
-// clsact qdisc itself -- another filter, or a future Attach, may still need
-// it. It is not an error for an interface to already lack the filter, or to
-// no longer exist on the host at all (netlink.LinkNotFoundError): Watch
-// (Milestone 3.2) calls Detach for interfaces that just dropped out of the
-// resolved interface set, and by the time that runs the interface may
-// already be gone entirely. Every interface is attempted even if one fails;
-// all failures are joined and returned together, matching Attach's own
-// all-attempted semantics.
+// Detach removes this package's ingress filter from each named interface,
+// leaving the clsact qdisc in place since another filter or a future attach may
+// still need it.
+//
+// An interface that already lacks the filter, or no longer exists at all, is not
+// an error: the watch loop detaches interfaces that just left the resolved set,
+// by which time one may already be gone. Every interface is attempted even if
+// one fails, and the failures are joined and returned together.
 func Detach(ifaceNames []string) error {
 	var errs []error
 	for _, name := range ifaceNames {
@@ -348,14 +313,11 @@ func Detach(ifaceNames []string) error {
 	return errors.Join(errs...)
 }
 
-// detachOne removes one named tc filter (identified by tcFilterName) from
-// one interface's TC hook (parent), if present. Like attachOne, it is the
-// single internal choke point every detach path in this package goes
-// through (Detach's loop above, DetachLocalEgress, and Watch's
-// netlink-driven reconcile), so instrumenting it here with detachHook
-// (hooks.go, Milestone 4) observes every detach attempt regardless of
-// caller. Not an error for the interface to already lack the filter, or to
-// no longer exist on the host at all (netlink.LinkNotFoundError).
+// detachOne removes the filter named tcFilterName from one interface's TC hook
+// at parent, if present. Like attachOne it is the choke point every detach path
+// goes through, so instrumenting it here observes every attempt whatever the
+// caller. An interface that already lacks the filter, or no longer exists, is
+// not an error.
 func detachOne(name, tcFilterName string, parent uint32) (err error) {
 	defer func() { detachHook(name, err) }()
 
@@ -388,26 +350,20 @@ func detachOne(name, tcFilterName string, parent uint32) (err error) {
 	return nil
 }
 
-// qdiscListFn and qdiscAddFn are package-level override points -- the same
-// pattern used throughout this package (interfaces.go's
-// routeListFn/linkByIndexFn) -- so ensureClsact's own tests can simulate
-// the concurrent-EEXIST race below without a live netlink socket or root
-// privileges.
+// qdiscListFn and qdiscAddFn are override points so ensureClsact's tests can
+// simulate the concurrent-EEXIST race below without a live netlink socket or
+// root.
 var (
 	qdiscListFn = netlink.QdiscList
 	qdiscAddFn  = netlink.QdiscAdd
 )
 
-// ensureClsact adds a clsact qdisc to link if one isn't already present.
+// ensureClsact adds a clsact qdisc to link if one is not already present.
 //
-// Listing qdiscs and then conditionally adding one is inherently racy
-// against any other agent doing the same thing to the same device --
-// notably Cilium, which also ensures a clsact qdisc exists on native
-// devices for its own tc/bpf programs. If something else wins that race
-// and creates the qdisc between this function's List and its Add call,
-// QdiscAdd returns EEXIST; that is exactly the outcome ensureClsact itself
-// was trying to reach (a clsact qdisc now exists on link), so it is
-// treated as success rather than propagated as an error.
+// Listing then conditionally adding is inherently racy against any other agent
+// doing the same to the same device, notably a cluster CNI ensuring its own
+// clsact qdisc. If something else wins that race, the add returns EEXIST, which
+// is the outcome this function wanted, so it is treated as success.
 func ensureClsact(link netlink.Link) error {
 	qdiscs, err := qdiscListFn(link)
 	if err != nil {

--- a/internal/plumbing/ebpf/attach/doc.go
+++ b/internal/plumbing/ebpf/attach/doc.go
@@ -2,58 +2,39 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package attach implements the eBPF/TC-BPF uSID datapath's control-daemon
-// load/attach/pin/watch lifecycle (design plan
-// .local/plan-ebpf-xdp-usid-datapath.md §4.1, §4.4, §5.4, §9; Milestones
-// 3.1 and 3.2 of .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+// Package attach implements the eBPF uSID datapath's control-daemon load,
+// attach, pin, and watch lifecycle.
 //
-// StartWatching (the package's entry point for galactic-cni's `run`
-// subcommand, internal/installer.Run) wraps Start (below) and additionally
-// launches Watch in a background goroutine: for as long as the caller's
-// context isn't canceled, Watch subscribes to netlink link and route change
-// events and re-evaluates the resolved interface set whenever one occurs
-// (design plan §4.1: "re-evaluate on interface/route change events
-// (netlink subscription), not just at startup"), attaching to newly
-// resolved interfaces and detaching from ones that dropped out -- Milestone
-// 3.2, this package's own gap flagged by Milestone 3.1's handoff notes.
+// StartWatching is the entry point for the control daemon. It wraps Start and
+// additionally launches Watch in a background goroutine, which subscribes to
+// netlink link and route events and re-evaluates the resolved interface set
+// whenever one occurs, attaching to newly resolved interfaces and detaching
+// from ones that dropped out, for as long as the caller's context lives.
 //
-// Start itself (still exported directly for tests and any caller that only
-// wants the one-time startup behavior) does three things, in order:
+// Start is exported for tests and for a caller wanting only the one-time
+// startup behavior. It does three things in order:
 //
-//  1. Runs internal/plumbing/ebpf/preflight's kernel-capability check and
-//     refuses to proceed at all if it fails -- there is no partial/unsafe
-//     fallback (design plan §6). This must run before anything below.
-//  2. Loads internal/plumbing/ebpf/prog's compiled usid_ingress object,
-//     pinning every map under a fixed bpffs directory (PinDir,
-//     /sys/fs/bpf/galactic by default) so a control-daemon restart reuses
-//     the maps already pinned there from a previous run instead of
-//     recreating them empty -- pinned-map continuity across a container
-//     restart (design plan §4.4/§9), this milestone's exit criterion.
-//  3. Resolves the interface set to attach to (design plan §4.1): an
-//     explicit GALACTIC_CNI_EBPF_INTERFACES override, if set, or
-//     auto-detection of the interface(s) carrying the default IPv6 route,
-//     then attaches usid_ingress to each one's ingress hook via a clsact
-//     qdisc + direct-action BPF filter (classic TC-BPF, not the newer
-//     kernel-6.6+-only TCX link mechanism -- the design plan explicitly
-//     says "TC-BPF (clsact qdisc, ingress)", and this keeps the attach path
-//     working across the widest kernel range the preflight check already
-//     targets). Re-running Attach against an interface that already has a
-//     galactic uSID filter replaces it (netlink.FilterReplace) rather than
-//     stacking a duplicate -- this is what makes Start idempotent across a
-//     container restart, alongside the maps' own pin persistence.
+//  1. Runs the kernel-capability preflight check and refuses to proceed if it
+//     fails. There is no partial fallback, and this must run before anything
+//     below.
+//  2. Loads the compiled usid_ingress object, pinning every map under a fixed
+//     bpffs directory, so a control-daemon restart reuses the maps already
+//     pinned there instead of recreating them empty.
+//  3. Resolves the interface set, from an explicit override or by
+//     auto-detection, and attaches usid_ingress to each one's ingress hook
+//     through a clsact qdisc and a direct-action filter. Classic TC-BPF rather
+//     than the newer tcx link mechanism, which keeps the attach path working
+//     across the kernel range the preflight check targets. Re-attaching
+//     replaces an existing galactic filter rather than stacking a duplicate,
+//     which together with the pins makes Start idempotent across a restart.
 //
-// Once attached, the classic tc filter holds its own kernel reference to
-// the loaded program independent of the process that created it (design
-// plan §5.4: "BPF programs, once attached, run independently of the
-// process that loaded them") -- so the returned *prog.UsidObjects can be
-// (and, in internal/installer.Run, is) kept open for the life of the
-// process and Closed only on shutdown, without disrupting already-attached
-// forwarding: Close releases this process's own map/program file
-// descriptors, it does not detach the filter or unpin the maps.
+// Once attached, the filter holds its own kernel reference to the program,
+// independent of the process that loaded it. The returned objects can therefore
+// stay open for the life of the process and be closed on shutdown without
+// disrupting forwarding: closing releases this process's descriptors, and does
+// not detach the filter or unpin the maps.
 //
-// This package does not yet populate locator_table/function_table/
-// vrf_table with real data (that's Milestone 3.3's GC-facing map API and
-// Milestones 6/7's control-plane encoder and CNI registration call), and
-// does not expose a health-check surface (Milestone 4). It only builds the
-// load/attach/pin/watch lifecycle those milestones build on.
+// This package populates none of the maps with real data and owns no
+// health-check surface beyond Health itself. It builds the lifecycle the
+// control-plane packages sit on.
 package attach

--- a/internal/plumbing/ebpf/attach/health.go
+++ b/internal/plumbing/ebpf/attach/health.go
@@ -16,34 +16,27 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 )
 
-// linkByNameFn and filterListFn are package-level override points -- the
-// same pattern used throughout this package (interfaces.go's
-// routeListFn/linkByIndexFn, watch.go's linkSubscribeFn/routeSubscribeFn) --
-// so Health's own tests can simulate an interface losing its attachment
-// without needing root or a live network interface.
+// linkByNameFn and filterListFn are override points, as elsewhere in this
+// package, so Health's tests can simulate an interface losing its attachment
+// without root or a live interface.
 var (
 	linkByNameFn = netlink.LinkByName
 	filterListFn = netlink.FilterList
 )
 
-// Health reports whether the eBPF uSID datapath is genuinely healthy right
-// now: objs is non-nil and its program/maps still have live, reachable
-// kernel file descriptors, and the program is still attached to every
-// interface in ifaces via this package's own TC-BPF ingress filter
-// (filterName). This is deliberately more than "the process is alive"
-// (design plan .local/plan-ebpf-xdp-usid-datapath.md §9: "confirms the BPF
-// program is actually attached and the maps are reachable -- not just that
-// the process is alive"; Milestone 4 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md) -- a process can be
-// running perfectly well while its BPF program has been unloaded out from
-// under it (e.g. someone ran `ip link del` on the attached interface, or
-// bpftool prog detach), and this function is what a caller (internal/
-// installer's gRPC health check) uses to notice that gap.
+// Health reports whether the eBPF uSID datapath is healthy right now: objs is
+// non-nil, its program and maps still have live kernel descriptors, and the
+// program is still attached to every interface in ifaces through this package's
+// TC-BPF ingress filter.
 //
-// A non-nil error joins every failing check (errors.Join), so a caller
-// logging the result sees the complete picture rather than just the first
-// problem encountered; every interface in ifaces is checked even after an
-// earlier interface or the program/map checks already failed.
+// That is deliberately more than "the process is alive". A process can run
+// perfectly well while its program has been unloaded from under it, by an
+// interface being deleted or a filter detached, and this is what lets a caller
+// notice the gap.
+//
+// A non-nil error joins every failing check, so a caller logging the result
+// sees the whole picture rather than the first problem. Every interface is
+// checked even after an earlier one failed.
 func Health(objs *prog.UsidObjects, ifaces []string) error {
 	if objs == nil {
 		return errors.New("attach: health: eBPF uSID datapath objects are nil (not loaded)")
@@ -56,10 +49,9 @@ func Health(objs *prog.UsidObjects, ifaces []string) error {
 	)
 }
 
-// checkProgramReachable confirms this process's own handle to usid_ingress
-// still refers to a live kernel program, via a lightweight
-// BPF_OBJ_GET_INFO_BY_FD query (program.Info()) rather than anything that
-// touches the packet path.
+// checkProgramReachable confirms this process's handle to usid_ingress still
+// refers to a live kernel program, through a lightweight info query rather than
+// anything touching the packet path.
 func checkProgramReachable(program *ebpf.Program) error {
 	if program == nil {
 		return errors.New("attach: health: usid_ingress program handle is nil")
@@ -70,10 +62,9 @@ func checkProgramReachable(program *ebpf.Program) error {
 	return nil
 }
 
-// checkMapsReachable confirms every one of the three control-plane maps
-// (locator_table, function_table, vrf_table) plus drop_reasons still has a
-// live, reachable kernel file descriptor, via the same lightweight Info()
-// query checkProgramReachable uses for the program.
+// checkMapsReachable confirms locator_table, function_table, vrf_table, and
+// drop_reasons still have live kernel descriptors, through the same lightweight
+// query checkProgramReachable uses.
 func checkMapsReachable(objs *prog.UsidObjects) error {
 	checks := []struct {
 		name string
@@ -98,13 +89,10 @@ func checkMapsReachable(objs *prog.UsidObjects) error {
 	return errors.Join(errs...)
 }
 
-// checkAttached confirms this package's own TC-BPF ingress filter
-// (filterName) is currently present on every interface in ifaces --
-// proving actual kernel-level attachment, not merely that this process's
-// program/map handles are still open (checkProgramReachable/
-// checkMapsReachable can pass even after the filter itself was removed by
-// something outside this process, e.g. `tc filter del` or the interface
-// being recreated).
+// checkAttached confirms this package's TC-BPF ingress filter is present on
+// every interface in ifaces. That proves kernel-level attachment, which the
+// program and map checks do not: those pass even after the filter itself was
+// removed from outside this process.
 func checkAttached(ifaces []string) error {
 	if len(ifaces) == 0 {
 		return errors.New("attach: health: no interfaces resolved to check attachment against")
@@ -119,11 +107,9 @@ func checkAttached(ifaces []string) error {
 	return errors.Join(errs...)
 }
 
-// checkAttachedOne confirms filterName is present among name's ingress
-// filters -- the same identification method detachOne already uses (match
-// by filter name, not by comparing file descriptor numbers, which are
-// process-local and not meaningfully comparable against a value returned
-// from a netlink query).
+// checkAttachedOne confirms the filter is present among name's ingress filters,
+// matched by name rather than by descriptor number, which is process-local and
+// not comparable against a netlink query result.
 func checkAttachedOne(name string) error {
 	iface, err := linkByNameFn(name)
 	if err != nil {
@@ -142,62 +128,47 @@ func checkAttachedOne(name string) error {
 	return errors.New("galactic uSID ingress filter not attached")
 }
 
-// Handle bundles a loaded *prog.UsidObjects with a Healthy check
-// (Milestone 4), so internal/installer's gRPC health-check handler can
-// query datapath health without depending on prog.UsidObjects or this
-// package's Health function directly -- and without needing to track the
-// datapath's resolved interface set itself (Healthy re-resolves it fresh on
-// every call, see below). Objs is exported so a caller that also needs the
-// raw maps for something else (e.g. internal/plumbing/ebpf/metrics's
-// Prometheus collector, also Milestone 4) can reach them without a second
-// load.
+// Handle bundles loaded objects with a health check, so a caller can query
+// datapath health without depending on the loaded types or on Health directly,
+// and without tracking the resolved interface set itself. Objs is exported so a
+// caller that also needs the raw maps, such as the metrics collector, can reach
+// them without a second load.
 type Handle struct {
 	Objs *prog.UsidObjects
 
-	// Watcher, if non-nil (StartWatching's return value in production),
-	// is consulted by Healthy alongside Health's own program/map/filter
-	// checks (ecv's review of #283):
-	//   - a Watch loop that is no longer running (Watcher.Alive() ==
-	//     false) can't self-heal drift on its own -- an externally
-	//     cleared tc filter or a moved default route would otherwise sit
-	//     unfixed indefinitely, since nothing else in this package
-	//     restarts it -- so Healthy reports that as unhealthy even if
-	//     Health's own checks currently pass;
-	//   - a failing Health result nudges the watcher (Watcher.Reconcile)
-	//     to re-evaluate before the next health-check tick, on the chance
-	//     the failure is exactly the kind of drift Watch's own reconcile
-	//     heals, rather than only ever healing via an unrelated netlink
-	//     event or the liveness probe restarting the container.
+	// Watcher, when non-nil, is consulted by Healthy alongside Health's own
+	// checks:
+	//   - A watch loop that is no longer running cannot self-heal drift, and
+	//     nothing else restarts it, so an externally cleared filter or a moved
+	//     default route would sit unfixed. Healthy reports that as unhealthy
+	//     even when Health's own checks pass.
+	//   - A failing Health result nudges the watcher to re-evaluate before the
+	//     next tick, in case the failure is the kind of drift its reconcile
+	//     heals, rather than waiting on an unrelated netlink event.
 	Watcher *Watcher
 }
 
-// Close releases this process's own BPF map/program file descriptors -- it
-// does not detach the filter or unpin the maps (see the package doc
-// comment for why that is safe).
+// Close releases this process's BPF map and program descriptors. It does not
+// detach the filter or unpin the maps; see the package doc comment for why that
+// is safe.
 func (h *Handle) Close() error {
 	return h.Objs.Close()
 }
 
-// Healthy re-resolves the current interface set (the same auto-detect/
-// override logic ResolveInterfaces always uses) and reports whether the
-// datapath is still attached to it and its maps are reachable. Re-resolving
-// fresh on every call, rather than reusing a cached set captured at
-// startup, means a health probe reflects the datapath's *current* desired
-// attachment state, consistent with Watch's own netlink-driven
-// re-evaluation (Milestone 3.2) -- a transient ResolveInterfaces failure
-// (e.g. no default route momentarily) is reported as unhealthy here too,
-// which is the correct, if occasionally noisy, behavior for a liveness/
-// readiness signal.
+// Healthy re-resolves the current interface set and reports whether the
+// datapath is still attached to it with its maps reachable.
 //
-// If h.Watcher is set, a non-nil Health result nudges it (Watcher.
-// Reconcile) before Healthy returns -- asynchronously and debounced by
-// Watch's own debounceInterval, so this call still reports the failure it
-// just observed, but the *next* Healthy call (one health-check interval
-// later) may find the drift already self-healed instead of needing an
-// unrelated netlink event or a full container restart to fix it (ecv's
-// review of #283). Separately, and regardless of Health's own result, a
-// dead watcher (h.Watcher.Alive() == false) is always reported as
-// unhealthy: it can no longer react to anything, including this nudge.
+// Resolving fresh on every call, rather than reusing a set captured at startup,
+// makes a probe reflect the datapath's current desired attachment, consistent
+// with the watcher's netlink-driven re-evaluation. A transient resolution
+// failure, such as a momentarily absent default route, is reported as unhealthy
+// too, which is correct if occasionally noisy for a liveness signal.
+//
+// When a watcher is set, a non-nil Health result nudges it before returning.
+// The nudge is asynchronous and debounced, so this call still reports what it
+// observed while the next one may find the drift already healed. Separately, a
+// watcher that is no longer running is always unhealthy: it can no longer react
+// to anything, including that nudge.
 func (h *Handle) Healthy() error {
 	ifaces, err := ResolveInterfaces()
 	if err != nil {
@@ -218,9 +189,8 @@ func (h *Handle) Healthy() error {
 	return healthErr
 }
 
-// tcxQueryFn is a package-level override point, matching linkByNameFn and
-// filterListFn above, so checkNotPreempted's tests need neither root nor a
-// live interface with a foreign program on it.
+// tcxQueryFn is an override point so checkNotPreempted's tests need neither
+// root nor a live interface with a foreign program on it.
 var tcxQueryFn = func(ifindex int) ([]ebpf.ProgramID, error) {
 	res, err := link.QueryPrograms(link.QueryOptions{
 		Target: ifindex,
@@ -251,20 +221,17 @@ var programNameFn = func(id ebpf.ProgramID) (string, error) {
 	return info.Name, nil
 }
 
-// ownProgramIDs returns the kernel ids of this datapath's own programs, for
-// checkNotPreempted to recognize itself by.
+// ownProgramIDs returns the kernel IDs of this datapath's own programs, so
+// checkNotPreempted can recognise itself.
 //
-// By id rather than by name, because reading a name means opening the
-// program by id, and BPF_PROG_GET_FD_BY_ID wants CAP_SYS_ADMIN or
-// CAP_PERFMON. This container carries neither (it drops ALL and adds BPF,
-// NET_ADMIN and NET_RAW), so that call returns EPERM here. An id needs no
-// such privilege: it comes from BPF_OBJ_GET_INFO_BY_FD on a descriptor
-// this process already holds.
+// By ID rather than by name, because reading a name means opening the program
+// by ID, which wants CAP_SYS_ADMIN or CAP_PERFMON. This container carries
+// neither, so that call returns EPERM. An ID needs no such privilege: it comes
+// from an info query on a descriptor this process already holds.
 //
-// Getting this wrong is what made the first version of this check useless.
-// It compared names, could not read them, and treated the failure as
-// nothing to report -- so it sat inert on a node that genuinely was
-// preempted.
+// Getting this wrong is what made the first version of the check useless. It
+// compared names, could not read them, and treated the failure as nothing to
+// report, so it sat inert on a node that genuinely was preempted.
 func ownProgramIDs(objs *prog.UsidObjects) map[ebpf.ProgramID]struct{} {
 	out := make(map[ebpf.ProgramID]struct{}, 2)
 	for _, p := range []*ebpf.Program{objs.UsidIngress, objs.UsidEgress} {
@@ -285,18 +252,16 @@ func ownProgramIDs(objs *prog.UsidObjects) map[ebpf.ProgramID]struct{} {
 // reportPreemption logs, and deliberately does not return, whatever
 // checkNotPreempted finds.
 //
-// This must never reach the health service. Both the liveness and the
-// readiness probe point at that one service, so anything reported through
-// it restarts this container -- and a restart cannot remove another CNI's
-// program from an interface. Wiring preemption into it produced a
-// permanent crashloop: measured at six restarts in as many minutes on a
-// node with a foreign program deliberately attached, each restart
-// changing nothing about the condition that caused it.
+// This must never reach the health service. Both the liveness and readiness
+// probes point at that one service, so anything reported through it restarts
+// the container, and a restart cannot remove another CNI's program from an
+// interface. Wiring preemption into it produces a permanent crashloop, each
+// restart changing nothing about the condition that caused it.
 //
-// Every other check in Health is a condition a restart plausibly fixes,
-// since restarting reloads the programs and re-attaches them. This one is
-// not, so it belongs in the log next to the other things an operator reads
-// rather than in the signal that decides whether this container lives.
+// Every other check in Health is a condition a restart plausibly fixes, since
+// restarting reloads and re-attaches the programs. This one is not, so it
+// belongs in the log an operator reads rather than in the signal that decides
+// whether this container lives.
 func reportPreemption(objs *prog.UsidObjects) {
 	if objs == nil {
 		return
@@ -309,32 +274,31 @@ func reportPreemption(objs *prog.UsidObjects) {
 }
 
 // checkNotPreempted confirms nothing runs ahead of this datapath on the
-// interfaces it owns exclusively.
+// interfaces it owns exclusively. own is the set of program IDs to recognise as
+// this datapath's own.
 //
 // Being attached is not the same as being reached. This package attaches
-// via clsact, and the kernel runs every tcx program on a hook before any
-// clsact filter on it, so another CNI's tcx program on the same interface
-// decides a packet's fate first. If it consumes or drops the packet,
-// usid_egress is never invoked and every counter here reads a clean zero,
-// because from this side nothing arrived. That is worth a check because it
-// is invisible from every vantage point this codebase otherwise has:
-// diagnosing one instance took kernel kfree_skb tracing, then bpftool to
-// see a tcx link `tc filter show` cannot display, then the other CNI's own
-// drop monitor to name the reason.
+// through clsact, and the kernel runs every tcx program on a hook before any
+// clsact filter, so another CNI's tcx program decides a packet's fate first. If
+// it consumes or drops the packet, usid_egress is never invoked and every
+// counter reads a clean zero, because from this side nothing arrived. That is
+// worth checking because it is invisible from every other vantage point:
+// diagnosing one instance took kernel tracing, then bpftool to see a tcx link
+// that tc cannot display, then the other CNI's own drop monitor to name the
+// reason.
 //
-// Scoped to this datapath's own per-attachment interfaces -- the taps and
-// veths carrying usid_egress -- and deliberately not to the shared uplinks
-// usid_ingress attaches to. On an uplink another CNI is expected: it is
-// that CNI's interface too, and this datapath's own receive classification
-// happens on a bond's slaves rather than on the master a cluster CNI
-// attaches to, so a tcx program there is not in the way of anything.
-// Checking uplinks would report every node in a fleet unhealthy over the
-// ordinary arrangement.
+// Scoped to this datapath's per-attachment interfaces, the taps and veths
+// carrying usid_egress, and not to the shared uplinks usid_ingress attaches to.
+// On an uplink another CNI is expected: the interface is that CNI's too, and
+// receive classification here happens on a bond's slaves rather than the master
+// a cluster CNI attaches to, so a program there is not in the way. Checking
+// uplinks would report every node in a fleet unhealthy over an ordinary
+// arrangement.
 //
-// Enumerating by filter rather than taking a caller-supplied list: an
-// interface carrying this package's own usid_egress filter is by definition
-// one this datapath owns, so the set defines itself and cannot drift out of
-// step with what is actually attached.
+// The interface set is enumerated by filter rather than supplied by the caller:
+// an interface carrying this package's usid_egress filter is by definition one
+// this datapath owns, so the set cannot drift out of step with what is
+// attached.
 func checkNotPreempted(own map[ebpf.ProgramID]struct{}) error {
 	links, err := linkListFn()
 	if err != nil {
@@ -368,29 +332,27 @@ func hasEgressFilter(l netlink.Link) bool {
 	return false
 }
 
-// checkNotPreemptedOne reports whether anything precedes this datapath on
-// one owned interface.
+// checkNotPreemptedOne reports whether anything precedes this datapath on one
+// owned interface. own is the set of program IDs belonging to this datapath.
 //
-// Reported by program id, with a name only when one can be read. The id
-// alone is enough to act on (`bpftool prog show id N` names it), and
-// insisting on the name is what left the first version of this check
-// unable to report anything at all -- see ownProgramIDs.
+// Findings are reported by program ID, with a name only when one can be read.
+// The ID alone is enough to act on, and insisting on the name is what left the
+// first version of this check unable to report anything.
 //
-// A failure to look is logged rather than returned. This check is a
-// diagnostic, and its own inability to run says nothing about whether the
-// datapath is carrying traffic, so failing health on it would report the
-// wrong thing. Logged, though, and not swallowed: silence that could mean
-// either "nothing is wrong" or "this never ran" is what allowed an inert
-// check to look identical to a passing one.
+// A failure to look is logged rather than returned. This is a diagnostic, and
+// its own inability to run says nothing about whether the datapath is carrying
+// traffic, so failing health on it would report the wrong thing. It is logged
+// rather than swallowed, because silence that could mean either "nothing is
+// wrong" or "this never ran" is what let an inert check look like a passing
+// one.
 func checkNotPreemptedOne(l netlink.Link, own map[ebpf.ProgramID]struct{}) error {
 	name := l.Attrs().Name
 
 	ids, err := tcxQueryFn(l.Attrs().Index)
 	if err != nil {
 		if errors.Is(err, ebpf.ErrNotSupported) {
-			// A kernel with no tcx cannot have a tcx program to be
-			// preempted by, so there is nothing to report and nothing
-			// to warn about either.
+			// A kernel with no tcx cannot have a tcx program to be preempted
+			// by, so there is nothing to report or warn about.
 			return nil
 		}
 		slog.Warn("attach: health: could not check whether another tc program precedes this datapath",

--- a/internal/plumbing/ebpf/attach/hooks.go
+++ b/internal/plumbing/ebpf/attach/hooks.go
@@ -4,24 +4,15 @@
 
 package attach
 
-// LoadHook and AttachHook are process-wide observability callbacks for BPF
-// program load and TC-BPF ingress filter attach/detach outcomes (design
-// plan .local/plan-ebpf-xdp-usid-datapath.md §9's "BPF program load/reload
-// events and failures" metric; Milestone 4 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md). They default to
-// no-ops so this package never needs a direct dependency on a metrics
-// library -- internal/plumbing/ebpf/metrics's Prometheus registration is
-// the only production caller of SetHooks, wiring real counters in once at
-// process startup (internal/installer.Run), exactly like watch.go's own
-// test-only onReconcileDone hook already does for tests within this
-// package.
+// LoadHook and AttachHook are process-wide observability callbacks for program
+// load and filter attach and detach outcomes. They default to no-ops, so this
+// package needs no dependency on a metrics library: the metrics package is the
+// only production caller of SetHooks, wiring real counters in once at process
+// startup.
 //
-// AttachHook is invoked from attachOne and detachOne -- the two internal
-// choke points every attach/detach path in this package ultimately goes
-// through (Start's initial Attach call, Watch's netlink-driven reconcile,
-// and Detach's direct callers) -- so installing it once observes every
-// attach/detach event this package ever performs, regardless of whether it
-// happened at startup or as part of a later re-attachment ("reload").
+// AttachHook is invoked from the two internal choke points every attach and
+// detach path goes through, so installing it once observes every such event this
+// package performs, whether at startup or during a later re-attachment.
 type LoadHook func(err error)
 
 // AttachHook reports the outcome of attaching or detaching this package's
@@ -42,9 +33,9 @@ var (
 	detachHook AttachHook = func(string, error) {}
 )
 
-// SetHooks installs h's callbacks, defaulting any nil field to a no-op. Not
-// safe to call concurrently with Load/Attach/Detach/Watch -- call once,
-// before starting the datapath, exactly like internal/installer.Run does.
+// SetHooks installs h's callbacks, defaulting any nil field to a no-op. Not safe
+// to call concurrently with the load, attach, or watch paths: call it once,
+// before starting the datapath.
 func SetHooks(h Hooks) {
 	loadHook = h.OnLoad
 	if loadHook == nil {

--- a/internal/plumbing/ebpf/attach/interfaces.go
+++ b/internal/plumbing/ebpf/attach/interfaces.go
@@ -18,21 +18,14 @@ import (
 	"go.datum.net/galactic/internal/plumbing/bond"
 )
 
-// routeListFn and linkByIndexFn are package-level function variables so
-// tests can substitute a fake netlink view without touching the real host
-// network stack -- the same override-var pattern internal/installer uses
-// for addrListFn.
+// routeListFn and linkByIndexFn are package vars so tests can substitute a fake
+// netlink view without touching the host network stack.
 //
-// routeListFn deliberately lists routes across every routing table, not
-// just the main table: passing RT_FILTER_TABLE with an unfiltered
-// (RT_TABLE_UNSPEC) Table lifts vishvananda/netlink's own default of
-// skipping any non-main-table route, rather than narrowing the result to
-// one specific table. A default route relevant to this node's
-// underlay/overlay interface selection may legitimately live in a
-// non-main table (e.g. a VRF-scoped underlay), and restricting
-// auto-detection to the main table only would make that topology
-// undetectable -- the caller (autoDetectInterfaces) still just looks for
-// any IPv6 default route, wherever it lives, exactly as before.
+// routeListFn lists routes across every routing table. Passing RT_FILTER_TABLE
+// with an unspecified table lifts netlink's default of skipping non-main-table
+// routes rather than narrowing to one table. A default route relevant to
+// interface selection may legitimately live in a non-main table, such as a
+// VRF-scoped underlay, and would otherwise be undetectable.
 var (
 	routeListFn = func() ([]netlink.Route, error) {
 		return netlink.RouteListFiltered(netlink.FAMILY_V6,
@@ -41,38 +34,31 @@ var (
 	linkByIndexFn = func(index int) (netlink.Link, error) {
 		return netlink.LinkByIndex(index)
 	}
-	// linkListFn enumerates every link on the host, for expandBondSlaves'
-	// slave lookup below. linkByNameFn (resolving one name to its Link) is
-	// already declared in health.go -- reused here rather than redeclared.
+	// linkListFn enumerates every link on the host, for expandBondSlaves.
+	// linkByNameFn is declared in health.go and reused here.
 	linkListFn = func() ([]netlink.Link, error) {
 		return netlink.LinkList()
 	}
 )
 
-// ResolveInterfaces returns the set of interface names the uSID datapath
-// should attach its TC-BPF ingress hook to (design plan §4.1).
+// ResolveInterfaces returns the interface names the uSID datapath should attach
+// its TC-BPF ingress hook to.
 //
-// If config.EnvCNIEBPFInterfaces is set, it is parsed as a comma-separated
-// list of interface names (whitespace trimmed, duplicates and empty
-// entries removed) and used directly -- no auto-detection is performed.
-// This is the explicit override for multi-homed nodes where auto-detection
-// is ambiguous.
+// When config.EnvCNIEBPFInterfaces is set it is parsed as a comma-separated
+// list, with whitespace trimmed and duplicates and empty entries removed, and
+// used as-is. That is the explicit override for multi-homed nodes where
+// auto-detection is ambiguous.
 //
-// Otherwise the interfaces are auto-detected: those carrying the default
-// IPv6 route, followed by those carrying a BGP-learned route, which is
-// where a fabric peer's SRv6 traffic arrives when the locators travel over
-// a segment the default route does not use (see isFabricPeerRoute).
-// Attaching to the wrong (or too few) interfaces fails as silent
-// blackholing of overlay traffic (design plan §4.1), so callers that get
-// an error here must not proceed with a partial or empty interface set.
+// Otherwise interfaces are auto-detected: those carrying the default IPv6
+// route first, then those carrying a BGP-learned route, which is where a fabric
+// peer's SRv6 traffic arrives when locators travel over a segment the default
+// route does not use. Attaching to too few interfaces shows up as silently
+// blackholed overlay traffic, so a caller that gets an error here must not
+// proceed with a partial or empty set.
 //
-// Either way, the resolved set is then run through expandBondSlaves: any
-// interface that is itself a Linux bonding master is expanded to include
-// its slave interfaces too, since ingress tc/eBPF classification on a
-// bonded interface happens on the slaves, not the master -- see
-// expandBondSlaves' own doc comment. This applies uniformly to both paths
-// above, so an operator using the override only needs to name the bond
-// master, not hand-list every slave alongside it.
+// Either way the result passes through expandBondSlaves, so an operator using
+// the override names only the bond master rather than hand-listing every
+// slave.
 func ResolveInterfaces() ([]string, error) {
 	var (
 		names []string
@@ -109,45 +95,26 @@ func parseInterfaceList(v string) []string {
 	return out
 }
 
-// autoDetectInterfaces returns the deduplicated set of interface names
-// carrying an IPv6 default route (::/0) or a BGP-learned route, default
-// routes first, and within each group in the order netlink reports them
-// -- analogous to the existing GALACTIC_ROUTER_BGP_LOCAL_ADDRESS
-// auto-detection-from-`lo` pattern (internal/plumbing/loaddr), but over
-// routes rather than addresses.
+// autoDetectInterfaces returns the deduplicated interface names carrying an
+// IPv6 default route or a BGP-learned route, default routes first and within
+// each group in the order netlink reports them.
 //
-// Skips wireguard-type links (excludedLinkType): a WireGuard mesh
-// interface can install its own IPv6 default-ish route alongside the real
-// fabric NIC's, and if netlink reports the mesh interface's route first,
-// ResolveNodeSourceAddress would bake the mesh interface's ULA in as this
-// node's SRv6 outer-header source address for every encapsulated packet.
-// That address is never reachable off-node (it's not advertised anywhere
-// outside the WireGuard mesh), so every cross-site SRv6 packet would leave
-// the box correctly SID-routed but with a source no intermediate network
-// would forward on (or a receiving node would recognize as this peer) --
-// silent packet loss with no error on either side. A WireGuard tunnel can
-// never legitimately be "the real fabric NIC" this datapath pushes raw
-// SRv6-encapsulated Ethernet frames onto, so it's excluded categorically
-// rather than by interface name (the specific mesh interface name is
-// deployment-specific; the underlying failure mode -- a tunnel interface
-// racing a real NIC for the default route -- is not).
+// WireGuard links are skipped. A mesh interface can install its own IPv6
+// default route alongside the real fabric NIC's, and if netlink reports it
+// first, this node's outer-header source address becomes a mesh address that is
+// not advertised outside the mesh. Every cross-site packet then leaves
+// correctly SID-routed with a source no intermediate network forwards on, and
+// is lost with no error at either end. A tunnel can never be the real fabric
+// NIC, so the exclusion is by link type rather than by a deployment-specific
+// interface name.
 //
-// Also skips any interface enslaved to a Linux VRF master (excludedMasterType),
-// for the identical reasoning, confirmed live: internal/ingresssidecar's
-// own per-VPC veth pair (ensureEgressDatapath's ivpN/ivsN, enslaved into
-// that VPC's VRF so usid_egress has a real ingress hook to attach to --
-// see that function's own doc comment) picks up a spurious
-// `default via fe80::... dev ivsN table <vrf>` route, almost certainly
-// from IPv6 router-solicitation/advertisement between the veth peers. With
-// six VPCs' VRFs present, that put ivs1 (the lowest VRF table id) ahead of
-// eth0 in this function's own result, so ResolveNodeSourceAddress
-// permanently resolved a link-local-only interface instead of the real
-// fabric NIC -- ensureEgressDatapath's own doc comment confirms the
-// consequence isn't cosmetic: usid_egress fails open (TC_ACT_UNSPEC,
-// uncounted) on every encapsulation attempt until this resolves. A VRF
-// slave -- this sidecar's own internal plumbing or a real tenant
-// attachment either one -- can never legitimately be "the real fabric NIC"
-// any more than a WireGuard mesh interface can.
+// Links enslaved to a VRF are skipped for the same reason. The ingress
+// sidecar's per-VPC veth pairs pick up a spurious default route in their VRF's
+// table, almost certainly from router advertisements between the peers, and
+// with several VPCs present that put a link-local-only veth ahead of the real
+// NIC. usid_egress then fails open, uncounted, on every encapsulation attempt.
+// A VRF slave, sidecar plumbing or tenant attachment alike, can no more be the
+// fabric NIC than a tunnel can.
 func autoDetectInterfaces() ([]string, error) {
 	routes, err := routeListFn()
 	if err != nil {
@@ -163,9 +130,9 @@ func autoDetectInterfaces() ([]string, error) {
 			}
 			link, err := linkByIndexFn(r.LinkIndex)
 			if err != nil {
-				// A route pointing at an interface we can't resolve isn't
-				// actionable here; skip it rather than failing the whole
-				// detection over one stale/racing route.
+				// A route pointing at an interface that will not resolve
+				// is not actionable; skip it rather than fail the whole
+				// detection over one stale route.
 				continue
 			}
 			if link.Type() == excludedLinkType {
@@ -186,14 +153,12 @@ func autoDetectInterfaces() ([]string, error) {
 		}
 	}
 
-	// Default-route interfaces first, and the ordering is contractual, not
-	// cosmetic: ResolveNodeSourceAddress takes names[0] and uses that
-	// interface's global address as the outer source of every packet this
-	// node encapsulates. That has to stay the interface carrying the
-	// default route. A private fabric segment's address is reachable only
-	// from that segment, so promoting it here would give cross-site SRv6
-	// a source no intermediate network forwards on -- the same silent loss
-	// the wireguard exclusion above exists to prevent.
+	// Default-route interfaces first, and the order is contractual.
+	// ResolveNodeSourceAddress takes names[0] and uses that interface's global
+	// address as the outer source of every encapsulated packet, which has to
+	// stay the interface carrying the default route. A private segment's
+	// address is reachable only from that segment, so promoting it would give
+	// cross-site traffic a source no intermediate network forwards on.
 	collect(isDefaultRoute)
 	collect(isFabricPeerRoute)
 
@@ -205,42 +170,36 @@ func autoDetectInterfaces() ([]string, error) {
 	return names, nil
 }
 
-// isFabricPeerRoute reports whether r is a route this node's own routing
-// daemon learned over BGP, making r's interface one where a fabric peer --
-// and so SRv6-encapsulated traffic from it -- can arrive.
+// isFabricPeerRoute reports whether r was learned over BGP, making r's
+// interface one where a fabric peer, and so SRv6-encapsulated traffic from it,
+// can arrive.
 //
-// Default-route detection alone is not enough, and the gap is not
-// theoretical. Encapsulated traffic arrives wherever a peer's route to
-// this node's locator points, which is not necessarily the default route's
-// interface: a fabric can carry its locators over a private segment shared
-// only by the nodes on it, reached by a specific route rather than the
-// default. Measured on such a pair -- iBGP and the locators over a VLAN on
-// a private bond, the default route still on the public NIC -- 10
-// correctly-formed SRv6 packets arrived on the VLAN, the ingress hook was
-// attached only to the public NIC, nothing was decapsulated, and the
-// kernel counted them as Ip6InHdrErrors because a local SID with no
-// seg6local action is all it saw. No error anywhere: the tenant datapath
-// was silently dead.
+// Default-route detection alone is not enough. Encapsulated traffic arrives
+// wherever a peer's route to this node's locator points, which need not be the
+// default route's interface: a fabric can carry locators over a private segment
+// reached by a specific route. When that happens and the hook is attached only
+// to the public NIC, correctly formed SRv6 packets arrive on the other
+// interface, nothing decapsulates them, and the kernel counts them as
+// Ip6InHdrErrors because all it sees is a local SID with no action. Nothing
+// reports an error while the tenant datapath is dead.
 //
 // BGP is the signal because a fabric peer is by definition one this node
-// exchanges routes with, so the interface reaching it carries a
-// BGP-learned route whatever addressing the segment uses. It holds for a
-// peer in this node's own uSID Block and for one in a different Block,
-// which a rule keyed on locator address space would not. The exclusions
-// applied to default routes apply here unchanged, and they matter more:
-// EVPN routes for tenant prefixes are BGP-learned too, and every one of
-// them points into a VRF, which isVRFSlave rejects.
+// exchanges routes with, so the interface reaching it carries a BGP-learned
+// route whatever addressing the segment uses. That holds for a peer in this
+// node's own uSID Block and for one in a different Block, which a rule keyed on
+// locator address space would not. The exclusions applied to default routes
+// matter more here: EVPN routes for tenant prefixes are BGP-learned too, and
+// every one points into a VRF.
 func isFabricPeerRoute(r netlink.Route) bool {
 	if r.Protocol != unix.RTPROT_BGP {
 		return false
 	}
-	// A discard is not a path to anything. FRR installs the locator and
-	// aggregate prefixes this node originates itself as blackholes, and
-	// reports them on lo, so without this every node with an originated
-	// aggregate would nominate lo as a fabric interface. Rejecting the
-	// known non-forwarding types rather than requiring RTN_UNICAST, because
-	// an ordinary unicast route is also reported as RTN_UNSPEC by some
-	// netlink paths and requiring unicast would then match nothing.
+	// A discard route is not a path to anything. The locator and aggregate
+	// prefixes this node originates are installed as blackholes on lo, so
+	// without this every node originating an aggregate would nominate lo as a
+	// fabric interface. Non-forwarding types are rejected rather than unicast
+	// required, because some netlink paths report an ordinary unicast route as
+	// RTN_UNSPEC and requiring unicast would match nothing.
 	switch r.Type {
 	case unix.RTN_BLACKHOLE, unix.RTN_UNREACHABLE, unix.RTN_PROHIBIT:
 		return false
@@ -248,25 +207,20 @@ func isFabricPeerRoute(r netlink.Route) bool {
 	return true
 }
 
-// excludedLinkType is the vishvananda/netlink Link.Type() value
-// autoDetectInterfaces never treats as a candidate fabric interface -- see
-// autoDetectInterfaces' own doc comment for why.
+// excludedLinkType is the netlink Link.Type() autoDetectInterfaces never treats
+// as a candidate fabric interface.
 const excludedLinkType = "wireguard"
 
-// excludedMasterType is the vishvananda/netlink Link.Type() value a link's
-// *master* is checked against by isVRFSlave -- see autoDetectInterfaces'
-// own doc comment for why a VRF slave is excluded the same way a
-// WireGuard link is.
+// excludedMasterType is the netlink Link.Type() a link's master is checked
+// against by isVRFSlave.
 const excludedMasterType = "vrf"
 
-// isVRFSlave reports whether link is enslaved to a Linux VRF master.
-// Resolves the master via linkByIndexFn rather than trusting link's own
-// Type() (a VRF slave is still reported as its real underlying type --
-// "veth", "bond", etc. -- only the separate MasterIndex/master-side
-// SlaveKind marks the enslavement), so this only ever excludes a link that
-// genuinely belongs to a VRF, not every enslaved link (a bond slave, which
-// expandBondSlaves deliberately wants included, is never itself a VRF
-// slave at the same time on any topology this codebase creates).
+// isVRFSlave reports whether link is enslaved to a Linux VRF master. The master
+// is resolved rather than link's own Type() trusted, because a VRF slave still
+// reports its underlying type and only the master marks the enslavement. That
+// keeps this to links genuinely in a VRF: a bond slave, which expandBondSlaves
+// wants included, is never also a VRF slave on any topology this codebase
+// creates.
 func isVRFSlave(link netlink.Link) bool {
 	idx := link.Attrs().MasterIndex
 	if idx <= 0 {
@@ -274,45 +228,31 @@ func isVRFSlave(link netlink.Link) bool {
 	}
 	master, err := linkByIndexFn(idx)
 	if err != nil {
-		// Master unresolvable isn't actionable here; don't exclude on a
-		// guess -- matches autoDetectInterfaces' own stance on an
-		// unresolvable route target just above.
+		// An unresolvable master is not actionable; do not exclude on a
+		// guess.
 		return false
 	}
 	return master.Type() == excludedMasterType
 }
 
-// expandBondSlaves expands any bonding-master interface in names to also
-// include its slave interfaces, and does the same for a VLAN interface
-// sitting on top of a bond (vlanBondMaster), leaving every other interface
-// unchanged.
+// expandBondSlaves expands any bonding master in names to include its slaves,
+// does the same for a VLAN sitting on top of a bond, and leaves every other
+// interface unchanged.
 //
-// On a Linux bonding master, RX ingress tc/eBPF classification happens on
-// the slave devices, not the bond master itself -- a well-known kernel
-// behavior (confirmed live: `tc filter show dev bond0 ingress` showed this
-// package's own filter correctly attached, `tc filter show dev <slave>
-// ingress` showed nothing on either slave, and every uSID datapath map
-// counter -- locator_table, function_table, vrf_table, drop_reasons --
-// stayed at zero despite tcpdump confirming packets arriving on the wire).
-// The bond master still carries the IP/route configuration ResolveInterfaces
-// resolves from (auto-detect) or an operator names directly (the
-// GALACTIC_CNI_EBPF_INTERFACES override), but attaching the ingress hook to
-// only the master silently never sees any traffic that arrives while
-// bonded -- so both master and slaves are attached, mirroring the
-// tc/bonding gotcha this replaces the historical per-node "list the master
-// plus every slave name in GALACTIC_CNI_EBPF_INTERFACES by hand" workaround.
+// RX ingress tc classification on a bond happens on the slave devices, not the
+// master. The master still carries the addresses and routes ResolveInterfaces
+// detects from, or that an operator names directly, but a hook attached only
+// there never sees traffic that arrives while bonded, and every datapath
+// counter stays at zero while packets arrive on the wire. Attaching both master
+// and slaves is what removes the need to hand-list slave names in the override.
 //
-// A name that can't be resolved at all is passed through unchanged (logged,
-// not failed): ResolveInterfaces' override path has never required its
-// named interfaces to actually exist on the host at resolution time (e.g.
-// internal/installer's static-conflist generation resolves this purely to
-// produce a config string, independent of whether/when this init
-// container's netns can see the interface) -- callers that do need the
-// interface to genuinely exist still get that failure from attachOne at
-// actual attach time, unchanged from before this function existed. Once a
-// name does resolve to a real bonding master, though, failing to enumerate
-// its slaves is treated as fatal -- silently falling back to "just the
-// master" would reproduce the exact bug this function exists to fix.
+// A name that does not resolve is passed through and logged rather than failed.
+// The override path has never required its interfaces to exist at resolution
+// time, since conflist generation resolves names purely to produce a config
+// string. A caller that needs the interface to exist still gets that failure at
+// attach time. Once a name does resolve to a real bonding master, though,
+// failing to enumerate its slaves is fatal: falling back to the master alone
+// would reproduce the bug this exists to fix.
 func expandBondSlaves(names []string) ([]string, error) {
 	var out []string
 	seen := make(map[string]bool)
@@ -336,9 +276,8 @@ func expandBondSlaves(names []string) ([]string, error) {
 
 		master := link
 		if !bond.IsMaster(master) {
-			// Not a bond itself. It may still sit on top of one: a VLAN
-			// over a bond has the same problem as the bond master, one
-			// level further up. See vlanBondMaster.
+			// Not a bond itself, but it may sit on one: a VLAN over a
+			// bond has the same problem one level up.
 			master = vlanBondMaster(link)
 			if master == nil {
 				continue
@@ -357,31 +296,24 @@ func expandBondSlaves(names []string) ([]string, error) {
 	return out, nil
 }
 
-// vlanBondMaster returns the bonding master a VLAN interface sits on top of,
-// or nil when link is not a VLAN or its parent is not a bond.
+// vlanBondMaster returns the bonding master a VLAN interface sits on, or nil
+// when link is not a VLAN or its parent is not a bond.
 //
 // A VLAN over a bond inherits the bond master's ingress problem rather than
 // escaping it. RX classification still happens on the physical slaves, so a
-// filter on the VLAN device never runs for traffic that arrives while
-// bonded, exactly as a filter on the bond master never does.
+// filter on the VLAN device never runs for traffic arriving while bonded, just
+// as a filter on the bond master never does. Packets show up in a capture on
+// the VLAN device, because the packet tap runs where tc classification does
+// not, while the datapath's counters stay flat.
 //
-// Measured on a fabric carrying its locators over a VLAN on a private bond,
-// with the ingress hook attached to the VLAN device: SRv6 packets arrived
-// (pcap on the VLAN device showed them, since the packet tap runs where tc
-// classification does not), the datapath's own counters did not move at all,
-// and nothing was decapsulated. Attaching to the parent bond's slaves moved
-// the per-VRF packet counter by exactly the number of packets sent, and
-// detaching them stopped it again.
+// The parent's slaves are what get added, not the parent itself, since
+// attaching to a bond master is inert for the same reason.
 //
-// The parent's own slaves are what gets added, not the parent: attaching to
-// a bond master is inert for the same reason, so naming it would achieve
-// nothing.
-//
-// The tag is not a problem here. These NICs strip it in hardware, so the
-// frame reaching tc on the slave carries ethertype IPv6 with the VLAN id in
-// skb metadata, which is what usid_ingress's Ethernet parse already
-// expects. A deployment whose NICs leave the tag in the packet data would
-// additionally need 802.1Q parsing in the datapath, which it does not have.
+// The tag is handled in the datapath, not here. NICs that strip it in hardware
+// leave the frame at tc with ethertype IPv6 and the VLAN id in skb metadata,
+// which usid_ingress pops before redirecting. A deployment whose NICs leave the
+// tag in packet data would additionally need 802.1Q parsing, which the datapath
+// does not have.
 func vlanBondMaster(link netlink.Link) netlink.Link {
 	if link.Type() != vlanLinkType {
 		return nil

--- a/internal/plumbing/ebpf/attach/watch.go
+++ b/internal/plumbing/ebpf/attach/watch.go
@@ -19,73 +19,53 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 )
 
-// debounceInterval coalesces a burst of netlink link/route change events
-// (e.g. an interface flapping, or several routes updating as part of one
-// routing-table change) into a single interface-set re-evaluation, instead
-// of re-running ResolveInterfaces -- and possibly re-attaching -- once per
-// individual netlink message. It is a package-level var (not a const) so
-// tests can shrink it and exercise Watch's event-to-reaction path in
-// milliseconds instead of real wall-clock time.
+// debounceInterval coalesces a burst of netlink link and route events, such as
+// an interface flapping or several routes changing together, into a single
+// interface-set re-evaluation rather than one per netlink message. A var, not a
+// const, so tests can shrink it.
 var debounceInterval = 250 * time.Millisecond
 
-// linkSubscribeFn and routeSubscribeFn are package-level override points --
-// the same pattern interfaces.go uses for routeListFn/linkByIndexFn -- so
-// tests can simulate real interface/route change events without a live
-// netlink socket or root privileges: a fake implementation receives the
-// exact channel Watch reads from and can push a synthetic
-// netlink.LinkUpdate/netlink.RouteUpdate onto it whenever the test wants to
-// simulate a change.
+// linkSubscribeFn and routeSubscribeFn are override points so tests can
+// simulate interface and route change events without a live netlink socket or
+// root. A fake receives the channel Watch reads from and can push synthetic
+// updates onto it.
 var (
 	linkSubscribeFn  = netlink.LinkSubscribeWithOptions
 	routeSubscribeFn = netlink.RouteSubscribeWithOptions
 )
 
-// resolveInterfacesFn is a package-level override point so Watch's own
-// tests can control what a re-evaluation resolves to across successive
-// calls (the "interface set changed" scenario this milestone exists for)
-// without touching the real netlink route table. Production code always
-// leaves this at its default, ResolveInterfaces, which has its own
-// independent override vars (routeListFn/linkByIndexFn) exercised by
-// interfaces_test.go.
+// resolveInterfacesFn is an override point so Watch's tests can control what
+// successive re-evaluations resolve to without touching the real route table.
+// Production always leaves it at ResolveInterfaces, which has override vars of
+// its own.
 var resolveInterfacesFn = ResolveInterfaces
 
-// onReconcileDone is a test-only hook invoked once after every debounced
-// re-evaluation (whether or not it changed anything, and whether or not
-// ResolveInterfaces itself failed). It lets tests wait deterministically
-// for a reconciliation attempt to finish instead of guessing with a sleep.
-// Production code never overrides it.
+// onReconcileDone is a test-only hook invoked after every debounced
+// re-evaluation, whether or not anything changed and whether or not resolution
+// failed, so tests can wait deterministically instead of sleeping. Production
+// never overrides it.
 var onReconcileDone = func() {}
 
-// Watcher is a live handle onto a running Watch loop, returned by
-// StartWatching alongside the objects/interfaces Start itself already
-// returns. It exists so a caller outside this package -- specifically
-// internal/installer's health-check ticker -- can (a) tell whether the
-// watch loop is still actually running, and (b) ask it to re-evaluate the
-// attachment set out of band, without needing to wait for the next
-// netlink link/route event or a container restart (ecv's review of #283:
-// "should a failed health check drive a reconcile before it fails the
-// probe?" and "should a dead watcher fail health?").
+// Watcher is a live handle on a running Watch loop, returned by StartWatching.
+// It lets a caller outside this package tell whether the loop is still running
+// and ask it to re-evaluate the attachment set out of band, without waiting for
+// the next netlink event or a container restart.
 type Watcher struct {
 	alive atomic.Bool
 	nudge chan struct{}
 }
 
-// newWatcher creates a Watcher in its not-yet-started state. alive is set
-// true once the Watch loop it is passed to actually starts running, and
-// false again once that loop exits for any reason (ctx canceled, or an
-// unrecoverable error) -- see Watch's own use of it below.
+// newWatcher creates a Watcher in its not-yet-started state. It is marked alive
+// once the Watch loop it is passed to starts running, and dead again once that
+// loop exits for any reason.
 func newWatcher() *Watcher {
 	return &Watcher{nudge: make(chan struct{}, 1)}
 }
 
-// Alive reports whether the Watch loop this Watcher was passed to is
-// still actually running. A Watch loop that has exited -- because its
-// initial netlink subscriptions failed and StartWatching's spawning
-// goroutine logged the error and gave up (watch.go's own doc comment),
-// with no retry -- can no longer react to netlink events or Reconcile
-// nudges at all, so a caller relying on it to self-heal drift (an
-// externally cleared tc filter, a moved default route) needs to know that
-// self-healing isn't happening anymore.
+// Alive reports whether the Watch loop this Watcher was passed to is still
+// running. A loop that exited, because its initial netlink subscriptions failed
+// and nothing retries them, can no longer react to events or nudges, so a
+// caller relying on it to heal drift needs to know that healing has stopped.
 func (w *Watcher) Alive() bool {
 	if w == nil {
 		return false
@@ -93,16 +73,13 @@ func (w *Watcher) Alive() bool {
 	return w.alive.Load()
 }
 
-// Reconcile asks the Watch loop to re-evaluate and re-assert the
-// attachment set as soon as its next debounce interval elapses, the same
-// path a real netlink link/route event drives. It is safe to call from any
-// goroutine and safe to call when nothing is actually wrong -- attachOne/
-// Detach are idempotent, so an unnecessary reconcile is a cheap no-op. A
-// pending, not-yet-delivered nudge is not duplicated (the channel is
-// buffered by exactly one and this send never blocks), so calling
-// Reconcile repeatedly in a tight loop coalesces into a single
-// re-evaluation, the same way a burst of netlink events already does via
-// scheduleReevaluate's debounce timer reset.
+// Reconcile asks the Watch loop to re-evaluate and re-assert the attachment set
+// at its next debounce interval, the same path a real netlink event drives.
+//
+// Safe from any goroutine and safe when nothing is wrong, since attach and
+// detach are idempotent. A pending nudge is not duplicated, the channel being
+// buffered by one and the send never blocking, so repeated calls coalesce into
+// one re-evaluation just as a burst of netlink events does.
 func (w *Watcher) Reconcile() {
 	if w == nil {
 		return
@@ -113,16 +90,12 @@ func (w *Watcher) Reconcile() {
 	}
 }
 
-// logDegradedSubscription logs a netlink subscription channel closing
-// (which Watch's select loop reacts to by setting that channel variable to
-// nil and no longer selecting on it -- a nil channel case in a Go select
-// simply never fires). Neither closure was previously logged at all
-// (ecv's review of #283), which mattered most in the otherKindAlreadyNil
-// case: once both the link and route subscriptions have closed, Watch's
-// main select degrades to reacting only to ctx.Done() and the health-
-// triggered nudge channel -- it can no longer notice any real interface or
-// route change on its own -- and that transition passed completely
-// silently before this.
+// logDegradedSubscription logs a netlink subscription channel closing, which
+// Watch reacts to by nil-ing that channel so its select case never fires again.
+// otherKindAlreadyNil says whether the other subscription is already gone,
+// which is the case worth noticing: with both closed, the loop reacts only to
+// context cancellation and out-of-band nudges and can no longer see any
+// interface or route change on its own.
 func logDegradedSubscription(kind string, otherKindAlreadyNil bool) {
 	if otherKindAlreadyNil {
 		slog.Error("attach: watch: both netlink link and route subscriptions have now closed; " +
@@ -133,60 +106,43 @@ func logDegradedSubscription(kind string, otherKindAlreadyNil bool) {
 	slog.Warn("attach: watch: netlink subscription closed", "kind", kind)
 }
 
-// Watch subscribes to netlink link and route change events and, for as
-// long as ctx is not canceled, re-evaluates the eBPF uSID datapath's
-// attachment set whenever one occurs (design plan §4.1: "re-evaluate on
-// interface/route change events (netlink subscription), not just at
-// startup" -- Milestone 3.2 of the implementation plan). It is meant to run
-// in its own goroutine alongside the Start (or Load+Attach) call whose
-// resolved interface set seeds initial.
+// Watch subscribes to netlink link and route change events and, until ctx is
+// canceled, re-evaluates the datapath's attachment set whenever one occurs. It
+// is meant to run in its own goroutine alongside the call whose resolved
+// interface set seeds initial. program is the loaded usid_ingress program to
+// attach.
 //
-// Change events are debounced (see debounceInterval) so a burst of related
-// netlink messages triggers one re-evaluation, not one per message. Each
-// re-evaluation calls ResolveInterfaces (via resolveInterfacesFn) again and
-// reconciles the actually-attached state against it:
-//   - every interface in the freshly-resolved set is (re-)attached to
-//     program, not just ones newly present -- Attach's underlying
-//     FilterReplace semantics make this idempotent and cheap, and it is
-//     deliberately unconditional (not gated on the interface set having
-//     changed at all) so that an external event that silently clears this
-//     package's own tc filter without ever removing the interface from the
-//     resolved set -- confirmed in a real deployment: the underlay routing
-//     daemon (FRR) restarting bounced the interface, which cleared the
-//     filter, but the interface never left the resolved set (still the
-//     default-route interface), so a diff-only reconcile never noticed and
-//     never healed it -- gets self-healed on the very next netlink event
-//     instead of silently blackholing traffic until the pod restarts;
-//   - every interface no longer present has this package's own tc filter
-//     removed via Detach, so a downed or reassigned interface stops
-//     silently forwarding into whatever VRF its Argument used to resolve
-//     to.
+// Events are debounced, so a burst of related messages triggers one
+// re-evaluation. Each re-evaluation resolves the interface set again and
+// reconciles the attached state against it:
+//   - Every interface in the fresh set is re-attached, not only newly present
+//     ones. Attach is idempotent and cheap, and doing it unconditionally is
+//     what heals an external event that clears this package's filter without
+//     removing the interface from the resolved set. An underlay routing daemon
+//     restarting bounces the interface and clears the filter while it remains
+//     the default-route interface, which a diff-only reconcile never notices.
+//   - Every interface no longer present has this package's filter removed, so a
+//     downed or reassigned interface stops forwarding into whatever VRF its
+//     Argument used to resolve to.
 //
-// A failure to attach or detach one interface during a re-evaluation is
-// logged and does not stop the watch loop or abandon that interface -- it
-// is retried on the next re-evaluation for as long as the mismatch between
-// the resolved set and the actually-attached set persists (see reconcile).
-// A failure of ResolveInterfaces itself during a re-evaluation is likewise
-// logged and skipped, leaving the previous attachment set in place rather
-// than tearing anything down on a transient resolution error.
+// A per-interface attach or detach failure is logged and retried on the next
+// re-evaluation, for as long as the mismatch persists. A resolution failure is
+// likewise logged and skipped, leaving the previous attachment set in place
+// rather than tearing anything down on a transient error.
 //
-// Watch's w parameter, if non-nil, is marked alive for as long as Watch's
-// loop is actually running (see Watcher's own doc comment) and receives an
-// out-of-band re-evaluation trigger via its Reconcile method -- passing
-// nil is fine and disables both; production always passes the *Watcher
-// StartWatching itself created.
+// w, when non-nil, is marked alive while this loop runs and supplies the
+// out-of-band re-evaluation trigger. Passing nil disables both.
 //
-// Watch returns nil when ctx is canceled. It returns a non-nil error only
-// if establishing the initial netlink subscriptions themselves fails.
+// Returns nil when ctx is canceled, and a non-nil error only if establishing
+// the initial netlink subscriptions fails.
 func Watch(ctx context.Context, program *ebpf.Program, initial []string, w *Watcher) error {
 	if program == nil {
 		return errors.New("attach: watch: program is nil")
 	}
 
-	// Buffered by one so the netlink library's own subscription goroutine
-	// (see vishvananda/netlink's linkSubscribeAt/routeSubscribeAt) can hand
-	// off one in-flight update without blocking forever if it races with
-	// this function returning (ctx canceled) right as a message arrives.
+	// Buffered by one so netlink's own subscription goroutine can hand off an
+	// in-flight update without blocking forever if it races with this function
+	// returning as a message arrives.
 	linkCh := make(chan netlink.LinkUpdate, 1)
 	routeCh := make(chan netlink.RouteUpdate, 1)
 	done := make(chan struct{})
@@ -207,11 +163,10 @@ func Watch(ctx context.Context, program *ebpf.Program, initial []string, w *Watc
 		return fmt.Errorf("attach: watch: subscribe to route updates: %w", err)
 	}
 
-	// Only now that both subscriptions are up does this loop actually start
-	// reacting to events -- mark it alive, and guarantee it is marked dead
-	// again on every return path (including a subscription failure above
-	// would have already returned before this point, correctly never
-	// claiming to be alive at all).
+	// Only now that both subscriptions are up does this loop react to events.
+	// Mark it alive, and guarantee it is marked dead again on every return
+	// path. A subscription failure returns above, so it never claims to be
+	// alive at all.
 	if w != nil {
 		w.alive.Store(true)
 		defer w.alive.Store(false)
@@ -267,11 +222,9 @@ func Watch(ctx context.Context, program *ebpf.Program, initial []string, w *Watc
 			scheduleReevaluate()
 
 		case <-nudge:
-			// An out-of-band request (Watcher.Reconcile, e.g. from a
-			// failing health check) to re-evaluate -- routed through the
-			// same debounce path a real netlink event uses, so a nudge
-			// racing an actual event still coalesces into one
-			// re-evaluation rather than two.
+			// An out-of-band request to re-evaluate, routed through the same
+			// debounce path a netlink event uses, so a nudge racing a real
+			// event coalesces into one re-evaluation.
 			scheduleReevaluate()
 
 		case <-debounceC:
@@ -288,26 +241,16 @@ func Watch(ctx context.Context, program *ebpf.Program, initial []string, w *Watc
 	}
 }
 
-// StartWatching runs Start and, if it succeeds, launches Watch in its own
-// goroutine (stopped when ctx is done) to keep the resolved interface set
-// re-evaluated against netlink link/route change events for the life of the
-// returned objects (design plan §4.1; Milestone 3.2). It is the production
-// entry point internal/installer.Run uses -- Start alone (Milestone 3.1)
-// only ever evaluates the interface set once, at startup.
+// StartWatching runs Start and, on success, launches Watch in its own goroutine
+// to keep the resolved interface set re-evaluated against netlink events for the
+// life of the returned objects. pinDir is the bpffs directory to pin into. Start
+// alone evaluates the interface set once, at startup.
 //
-// The returned *Watcher is StartWatching's caller's handle onto that
-// background loop -- Alive reports whether it is still running, and
-// Reconcile requests an out-of-band re-evaluation (see internal/installer's
-// health-check ticker, which uses both: it fails health if the watch loop
-// has died, and nudges a reconcile when the datapath's own health checks
-// fail, on the chance the failure is something Watch's reconcile can heal
-// without waiting for an unrelated netlink event or the liveness probe
-// restarting the container -- ecv's review of #283).
+// The returned *Watcher is the caller's handle on that loop: Alive reports
+// whether it still runs, and Reconcile requests an out-of-band re-evaluation.
 //
-// Canceling ctx stops the background watch loop; it does not Close objs --
-// the caller still owns objs and must Close it itself, exactly as with
-// Start (see the package doc comment for why that's safe against an
-// already-attached filter).
+// Canceling ctx stops the loop but does not close the returned objects. The
+// caller still owns and must close them, as with Start.
 func StartWatching(ctx context.Context, pinDir string) (
 	objs *prog.UsidObjects, ifaces []string, watcher *Watcher, err error,
 ) {
@@ -336,9 +279,8 @@ func toSet(names []string) map[string]struct{} {
 	return set
 }
 
-// diffSets returns, in sorted order (for deterministic logging and
-// testing), the names present in next but not current (added) and present
-// in current but not next (removed).
+// diffSets returns the names present in next but not current, and present in
+// current but not next, each sorted for deterministic logging and tests.
 func diffSets(current, next map[string]struct{}) (added, removed []string) {
 	for name := range next {
 		if _, ok := current[name]; !ok {
@@ -355,21 +297,17 @@ func diffSets(current, next map[string]struct{}) (added, removed []string) {
 	return added, removed
 }
 
-// reconcile brings the actual attachment state toward next, starting from
-// current (the last-known actually-attached set), and returns the
-// resulting actually-attached set.
+// reconcile brings the attached state toward next, starting from current, the
+// last-known attached set, and returns the resulting attached set.
 //
-// Every interface in next is (re-)attached unconditionally, not only ones
-// added since current -- see Watch's doc comment above for why a
-// diff-only reconcile (the original design) misses external drift that
-// clears the tc filter without ever changing the resolved interface set.
-// attachOne (FilterReplace) is idempotent, so re-asserting an
-// already-correctly-attached interface is a cheap no-op.
+// Every interface in next is re-attached unconditionally rather than only those
+// added since current, because a diff-only reconcile misses external drift that
+// clears the filter without changing the resolved set. Attaching is idempotent,
+// so re-asserting a correctly attached interface is a cheap no-op.
 //
-// A per-interface attach or detach failure is logged and that interface is
-// simply left out of (for a failed attach) or kept in (for a failed detach)
-// the returned set -- which means it is retried again on the next
-// reconcile, without any separate retry-tracking state.
+// A per-interface failure is logged, and that interface is left out of the
+// returned set on a failed attach or kept in it on a failed detach, which
+// retries it on the next reconcile with no separate retry state.
 func reconcile(program *ebpf.Program, current, next map[string]struct{}) map[string]struct{} {
 	added, removed := diffSets(current, next)
 	if len(added) != 0 || len(removed) != 0 {

--- a/internal/plumbing/ebpf/doc.go
+++ b/internal/plumbing/ebpf/doc.go
@@ -2,45 +2,28 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package ebpf is the umbrella directory for the TC-BPF uSID datapath that
-// replaced galactic's legacy per-endpoint seg6local ingress route model in
-// the 2026-08-02 direct cutover (internal/plumbing/srv6/srv6.go, deleted --
-// this datapath is now the only ingress/decap path). It holds no code of
-// its own; see design plan .local/plan-ebpf-xdp-usid-datapath.md and its
-// milestone breakdown, .local/implementation-plan-ebpf-xdp-usid-datapath.md,
-// for the full design. This file only orients a reader across the
-// sub-packages, roughly in the order a packet (and a reader) passes through
-// them:
+// Package ebpf is the umbrella directory for the TC-BPF uSID datapath, the only
+// ingress and decap path in this codebase. It holds no code of its own; this
+// file orients a reader across the sub-packages, roughly in the order a packet
+// passes through them:
 //
-//   - preflight: the kernel-capability check (BTF, HASH maps, SCHED_CLS,
-//     and specifically bpf_fib_lookup's VRF-tbid parameter) that must pass
-//     before anything below is loaded -- there is no partial/unsafe
-//     fallback.
-//   - uformat: the pure-Go bit-layout encode/decode library for the uFMT
-//     48+16 uSID carrier (Block/Node-ID/Function/Argument) -- no kernel
-//     dependency; shared by prog's map-key arithmetic and by
-//     internal/plumbing/srv6's ComputeSID so the kernel program and the Go
-//     control plane can never drift on bit positions.
-//   - prog: the compiled TC-BPF program itself (usid.c) and its bpf2go-
-//     generated Go bindings; the single source of truth for the 9-step
-//     packet path (parse, locator_table match, read Function, function_table
-//     match, read Argument, vrf_table match, strip outer header,
-//     bpf_fib_lookup, redirect).
-//   - attach: the load/pin/attach/detach/watch lifecycle that wires prog's
-//     compiled object into galactic-cni's `run` subcommand, including
-//     netlink-driven re-attachment when an interface/route change -- or an
-//     external event silently clearing the filter -- requires it.
-//   - usidmap: the read/write API that populates and reconciles
-//     locator_table/function_table/vrf_table, used by the CNI ADD path's
-//     registration call (internal/cnibgp/bgp.go) and by the GC controller's
-//     sweep (internal/gc).
-//   - metrics: Prometheus metrics and health-check event hooks spanning the
-//     whole datapath (load/attach events, drops by reason, per-Argument
-//     hit counters and Argument-space utilization).
+//   - preflight: the kernel-capability check that must pass before anything
+//     below is loaded. There is no partial fallback.
+//   - uformat: the pure-Go bit-layout library for the uFMT 48+16 uSID carrier,
+//     with no kernel dependency. Shared by the program's map-key arithmetic and
+//     by the control plane's SID computation, so the two cannot drift on bit
+//     positions.
+//   - prog: the compiled program itself and its generated bindings, and the
+//     single source of truth for the nine-step packet path.
+//   - attach: the load, pin, attach, detach, and watch lifecycle, including
+//     netlink-driven re-attachment when an interface or route change, or an
+//     external event silently clearing the filter, requires it.
+//   - usidmap: the read/write API that populates and reconciles the three
+//     control-plane maps, used by the CNI ADD path and by garbage collection.
+//   - metrics: Prometheus metrics and health event hooks spanning the whole
+//     datapath.
 //
-// internal/cnibgp and internal/gc are the two callers outside this tree that
-// drive usidmap's register/unregister/reconcile calls; internal/reconcile
-// and internal/plumbing/srv6's ComputeSID independently compute the same
-// SID this datapath decodes, for the BGP control-plane side of the same
-// design.
+// The CNI publish path and garbage collection are the two callers outside this
+// tree driving the map registrations; the BGP reconcilers independently compute
+// the same SID this datapath decodes.
 package ebpf

--- a/internal/plumbing/ebpf/edgeattach/attach.go
+++ b/internal/plumbing/ebpf/edgeattach/attach.go
@@ -21,33 +21,26 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
 )
 
-// linkByNameFn and linkListFn are package-level override points, the same
-// pattern internal/plumbing/ebpf/attach uses for its own identically-named
-// vars, so ResolveTargets' tests can substitute a fake netlink view without
-// touching the real host network stack.
+// linkByNameFn and linkListFn are override points, as elsewhere in this
+// codebase, so ResolveTargets' tests can substitute a fake netlink view without
+// touching the host network stack.
 var (
 	linkByNameFn = netlink.LinkByName
 	linkListFn   = netlink.LinkList
 )
 
-// PinDir is the default bpffs directory every edgeprog map is pinned
-// under -- deliberately distinct from internal/plumbing/ebpf/attach.PinDir
-// and internal/plumbing/ebpf/gwattach's own PinDir, so every datapath in
-// this codebase is fully independent under bpffs even where map names
-// don't actually collide.
+// PinDir is the default bpffs directory every edge program map is pinned under,
+// deliberately distinct from the other datapaths' directories so each is fully
+// independent under bpffs even where map names do not collide.
 const PinDir = "/sys/fs/bpf/galactic-edge"
 
-// preflightCheckFn is a package-level override point so tests can force
-// the preflight failure path without touching the real kernel -- same
-// pattern as internal/plumbing/ebpf/attach's identical var.
+// preflightCheckFn is an override point so tests can force the preflight
+// failure path without touching the real kernel.
 var preflightCheckFn = edgepreflight.Check
 
-// Load runs the kernel preflight check and, only if it passes, loads
-// edgeprog's compiled object with every map pinned under pinDir. A map
-// already pinned there from a previous process is reused as-is; see
-// internal/plumbing/ebpf/attach.Load's identical doc comment for the full
-// rationale (schema-mismatch recreation, pin-by-name semantics) -- not
-// repeated here, since it applies unchanged.
+// Load runs the kernel preflight check and, only if it passes, loads the edge
+// program with every map pinned under pinDir. A map already pinned there by a
+// previous process is reused as-is.
 func Load(pinDir string) (*edgeprog.EdgedsrObjects, error) {
 	if err := preflightCheckFn(); err != nil {
 		return nil, fmt.Errorf(
@@ -72,15 +65,12 @@ func Load(pinDir string) (*edgeprog.EdgedsrObjects, error) {
 	opts := &ebpf.CollectionOptions{Maps: ebpf.MapOptions{PinPath: pinDir}}
 	loadErr := spec.LoadAndAssign(&loaded, opts)
 	if loadErr != nil && errors.Is(loadErr, ebpf.ErrMapIncompatible) {
-		// Every map here is control-plane-owned and reconstructable
-		// (edgemap.VIPTable.Register repopulates vip_table from live
-		// NetworkRule CRDs; vip_stats_table is a pure cache the datapath
-		// itself repopulates from live traffic -- see edgedsr.c's struct
-		// vip_stats_value doc comment for why vip_stats_table exists
-		// separately from vip_table; encap_config_table is a single entry
-		// internal/gateway.NewKernelDatapath rewrites once at process
-		// startup) -- a stale pin from an older, incompatible map layout
-		// is safe to recreate rather than fatal.
+		// Every map here is control-plane-owned and reconstructable: the VIP
+		// table is repopulated from live CRDs, the statistics map is a
+		// pure cache the datapath refills from traffic, and the
+		// encapsulation config is a single entry rewritten at process
+		// startup. A stale pin from an incompatible layout is safe to
+		// recreate rather than fatal.
 		slog.Warn("edgeattach: pinned eBPF map incompatible with the newly compiled map spec, recreating "+
 			"(control-plane state will repopulate on the next NetworkRule reconcile)", "pinDir", pinDir, "err", loadErr)
 		if unpinErr := unpinIncompatibleMaps(spec, pinDir); unpinErr != nil {
@@ -120,26 +110,21 @@ func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
 	return errors.Join(errs...)
 }
 
-// ResolveTargets resolves ifaceName to the set of interface names Attach
-// should actually attach the XDP program to.
+// ResolveTargets resolves ifaceName to the interface names Attach should
+// actually attach the XDP program to.
 //
-// If ifaceName is not a Linux bonding master, the result is just
-// []string{ifaceName} -- the common case. If it is a bonding master, the
-// result is its slave interfaces instead, with ifaceName itself excluded:
-// unlike internal/plumbing/ebpf/attach's TC-BPF path (which attaches to
-// both a bond master and its slaves, since the master still carries the
-// route/tc-filter attachment point), native-mode XDP against a bonding
-// master is not reliable -- confirmed failing outright ("operation not
-// supported") on a real gateway node (802.3ad over an igb/tg3 slave pair).
-// Some kernels' bonding driver does implement ndo_bpf by forwarding the
-// attach to every slave, but that still requires each slave's own driver
-// to support native XDP -- not a given for every NIC driver (tg3 is a
-// commonly cited example that doesn't) -- so attaching to the master
-// remains something this package never relies on working, only to real
-// slaves whose own native XDP support this package can reason about
-// directly. A bonding master with no slaves is an error: silently falling
-// back to attaching nothing (or to the master, which would only risk
-// repeating the failure this function exists to avoid) would leave the
+// An interface that is not a bonding master resolves to itself, the common
+// case. A bonding master resolves to its slaves instead, with the master
+// excluded: unlike the TC-BPF path, which attaches to both because the master
+// still carries the filter attachment point, native XDP against a bonding
+// master is not reliable and fails outright on real hardware. Some kernels'
+// bonding driver does forward the attach to every slave, but that still
+// requires each slave's driver to support native XDP, which is not a given, so
+// this attaches only to real slaves whose support can be reasoned about
+// directly.
+//
+// A bonding master with no slaves is an error: attaching nothing, or attaching
+// to the master and risking the failure this exists to avoid, would leave the
 // gateway datapath running with no ingress attachment at all.
 func ResolveTargets(ifaceName string) ([]string, error) {
 	iface, err := linkByNameFn(ifaceName)
@@ -162,19 +147,15 @@ func ResolveTargets(ifaceName string) ([]string, error) {
 	return slaves, nil
 }
 
-// Attach attaches program (edgeprog.EdgedsrObjects.EdgeLb) to every
-// interface in ifaceNames' XDP hook in native (driver) mode, returning the
-// resulting link.Link for each -- in the same order as ifaceNames -- for
-// the caller to hold open and Close on shutdown. Callers resolve ifaceNames
-// via ResolveTargets first, so this is usually a single bond slave or
-// [ifaceName] itself, never the bond master (see ResolveTargets' own doc
-// comment for why); see doc.go for why native mode is required, not merely
-// preferred, and why no pinning or Watch-style re-attachment is needed
-// here.
+// Attach attaches program to the XDP hook of every interface in ifaceNames, in
+// native driver mode, returning the resulting link for each in the same order
+// for the caller to hold open and close on shutdown. Callers resolve ifaceNames
+// through ResolveTargets first, so this is usually a single interface and never
+// a bond master.
 //
-// If attaching to one interface fails partway through, every link already
-// attached in this call is Closed before returning the error -- a caller
-// that gets an error here holds no partial attachment to clean up itself.
+// If attaching one interface fails partway through, every link already attached
+// in this call is closed before returning, so a caller that gets an error holds
+// no partial attachment to clean up.
 func Attach(program *ebpf.Program, ifaceNames []string) ([]link.Link, error) {
 	if program == nil {
 		return nil, errors.New("edgeattach: program is nil")
@@ -197,9 +178,8 @@ func Attach(program *ebpf.Program, ifaceNames []string) ([]link.Link, error) {
 	return links, nil
 }
 
-// attachOne attaches program to ifaceName's XDP hook in native (driver)
-// mode -- the single-interface mechanism Attach applies to every name in
-// ifaceNames.
+// attachOne attaches program to ifaceName's XDP hook in native driver mode, the
+// single-interface mechanism Attach applies across its list.
 func attachOne(program *ebpf.Program, ifaceName string) (link.Link, error) {
 	iface, err := netlink.LinkByName(ifaceName)
 	if err != nil {

--- a/internal/plumbing/ebpf/edgeattach/doc.go
+++ b/internal/plumbing/ebpf/edgeattach/doc.go
@@ -2,52 +2,34 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package edgeattach loads internal/plumbing/ebpf/edgeprog's compiled XDP
-// program and attaches it to the gateway node's public/underlay-facing
-// uplink. Load mirrors internal/plumbing/ebpf/attach.Load's mechanics
-// (pinned maps, verifier-error unwrapping, incompatible-map recreation on a
-// schema change) almost verbatim, since none of that is
-// attach-mechanism-specific; Attach itself is genuinely new, not a port of
-// internal/plumbing/ebpf/gwattach's TC-BPF clsact+filter mechanics (the
-// earlier, rejected Geneve-based design) -- XDP attaches via a kernel
-// bpf_link (github.com/cilium/ebpf/link.AttachXDP), a different
-// netlink/bpf-link surface than TC's netlink.BpfFilter entirely.
+// Package edgeattach loads the compiled edge XDP program and attaches it to the
+// gateway node's underlay-facing uplink.
 //
-// The configured uplink (config.GatewayConfig.PublicInterface) is usually a
-// single physical interface, in which case ResolveTargets/Attach have
-// exactly one attach target, attached once at process startup. If it names
-// a Linux bonding master instead, ResolveTargets expands it to that bond's
-// slave interfaces and Attach attaches to every one of them -- native-mode
-// XDP against a bonding master is not reliable (see ResolveTargets' own
-// doc comment for the confirmed failure and why it's not simply "bonding
-// never implements ndo_bpf"), unlike internal/plumbing/ebpf/attach's
-// TC-BPF path, which attaches to both the master and its slaves. Either
-// way there is no
-// Watch-style netlink-driven re-attachment here: the attach target set is
-// resolved once at process startup and never revisited -- there is no
-// external network event (a Geneve device appearing, a NIC renumbering, a
-// bond's active slave changing) this package needs to notice on its own,
-// unlike internal/plumbing/ebpf/attach's SRv6 underlay-facing interface
-// set.
+// Load mirrors the uSID datapath's own loading mechanics almost verbatim,
+// pinned maps and incompatible-map recreation included, none of which is
+// attach-mechanism specific. Attach is genuinely different: XDP attaches
+// through a kernel bpf_link, a different surface than a TC filter entirely.
 //
-// Native XDP support is required, not merely preferred: Attach always
-// requests link.XDPDriverMode and returns an error rather than silently
-// retrying in link.XDPGenericMode (SKB mode) if the interface's driver
-// doesn't support it. Generic mode has materially different performance
-// characteristics -- accepting it silently would defeat the reason this
-// design chose XDP over TC-BPF in the first place, and violates the same
-// "no partial/unsafe fallback" invariant
-// internal/plumbing/ebpf/preflight/edgepreflight already hold the rest of
-// this datapath to.
+// The configured uplink is usually one physical interface, attached once at
+// process startup. One naming a bonding master is expanded to that bond's
+// slaves and every one is attached, native XDP against a bonding master being
+// unreliable.
 //
-// Unlike a TC-BPF filter (which persists in the kernel's qdisc structure
-// independent of any process holding a reference), an unpinned bpf_link
-// detaches automatically when the last file descriptor referencing it is
-// closed. This package does not pin the returned links: the owning process
-// (galactic-gateway) is expected to hold every one of them open for its own
-// lifetime and Close each on shutdown, the same "keep the fd, don't pin"
-// simplification gwattach's own AttachPublic used for its single fixed
-// interface. A process restart therefore has a genuinely clean slate -- no
-// existing attach to conflict with -- so there is no TC-FilterReplace-style
-// "replace what's already there" case to handle.
+// Either way there is no netlink-driven re-attachment here. The target set is
+// resolved once at startup and never revisited: there is no external event this
+// package needs to notice on its own, unlike the uSID datapath's underlay-facing
+// interface set.
+//
+// Native mode is required, not preferred. Attach always requests driver mode and
+// returns an error rather than silently retrying in generic mode, which has
+// materially different performance characteristics: accepting it silently would
+// defeat the reason this design chose XDP, and would violate the same no-partial-
+// fallback invariant the preflight checks hold the rest of the datapath to.
+//
+// Unlike a TC filter, which persists in the kernel independent of any process
+// holding a reference, an unpinned link detaches when the last descriptor
+// referencing it closes. This package does not pin the returned links: the
+// owning process holds them open for its lifetime and closes them on shutdown.
+// A restart therefore starts from a genuinely clean slate, with no existing
+// attachment to conflict with and so no replace case to handle.
 package edgeattach

--- a/internal/plumbing/ebpf/edgemap/doc.go
+++ b/internal/plumbing/ebpf/edgemap/doc.go
@@ -2,54 +2,40 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package edgemap implements the read/write API that populates
-// internal/plumbing/ebpf/edgeprog's vip_table -- the Maglev/DSR datapath's
-// only control-plane-writable map with a nontrivial schema. encap_config_table
-// (a single entry: this node's own SRv6-reachable encap source address) is
-// written directly by internal/gateway.NewKernelDatapath instead of through
-// a wrapper here -- one field, one Put call, at process startup only, not
-// worth a dedicated type.
+// Package edgemap implements the read/write API that populates the edge
+// Maglev datapath's vip_table, its only control-plane-writable map with a
+// nontrivial schema. encap_config_table, a single entry holding this node's
+// encapsulation source address, is written directly at process startup rather
+// than through a wrapper: one field, one call.
 //
-// vip_stats_table is a partial exception to "control-plane maps": this
-// package reads it (VIPTable.Get/List, to report a VIP's hit counters) and
-// deletes from it (VIPTable.Unregister, so a removed VIP's counters don't
-// linger), but never writes to it -- edgedsr.c populates every
-// vip_stats_table row itself, lazily, on a VIP's first matching packet. See
-// VIPTable.Register's doc comment for why (issue #361): vip_table and
-// vip_stats_table used to be one map (edgenat.c's rule_table/
-// rule_stats_table predecessor), and Register's read-modify-write to
-// preserve that map's counters across re-registration raced the datapath's
-// own per-packet increments into the same fields, discarding whichever
-// landed second. Splitting the counters into a map Register never touches
-// at all removes the race instead of narrowing it.
+// vip_stats_table is a partial exception. This package reads it, to report a
+// VIP's counters, and deletes from it, so a removed VIP's counters do not
+// linger, but never writes it: the datapath populates each row lazily on a
+// VIP's first matching packet.
 //
-// This package does not itself decide *when* to register anything, load the
-// program, or attach it to an interface -- that is internal/gateway.Engine's
-// job (via its Datapath interface) and internal/plumbing/ebpf/edgeattach's,
-// analogous to internal/plumbing/ebpf/attach but for this program.
+// The two were once one map, and Register's read-modify-write to preserve
+// counters across re-registration raced the datapath's per-packet increments
+// into the same fields, discarding whichever landed second. Splitting the
+// counters into a map Register never touches removes the race rather than
+// narrowing it.
 //
-// # Why VIPTable carries a Generation field
+// This package decides nothing about when to register, and neither loads nor
+// attaches the program. Those are the engine's and the attach package's jobs.
 //
-// internal/gateway.Engine is a single long-lived process, but it can still
-// crash mid-reconcile and leave vip_table entries behind with no
-// corresponding NetworkRule left to reconcile them against.
-// VIPTable.Reconcile's cutoff/Generation mechanism guards exactly that
-// crash-restart window -- the same register-after-snapshot-is-safe
-// guarantee internal/plumbing/ebpf/usidmap.VRFTable's identical mechanism
-// already documents. Generation lives on vip_table's own value
-// (EdgedsrVipValue), not vip_stats_table -- it is stamped by Register, which
-// never touches vip_stats_table (see above).
+// # Why VIPTable carries a generation
+//
+// The engine is a single long-lived process, but it can crash mid-reconcile and
+// leave entries behind with no rule left to reconcile them against. Reconcile's
+// cutoff guards exactly that restart window, the same register-after-snapshot
+// guarantee usidmap.VRFTable documents. The generation lives on vip_table's own
+// value, not on the stats map, since Register never touches that one.
 //
 // # Testability
 //
-// VIPTable is built against the Table interface (table.go), not directly
-// against *ebpf.Map -- KernelTable adapts a real, loaded map (e.g.
-// edgeprog.EdgedsrObjects.VipTable) for production use, while this
-// package's own tests substitute an in-memory fake implementation to
-// exercise register/unregister/reconcile logic without a kernel or root
-// privileges. Table/Iterator/KernelTable are a deliberate duplicate of
-// usidmap's identical types, not an import of them -- this package and
-// usidmap serve two unrelated datapaths (edge ingress Maglev/DSR LB vs.
-// SRv6 uSID decap) with no shared map/key layout, so importing usidmap
+// VIPTable is built against the Table interface rather than directly against a
+// loaded map: KernelTable adapts a real map for production, and tests
+// substitute an in-memory fake. Table, Iterator, and KernelTable are a
+// deliberate duplicate of usidmap's rather than an import: the two packages
+// serve unrelated datapaths with no shared map or key layout, so importing
 // would gain nothing but coupling.
 package edgemap

--- a/internal/plumbing/ebpf/edgemap/table.go
+++ b/internal/plumbing/ebpf/edgemap/table.go
@@ -9,50 +9,42 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Table is the minimal map-operation surface every table type in this
-// package is written against, instead of directly against *ebpf.Map. Its
-// method set matches *ebpf.Map's own Put/Lookup/Delete/Iterate closely
-// enough that KernelTable (below) is a one-line adapter; this package's
-// own tests substitute a fake, in-memory implementation to exercise
-// register/unregister/reconcile logic without a kernel or root
-// privileges -- see internal/plumbing/ebpf/usidmap's identical Table
-// interface, which this one deliberately duplicates rather than imports
-// (see doc.go).
+// Table is the minimal map-operation surface every table type in this package is
+// written against, rather than a loaded map directly. Its method set is close
+// enough to the real map's that KernelTable is a one-line adapter, and tests
+// substitute an in-memory fake to exercise register, unregister, and reconcile
+// logic without a kernel or root. It duplicates the uSID map layer's identical
+// interface rather than importing it; see the package doc comment.
 type Table interface {
 	// Put creates or overwrites the map entry at key with value.
 	Put(key, value any) error
 
-	// Lookup reads the map entry at key into valueOut. It returns
-	// ebpf.ErrKeyNotExist (or, for a fake Table, an error satisfying
-	// errors.Is(err, ebpf.ErrKeyNotExist)) if key is absent.
+	// Lookup reads the entry at key into valueOut, returning an error matching
+	// ebpf.ErrKeyNotExist when key is absent.
 	Lookup(key, valueOut any) error
 
 	// Delete removes the map entry at key. It returns ebpf.ErrKeyNotExist
 	// (see Lookup) if key is already absent.
 	Delete(key any) error
 
-	// Iterate returns an Iterator walking every entry currently in the
-	// map, in unspecified order -- matching *ebpf.Map.Iterate's own
-	// documented behavior.
+	// Iterate returns an Iterator over every entry currently in the map, in
+	// unspecified order.
 	Iterate() Iterator
 }
 
 // Iterator matches *ebpf.MapIterator's own Next/Err method set.
 type Iterator interface {
-	// Next decodes the next key/value pair into keyOut/valueOut and
-	// reports whether one was available. Callers must check Err after
-	// Next returns false to distinguish "iteration finished" from "an
-	// error interrupted iteration."
+	// Next decodes the next pair into keyOut and valueOut and reports whether
+	// one was available. Callers must check Err after it returns false, to tell
+	// a finished iteration from an interrupted one.
 	Next(keyOut, valueOut any) bool
 
 	// Err returns the first error encountered during iteration, if any.
 	Err() error
 }
 
-// KernelTable adapts a real, loaded *ebpf.Map -- e.g.
-// edgeprog.EdgedsrObjects.VipTable, once loaded by
-// internal/plumbing/ebpf/edgeattach -- to the Table interface every table
-// type in this package is written against.
+// KernelTable adapts a real, loaded map to the Table interface every table type
+// in this package is written against.
 type KernelTable struct {
 	Map *ebpf.Map
 }
@@ -62,12 +54,10 @@ func (k KernelTable) Lookup(key, valueOut any) error { return k.Map.Lookup(key, 
 func (k KernelTable) Delete(key any) error           { return k.Map.Delete(key) }
 func (k KernelTable) Iterate() Iterator              { return k.Map.Iterate() }
 
-// clockFn is a package-level override point so tests can control the
-// generation values Register/Generation observe deterministically, instead
-// of racing against a real, always-advancing clock. Production code always
-// leaves this at its default, monotonicNow -- same CLOCK_MONOTONIC choice,
-// for the same wall-clock-can-jump-backwards reason, as
-// internal/plumbing/ebpf/usidmap/table.go's identical function.
+// clockFn is an override point so tests can control the generation values
+// deterministically instead of racing a real, always-advancing clock. It uses
+// the monotonic clock for the same reason the uSID map layer does: a wall clock
+// can jump backwards.
 var clockFn = monotonicNow
 
 func monotonicNow() uint64 {

--- a/internal/plumbing/ebpf/edgemap/viptable.go
+++ b/internal/plumbing/ebpf/edgemap/viptable.go
@@ -14,67 +14,47 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/edgeprog"
 )
 
-// MaxBackends is edgedsr.c's EDGE_MAX_BACKENDS, hand-kept in sync -- bpf2go's
-// -type flag generates a Go struct matching struct vip_value's fixed-size
-// Backends array, but the #define itself has no BTF representation to
-// generate a Go constant from (same reason
-// internal/plumbing/ebpf/prog/dropreason.go's constants are hand-kept, not
-// generated). Register rejects more backends than this before ever writing
-// to the map, rather than letting a silently-truncated Put succeed. Matches
-// NetworkRuleSpec.Backends' own +kubebuilder:validation:MaxItems=64
-// (go.datum.net/network's rule_types.go) -- edgenat.c's predecessor rule_key
-// capped this at 8, silently below the CRD's own advertised limit; closed as
-// a side effect of the DSR/Maglev rewrite rather than carried forward
-// unexamined.
+// MaxBackends mirrors the datapath's own backend cap, hand-kept in sync: the
+// generated Go struct matches the fixed-size array, but a C define has no BTF
+// representation to generate a constant from. Register rejects more backends
+// than this before writing, rather than letting a silently truncated write
+// succeed. It matches the CRD's own maximum.
 const MaxBackends = 64
 
-// MaglevTableSize is edgedsr.c's EDGE_MAGLEV_TABLE_SIZE, hand-kept in sync
-// for the same reason as MaxBackends. It is the fixed slot count of
-// vip_value's own maglev_table array -- every Register call must supply a
-// [MaglevTableSize]byte array built from internal/maglev.Table's own
-// Backends()/Lookup() (see kerneldatapath.go's buildMaglevBackends), sized
-// to exactly this constant, not internal/maglev.Table's own configurable
-// Size().
+// MaglevTableSize mirrors the datapath's Maglev table slot count, hand-kept in
+// sync for the same reason as MaxBackends. Every Register call must supply an
+// array of exactly this size, not one sized to the Maglev builder's own
+// configurable size.
 const MaglevTableSize = 1021
 
-// MaxVIPTableEntries is vip_table's own __uint(max_entries, ...) in
-// edgedsr.c, hand-kept in sync for the same reason as MaxBackends (a map's
-// max_entries has no BTF representation bpf2go could generate a Go constant
-// from). internal/gateway's QuotaEnforcer uses this as the hard ceiling
-// protecting the shared map's fixed capacity across every tenant on the
-// node -- vip_table itself has no notion of "full,"
-// bpf_map_update_elem simply starts failing once it is, so this quota exists
-// to fail closed at the control-plane admission point instead.
+// MaxVIPTableEntries mirrors vip_table's own maximum entry count, hand-kept in
+// sync for the same reason as MaxBackends. The engine's quota enforcer uses it
+// as the hard ceiling protecting the shared map's capacity across every tenant
+// on the node: the map itself has no notion of full, updates simply start
+// failing once it is, so the quota fails closed at admission instead.
 const MaxVIPTableEntries = 4096
 
-// beU16 converts v between host and big-endian ("network") representation
-// by a full 2-byte swap -- its own inverse, so this same function is used
-// for both directions. Required because edgeprog's generated Go structs
-// store a C __be16 field as a plain uint16, and cilium/ebpf's BTF-based
-// marshalling writes it using the host's native (little-endian, on every
-// architecture this repo targets) byte order with no swap of its own.
+// beU16 swaps a uint16 between host and network byte order. A full 2-byte swap
+// is its own inverse, so one function serves both directions. Needed because
+// the generated Go structs store a big-endian C field as a plain uint16, which
+// the marshalling writes in host order with no swap.
 func beU16(v uint16) uint16 {
 	return v<<8 | v>>8
 }
 
-// VIPKey identifies one vip_table row: (proto, VIP port, VIP address). No
-// tenant dimension here -- a VIP is globally unique by construction (it's a
-// public address), so this key never needs one; see edgedsr.c's struct
-// vip_key doc comment.
+// VIPKey identifies one vip_table row: protocol, VIP port, and VIP address.
+// There is no tenant dimension, a VIP being globally unique by construction.
 type VIPKey struct {
 	Proto uint8
 	VPort uint16
 	VIP   netip.Addr
 }
 
-// Backend is one VIPEntry load-balancing target: the backend Pod's own
-// address/port, plus the SRv6 uSID of the worker node it's reachable
-// through -- resolved by the caller (internal/gateway's control plane) the
-// same way any other cross-node SRv6 destination is, never parsed from a
-// packet. Unchanged from edgenat.c's predecessor Backend type: DSR still
-// needs exactly these three fields, it just never rewrites Addr/Port for
-// NAT purposes, only carries them through as identifying metadata (see
-// edgedsr.c's struct backend doc comment).
+// Backend is one load-balancing target: the backend pod's address and port,
+// plus the SRv6 uSID of the worker node reaching it, resolved by the control
+// plane like any other cross-node SRv6 destination and never parsed from a
+// packet. The address and port are carried through as identifying metadata and
+// never rewritten.
 type Backend struct {
 	Addr netip.Addr
 	Port uint16
@@ -86,62 +66,52 @@ type VIPEntry struct {
 	VIPKey
 	Backends []Backend
 
-	// MaglevTable is the precomputed Maglev lookup table this entry was
-	// registered with -- MaglevTable[slot] is an index into Backends,
-	// sorted in the same order internal/maglev.Table.Backends() returns
-	// (see kerneldatapath.go's buildMaglevBackends). Callers reading this
-	// back (e.g. diagnostics) must not mutate it.
+	// MaglevTable is the precomputed lookup table this entry was registered
+	// with: each slot holds an index into Backends, in the order the Maglev
+	// builder returns them. A caller reading it back must not mutate it.
 	MaglevTable [MaglevTableSize]byte
 
-	// Generation is this table's monotonic-clock reading at the time this
-	// entry was last written by Register -- see doc.go's "why VIPTable
-	// carries a Generation field" section.
+	// Generation is this table's monotonic-clock reading when Register last
+	// wrote this entry. See the package doc comment.
 	Generation uint64
 
-	// Packets/Bytes/DroppedPackets/LastSeenNs are per-VIP hit counters
-	// maintained by the datapath itself (edgedsr.c's vip_stats_table).
-	// Packets counts every packet that matched this VIP+port+protocol,
-	// regardless of outcome; DroppedPackets is the subset of those the
-	// datapath then dropped (count_claimed_drop) -- so DroppedPackets is
-	// always <= Packets. LastSeenNs is a CLOCK_MONOTONIC nanosecond
-	// timestamp of the most recent matching packet, 0 if none yet.
+	// Packets, Bytes, DroppedPackets, and LastSeenNs are per-VIP counters
+	// maintained by the datapath. Packets counts every packet matching this
+	// VIP, port, and protocol whatever the outcome, and DroppedPackets is the
+	// subset the datapath then dropped, so it never exceeds Packets. LastSeenNs
+	// is a monotonic nanosecond timestamp of the most recent match, 0 if none.
 	//
-	// These live in a separate map from the rest of VIPEntry (vip_table
-	// itself), keyed identically -- see Register's doc comment for why
-	// (issue #361): Register never reads or writes them, so re-registering
-	// a VIP (e.g. every controller reconcile pass) can never race, and
-	// therefore never lose, the datapath's own increments. A key with no
-	// vip_stats_table row yet (a VIP that has never seen a matching packet)
-	// reads back as all zero, not an error.
+	// They live in a separate map from the rest of the entry, keyed identically,
+	// so Register never reads or writes them and re-registering a VIP cannot
+	// race, and so lose, the datapath's increments. A key with no stats row yet
+	// reads back as all zero rather than an error.
 	Packets        uint64
 	Bytes          uint64
 	DroppedPackets uint64
 	LastSeenNs     uint64
 }
 
-// VIPTable is the read/write API for vip_table and vip_stats_table
-// together -- two separate eBPF maps, keyed identically (VIPKey), that this
-// type presents as one logical table (see Register's doc comment for why
-// they're split: issue #361). table backs vip_table (config: backend list,
-// Maglev lookup table, Generation); stats backs vip_stats_table (the
-// datapath's own hit counters -- Register never touches it).
+// VIPTable is the read/write API for vip_table and vip_stats_table together,
+// two separate maps keyed identically that this type presents as one logical
+// table. table holds the configuration: backend list, Maglev table, and
+// generation. stats holds the datapath's counters, which Register never
+// touches.
 type VIPTable struct {
 	table Table
 	stats Table
 	clock func() uint64
 }
 
-// NewVIPTable wraps table (vip_table) and stats (vip_stats_table) as a
-// VIPTable. Production callers pass two KernelTables wrapping a loaded
-// *edgeprog.EdgedsrObjects's VipTable/VipStatsTable map fields; tests pass
-// fake Tables.
+// NewVIPTable wraps the configuration and statistics maps as a VIPTable.
+// Production callers pass kernel tables over the two loaded maps; tests pass
+// fakes.
 func NewVIPTable(table, stats Table) *VIPTable {
 	return &VIPTable{table: table, stats: stats, clock: clockFn}
 }
 
 // Generation returns a snapshot of this table's monotonic clock. A caller
-// intending to call Reconcile must capture this immediately *before*
-// listing the NetworkRule CRDs that will become Reconcile's live set.
+// intending to call Reconcile must read it immediately before listing the CRDs
+// that become that call's live set.
 func (t *VIPTable) Generation() uint64 {
 	return t.clock()
 }
@@ -167,23 +137,15 @@ func toWireBackends(backends []Backend) ([MaxBackends]edgeprog.EdgedsrBackend, e
 	return out, nil
 }
 
-// Register writes (or overwrites) the vip_table entry for key, mapping it
-// to backends and maglevTable and stamping it with this table's current
-// Generation. maglevTable[slot] must be an index into backends (i.e. into
-// the same slice, in the same order) -- see kerneldatapath.go's
-// buildMaglevBackends for how the caller builds both together from a
-// DesiredRule's backend list. Rejects an empty or over-capacity backend
-// list before ever writing to the map, per MaxBackends' doc comment.
+// Register writes, or overwrites, the vip_table entry for key, mapping it to
+// backends and maglevTable and stamping it with the current generation. Each
+// slot of maglevTable must be an index into backends, in the same order.
+// Rejects an empty or over-capacity backend list before writing.
 //
-// This is a blind overwrite of vip_table, not a read-modify-write -- same
-// issue #361 rationale as edgenat.c's predecessor rule_table.Register: it
-// never touches vip_stats_table at all, so it has nothing to race against
-// the datapath's own per-packet __sync_fetch_and_add calls into that map.
-// Moving the counters to their own map (vip_stats_table, populated lazily
-// by the datapath itself, never by this method) closes the race instead of
-// narrowing it: nothing this method does can ever discard a concurrent
-// datapath increment, because this method has no reason to read or write
-// that map.
+// A blind overwrite rather than a read-modify-write, because it never touches
+// the statistics map and so has nothing to race against the datapath's
+// per-packet increments. Keeping the counters in a map this method has no
+// reason to read closes that race rather than narrowing it.
 func (t *VIPTable) Register(key VIPKey, backends []Backend, maglevTable [MaglevTableSize]byte) error {
 	if len(backends) == 0 {
 		return fmt.Errorf("edgemap: vip_table: register %+v: at least one backend is required", key)
@@ -215,21 +177,16 @@ func (t *VIPTable) Register(key VIPKey, backends []Backend, maglevTable [MaglevT
 }
 
 // Unregister removes the vip_table entry for key, if present, and its
-// vip_stats_table counterpart, if any (best-effort past that point -- see
-// below). Not an error if either is already absent.
+// statistics row, if any. Neither being present is not an error.
 //
-// Deleting the stats row too, rather than leaving it behind, keeps
-// vip_stats_table from accumulating rows for VIPs that no longer exist:
-// unlike vip_table, whose capacity is enforced up front by
-// internal/gateway's QuotaEnforcer, nothing else here bounds
-// vip_stats_table's own occupancy, and it is a plain BPF_MAP_TYPE_HASH
-// (edgedsr.c), not self-evicting the way an LRU map would be. If the stats
-// delete fails after the config delete already succeeded, the VIP itself is
-// still gone (the caller's Reconcile/RemoveRule sees it as removed); the
-// orphaned stats row is a latent leak, not a correctness problem for
-// anything reading vip_table, so this reports the error rather than
-// silently swallowing it, but does not roll back the config delete to "fix"
-// it.
+// The statistics row is deleted rather than left behind so that map does not
+// accumulate rows for VIPs that no longer exist: unlike vip_table, whose
+// capacity the quota enforcer bounds up front, nothing else bounds it, and it
+// is a plain hash map rather than a self-evicting one.
+//
+// If the statistics delete fails after the configuration delete succeeded, the
+// VIP is still gone and the orphaned row is a latent leak rather than a
+// correctness problem, so the error is reported without rolling back.
 func (t *VIPTable) Unregister(key VIPKey) error {
 	wireKey, err := toWireKey(key)
 	if err != nil {
@@ -244,9 +201,9 @@ func (t *VIPTable) Unregister(key VIPKey) error {
 	return nil
 }
 
-// lookupStats reads vip_stats_table's row for wireKey, defaulting to the
-// zero value (a VIP that has never seen a matching packet has no row yet --
-// see VIPEntry's doc comment) rather than treating a miss as an error.
+// lookupStats reads the statistics row for wireKey, defaulting to the zero
+// value rather than treating a miss as an error: a VIP that has never seen a
+// matching packet has no row yet.
 func (t *VIPTable) lookupStats(wireKey edgeprog.EdgedsrVipKey) (edgeprog.EdgedsrVipStatsValue, error) {
 	var stats edgeprog.EdgedsrVipStatsValue
 	if err := t.stats.Lookup(wireKey, &stats); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
@@ -322,12 +279,10 @@ func (t *VIPTable) List() ([]VIPEntry, error) {
 	return entries, nil
 }
 
-// Reconcile brings vip_table into agreement with live -- the caller's
-// current set of VIPKeys that have a live NetworkRule CRD -- removing every
-// vip_table entry whose key is absent from live, *except* an entry whose
-// Generation is >= cutoff (it was written after the caller's live snapshot
-// was taken, so deleting it could race a fresh Register). See doc.go's "why
-// VIPTable carries a Generation field."
+// Reconcile brings vip_table into agreement with live, the caller's current set
+// of keys backed by a live NetworkRule, removing every entry whose key is absent
+// from live except one whose generation is at or above cutoff, which was written
+// after the caller's snapshot and could race a fresh Register.
 func (t *VIPTable) Reconcile(live map[VIPKey]struct{}, cutoff uint64) (removed []VIPEntry, err error) {
 	entries, err := t.List()
 	if err != nil {

--- a/internal/plumbing/ebpf/edgemetrics/collector.go
+++ b/internal/plumbing/ebpf/edgemetrics/collector.go
@@ -16,38 +16,30 @@ import (
 
 const namespace = "galactic_edge"
 
-// DropReasonsReader abstracts drop_reasons's per-CPU lookup (a
-// BPF_MAP_TYPE_PERCPU_ARRAY keyed by drop reason index) down to the one
-// operation Collector needs, so tests can substitute an in-memory fake
-// instead of a real, kernel-loaded map -- same interface shape as
-// internal/plumbing/ebpf/metrics's identical type. *ebpf.Map already
-// satisfies this interface structurally.
+// DropReasonsReader narrows the drop-reason map, a per-CPU array keyed by
+// reason index, to the one operation Collector needs, so tests can substitute an
+// in-memory fake. A real loaded map already satisfies it structurally.
 type DropReasonsReader interface {
 	Lookup(key, valueOut any) error
 }
 
-// Collector is a prometheus.Collector reading the edge gateway's live eBPF
-// map state at every scrape: per-VIP hit counters from vip_table/
-// vip_stats_table, and drops by reason (package doc comment). Unlike this
-// package's Full-NAT predecessor, there is no conn_table here at all --
-// DSR keeps no per-flow state to report on (see edgedsr.c's own header
-// comment).
+// Collector reads the edge gateway's live map state at every scrape: per-VIP
+// counters and drops by reason. There is no connection table here at all, direct
+// server return keeping no per-flow state to report.
 type Collector struct {
 	vipTable    *edgemap.VIPTable
 	dropReasons DropReasonsReader
 }
 
-// NewCollector builds a Collector from already-constructed values, so tests
-// can pass fakes (a fake edgemap.Table wrapped in edgemap.NewVIPTable, and
-// any DropReasonsReader) without a kernel. Production callers normally use
+// NewCollector builds a Collector from already-constructed values, so tests can
+// pass fakes without a kernel. Production callers normally use
 // NewCollectorFromObjects.
 func NewCollector(vipTable *edgemap.VIPTable, dropReasons DropReasonsReader) *Collector {
 	return &Collector{vipTable: vipTable, dropReasons: dropReasons}
 }
 
 // NewCollectorFromObjects builds a Collector reading directly from a loaded
-// *edgeprog.EdgedsrObjects's vip_table/vip_stats_table/drop_reasons maps --
-// e.g. the object internal/plumbing/ebpf/edgeattach.Load returns.
+// object set's maps.
 func NewCollectorFromObjects(objs *edgeprog.EdgedsrObjects) *Collector {
 	return NewCollector(
 		edgemap.NewVIPTable(edgemap.KernelTable{Map: objs.VipTable}, edgemap.KernelTable{Map: objs.VipStatsTable}),
@@ -117,11 +109,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.collectDrops(ch)
 }
 
-// protoLabel renders a vip_key.proto value as a metric label -- the
-// IANA-numeric value's name where this package knows it (tcp/udp, the
-// only two protocols NetworkRuleSpec.Protocol accepts), the raw number
-// otherwise, so an unrecognized value is still visible rather than
-// silently dropped.
+// protoLabel renders a protocol number as a metric label: its name where this
+// package knows it, and the raw number otherwise, so an unrecognized value is
+// still visible rather than silently dropped.
 func protoLabel(proto uint8) string {
 	switch proto {
 	case 6:

--- a/internal/plumbing/ebpf/edgemetrics/doc.go
+++ b/internal/plumbing/ebpf/edgemetrics/doc.go
@@ -2,34 +2,22 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package edgemetrics implements the edge XDP Maglev/DSR gateway's
-// Prometheus instrumentation, following the same split
-// internal/plumbing/ebpf/metrics already established for the SRv6 uSID
-// datapath:
+// Package edgemetrics implements the edge XDP gateway's Prometheus
+// instrumentation, following the same split as the uSID datapath's:
 //
-//   - Per-VIP hit counters (Packets/Bytes/DroppedPackets, current backend
-//     count) and drop-by-reason state are all *state currently held in a
-//     BPF map* -- vip_table, vip_stats_table, drop_reasons. Collector
-//     (collector.go) reads these live, directly from the map, at every
-//     Prometheus scrape via a custom prometheus.Collector, rather than
-//     mirroring them into incrementally-Set() Gauges: a vip_table entry
-//     internal/gateway.Engine.ReconcileOrphans removes simply stops being
-//     emitted on the *next* scrape this way, instead of leaking a stale
-//     label combination forever (a Gauge/GaugeVec has no way to "expire" a
-//     label combination on its own; only a Collector that re-derives its
-//     label set from the live source of truth at every Collect() call
-//     gets that for free).
-//   - Rule applications rejected before ever reaching the datapath (e.g.
-//     QuotaEnforcer denials) are a control-plane-only fact with no BPF map
-//     to read it back from -- that is
-//     internal/gateway.PrometheusTelemetryEmitter's ordinary CounterVec,
-//     incremented in place at Engine's own call sites, not this package's
-//     concern.
+//   - Per-VIP counters, backend counts, and drops by reason are state
+//     currently held in a BPF map, read live at every scrape through a custom
+//     collector rather than mirrored into gauges. An entry the engine's orphan
+//     sweep removes then stops being emitted on the next scrape, instead of
+//     leaking a stale label combination forever: a gauge cannot expire one,
+//     while a collector that re-derives its label set at every collection gets
+//     that for free.
+//   - Rule applications rejected before reaching the datapath, such as a quota
+//     denial, are a control-plane fact with no map to read them back from.
+//     Those are an ordinary counter incremented at the engine's own call sites,
+//     not this package's concern.
 //
-// Unlike this package's Full-NAT edgenat.c-backed predecessor, there is no
-// conn_table utilization metric here at all: DSR keeps no per-flow state
-// to report on (see edgedsr.c's own header comment), and there is no
-// per-rule primary/secondary placement metric either -- DSR's anycast
-// model means every gateway node serves every VIP identically, with no
-// primary/secondary distinction left to report.
+// There is no connection-table utilization metric: direct server return keeps
+// no per-flow state to report. There is no per-rule placement metric either,
+// every gateway node serving every VIP identically under anycast.
 package edgemetrics

--- a/internal/plumbing/ebpf/edgepreflight/kernel_prober.go
+++ b/internal/plumbing/ebpf/edgepreflight/kernel_prober.go
@@ -15,33 +15,25 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 )
 
-// bpfFuncXDPAdjustHead is the raw BPF_FUNC_xdp_adjust_head helper ID from
-// the kernel UAPI's enum bpf_func_id (include/uapi/linux/bpf.h). This
-// numeric ID is stable ABI once a helper is introduced -- unlike
-// preflight's tbid check, no BTF struct-field probe is possible for "does
-// this helper exist," so features.HaveProgramHelper (the same
-// creation-attempt technique preflight's own SchedCLS/HashMap checks use,
-// just applied to a specific helper rather than a program/map type) is the
-// house convention here instead of a version-string heuristic.
+// bpfFuncXDPAdjustHead is the raw helper ID from the kernel's helper enum. That
+// numeric ID is stable ABI once a helper is introduced.
 //
-// github.com/cilium/ebpf v0.22.0's asm package does not export a named
-// constant for this helper (BuiltinFunc constants are resolved per platform
-// via BuiltinFuncForPlatform for helpers the library hasn't
-// special-cased) -- cited directly against the raw enum value confirmed
-// empirically on this repo's target kernel (7.1.3-200.fc44.x86_64) during
-// this design's Phase 0 spike.
+// No BTF struct-field probe is possible for whether a helper exists, unlike the
+// uSID datapath's table-id check, so support is detected by attempting to load a
+// program using it, the same technique the program and map type checks use.
+//
+// The eBPF library exports no named constant for this helper, resolving such
+// constants per platform for helpers it has not special-cased, so the raw enum
+// value is cited directly.
 const bpfFuncXDPAdjustHead asm.BuiltinFunc = 44
 
-// KernelProber is the real, kernel-backed [Prober] implementation used in
-// production. It probes the actual running kernel via
-// github.com/cilium/ebpf's features package (which detects support by
-// actually attempting the create/load syscall) and via kernel BTF
-// introspection for BTF presence.
+// KernelProber is the real Prober implementation. It probes the running kernel
+// by attempting the create and load syscalls, and by BTF introspection for BTF
+// presence.
 //
-// The zero value is not ready to use; construct with [NewKernelProber]. A
-// *KernelProber may be reused across multiple Check/CheckWith calls -- its
-// one piece of internal state (the loaded kernel BTF spec) is cached after
-// the first probe that needs it.
+// The zero value is not ready to use; construct with NewKernelProber. One may be
+// reused across calls: its only internal state, the loaded BTF spec, is cached
+// after the first probe that needs it.
 type KernelProber struct {
 	specOnce sync.Once
 	spec     *btf.Spec
@@ -53,9 +45,8 @@ func NewKernelProber() *KernelProber {
 	return &KernelProber{}
 }
 
-// XDP implements [Prober] by attempting to create a minimal
-// BPF_PROG_TYPE_XDP program and reporting whether the kernel accepted the
-// program type.
+// XDP reports whether the kernel accepts the XDP program type, by attempting to
+// create a minimal program of that type.
 func (k *KernelProber) XDP() error {
 	if err := ensureMemlockRemoved(); err != nil {
 		return err

--- a/internal/plumbing/ebpf/edgepreflight/preflight.go
+++ b/internal/plumbing/ebpf/edgepreflight/preflight.go
@@ -2,55 +2,37 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package edgepreflight implements the startup kernel-capability check for
-// internal/plumbing/ebpf/edgeprog's XDP Maglev/DSR load-balancing gateway
-// datapath.
+// Package edgepreflight implements the startup kernel-capability check for the
+// XDP Maglev load-balancing gateway datapath.
 //
-// This is a sibling of internal/plumbing/ebpf/preflight, not an extension
-// of it: that package's Prober interface is scoped specifically to the
-// SRv6 uSID TC-BPF datapath's own capability list (SCHED_CLS, plain
-// BPF_MAP_TYPE_HASH, bpf_fib_lookup's tbid parameter) and forcing every
-// caller of either datapath to satisfy the union of both lists would be
-// worse interface hygiene than two small, focused ones (CONVENTIONS.md:
-// "prefer creating a focused sub-package over adding to an existing large
-// one"). The two datapaths' checks are structurally identical (a Prober
-// interface + KernelProber + capabilityChecks + Check/CheckWith) but list
-// genuinely different capabilities:
+// It is a sibling of internal/plumbing/ebpf/preflight, not an extension: that
+// package's probe interface is scoped to the SRv6 uSID datapath's own
+// capability list, and forcing every caller of either datapath to satisfy the
+// union would be worse than two small focused interfaces. The two are
+// structurally identical but list genuinely different capabilities:
 //
-//   - BPF_PROG_TYPE_XDP itself.
-//   - bpf_xdp_adjust_head -- edgedsr.c grows the packet by 40 bytes to make
-//     room for the pushed outer SRv6 header on every claimed-VIP packet.
-//     This helper has no __sk_buff-based equivalent usid.c's preflight
-//     needed to check for.
-//   - BPF_MAP_TYPE_HASH -- vip_table and vip_stats_table are both this
-//     type; already covered by preflight's HashMap check conceptually but
-//     probed again here independently so this package has no runtime
-//     dependency on the other one.
-//   - Kernel BTF, for the same CO-RE-adjacent reason usid.c's preflight
-//     requires it: edgedsr.c is compiled with -g and bpf2go's generated Go
-//     bindings for vip_value/vip_stats_value/backend/encap_config depend
-//     on the running kernel accepting BTF-annotated map value types.
+//   - The XDP program type itself.
+//   - bpf_xdp_adjust_head, which the datapath uses to grow the packet for the
+//     pushed outer header. It has no sk_buff-based equivalent the other
+//     package needed to check.
+//   - The hash map type, which both this datapath's maps use. Probed here
+//     independently so this package has no runtime dependency on the other.
+//   - Kernel BTF, since the program is compiled with debug info and the
+//     generated bindings depend on the kernel accepting annotated map value
+//     types.
 //
-// Deliberately NOT checked here, unlike this package's Full-NAT edgenat.c
-// predecessor: BPF_MAP_TYPE_LRU_HASH (that was conn_table's type; DSR has
-// no conn_table at all, see edgedsr.c's own header comment) and
-// bpf_csum_diff (Full-NAT needed it to fix up checksums after DNAT/SNAT;
-// DSR forwards every packet completely unmodified, so its own checksum is
-// already correct and this program never touches one). Removed as a direct
-// consequence of the DSR/Maglev rewrite, not carried forward unexamined.
+// Deliberately not checked: the LRU hash type and the checksum-diff helper.
+// This datapath has no connection table, and it forwards every packet
+// unmodified, so its checksum is already correct and it never touches one.
 //
-// Also deliberately NOT checked here: whether a specific interface's driver
-// supports *native* (driver-mode) XDP attach, as opposed to generic
-// (SKB-mode) attach. That is a per-interface, per-driver property (the
-// design's own spike found the geneve driver lacks it entirely, while a
-// veth or a real NIC's driver normally has it) -- it cannot be answered in
-// the abstract the way "does this kernel support BPF_PROG_TYPE_XDP at all"
-// can, so it is checked at attach time, against the actual interface being
-// attached to, by internal/plumbing/ebpf/edgeattach, not here.
+// Also not checked: whether a specific interface's driver supports native XDP
+// attach rather than generic. That is a per-interface, per-driver property,
+// unanswerable in the abstract the way kernel-wide XDP support is, so it is
+// checked at attach time against the actual interface.
 //
-// Every check below follows preflight's own hard invariant: no partial
-// pass, and no unsafe/degraded fallback on failure -- a node missing any
-// one of these capabilities must not run the edge gateway datapath at all.
+// Every check follows the same invariant: no partial pass, and no degraded
+// fallback on failure. A node missing any one of these must not run the edge
+// gateway datapath at all.
 package edgepreflight
 
 import (
@@ -58,11 +40,9 @@ import (
 	"fmt"
 )
 
-// Prober is the kernel-capability probe interface this package's checks run
-// against. [NewKernelProber] returns the real, kernel-backed implementation
-// used in production; tests substitute a stubbed implementation to exercise
-// the pass case and each individual failure case in [CheckWith] without
-// touching the real kernel.
+// Prober is the kernel-capability probe interface the checks run against.
+// NewKernelProber returns the real implementation; tests substitute a stub to
+// exercise the pass case and each failure case without a kernel.
 type Prober interface {
 	// XDP reports whether the running kernel supports BPF_PROG_TYPE_XDP.
 	XDP() error
@@ -75,15 +55,13 @@ type Prober interface {
 	// required for edgedsr.c's bpf2go-generated map value types to load.
 	BTF() error
 
-	// XDPAdjustHead reports whether this kernel's XDP programs can call
-	// bpf_xdp_adjust_head -- required to grow the packet for the pushed
-	// outer SRv6 header.
+	// XDPAdjustHead reports whether this kernel's XDP programs can grow a
+	// packet, which the pushed outer header requires.
 	XDPAdjustHead() error
 }
 
-// capabilityCheck names one required capability, binds it to its probe
-// function, and carries a one-line "why this matters" note used to build
-// [CheckWith]'s aggregate error.
+// capabilityCheck names one required capability, binds it to its probe, and
+// carries a one-line actionable note used to build the aggregate error.
 type capabilityCheck struct {
 	name string
 	fn   func() error
@@ -116,20 +94,16 @@ func capabilityChecks(p Prober) []capabilityCheck {
 }
 
 // Check runs every capability probe this datapath depends on against the
-// real running kernel (via [NewKernelProber]) and returns a clear,
-// actionable error if any is missing.
+// running kernel and returns an actionable error if any is missing.
 func Check() error {
 	return CheckWith(NewKernelProber())
 }
 
-// CheckWith runs the same checks as [Check] against an arbitrary [Prober].
-// Every check always runs, even after an earlier one fails, so a caller
-// sees every missing capability at once. If nothing is missing, CheckWith
-// returns nil; otherwise it returns a single non-nil error (built with
-// [errors.Join]) describing every failure. There is no partial-pass return
-// value: callers must treat any non-nil error as "do not load the edge
-// gateway datapath on this node," never as a signal to fall back to a
-// degraded or unsafe mode.
+// CheckWith runs the same probes as Check against an arbitrary Prober. Every
+// check runs even after an earlier one fails, so a caller sees every missing
+// capability at once. It returns nil when nothing is missing, and otherwise a
+// single joined error describing every failure. There is no partial-pass
+// return: any non-nil error means do not load this datapath on this node.
 func CheckWith(p Prober) error {
 	checks := capabilityChecks(p)
 

--- a/internal/plumbing/ebpf/edgeprog/doc.go
+++ b/internal/plumbing/ebpf/edgeprog/doc.go
@@ -2,54 +2,35 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package edgeprog holds the compiled XDP program that implements the edge
-// gateway's Maglev/DSR (Direct Server Return) consistent-hash
-// load-balancing datapath, plus a direct SRv6 uSID push -- no Geneve
-// overlay, no separate gateway-tier decap step, no kernel VRF/FIB
-// dependency for the encap itself, and (unlike the Full-NAT predecessor
-// this replaces) no address/port rewriting or reverse-path decap of any
-// kind: the backend answers the client directly, so this program only
-// ever needs a forward path. See the DSR/Maglev design plan (kitt
-// notebook, projects/galactic/dsr-maglev-nptv6-nat66-design.md) for the
-// full rationale, and edgedsr.c's own header comment for what this
-// simplification removes versus the Full-NAT edgenat.c it replaces
-// (removed entirely, not kept as an alternate mode -- breaking change, no
-// migration path).
+// Package edgeprog holds the compiled XDP program implementing the edge
+// gateway's Maglev direct-server-return load-balancing datapath, plus a direct
+// SRv6 uSID push. No overlay, no separate decap step, no kernel VRF dependency
+// for the encapsulation, and no address or port rewriting: the backend answers
+// the client directly, so this program only ever needs a forward path.
 //
-// edgedsr.c is the single source of truth for the packet path; see its
-// header comment for the full walkthrough. `go generate` (via bpf2go,
-// github.com/cilium/ebpf's code generator) compiles it with clang into a
-// CO-RE-portable BPF object and generates matching Go bindings
-// (EdgedsrObjects, LoadEdgedsr, LoadEdgedsrObjects, plus per-map/
-// per-program fields) in this package -- run `go generate ./...` from the
-// repo root, or `go generate` from this directory, after editing
-// edgedsr.c.
+// edgedsr.c is the single source of truth for the packet path; its header
+// comment walks it. `go generate` compiles it with clang into a
+// CO-RE-portable BPF object and generates the matching Go bindings here. Run it
+// after editing the C source.
 //
-// Same not-committed-generated-artifacts convention as
-// internal/plumbing/ebpf/prog (see that package's doc.go): *_bpfel.go/
-// *_bpfel.o and *_bpfeb.go/*_bpfeb.o are gitignored, regenerated fresh by
-// `task build:ebpf` at every build site.
+// The generated files are gitignored rather than committed and are regenerated
+// at every build site, for the same reason as the other datapath packages: a
+// committed binary blob can drift out of sync with its source with nothing short
+// of a byte-diff to catch it.
 //
-// Placement: sibling of internal/plumbing/ebpf/prog under the shared
-// internal/plumbing/ebpf/ umbrella, kept as its own package rather than a
-// second program in prog itself -- this is a different datapath domain
-// (edge ingress NAT/LB vs. SRv6 uSID decap) with no shared map/key layout,
-// so folding it into prog would couple two things that change for
-// unrelated reasons (CONVENTIONS.md: "prefer creating a focused
-// sub-package over adding to an existing large one").
+// It is a sibling of the uSID datapath package rather than a second program
+// inside it. The two are different domains, edge ingress load balancing against
+// uSID decap, sharing no map or key layout, so folding them together would
+// couple things that change for unrelated reasons.
 //
-// This package does not itself load or attach the compiled program to any
-// interface -- that is internal/plumbing/ebpf/edgeattach's job, and
-// ultimately internal/gateway's KernelDatapath, which calls into
-// edgeattach/edgemap from Engine's convergence loop.
+// This package neither loads nor attaches the program; the attach package and
+// the gateway engine's datapath do that.
 package edgeprog
 
-// See internal/plumbing/ebpf/prog/doc.go for why -idirafter lists both
-// multiarch directories and why -cc is omitted (same clang/bpf2go
-// environment, same rationale, not repeated here).
+// See the uSID program package's doc.go for why the include flags list both
+// multiarch directories and why the compiler is not named explicitly.
 //
-// Unlike edgenat.c, edgedsr.c never takes the address of a field inside a
-// packed struct (no rewrite-by-pointer of any header field -- see its own
-// header comment), so -Wno-address-of-packed-member is no longer needed.
+// This program never takes the address of a field inside a packed struct, so it
+// needs no warning suppression for that.
 //
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type vip_key -type backend -type vip_value -type vip_stats_value -type encap_config Edgedsr edgedsr.c

--- a/internal/plumbing/ebpf/edgeprog/dropreason.go
+++ b/internal/plumbing/ebpf/edgeprog/dropreason.go
@@ -4,19 +4,15 @@
 
 package edgeprog
 
-// Drop reason indices into the drop_reasons map (edgedsr.c's `enum
-// edge_drop_reason`), exported for callers outside this package --
-// notably internal/plumbing/ebpf/edgemetrics's Prometheus collector, which
-// needs a stable, human-readable label per index. Hand-kept in sync with
-// edgedsr.c for the same reason internal/plumbing/ebpf/prog's identical
-// DropReason* constants are: bpf2go's -type flag cannot generate a Go type
-// for a C enum that is only ever used as a literal constant, never as a
-// typed variable/field the compiler retains distinct BTF for.
+// Drop reason indices into the drop_reasons map, mirroring the datapath's own
+// enum and exported for callers outside this package, notably the Prometheus
+// collector, which needs a stable label per index. Hand-kept in sync with the C
+// source, because the generator cannot produce a Go type for an enum used only
+// as a literal constant.
 //
-// A much smaller set than the Full-NAT edgenat.c predecessor's: DSR has no
-// conn_table, no PAT/SNAT-port allocation, and no return/decap branch, so
-// there is nothing analogous to DropReasonNoConnNotSyn/PATExhausted/
-// MalformedReturn/NoReturnConn to carry forward.
+// A small set: direct server return has no connection table, no port allocation,
+// and no return path, so there is nothing analogous to a full-NAT datapath's
+// state-related reasons.
 const (
 	DropReasonEmptyBackendList uint32 = 0
 	DropReasonNoEncapConfig    uint32 = 1
@@ -28,9 +24,9 @@ const (
 	DropReasonCount            uint32 = 7
 )
 
-// DropReasonNames maps each DropReason* index to a short, stable,
-// metrics/log-friendly name, decoupling Prometheus label values and any
-// other external representation from edgedsr.c's C identifier spelling.
+// DropReasonNames maps each index to a short, stable, metrics-friendly name,
+// decoupling label values and any other external representation from the C
+// identifier spelling.
 var DropReasonNames = map[uint32]string{
 	DropReasonEmptyBackendList: "empty_backend_list",
 	DropReasonNoEncapConfig:    "no_encap_config",

--- a/internal/plumbing/ebpf/edgeprog/edgedsr.c
+++ b/internal/plumbing/ebpf/edgeprog/edgedsr.c
@@ -4,88 +4,50 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// edgedsr.c implements the XDP ingress datapath for the edge gateway's
-// Maglev/DSR (Direct Server Return) consistent-hash load-balancing engine,
-// IPv6-only, phase 1 scope (plain TCP/UDP, no extension headers) -- see the
-// design plan's §0 for the full architectural rationale. This replaces
-// edgenat.c's Full-NAT (DNAT+SNAT) datapath entirely, not a mode alongside
-// it: breaking change, no migration path, per the redesign's explicit
-// decision to drop Full-NAT rather than grow a second personality.
+// edgedsr.c implements the XDP ingress datapath for the edge gateway's Maglev
+// direct-server-return load balancer. IPv6-only, plain TCP and UDP, no
+// extension headers.
 //
-// The defining simplification versus edgenat.c: this program does NO
-// address or port rewriting at all. It picks a backend via consistent
-// hashing on the client's own (address, port) and pushes an SRv6 outer
-// header addressed to that backend's worker node -- the untouched original
-// packet travels inside, unmodified. The backend answers the client
-// *directly* (internal/plumbing/vip's loopback bind, or the tap-boundary
-// substitution in internal/plumbing/ebpf/prog/usid.c, for a VM backend) --
-// reply traffic never re-enters this program at all. Consequences that
-// follow directly from that:
+// It does no address or port rewriting at all. It picks a backend by consistent
+// hashing on the client's own address and port, then pushes an SRv6 outer
+// header addressed to that backend's worker node; the original packet travels
+// inside unmodified. The backend answers the client directly, so reply traffic
+// never re-enters this program. That has three consequences:
 //
-//   - No conn_table. Full-NAT needed one to remember which backend/SNAT
-//     port a flow was assigned, because DNAT/SNAT state has to persist for
-//     the life of the connection. DSR has nothing to remember: the same
-//     consistent-hash table produces the same backend for the same flow on
-//     every packet, forwards or not, with no state at all.
-//   - No return/decap branch. Full-NAT's handle_return existed solely to
-//     route its own SNAT'd replies back through this node. DSR never sees
-//     replies, so there is nothing to decap here.
-//   - No PAT/SNAT-port allocation, no L3/L4 checksum touch anywhere in this
-//     file -- the packet's own checksum is already correct for its own,
-//     completely unmodified content.
-//
-// What IS reused from edgenat.c, unchanged: push_outer_header/
-// resolve_fib_and_write_eth's SRv6 encap-push mechanics (one
-// bpf_xdp_adjust_head(-40) growing the packet, a fresh 54-byte
-// Ethernet+IPv6 header written at the front, bpf_fib_lookup resolving the
-// L2 next-hop) -- encapsulating toward a backend's worker-node uSID is
-// identical work whether or not the datapath also NATs, so this file
-// copies that mechanism rather than reinventing it.
+//   - No connection table. A full-NAT datapath needs one to remember which
+//     backend and translated port a flow was assigned, because that state must
+//     persist for the life of the connection. Here the same hash table produces
+//     the same backend for the same flow on every packet, with no state.
+//   - No return or decap branch, since this node never sees replies.
+//   - No port allocation and no checksum touch anywhere in this file, the
+//     packet's own checksum already being correct for its unmodified content.
 //
 // Packet path:
 //
-//  1. Parse the outer Ethernet + IPv6 header (bounds-checked). Not IPv6, or
-//     unparseable -- XDP_PASS (falls through to the kernel stack).
-//  2. Parse the L4 header (TCP or UDP only; anything else -- XDP_PASS).
-//     Only source/destination port are read; nothing here is ever
-//     rewritten, so no pointer-to-field resolution is needed the way
-//     edgenat.c's parse_l4/l4_view needed for its later rewrite.
-//  3. Match (proto, dst port, dst addr) against vip_table, keyed
-//     identically to edgenat.c's former rule_table -- a VIP is globally
-//     unique by construction, no tenant dimension needed. No match --
-//     XDP_PASS (not one of this gateway's VIPs).
-//  4. Claimed past this point (this gateway owns this VIP+port+protocol):
-//     bump vip_stats_table's hit counters (packets/bytes/last_seen_ns),
-//     lazily creating the row on first match -- same split-from-vip_table
-//     convention edgenat.c's rule_stats_table used, and for the identical
-//     reason (issue #361: a control-plane Register's read-modify-write
-//     must never race this program's own per-packet increments).
-//  5. Empty backend list -- drop, counted (EMPTY_BACKEND_LIST). Otherwise,
-//     hash the client's own (address, port) and look up the precomputed
-//     Maglev table (vip_table's own maglev_table field, populated by the
-//     Go control plane's internal/maglev.Table -- see edgemap's doc
-//     comment) to get a backend index, deterministically and statelessly:
-//     every gateway node computes the identical index for the identical
-//     flow from the identical (VIP, backend list) input, which is what
-//     makes this design safe under anycast/ECMP (design plan §0's go/no-go
-//     spike) -- a flow's packets landing on a different gateway node
-//     mid-connection still resolve to the same backend.
-//  6. Push a fresh 40-byte outer IPv6 header addressed to the chosen
-//     backend's own worker-node SRv6 uSID (vip_table's per-backend field,
-//     resolved by the Go control plane the same way any other cross-node
-//     SRv6 destination is -- srv6.ComputeSID over the backend's
-//     BGPRouter/BGPAdvertisement), sourced from this node's own
-//     encap_config_table entry (this node's plain SRv6-reachable address --
-//     unlike edgenat.c's gw_config, this is never a NAT/SNAT source and
-//     never needs to match anything on a return path, since there is no
-//     return path through this node at all). Resolve the L2 next-hop via
-//     bpf_fib_lookup and XDP_TX back out this same interface.
+//  1. Parse the outer Ethernet and IPv6 header, bounds-checked. Not IPv6, or
+//     unparseable: XDP_PASS to the kernel stack.
+//  2. Parse the L4 header, TCP or UDP only. Only the ports are read, and
+//     nothing is ever rewritten.
+//  3. Match (proto, destination port, destination address) against vip_table. A
+//     VIP is globally unique by construction, so no tenant dimension is needed.
+//     No match: XDP_PASS.
+//  4. Claimed past this point. Bump vip_stats_table's counters, creating the
+//     row on first match. Stats live in their own map so a control-plane
+//     read-modify-write can never race these per-packet increments.
+//  5. An empty backend list is a counted drop. Otherwise hash the client's
+//     address and port and index the precomputed Maglev table to get a backend.
+//     Every gateway node computes the same index for the same flow from the
+//     same inputs, which is what makes this safe under anycast: a flow landing
+//     on a different node mid-connection still resolves to the same backend.
+//  6. Push a fresh 40-byte outer IPv6 header addressed to that backend's
+//     worker-node uSID, sourced from this node's encap_config_table entry,
+//     which is simply this node's SRv6-reachable address and is never compared
+//     against anything on a receive path. Resolve the L2 next hop and XDP_TX
+//     back out the same interface.
 //
-// The same eBPF-verifier bounds-narrowing gotcha edgenat.c's own header
-// comment documents applies to the backend-index lookup below (a Maglev
-// table entry is a plain byte read from a map, not derived from a %
-// expression the verifier can bound on its own) -- EDGE_BARRIER_VAR is
-// reused unchanged.
+// The verifier's bounds-narrowing behavior described at EDGE_BARRIER_VAR
+// applies to the backend-index lookup below, a plain byte read from a map
+// rather than an expression the verifier can bound.
 #include <linux/bpf.h>
 
 // __u8/__u16/__u32/__u64/__s16/__s32/__be16/__be32 all come transitively
@@ -98,9 +60,7 @@
 
 // EDGE_BARRIER_VAR forces the compiler to treat var as opaque immediately
 // before a bounds-narrowing operation on it, so that operation survives
-// dead-code elimination even when clang can otherwise prove the narrowing
-// is redundant -- see edgenat.c's identical macro and header-comment
-// gotcha; unchanged here.
+// dead-code elimination even where clang can prove the narrowing redundant.
 #define EDGE_BARRIER_VAR(var) asm volatile("" : "=r"(var) : "0"(var))
 
 // ---------------------------------------------------------------------
@@ -125,32 +85,24 @@ static __u64 (*bpf_ktime_get_ns)(void) = (void *) BPF_FUNC_ktime_get_ns;
 #define EDGE_IPPROTO_UDP 17
 #define EDGE_IPPROTO_IPV6 41 // this program's own pushed outer header's Next Header, always
 
-// EDGE_MAX_BACKENDS matches NetworkRuleSpec.Backends' own
-// +kubebuilder:validation:MaxItems=64 (go.datum.net/network's rule_types.go)
-// -- edgenat.c's identical constant was fixed at 8, silently below the
-// CRD's own advertised limit; closed here as a natural side effect of this
-// rewrite rather than carried forward unexamined. Must stay a power of two
-// for the EDGE_BARRIER_VAR mask trick below.
+// EDGE_MAX_BACKENDS matches the CRD's own maximum backend count. It must stay a
+// power of two for the masking below to be equivalent to a range check.
 #define EDGE_MAX_BACKENDS 64
 
-// EDGE_MAGLEV_TABLE_SIZE is this program's per-VIP Maglev lookup table
-// size (internal/maglev.Table, mirrored here as a flat backend-index
-// array -- see edgemap's doc comment for the Go-side construction). The
-// Maglev paper recommends >=100x the backend count for its disruption
-// bound to hold with wide margin; at EDGE_MAX_BACKENDS=64 that would be
-// 6400+, but this is a *per-VIP* table (bounded by vip_table's own
-// max_entries below), not the paper's single datacenter-wide table -- 1021
-// (prime, ~16x this program's own backend cap) keeps each vip_table row's
-// memory cost modest (~3KB) while still giving a meaningfully bounded
-// disruption fraction (internal/maglev.Table's own tests pin the bound at
-// this multiplier). Revisit if a real deployment's measured disruption on
-// backend-set changes needs a tighter bound than this ratio gives.
+// EDGE_MAGLEV_TABLE_SIZE is the per-VIP Maglev lookup table size, mirrored here
+// as a flat backend-index array.
+//
+// The Maglev paper recommends at least 100 times the backend count for its
+// disruption bound to hold with wide margin, which at this backend cap would be
+// 6400 or more. That figure is for a single datacenter-wide table; this is per
+// VIP, so 1021, prime and roughly 16 times the backend cap, keeps each row's
+// memory cost near 3KB while still bounding disruption meaningfully. Revisit if
+// a deployment's measured disruption on backend-set changes needs tighter.
 #define EDGE_MAGLEV_TABLE_SIZE 1021
 
 // ---------------------------------------------------------------------
-// Minimal, self-contained header structs -- byte-exact to the wire
-// formats, matching edgenat.c/usid.c's own convention (one external header
-// dependency: <linux/bpf.h>).
+// Minimal, self-contained header structs, byte-exact to the wire formats, with
+// one external header dependency.
 // ---------------------------------------------------------------------
 
 struct edge_ethhdr {
@@ -168,10 +120,8 @@ struct edge_ip6hdr {
 	__u8 daddr[16];
 } __attribute__((packed));
 
-// Only source/dest port are ever read (both TCP and UDP place them at the
-// identical offset) -- unlike edgenat.c's edge_tcphdr/edge_udphdr, no
-// other field of either header is ever touched, so one shared struct
-// suffices instead of two protocol-specific ones.
+// Only the ports are ever read, and TCP and UDP place them at the same offset,
+// so one shared struct covers both.
 struct edge_l4ports {
 	__be16 source;
 	__be16 dest;
@@ -181,11 +131,9 @@ struct edge_l4ports {
 // Map key/value types.
 // ---------------------------------------------------------------------
 
-// struct backend is one load-balancing target -- identical fields to
-// edgenat.c's struct backend (this file's own encap-push needs exactly the
-// same three fields; DSR just never touches addr/port for rewriting,
-// only carries them through as identifying metadata the Go control plane
-// may want for telemetry, and usid for the actual encap destination).
+// struct backend is one load-balancing target. addr and port are carried
+// through as identifying metadata for the control plane; only usid is used, as
+// the encapsulation destination.
 struct backend {
 	__u8 addr[16];
 	__be16 port;
@@ -202,17 +150,14 @@ struct vip_key {
 	__u8 vip[16];
 };
 
-// struct vip_value is vip_table's value: the backend set for one
-// VIP+port+protocol, plus a precomputed Maglev lookup table mapping each
-// of EDGE_MAGLEV_TABLE_SIZE slots to an index into backends[]. generation
-// is a __u64 monotonic-clock reading stamped by the Go control plane on
-// every Register call, backing the same crash-safe Reconcile cutoff
-// pattern usid.c's vrf_value.generation and edgenat.c's former
-// rule_value.generation already use -- this program never reads it.
+// struct vip_value is vip_table's value: the backend set for one VIP, port, and
+// protocol, plus a precomputed Maglev table mapping each slot to an index into
+// backends. generation is a monotonic reading stamped by the control plane on
+// every registration, backing the crash-safe reconcile cutoff, and is never
+// read here.
 //
-// Deliberately no packet/byte/drop counters here, for the identical
-// issue-#361 reason edgenat.c's own rule_value doc comment gives: see
-// struct vip_stats_value below, a separate map this program alone writes.
+// Deliberately no counters: see struct vip_stats_value below, a separate map
+// only this program writes.
 struct vip_value {
 	__u32 backend_count;
 	struct backend backends[EDGE_MAX_BACKENDS];
@@ -220,11 +165,9 @@ struct vip_value {
 	__u64 generation;
 };
 
-// struct vip_stats_value is vip_stats_table's value -- identical shape and
-// identical reason for existing as its own map as edgenat.c's former
-// rule_stats_value (issue #361): the Go control plane's Register never
-// writes this map at all, so its own per-packet __sync_fetch_and_add calls
-// here never race a control-plane read-modify-write.
+// struct vip_stats_value is vip_stats_table's value. It is a separate map
+// because the control plane never writes it, so this program's per-packet
+// atomic increments can never race a control-plane read-modify-write.
 struct vip_stats_value {
 	__u64 packets;
 	__u64 bytes;
@@ -232,13 +175,10 @@ struct vip_stats_value {
 	__u64 last_seen_ns;
 };
 
-// struct encap_config is encap_config_table's single-entry value: this
-// gateway node's own plain SRv6-reachable address, used as the outer
-// source for every pushed header. Unlike edgenat.c's gw_config (which
-// doubled as the Full-NAT return-branch match address), this is never
-// compared against anything on a receive path -- DSR has no return branch
-// through this node at all -- so it is exactly this node's own
-// loaddr.Detect()-equivalent address, nothing more.
+// struct encap_config is encap_config_table's single-entry value: this gateway
+// node's SRv6-reachable address, used as the outer source of every pushed
+// header. It is never compared against anything on a receive path, since no
+// return traffic passes through this node.
 struct encap_config {
 	__u8 encap_src[16];
 };
@@ -304,11 +244,9 @@ static EDGE_ALWAYS_INLINE void count_claimed_drop(__u32 reason, struct vip_stats
 }
 
 // fnv1a_flow is a deterministic, stateless hash of a flow's client-facing
-// tuple -- identical technique to edgenat.c's own fnv1a_flow, reused here
-// as the sole input to Maglev slot selection (hash % EDGE_MAGLEV_TABLE_SIZE)
-// rather than a direct hash % backend_count: this is exactly what makes
-// backend-set changes reassign only ~1/N of flows instead of ~100% of
-// them (see internal/maglev's own doc comment).
+// tuple. It feeds Maglev slot selection rather than a direct modulo over the
+// backend count, which is what makes a backend-set change reassign roughly one
+// flow in N instead of nearly all of them.
 static EDGE_ALWAYS_INLINE __u32 fnv1a_flow(const __u8 addr[16], __be16 port)
 {
 	__u32 h = 2166136261u;
@@ -323,14 +261,11 @@ static EDGE_ALWAYS_INLINE __u32 fnv1a_flow(const __u8 addr[16], __be16 port)
 	return h;
 }
 
-// resolve_fib_and_write_eth and push_outer_header are edgenat.c's own
-// encap-push mechanics, unchanged (see edgenat.c's identical functions for
-// the full byte-level rationale) -- copied rather than shared via a common
-// header because the two datapaths' surrounding types (struct edge_ip6hdr
-// etc.) are independently defined in each file per this codebase's
-// existing one-external-header-dependency convention; duplicating ~40
-// lines of proven, unchanging mechanism is judged preferable to a shared
-// header neither file otherwise needs.
+// resolve_fib_and_write_eth and push_outer_header carry the encapsulation
+// mechanics: grow the packet, write a fresh Ethernet and IPv6 header at the
+// front, and resolve the L2 next hop. They are duplicated rather than shared
+// through a header because each datapath file defines its own header structs
+// under the one-external-dependency convention.
 static EDGE_ALWAYS_INLINE long resolve_fib_and_write_eth(void *ctx, __u32 ifindex,
 							  const __u8 src[16], const __u8 dst[16],
 							  __u16 tot_len, struct edge_ethhdr *eth)
@@ -384,18 +319,12 @@ static EDGE_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 s
 	struct edge_ethhdr *eth = data;
 	struct edge_ip6hdr *outer = (void *) (eth + 1);
 
-	// vtc_flow's first nibble is the IPv6 version field -- must be 6, not
-	// left at a zeroed default. Found via live-kernel investigation (not
-	// BPF_PROG_TEST_RUN, which never validates this): a real receiver
-	// downstream of this push (e.g. tcpdump on a veth peer) parses this
-	// pushed header as "invalid IPv6, version 0 != 6" -- a real,
-	// previously uncaught bug (inherited unchanged from the removed
-	// edgenat.c's identical push_outer_header), not specific to DSR.
-	// usid_ingress's own decap doesn't validate the version nibble at all
-	// (it reads fields at fixed offsets unconditionally), so this was
-	// invisible on that specific receive path -- but any version-checking
-	// intermediate hop or receiver would legitimately reject every packet
-	// this datapath ever pushed.
+	// vtc_flow's first nibble is the IPv6 version and must be 6 rather than a
+	// zeroed default. A synthetic program run never validates this, but any
+	// receiver downstream parses such a header as invalid IPv6 with version 0.
+	// usid_ingress's decap reads fields at fixed offsets and never checks the
+	// version, so this is invisible on that path, while any version-checking
+	// hop or receiver would reject every packet pushed.
 	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
 	outer->vtc_flow[0] = 0x60;
 	outer->payload_len = inner_payload_len_plus_ip6hdr;
@@ -471,32 +400,24 @@ int edge_lb(struct xdp_md *ctx)
 		return XDP_DROP;
 	}
 
-	// Maglev slot selection: confirmed empirically via BPF_PROG_TEST_RUN
-	// that, unlike a literal array index, the verifier does NOT track a
-	// bounded range through clang's emitted division-by-constant sequence
-	// for hash % EDGE_MAGLEV_TABLE_SIZE (1021 is prime, so clang lowers
-	// the mod to a multiply-and-shift reciprocal trick, not a mask) --
-	// "R2 unbounded memory access" at the maglev_table read below without
-	// this. The same EDGE_BARRIER_VAR-then-clamp technique the
-	// backend_idx step already needs (for a different reason: a plain
-	// byte read from a map, not derivable from any expression at all) is
-	// applied here too, just as an explicit range clamp instead of a mask
-	// (EDGE_MAGLEV_TABLE_SIZE is prime, not a power of two, so no bitmask
-	// is equivalent to bounding it).
+	// Maglev slot selection. Unlike a literal array index, the verifier does
+	// not track a bounded range through clang's division-by-constant sequence
+	// for this modulo: the table size is prime, so clang lowers it to a
+	// multiply-and-shift reciprocal rather than a mask, and the read below is
+	// rejected as unbounded without help. The same barrier-then-clamp technique
+	// the backend index needs is applied here, as an explicit range clamp
+	// rather than a mask, since no bitmask bounds a prime.
 	__u32 slot = fnv1a_flow(ip6->saddr, ports->source) % EDGE_MAGLEV_TABLE_SIZE;
 	EDGE_BARRIER_VAR(slot);
 	if (slot >= EDGE_MAGLEV_TABLE_SIZE)
 		slot = EDGE_MAGLEV_TABLE_SIZE - 1;
 	__u8 backend_idx = rule->maglev_table[slot];
 
-	// backend_idx is a plain byte read from a map value, not derived from
-	// a %-expression the verifier can bound on its own -- the same
-	// bounds-narrowing gotcha edgenat.c's own header comment and
-	// EDGE_BARRIER_VAR macro document, reused unchanged: EDGE_MAX_BACKENDS
-	// must stay a power of two for this mask to be equivalent to a
-	// range-check, and the barrier call keeps clang from eliminating it
-	// as dead code once it (correctly, but unhelpfully for the verifier)
-	// proves the mask redundant given backend_idx's declared type.
+	// backend_idx is a plain byte read from a map value, not derived from an
+	// expression the verifier can bound. EDGE_MAX_BACKENDS must stay a power of
+	// two for this mask to be equivalent to a range check, and the barrier
+	// keeps clang from eliminating the mask as dead once it proves it redundant
+	// given the declared type.
 	EDGE_BARRIER_VAR(backend_idx);
 	backend_idx &= (EDGE_MAX_BACKENDS - 1);
 	struct backend *b = &rule->backends[backend_idx];
@@ -508,26 +429,17 @@ int edge_lb(struct xdp_md *ctx)
 		return XDP_DROP;
 	}
 
-	// The inner packet is pushed completely unmodified -- this is DSR's
-	// entire premise (design plan §0): no DNAT, no SNAT, no checksum
-	// touch, the client's own packet travels inside untouched all the way
-	// to the backend, which replies to the client directly.
+	// The inner packet is pushed completely unmodified: no translation and no
+	// checksum touch, the client's packet travelling inside untouched to the
+	// backend, which replies to the client directly.
 	//
-	// push_outer_header's own parameter name says "plus ip6hdr": the
-	// outer header's payload_len must cover the *entire* inner packet,
-	// including the inner IPv6 header itself (40 bytes), not just the
-	// inner UDP/TCP payload ip6->payload_len alone names. A previous
-	// version of this call site passed ip6->payload_len directly,
-	// undercounting the outer header's declared length by exactly 40
-	// bytes on every packet -- found via live-kernel investigation (a
-	// real receiver, e.g. tcpdump on a veth peer, parsed the result as
-	// "length 24 < 40 (invalid)"), inherited unchanged from the removed
-	// edgenat.c's identical bug. usid_ingress's own decap doesn't
-	// validate payload_len at all (fixed-offset reads only), so this was
-	// invisible on that specific receive path, same as the version-nibble
-	// bug this file's other recent fix addresses -- but any
-	// length-validating intermediate hop or receiver would have rejected
-	// every packet this datapath ever pushed.
+	// The outer header's payload length must cover the entire inner packet
+	// including its own 40-byte IPv6 header, not just the transport payload the
+	// inner payload_len names. Passing that field directly undercounts the outer
+	// length by exactly 40 bytes on every packet, which a receiver parses as an
+	// invalid length. usid_ingress's decap reads at fixed offsets and never
+	// validates the length, so this is invisible on that path while any
+	// length-validating hop would reject every packet pushed.
 	__be16 inner_payload_len_plus_ip6hdr =
 		__builtin_bswap16((__u16) sizeof(struct edge_ip6hdr) + __builtin_bswap16(ip6->payload_len));
 

--- a/internal/plumbing/ebpf/egressroutemap/doc.go
+++ b/internal/plumbing/ebpf/egressroutemap/doc.go
@@ -3,22 +3,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package egressroutemap implements the read/write API for the eBPF uSID
-// datapath's egress_route_table and node_src_addr_table maps
-// (internal/plumbing/ebpf/prog/usid.c's struct egress_route_key/value and
-// usid_egress's egress-routing extension) -- see
-// docs/plans/tc-bpf-egress-srv6-encap.md for the mechanism this replaces
-// (internal/plumbing/srv6's kernel-native SEG6 lwtunnel route
-// encapsulation, confirmed broken by CVE-2026-31668 under this
-// codebase's own per-tenant-VRF architecture) and why.
+// datapath's egress_route_table, node_src_addr_table, and public_uplink_table
+// maps, which together drive usid_egress's encapsulation.
 //
-// Two callers, two processes, mirroring vipxlatmap's own precedent for
-// exactly this shape: internal/runtime/gobgp/monitor.go
-// (galactic-router, a long-lived daemon that never loads/attaches an
-// eBPF program of its own) writes Register/Unregister entries as EVPN
-// paths arrive and are withdrawn -- the same events that used to drive
-// srv6.RouteEgressAdd/RouteEgressDel/RouteMainAdd/RouteMainDel -- and
-// internal/cnibgp (galactic-cni, the process that actually loads and
-// attaches usid_egress) writes this node's own SetNodeSourceAddress
-// entry once, at datapath registration time, alongside its existing
-// attachUsidEgress call.
+// It replaces kernel SEG6 lwtunnel route encapsulation, which is unusable under
+// per-tenant VRFs: the lwtunnel reuses one route cache across the input and
+// output resolution paths, whose routing contexts differ once every tenant has
+// its own VRF.
+//
+// Two callers in two processes. The router, a long-lived daemon that never
+// loads a program of its own, registers and unregisters route entries as EVPN
+// paths arrive and are withdrawn. The CNI side, which does load and attach
+// usid_egress, writes this node's source address and uplink entries at datapath
+// registration time.
 package egressroutemap

--- a/internal/plumbing/ebpf/egressroutemap/egressroute.go
+++ b/internal/plumbing/ebpf/egressroutemap/egressroute.go
@@ -19,67 +19,55 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
-// neighborResolveTimeout/neighborResolvePollInterval bound how long
-// resolveNeighbor will wait for a solicited neighbor entry to resolve --
-// see that function's own doc comment for why an active solicit is
-// needed at all. Real ND round-trips on a healthy fabric link are
-// sub-100ms; this budget is generous headroom above that, not an
-// expected steady-state wait.
+// neighborResolveTimeout and neighborResolvePollInterval bound how long
+// resolveNeighbor waits for a solicited neighbor entry to resolve. A real
+// exchange on a healthy link is well under 100ms, so this is headroom rather
+// than an expected wait.
 const (
 	neighborResolveTimeout      = 2 * time.Second
 	neighborResolvePollInterval = 100 * time.Millisecond
 )
 
-// neighborSolicitDialTimeout bounds solicitNeighbor's own Dial -- a plain
-// UDP dial doesn't block on the network, but this still guards against
-// the pathological case (an unreachable or filtered link) rather than
-// trust that indefinitely.
+// neighborSolicitDialTimeout bounds solicitNeighbor's Dial. A UDP dial does not
+// block on the network, but this guards the pathological case of an unreachable
+// or filtered link.
 const neighborSolicitDialTimeout = 200 * time.Millisecond
 
-// egressRouteFamilyINET6/egressRouteFamilyINET4 mirror usid.c's
-// USID_EGRESS_ROUTE_FAMILY_INET6/USID_EGRESS_ROUTE_FAMILY_INET4 --
-// bpf2go generates no symbol for a #define, so this package names the raw
-// values once here, the same way usid_test.go's own identically-named
-// constants do for the datapath's own tests.
+// egressRouteFamilyINET6 and egressRouteFamilyINET4 mirror the datapath's
+// family constants. bpf2go generates no symbol for a #define, so the raw values
+// are named once here.
 const (
 	egressRouteFamilyINET6 = uint8(0)
 	egressRouteFamilyINET4 = uint8(1)
 )
 
-// egressRouteKeyFixedBits is the number of bits egress_route_key's fixed
-// (always fully matched) portion occupies ahead of the variable-length
-// address bits -- table_id (32) + family (8) -- matching usid.c's own
-// `8 * (sizeof(rkey.table_id) + sizeof(rkey.family))` computation exactly.
+// egressRouteKeyFixedBits is how many bits of egress_route_key are always
+// matched in full ahead of the variable-length address: table_id plus family.
+// It must match the datapath's own computation exactly.
 const egressRouteKeyFixedBits = 8 * (4 + 1)
 
-// DefaultPrefix is the IPv6 default route (::/0) Register installs when
-// called with it -- srv6.EgressDefaultRouteAdd's own defaultRoutePrefix,
-// reproduced here rather than imported (internal/plumbing/srv6 has no
-// eBPF/cilium dependency today and this package does not want to be the
-// reason it acquires one just for a shared constant).
+// DefaultPrefix is the IPv6 default route Register installs when called with
+// it. Defined here rather than imported from internal/plumbing/srv6, which has
+// no eBPF dependency today and should not acquire one for a shared constant.
 var DefaultPrefix = &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)}
 
-// EgressRouteTable is the read/write API for egress_route_table -- the
-// TC-BPF replacement for srv6.RouteEgressAdd/RouteEgressDel (a specific
-// destination prefix) and srv6.EgressDefaultRouteAdd/EgressDefaultRouteDel
-// (prefix == DefaultPrefix); both are the same primitive here, unlike
-// their netlink-route counterparts, since a longest-prefix-match trie
-// naturally gives a more specific entry priority over a ::/0 one with no
-// special-casing needed.
+// EgressRouteTable is the read/write API for egress_route_table. A specific
+// destination prefix and the ::/0 default are the same primitive here, unlike
+// their netlink counterparts, since a longest-prefix-match trie already gives
+// the more specific entry priority.
 type EgressRouteTable struct {
 	table usidmap.Table
 }
 
-// NewEgressRouteTable wraps table as an EgressRouteTable. Production
-// callers pass a usidmap.KernelTable wrapping a loaded egress_route_table
-// map (see OpenPinnedEgressRouteTable); tests pass a fake usidmap.Table.
+// NewEgressRouteTable wraps table as an EgressRouteTable. Production callers
+// pass a kernel table over the loaded map; tests pass a fake.
 func NewEgressRouteTable(table usidmap.Table) *EgressRouteTable {
 	return &EgressRouteTable{table: table}
 }
 
-// buildKey composes egress_route_table's LPM key for (tableID, prefix) --
-// see usid.c's struct egress_route_key doc comment for the exact bit
-// layout this must match byte-for-byte.
+// buildKey composes egress_route_table's longest-prefix-match key for
+// (tableID, prefix). The layout must match the datapath's struct
+// egress_route_key byte for byte.
 func buildKey(tableID uint32, prefix *net.IPNet) (prog.UsidEgressRouteKey, error) {
 	if prefix == nil {
 		return prog.UsidEgressRouteKey{}, errors.New("egressroutemap: egress_route_table: prefix is nil")
@@ -107,10 +95,8 @@ func buildKey(tableID uint32, prefix *net.IPNet) (prog.UsidEgressRouteKey, error
 	return key, nil
 }
 
-// sidTo16 returns sid's raw 16 bytes in wire order, or an error if sid is
-// not a genuine IPv6 address -- SRv6 SIDs are IPv6-only in this
-// architecture (matching srv6.RouteEgressAdd's own "gateway must be a
-// real SRv6 SID" guard).
+// sidTo16 returns sid's raw 16 bytes in wire order, or an error if sid is not a
+// genuine IPv6 address. SRv6 SIDs are IPv6-only in this architecture.
 func sidTo16(sid net.IP) ([16]byte, error) {
 	if sid == nil {
 		return [16]byte{}, errors.New("egressroutemap: egress_route_table: sid is nil")
@@ -127,28 +113,22 @@ func sidTo16(sid net.IP) ([16]byte, error) {
 	return a.As16(), nil
 }
 
-// resolveLinkAndL2Fn is a package-level override point so tests can
-// substitute a fake resolver instead of touching the real host network
-// stack -- the same pattern internal/plumbing/ebpf/attach's own
-// routeListFn/linkByIndexFn vars establish, needed here because Register
-// otherwise always calls the real netlink functions below regardless of
-// whether the usidmap.Table it was given is itself a fake.
+// resolveLinkAndL2Fn is an override point so tests can substitute a fake
+// resolver instead of touching the host network stack. Needed because Register
+// calls the real netlink functions whether or not the usidmap.Table it was
+// given is a fake.
 var resolveLinkAndL2Fn = resolveLinkAndL2
 
-// resolveLinkAndL2 resolves sid's real, immediate next-hop -- the exact
-// link plus the concrete L2 (destination and source MAC) address a
-// packet must carry to actually reach it -- via netlink.RouteGet and the
-// kernel's own already-populated neighbor cache.
+// resolveLinkAndL2 resolves sid's immediate next hop: the link plus the
+// destination and source MAC a packet must carry to reach it, from netlink and
+// the kernel's neighbor cache.
 //
-// This mirrors srv6.resolveNextHop's own job (and, for the exact same
-// reason: IPv6 route installation/resolution does not recurse through an
-// indirect gateway on its own), but cannot simply call it: this package
-// is already imported by internal/plumbing/srv6 (for pinDir/
-// attach.ResolveInterfaces), so the reverse import would be a cycle.
-// Resolving the L2 addresses too, not just the link/next-hop, is new
-// here relative to that function -- see struct egress_route_value's own
-// doc comment in usid.c for why usid_egress needs them precomputed
-// rather than resolving them itself at packet-processing time.
+// IPv6 resolution does not recurse through an indirect gateway on its own,
+// which is why the flattening is needed. It duplicates srv6.resolveNextHop
+// rather than calling it because that package already imports this one, so the
+// reverse import would be a cycle. Resolving the L2 addresses as well as the
+// link is what lets usid_egress avoid resolving them per packet; see struct
+// egress_route_value in usid.c.
 func resolveLinkAndL2(sid net.IP) (linkIndex int, dmac, smac net.HardwareAddr, err error) {
 	routes, err := netlink.RouteGet(sid)
 	if err != nil {
@@ -176,18 +156,15 @@ func resolveLinkAndL2(sid net.IP) (linkIndex int, dmac, smac net.HardwareAddr, e
 	return linkIndex, dmac, smac, nil
 }
 
-// resolveNeighbor returns nextHop's resolved L2 address on linkIndex,
-// actively soliciting the kernel to populate it first if a passive read
-// of the neighbor cache doesn't already have one.
+// resolveNeighbor returns nextHop's resolved L2 address on linkIndex, actively
+// soliciting the kernel to populate it when a passive cache read finds
+// nothing.
 //
-// A cache read alone is not enough: a brand-new pod netns (or any link
-// that has simply never sent traffic toward nextHop) starts with an
-// empty neighbor cache, and installing an SRv6 egress route generates no
-// traffic of its own that would populate it -- a same-node SID next-hop's
-// egress route can otherwise fail to resolve for a gateway pod's entire
-// uptime, restarts included, purely because nothing ever asks the kernel
-// to actually solicit it; a single manual ping resolves it instantly. See
-// solicitNeighbor's own doc comment for how the solicit itself is done.
+// A cache read alone is not enough. A new pod namespace, or any link that has
+// never sent traffic toward nextHop, starts with an empty cache, and installing
+// an egress route generates no traffic that would populate it. A same-node next
+// hop can otherwise stay unresolved for a pod's entire uptime while a single
+// manual ping resolves it instantly.
 func resolveNeighbor(linkIndex int, nextHop net.IP) (net.HardwareAddr, error) {
 	if mac, err := lookupNeighbor(linkIndex, nextHop); err != nil {
 		return nil, err
@@ -213,29 +190,22 @@ func resolveNeighbor(linkIndex int, nextHop net.IP) (net.HardwareAddr, error) {
 	}
 }
 
-// solicitNeighbor asks the kernel to resolve nextHop's L2 address the
-// same way any ordinary traffic toward it would: by actually sending it
-// a packet. Installing an SRv6 egress route generates no traffic of its
-// own (resolveNeighbor's own doc comment), so nothing else will ever do
-// this on Register's behalf.
+// solicitNeighbor asks the kernel to resolve nextHop's L2 address the way
+// ordinary traffic would, by sending it a packet. Installing an egress route
+// generates no traffic of its own, so nothing else does this on Register's
+// behalf.
 //
-// An administrative netlink.NeighSet(NUD_NONE, NTF_USE) -- the "mark as
-// used, please resolve" signal without ever constructing a real packet --
-// looked like the right tool here (it's the documented kernel mechanism,
-// and the technique Cilium's own neighbor-discovery code uses elsewhere),
-// but did not hold up: verified against a live veth pair with an empty
-// cache, it reliably parks the entry in NUD_INCOMPLETE and never carries
-// it further, while sending the peer an actual packet resolves it in well
-// under a millisecond every time. This is the version that was actually
-// verified to work, not the one that merely looked like it should.
+// An administrative NeighSet with NUD_NONE and NTF_USE, the documented "mark as
+// used, please resolve" signal, does not work here: against a live veth pair
+// with an empty cache it parks the entry in NUD_INCOMPLETE and never carries it
+// further, while sending a real packet resolves it in well under a
+// millisecond.
 //
-// The destination port needs no listener and whatever becomes of the
-// datagram past this host's own output path is irrelevant -- constructing
-// and writing it is what drives the kernel to resolve (or refresh)
-// nextHop's neighbor entry before the packet ever reaches the wire, which
-// is the only part this function is here for. Every error from Dial or
-// Write is intentionally ignored: resolveNeighbor's own poll loop is the
-// sole judge of whether this worked.
+// The destination port needs no listener, and what becomes of the datagram past
+// this host's output path is irrelevant. Constructing and writing it is what
+// drives the kernel to resolve the neighbor before the packet reaches the wire.
+// Errors from Dial and Write are ignored deliberately: resolveNeighbor's poll
+// loop is the only judge of whether this worked.
 func solicitNeighbor(nextHop net.IP) {
 	dialer := &net.Dialer{Timeout: neighborSolicitDialTimeout}
 	conn, err := dialer.DialContext(context.Background(), "udp6", net.JoinHostPort(nextHop.String(), "9"))
@@ -246,9 +216,9 @@ func solicitNeighbor(nextHop net.IP) {
 	_, _ = conn.Write([]byte{0})
 }
 
-// lookupNeighbor reads linkIndex's current IPv6 neighbor cache for
-// nextHop, without soliciting -- resolveNeighbor's passive fast path,
-// and its own poll step once a solicit is in flight.
+// lookupNeighbor reads linkIndex's IPv6 neighbor cache for nextHop without
+// soliciting. It is resolveNeighbor's passive fast path and its poll step once
+// a solicit is in flight.
 func lookupNeighbor(linkIndex int, nextHop net.IP) (net.HardwareAddr, error) {
 	neighs, err := netlink.NeighList(linkIndex, netlink.FAMILY_V6)
 	if err != nil {
@@ -262,20 +232,13 @@ func lookupNeighbor(linkIndex int, nextHop net.IP) (net.HardwareAddr, error) {
 	return nil, nil
 }
 
-// Register installs (or replaces) egress_route_table's entry for prefix
-// in Linux VRF table tableID, encapsulating toward sid -- the TC-BPF
-// replacement for srv6.RouteEgressAdd (a specific prefix) and
-// srv6.EgressDefaultRouteAdd (prefix == DefaultPrefix).
+// Register installs or replaces egress_route_table's entry for prefix in Linux
+// VRF table tableID, encapsulating toward sid.
 //
-// Resolves sid's own link and L2 (dmac/smac) information at registration
-// time via resolveLinkAndL2, storing all of it in the installed entry --
-// see struct egress_route_value's own doc comment in usid.c for why
-// usid_egress cannot resolve this itself, at packet-processing time, the
-// way it originally did. This means Register can fail the same way
-// srv6.RouteEgressAdd's own pre-TC-BPF implementation could (no route yet,
-// no resolved neighbor yet) -- callers that iterate multiple candidate
-// SIDs (e.g. EgressDefaultRouteAdd's own shard-SID list) must expect and
-// tolerate that.
+// It resolves sid's link and L2 addresses here, at registration time, and
+// stores them in the entry, because usid_egress cannot resolve them at packet
+// time. Register therefore fails when there is no route or no resolvable
+// neighbor yet, and a caller iterating candidate SIDs must tolerate that.
 func (t *EgressRouteTable) Register(tableID uint32, prefix *net.IPNet, sid net.IP) error {
 	key, err := buildKey(tableID, prefix)
 	if err != nil {
@@ -300,28 +263,21 @@ func (t *EgressRouteTable) Register(tableID uint32, prefix *net.IPNet, sid net.I
 	return nil
 }
 
-// RegisterPassThrough installs (or replaces) egress_route_table's entry
-// for prefix in Linux VRF table tableID as a local pass-through: unlike
-// Register, this never encapsulates -- it exists purely so this exact
-// prefix wins the LPM lookup over a shorter, less specific entry (in
-// practice, always the tenant VRF's own ::/0 NAT66 default installed by
-// Register(tableID, DefaultPrefix, ...)), and usid_egress recognizes it
-// via link_ifindex == 0 (struct egress_route_value's own doc comment in
-// usid.c) and defers to the kernel instead of redirecting.
+// RegisterPassThrough installs or replaces egress_route_table's entry for
+// prefix in Linux VRF table tableID as a local pass-through. Unlike Register it
+// never encapsulates: it exists so this exact prefix wins the longest-prefix
+// lookup over a shorter entry, in practice the VRF's ::/0 NAT66 default.
+// usid_egress recognises it by link_ifindex == 0 and defers to the kernel
+// instead of redirecting.
 //
-// Callers register their own attachment's IPAM-assigned prefix here, at
-// CNI ADD time, for every VRF that prefix lives in. Without this, two
-// attachments sharing one VRF on the same node -- with a perfectly good
-// kernel connected route already routing between them -- have that
-// traffic silently hijacked by the VRF's own ::/0 default and redirected
-// toward a NAT66 shard SID instead of ever being delivered locally: found
-// live in containerlab's ns30 fixture (two attachments, one VPC, one
-// node), the same class of bug as the multicast/link-local carve-out in
-// usid_egress, just for ordinary same-VRF unicast peers instead of NDP.
+// Callers register their own attachment's IPAM-assigned prefix here at CNI ADD
+// time, for every VRF that prefix lives in. Without it, two attachments sharing
+// a VRF on one node, with a working connected route between them, have that
+// traffic hijacked by the ::/0 default and redirected toward a NAT66 shard
+// instead of delivered locally.
 //
-// No sid/link/L2 resolution happens here (contrast Register) -- a
-// pass-through entry carries no SID and is never encapsulated toward, so
-// there is nothing to resolve.
+// Nothing is resolved here, unlike Register: a pass-through entry carries no
+// SID and is never encapsulated toward.
 func (t *EgressRouteTable) RegisterPassThrough(tableID uint32, prefix *net.IPNet) error {
 	key, err := buildKey(tableID, prefix)
 	if err != nil {
@@ -334,13 +290,11 @@ func (t *EgressRouteTable) RegisterPassThrough(tableID uint32, prefix *net.IPNet
 	return nil
 }
 
-// Lookup reads egress_route_table's entry for (tableID, prefix) -- the
-// exact entry Register would have installed for that pair -- reporting
-// whether it exists. Note this is an exact-match lookup on the same key
-// Register/Unregister use, not the longest-prefix-match usid_egress
-// itself performs against an arbitrary packet destination; it exists for
-// tests and observability, not to answer "what would this destination
-// resolve to."
+// Lookup reads egress_route_table's entry for (tableID, prefix) and reports
+// whether it exists. This is an exact-match lookup on the key Register and
+// Unregister use, not the longest-prefix match usid_egress performs against a
+// packet destination, so it serves tests and observability rather than
+// answering what a given destination would resolve to.
 func (t *EgressRouteTable) Lookup(tableID uint32, prefix *net.IPNet) (sid net.IP, ok bool, err error) {
 	key, err := buildKey(tableID, prefix)
 	if err != nil {
@@ -359,10 +313,9 @@ func (t *EgressRouteTable) Lookup(tableID uint32, prefix *net.IPNet) (sid net.IP
 	return sid, true, nil
 }
 
-// Unregister removes egress_route_table's entry for (tableID, prefix), if
-// present. Not an error if already absent, mirroring this codebase's
-// other map-writer packages' identical idempotency contract (e.g.
-// usidmap.VRFTable.Unregister, vipxlatmap's unregister).
+// Unregister removes egress_route_table's entry for (tableID, prefix). An entry
+// that is already absent is not an error, matching the other map writers in
+// this codebase.
 func (t *EgressRouteTable) Unregister(tableID uint32, prefix *net.IPNet) error {
 	key, err := buildKey(tableID, prefix)
 	if err != nil {
@@ -377,10 +330,9 @@ func (t *EgressRouteTable) Unregister(tableID uint32, prefix *net.IPNet) error {
 	return nil
 }
 
-// NodeSourceAddress is the read/write API for node_src_addr_table -- this
-// node's own SRv6/underlay-facing source address, the single value
-// usid_egress's egress-routing extension writes into every outer header
-// it pushes.
+// NodeSourceAddress is the read/write API for node_src_addr_table: this node's
+// underlay-facing source address, the value usid_egress writes into every outer
+// header it pushes.
 type NodeSourceAddress struct {
 	table usidmap.Table
 }
@@ -389,17 +341,13 @@ type NodeSourceAddress struct {
 // BPF_MAP_TYPE_ARRAY, one entry, matching usid.c's own `src_key = 0`.
 const nodeSourceAddressKey = uint32(0)
 
-// Set writes this node's own source address. Called once, at CNI
-// datapath registration time (mirroring attachUsidEgress's own
-// once-per-node lifecycle), not per CNI ADD/DEL -- see usid.c's own
-// node_src_addr_table comment for why a single-entry array, not a field
-// on every egress_route_table entry.
+// Set writes this node's source address. Called once at datapath registration
+// time rather than per CNI ADD or DEL, since the value is a per-node constant.
 //
-// addr must be a specified (non-nil, non-unspecified) IPv6 address --
-// usid_egress treats an all-zero entry as "not configured yet" and fails
-// open rather than encapsulate with a garbage source (BPF_MAP_TYPE_ARRAY
-// has no genuine "missing key" state to detect that some other way; see
-// that check's own comment in usid.c).
+// addr must be a specified IPv6 address. usid_egress treats an all-zero entry
+// as "not configured yet" and fails open rather than encapsulate with a garbage
+// source, and an array map has no genuine missing-key state to signal that any
+// other way.
 func (n *NodeSourceAddress) Set(addr net.IP) error {
 	raw, err := sidTo16(addr) // identical validation: a specified, non-unspecified IPv6 address
 	if err != nil {
@@ -411,10 +359,9 @@ func (n *NodeSourceAddress) Set(addr net.IP) error {
 	return nil
 }
 
-// Get reads this node's own currently-registered source address,
-// reporting whether one has ever been Set (an unset/all-zero entry --
-// see Set's own comment for why that's the map's "not configured" state
-// -- reports ok=false, not an all-zero net.IP).
+// Get reads this node's registered source address and reports whether one has
+// ever been Set. An unset, all-zero entry reports ok false rather than an
+// all-zero address.
 func (n *NodeSourceAddress) Get() (addr net.IP, ok bool, err error) {
 	var raw [16]byte
 	if err := n.table.Lookup(nodeSourceAddressKey, &raw); err != nil {
@@ -430,34 +377,27 @@ func (n *NodeSourceAddress) Get() (addr net.IP, ok bool, err error) {
 	return net.IP(raw[:]), true, nil
 }
 
-// PublicUplink is the read/write API for public_uplink_table -- this
-// node's own fabric-uplink interface's real, physical next hop.
-// usid_egress redirects a DSR backend's VIP-sourced reply here
-// unconditionally, immediately after apply_vip_xlat rewrites its source,
-// bypassing egress_route_table's own NAT66 default entirely -- see
-// struct public_uplink_value's own doc comment in usid.c for the full
-// mechanism and the real bug (a DSR reply silently re-SNAT'd through a
-// NAT66 shard, the client discarding it as unrecognized) this closes.
+// PublicUplink is the read/write API for public_uplink_table: this node's
+// fabric-uplink next hop. usid_egress redirects a DSR backend's VIP-sourced
+// reply there unconditionally, right after apply_vip_xlat rewrites its source,
+// bypassing egress_route_table's NAT66 default. Without it such a reply is
+// re-translated through a shard and the client discards it.
 type PublicUplink struct {
 	table usidmap.Table
 }
 
-// publicUplinkKey is public_uplink_table's only valid key --
-// BPF_MAP_TYPE_ARRAY, one entry, matching node_src_addr_table's identical
-// convention.
+// publicUplinkKey is public_uplink_table's only valid key. The map is a
+// one-entry array, matching node_src_addr_table.
 const publicUplinkKey = uint32(0)
 
-// Set writes this node's own fabric-uplink next hop: linkIndex is the
-// interface to redirect out, dmac/smac the Ethernet addressing needed to
-// actually reach that next hop (both exactly 6 bytes). Called once, at
-// CNI datapath registration time, the same lifecycle as
-// NodeSourceAddress.Set.
+// Set writes this node's fabric-uplink next hop. linkIndex is the interface to
+// redirect out of, and dmac and smac the Ethernet addressing to reach that next
+// hop, both exactly 6 bytes. Called once at datapath registration time, the same
+// lifecycle as NodeSourceAddress.Set.
 //
-// linkIndex == 0 is rejected: usid_egress treats it as "not configured
-// yet" and fails open (falling through to egress_route_table) rather
-// than redirect out a nonexistent interface -- see this map's own
-// link_ifindex == 0 sentinel convention (also used, for an unrelated
-// purpose, by egress_route_table's own pass-through entries).
+// linkIndex 0 is rejected: usid_egress reads it as "not configured yet" and
+// falls through to egress_route_table rather than redirect out a nonexistent
+// interface.
 func (p *PublicUplink) Set(linkIndex int, dmac, smac net.HardwareAddr) error {
 	if linkIndex == 0 {
 		return errors.New("egressroutemap: public_uplink_table: set: linkIndex must not be 0")
@@ -475,9 +415,8 @@ func (p *PublicUplink) Set(linkIndex int, dmac, smac net.HardwareAddr) error {
 	return nil
 }
 
-// Get reads this node's own currently-registered fabric-uplink next hop,
-// reporting whether one has ever been Set (an unset/link_ifindex==0
-// entry -- see Set's own comment -- reports ok=false).
+// Get reads this node's registered fabric-uplink next hop and reports whether
+// one has ever been Set. An unset entry reports ok false.
 func (p *PublicUplink) Get() (linkIndex int, dmac, smac net.HardwareAddr, ok bool, err error) {
 	var value prog.UsidPublicUplinkValue
 	if err := p.table.Lookup(publicUplinkKey, &value); err != nil {

--- a/internal/plumbing/ebpf/egressroutemap/pin.go
+++ b/internal/plumbing/ebpf/egressroutemap/pin.go
@@ -15,17 +15,13 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
-// OpenPinnedEgressRouteTable opens egress_route_table from its pinned path
-// under pinDir (internal/plumbing/ebpf/attach.Load pins every usid_ingress
-// map at <pinDir>/<map name> -- see usidmap.OpenPinnedRegistry's identical
-// convention) and returns an *EgressRouteTable wrapping it.
+// OpenPinnedEgressRouteTable opens egress_route_table from its pinned path under
+// pinDir and returns a table wrapping it. The datapath's maps are each pinned at
+// <pinDir>/<map name>.
 //
-// The returned io.Closer should be closed once at process shutdown for a
-// long-lived caller (galactic-router), or immediately after use for a
-// short-lived one (galactic-cni's own per-CNI-ADD/DEL process) --
-// mirroring vipxlatmap.OpenPinnedVipXlatTable's identical note; closing
-// only releases this process's own file descriptor onto the kernel-side
-// map object, never the map's pinned lifetime itself.
+// The returned closer should be closed once at process shutdown for a long-lived
+// caller, or immediately after use for a short-lived one. Either way it releases
+// only this process's own descriptor, never the map's pinned lifetime.
 func OpenPinnedEgressRouteTable(pinDir string) (*EgressRouteTable, io.Closer, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapEgressRouteTable), nil)
 	if err != nil {
@@ -35,10 +31,9 @@ func OpenPinnedEgressRouteTable(pinDir string) (*EgressRouteTable, io.Closer, er
 	return NewEgressRouteTable(usidmap.KernelTable{Map: m}), m, nil
 }
 
-// OpenPinnedNodeSourceAddress opens node_src_addr_table from its pinned
-// path under pinDir and returns a *NodeSourceAddress wrapping it. See
-// OpenPinnedEgressRouteTable's own comment for the pinning convention and
-// close-lifetime contract.
+// OpenPinnedNodeSourceAddress opens node_src_addr_table from its pinned path
+// under pinDir and returns a wrapper. See OpenPinnedEgressRouteTable for the
+// pinning convention and close contract.
 func OpenPinnedNodeSourceAddress(pinDir string) (*NodeSourceAddress, io.Closer, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapNodeSrcAddrTable), nil)
 	if err != nil {
@@ -48,10 +43,9 @@ func OpenPinnedNodeSourceAddress(pinDir string) (*NodeSourceAddress, io.Closer, 
 	return &NodeSourceAddress{table: usidmap.KernelTable{Map: m}}, m, nil
 }
 
-// OpenPinnedPublicUplink opens public_uplink_table from its pinned path
-// under pinDir and returns a *PublicUplink wrapping it. See
-// OpenPinnedEgressRouteTable's own comment for the pinning convention and
-// close-lifetime contract.
+// OpenPinnedPublicUplink opens public_uplink_table from its pinned path under
+// pinDir and returns a wrapper. See OpenPinnedEgressRouteTable for the pinning
+// convention and close contract.
 func OpenPinnedPublicUplink(pinDir string) (*PublicUplink, io.Closer, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapPublicUplinkTable), nil)
 	if err != nil {

--- a/internal/plumbing/ebpf/ifindexvrfmap/clock.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/clock.go
@@ -6,12 +6,10 @@ package ifindexvrfmap
 
 import "golang.org/x/sys/unix"
 
-// monotonicNow returns a nanosecond CLOCK_MONOTONIC reading, used to stamp
-// this process's own in-memory Generation bookkeeping (see doc.go). A
-// deliberate small duplicate of usidmap's own unexported monotonicNow and
-// nptv6map's own copy of the same -- see nptv6map/clock.go's doc comment
-// for why duplicating this five-line syscall wrapper, rather than exporting
-// it from usidmap, is the intentional choice here.
+// monotonicNow returns a nanosecond reading from the monotonic clock, stamping
+// this process's in-memory generation bookkeeping. A deliberate small duplicate
+// of the equivalent in the sibling map packages, for the reason given there:
+// it is a few lines wrapping one syscall.
 func monotonicNow() uint64 {
 	var ts unix.Timespec
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)

--- a/internal/plumbing/ebpf/ifindexvrfmap/doc.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/doc.go
@@ -3,60 +3,40 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package ifindexvrfmap implements the read/write API for the eBPF uSID
-// datapath's ifindex_vrf_table map (internal/plumbing/ebpf/prog/usid.c's
-// struct ifindex_vrf_value comment): one row per attachment (veth or tap),
-// keyed by that attachment's own host-side interface ifindex, mapping it to
-// the (Block, Argument) its VRF resolves to. usid_egress consults this to
-// resolve which VRF a plain, not-yet-encapsulated outbound packet on a
-// tenant's own interface belongs to, since it has no outer uSID destination
-// to decode that from the way usid_ingress does.
+// datapath's ifindex_vrf_table map: one row per attachment, veth or tap, keyed
+// by that attachment's host-side interface ifindex and mapping it to the
+// (Block, Argument) its VRF resolves to.
 //
-// # Reusing usidmap.Table/KernelTable/Iterator instead of duplicating them
+// usid_egress consults it to resolve which VRF a plain, not-yet-encapsulated
+// outbound packet belongs to, having no outer uSID destination to decode that
+// from the way usid_ingress does.
 //
-// Same reasoning as nptv6map's own doc comment: ifindex_vrf_table is a map
-// of the same usid.c/prog package as vrf_table, not a second datapath, so
-// this package imports and depends on usidmap.Table/KernelTable/Iterator
-// directly rather than re-declaring them.
+// # Reusing usidmap's map interfaces
 //
-// # Lifecycle: CNI DEL, not a periodic GC sweep
+// As in nptv6map: this is a map of the same datapath program as vrf_table, so
+// the map-operation seam, kernel adapter, and iterator usidmap defines are
+// imported rather than re-declared.
 //
-// Unlike vrf_table (whose (Block, Argument) key is shared by every
-// attachment on one VPC/node, and therefore needs the GC-driven
-// list-live-CRDs-then-reconcile pattern -- see usidmap.VRFTable.Reconcile
-// and gc.SweepEBPFVRFTable), ifindex_vrf_table's key is a single
-// attachment's own host-side ifindex: genuinely private to that one
-// attachment, exactly the same category internal/cni's own cmdDel doc
-// comment already puts the host/guest veth pair itself in ("the veth pair
-// is genuinely private to this attachment ... no sibling pod can ever still
-// be depending on it, so there is no ADD-race to defer to GC for") and
-// internal/cnitap's cmdDel puts the tap device in.
+// # Lifecycle: CNI DEL, not a periodic sweep
 //
-// Register happens from internal/cnibgp's registerEBPFDatapath, the exact
-// call site that already registers this same attachment's vrf_table entry
-// (Milestone 7.1), keyed additionally by the host-side interface's ifindex
-// (resolved there via netlink.LinkByName + intf.GenerateInterfaceNameHost --
-// see registerEBPFDatapath's own doc comment for why that one, narrow,
-// read-only kernel query is an accepted exception to galactic-bgp's
-// otherwise "zero kernel-interface dependency" design).
+// vrf_table's key is shared by every attachment on one VPC and node, so it needs
+// the GC-driven list-live-CRDs-then-reconcile pattern. This table's key is a
+// single attachment's own ifindex, private to that attachment exactly as its
+// veth pair or tap device is, with no sibling that could still depend on it.
 //
-// Unregister happens directly at CNI DEL time -- internal/cni's and
-// internal/cnitap's own cmdDel, immediately before (and using the same
-// already-resolved ifindex as) their existing veth.Delete/tap.Delete calls
-// -- rather than from a periodic GC sweep: no CRD anywhere records an
-// ifindex (crdnames carries no such annotation), so there is no live-set
-// gc.SweepEBPFVRFTable's own pattern could reconcile against without
-// inventing a new liveness-tracking mechanism this codebase has no
-// analogue for. CNI DEL already knows precisely when this attachment's own
-// interface is being destroyed and is best-effort/log-only on every other
-// step in that same function, so wiring Unregister there needs no new
-// machinery at all.
+// Register happens at the same call site that registers this attachment's
+// vrf_table entry, keyed additionally by the host-side ifindex resolved there.
+// Unregister happens at CNI DEL, immediately before the interface is destroyed
+// and using the same already-resolved ifindex.
 //
-// Register/Unregister/Get/List/Reconcile method shapes mirror
-// usidmap.VRFTable's own for API consistency and testability, including a
-// process-local Generation (see nptv6map's doc comment for why this table's
-// value carries no kernel-persisted generation field either) -- but
-// Reconcile is not wired into any production sweep today, precisely because
-// CNI DEL already owns this table's cleanup; it exists for parity, test
-// coverage, and as a future defense-in-depth backstop (e.g. a kubelet force
-// delete that skips CNI DEL entirely) should one ever be added.
+// A sweep is not an option anyway: no CRD records an ifindex, so there is no
+// live set to reconcile against without inventing a liveness mechanism this
+// codebase has no analogue for. CNI DEL already knows exactly when the interface
+// goes away and is best-effort on every other step in the same function.
+//
+// The method shapes mirror usidmap.VRFTable for consistency and testability,
+// including a process-local generation. Reconcile is not wired into any
+// production sweep, since CNI DEL owns cleanup; it exists for parity, test
+// coverage, and as a backstop should one ever be needed, such as for a forced
+// delete that skips CNI DEL.
 package ifindexvrfmap

--- a/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/ifindexvrf.go
@@ -17,9 +17,8 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
-// IfindexVRFEntry is one fully decoded ifindex_vrf_table row, decoupled from
-// prog.UsidIfindexVrfValue's cilium/ebpf/BTF-generated field layout --
-// mirrors usidmap.VRFEntry's own reasoning.
+// IfindexVRFEntry is one decoded ifindex_vrf_table row, kept separate from the
+// generated kernel layout.
 type IfindexVRFEntry struct {
 	Ifindex uint32
 	Block   uint64
@@ -27,9 +26,9 @@ type IfindexVRFEntry struct {
 	// Argument is the 12-bit uSID Argument this ifindex's VRF resolves to.
 	Argument uint16
 
-	// Generation is this process's own in-memory bookkeeping of when this
-	// entry was last (re-)registered -- see doc.go and nptv6map's own doc
-	// comment for why this is not kernel-persisted.
+	// Generation is this process's in-memory record of when this entry was last
+	// registered. See the package doc comment for why it is not
+	// kernel-persisted.
 	Generation uint64
 }
 
@@ -42,22 +41,17 @@ type IfindexVRFTable struct {
 	generation map[uint32]uint64
 }
 
-// NewIfindexVRFTable wraps table as an IfindexVRFTable. Production callers
-// pass a usidmap.KernelTable wrapping a loaded *prog.UsidObjects's
-// IfindexVrfTable map (or OpenPinned, below); tests pass a fake
-// usidmap.Table.
+// NewIfindexVRFTable wraps table as an IfindexVRFTable. Production callers pass
+// a kernel table over the loaded map, or use OpenPinned; tests pass a fake.
 func NewIfindexVRFTable(table usidmap.Table) *IfindexVRFTable {
 	return &IfindexVRFTable{table: table, clock: monotonicNow, generation: make(map[uint32]uint64)}
 }
 
 // OpenPinned opens ifindex_vrf_table from its pinned path under pinDir and
-// returns an IfindexVRFTable wrapping it, mirroring
-// usidmap.OpenPinnedRegistry -- for a process (internal/cnibgp's
-// registerEBPFDatapath, internal/cni's and internal/cnitap's cmdDel) that
-// did not itself load the datapath but needs to read/write this one map.
-// The returned *ebpf.Map is also this table's own io.Closer and must be
-// closed once the caller is done; it does not affect the map's pinned
-// lifetime.
+// returns a table wrapping it, for a process that did not itself load the
+// datapath but needs to read or write this one map. The returned map is also the
+// table's closer and must be closed when the caller is done, which does not
+// affect its pinned lifetime.
 func OpenPinned(pinDir string) (*IfindexVRFTable, *ebpf.Map, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapIfindexVrfTable), nil)
 	if err != nil {
@@ -71,10 +65,9 @@ func (t *IfindexVRFTable) Generation() uint64 {
 	return t.clock()
 }
 
-// Register writes (or overwrites) the ifindex_vrf_table entry for ifindex,
-// mapping it to (block, argument). Like nptv6map.NPTv6Table.Register, this
-// carries no counters and is always a plain overwrite -- there is no
-// read-modify-write step.
+// Register writes, or overwrites, the ifindex_vrf_table entry for ifindex,
+// mapping it to (block, argument). It carries no counters, so every call is a
+// plain overwrite with no read-modify-write step.
 func (t *IfindexVRFTable) Register(ifindex uint32, block uint64, argument uint16) error {
 	if err := uformat.ValidateBlock(block); err != nil {
 		return fmt.Errorf("ifindexvrfmap: ifindex_vrf_table: register ifindex=%d: %w", ifindex, err)
@@ -94,10 +87,9 @@ func (t *IfindexVRFTable) Register(ifindex uint32, block uint64, argument uint16
 	return nil
 }
 
-// Unregister removes the ifindex_vrf_table entry for ifindex, if present.
-// Not an error to unregister an already-absent entry -- DEL is idempotent
-// per the CNI spec, and every caller of this (internal/cni's and
-// internal/cnitap's cmdDel) treats every cleanup step as best-effort.
+// Unregister removes the ifindex_vrf_table entry for ifindex if present. An
+// already-absent entry is not an error: DEL is idempotent per the CNI spec, and
+// every caller treats cleanup as best-effort.
 func (t *IfindexVRFTable) Unregister(ifindex uint32) error {
 	if err := t.table.Delete(ifindex); err != nil {
 		if !errors.Is(err, ebpf.ErrKeyNotExist) {
@@ -141,12 +133,10 @@ func (t *IfindexVRFTable) List() ([]IfindexVRFEntry, error) {
 	return entries, nil
 }
 
-// Reconcile brings ifindex_vrf_table into agreement with live -- the
-// caller's current set of ifindexes that should have an entry -- removing
-// every entry whose key is absent from live, except an entry whose
-// Generation is >= cutoff. Mirrors usidmap.VRFTable.Reconcile's exact
-// semantics; see doc.go for why this is not wired into any production
-// sweep for this table today.
+// Reconcile brings ifindex_vrf_table into agreement with live, the caller's
+// current set of ifindexes that should have an entry, removing every entry whose
+// key is absent except one whose generation is at or above cutoff. See the
+// package doc comment for why no production sweep uses it today.
 func (t *IfindexVRFTable) Reconcile(live map[uint32]struct{}, cutoff uint64) (removed []IfindexVRFEntry, err error) {
 	entries, err := t.List()
 	if err != nil {

--- a/internal/plumbing/ebpf/metrics/collector.go
+++ b/internal/plumbing/ebpf/metrics/collector.go
@@ -17,38 +17,31 @@ import (
 
 const namespace = "galactic_usid"
 
-// DropReasonsReader abstracts drop_reasons's per-CPU lookup (a
-// BPF_MAP_TYPE_PERCPU_ARRAY keyed by drop reason index, design plan §4.4)
-// down to the one operation Collector needs, so tests can substitute an
-// in-memory fake instead of a real, kernel-loaded map. *ebpf.Map already
-// satisfies this interface structurally -- see NewCollectorFromObjects.
+// DropReasonsReader narrows the drop-reason map, a per-CPU array keyed by
+// reason index, to the one operation Collector needs, so tests can substitute an
+// in-memory fake. A real loaded map already satisfies it structurally.
 type DropReasonsReader interface {
 	Lookup(key, valueOut any) error
 }
 
-// Collector is a prometheus.Collector reading the eBPF uSID datapath's live
-// map state at every scrape (package doc comment): packets/bytes per
-// (uSID Block, Argument) vrf_table entry, drops by reason, and current
-// Argument-space utilization per uSID Block.
+// Collector reads the uSID datapath's live map state at every scrape:
+// per-Argument packet and byte counters, drops by reason, and Argument-space
+// utilization per Block.
 type Collector struct {
 	vrf         *usidmap.VRFTable
 	locator     *usidmap.LocatorTable
 	dropReasons DropReasonsReader
 }
 
-// NewCollector builds a Collector from already-constructed table/reader
-// values. Production callers normally use NewCollectorFromObjects; this
-// constructor exists so tests can pass fakes satisfying usidmap.Table (via
-// usidmap.NewVRFTable/NewLocatorTable) and DropReasonsReader without a
-// kernel.
+// NewCollector builds a Collector from already-constructed tables and reader.
+// Production callers normally use NewCollectorFromObjects; this exists so tests
+// can pass fakes without a kernel.
 func NewCollector(vrf *usidmap.VRFTable, locator *usidmap.LocatorTable, dropReasons DropReasonsReader) *Collector {
 	return &Collector{vrf: vrf, locator: locator, dropReasons: dropReasons}
 }
 
-// NewCollectorFromObjects builds a Collector reading directly from a
-// loaded *prog.UsidObjects's vrf_table/locator_table/drop_reasons maps --
-// e.g. the object internal/plumbing/ebpf/attach.Load/.Start/.StartWatching
-// returns.
+// NewCollectorFromObjects builds a Collector reading directly from a loaded
+// object set's maps.
 func NewCollectorFromObjects(objs *prog.UsidObjects) *Collector {
 	return NewCollector(
 		usidmap.NewVRFTable(usidmap.KernelTable{Map: objs.VrfTable}),
@@ -57,9 +50,8 @@ func NewCollectorFromObjects(objs *prog.UsidObjects) *Collector {
 	)
 }
 
-// labelBlock is the Prometheus label name for a uSID Block value, shared
-// across every metric Desc below that carries one (goconst: avoid repeating
-// the "block" string literal at each call site).
+// labelBlock is the Prometheus label name for a uSID Block, shared by every
+// metric below that carries one.
 const labelBlock = "block"
 
 var (
@@ -106,22 +98,17 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.collectDrops(ch)
 }
 
-// formatBlock renders a uSID Block value as a metric label -- hex, matching
-// the %#x formatting usidmap/uformat's own error messages already use for
-// Block values throughout this codebase.
+// formatBlock renders a Block as a metric label, in hex, matching how Block
+// values are formatted in error messages elsewhere.
 func formatBlock(block uint64) string {
 	return fmt.Sprintf("%#x", block)
 }
 
 func (c *Collector) collectVRF(ch chan<- prometheus.Metric) {
-	// Seed every currently-active uSID Block (from locator_table, the set
-	// of Blocks this node is actually configured for) with a zero count,
-	// so a Block with no vrf_table entries yet still reports
-	// arguments_used=0 / utilization_ratio=0 rather than simply being
-	// absent -- important for exhaustion alerting (package doc comment):
-	// an alert on "utilization > 0.9" needs the series to exist at 0 to
-	// have something to compare against later, not spring into existence
-	// only once traffic starts.
+	// Seed every currently active Block with a zero count, so one with no
+	// entries yet still reports zero rather than being absent. An alert on high
+	// utilization needs the series to exist at zero to compare against, not
+	// spring into existence once traffic starts.
 	perBlockUsed := make(map[uint64]int)
 	if c.locator != nil {
 		locatorEntries, err := c.locator.List()

--- a/internal/plumbing/ebpf/metrics/doc.go
+++ b/internal/plumbing/ebpf/metrics/doc.go
@@ -3,40 +3,24 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package metrics implements the eBPF uSID datapath's Prometheus
-// instrumentation (design plan .local/plan-ebpf-xdp-usid-datapath.md §9's
-// observability bullet: "Export Prometheus metrics for: packets/bytes per
-// Argument (VRF), drops by reason (drop_reasons map), BPF program
-// load/reload events and failures, and ... current Argument-space
-// utilization per uSID Block"; Milestone 4 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+// instrumentation.
 //
-// Two different kinds of signal need two different Prometheus
-// instrumentation styles here, and this package keeps them in separate
-// files for that reason:
+// Two kinds of signal need two instrumentation styles, which is why they live
+// in separate files:
 //
-//   - packets/bytes per Argument, drops by reason, and per-Block Argument
-//     utilization (collector.go) are all *state currently held in a BPF
-//     map* -- vrf_table, locator_table, drop_reasons. These are read live,
-//     directly from the map, at every Prometheus scrape via a custom
-//     prometheus.Collector, rather than mirrored into incrementally-
-//     `Set()` Gauges: a vrf_table entry the GC sweep removes (Milestone
-//     7.3, internal/plumbing/ebpf/usidmap.VRFTable.Reconcile) simply stops
-//     being emitted on the *next* scrape this way, instead of leaking a
-//     stale label combination in a Gauge/GaugeVec forever (Prometheus
-//     Gauges have no way to "expire" a label combination on their own;
-//     only a Collector that re-derives its label set from the live source
-//     of truth at every Collect() call gets that for free).
-//   - BPF program load/reload events and failures (events.go) are
-//     discrete occurrences at the moment they happen (a Load() call
-//     succeeding or failing; an interface being attached/detached),
-//     not values held anywhere the collector could re-read later --
-//     so these are ordinary prometheus.CounterVecs, incremented in place
-//     via internal/plumbing/ebpf/attach's LoadHook/AttachHook callbacks
-//     (attach/hooks.go), wired once via attach.SetHooks at process
-//     startup (internal/installer.Run).
+//   - Per-Argument counters, drops by reason, and per-Block Argument
+//     utilization are state currently held in a BPF map. They are read live
+//     from the map at every scrape through a custom collector, rather than
+//     mirrored into gauges. An entry the GC sweep removes then simply stops
+//     being emitted on the next scrape, instead of leaking a stale label
+//     combination forever: a gauge cannot expire one, while a collector that
+//     re-derives its label set from the live source at every collection gets
+//     that for free.
+//   - Program load and attach events are discrete occurrences at the moment
+//     they happen, held nowhere a collector could re-read them, so they are
+//     ordinary counters incremented in place through the attach package's
+//     hooks, wired once at process startup.
 //
-// Metrics (metrics.go) bundles both into one prometheus.Registry plus an
-// http.Handler for internal/installer.Run to serve, so that package only
-// needs to call metrics.New() once and doesn't need to import
-// prometheus/promhttp directly.
+// Metrics bundles both into one registry plus an HTTP handler, so the caller
+// constructs it once and needs no Prometheus imports of its own.
 package metrics

--- a/internal/plumbing/ebpf/metrics/events.go
+++ b/internal/plumbing/ebpf/metrics/events.go
@@ -10,11 +10,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 )
 
-// EventCounters are ordinary Prometheus counters for BPF program
-// load/reload events and failures (package doc comment). Unlike Collector
-// (map state read live at scrape time), these are discrete events observed
-// exactly once, at the moment they happen, via
-// internal/plumbing/ebpf/attach's LoadHook/AttachHook callbacks.
+// EventCounters are ordinary Prometheus counters for program load and attach
+// events. Unlike the collector, which reads map state live at scrape time, these
+// are discrete events observed exactly once, when they happen, through the
+// attach package's hooks.
 type EventCounters struct {
 	load   *prometheus.CounterVec
 	attach *prometheus.CounterVec
@@ -39,10 +38,9 @@ func NewEventCounters() *EventCounters {
 	}
 }
 
-// MustRegister registers every counter this type owns against reg. Panics
-// on a duplicate registration, matching prometheus.Registerer.MustRegister's
-// own documented behavior -- callers only ever do this once per process, at
-// startup (see Metrics.New).
+// MustRegister registers every counter this type owns against reg, panicking on
+// a duplicate as the underlying registry does. Callers do this once per process,
+// at startup.
 func (c *EventCounters) MustRegister(reg prometheus.Registerer) {
 	reg.MustRegister(c.load, c.attach)
 }

--- a/internal/plumbing/ebpf/metrics/metrics.go
+++ b/internal/plumbing/ebpf/metrics/metrics.go
@@ -13,21 +13,19 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 )
 
-// Metrics bundles this milestone's Prometheus instrumentation into one
-// private registry (deliberately not prometheus.DefaultRegisterer -- a
-// private registry keeps this package's metrics free of global-registration
-// panics if a test, or a future caller, constructs more than one Metrics in
-// the same process) plus an http.Handler for internal/installer.Run to
-// serve, so that package doesn't need to import prometheus/promhttp
-// directly.
+// Metrics bundles this datapath's Prometheus instrumentation into one private
+// registry, plus an HTTP handler for the caller to serve so it needs no
+// Prometheus imports of its own. A private registry rather than the global one,
+// so constructing more than one in a process cannot panic on duplicate
+// registration.
 type Metrics struct {
 	Registry *prometheus.Registry
 	Events   *EventCounters
 }
 
-// New builds a Metrics with EventCounters already registered. Call
-// RegisterDatapathCollector once the eBPF uSID datapath has actually been
-// loaded to also expose live vrf_table/locator_table/drop_reasons state.
+// New builds a Metrics with the event counters already registered. Call
+// RegisterDatapathCollector once the datapath is loaded to also expose live map
+// state.
 func New() *Metrics {
 	reg := prometheus.NewRegistry()
 	events := NewEventCounters()
@@ -35,10 +33,8 @@ func New() *Metrics {
 	return &Metrics{Registry: reg, Events: events}
 }
 
-// RegisterDatapathCollector registers a Collector reading live
-// vrf_table/locator_table/drop_reasons state from objs at every scrape.
-// Call once, after the datapath is loaded (internal/installer.Run, right
-// after a successful ebpfStartFn call).
+// RegisterDatapathCollector registers a collector reading live map state from
+// objs at every scrape. Call it once, after the datapath is loaded.
 func (m *Metrics) RegisterDatapathCollector(objs *prog.UsidObjects) error {
 	return m.Registry.Register(NewCollectorFromObjects(objs))
 }

--- a/internal/plumbing/ebpf/nat66attach/attach.go
+++ b/internal/plumbing/ebpf/nat66attach/attach.go
@@ -19,20 +19,15 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
 )
 
-// PinDir is the default bpffs directory every nat66prog map is pinned
-// under -- deliberately distinct from every other datapath's own PinDir
-// in this codebase (internal/plumbing/ebpf/attach.PinDir,
-// internal/plumbing/ebpf/edgeattach.PinDir), so this datapath is fully
-// independent under bpffs even where map names don't actually collide.
+// PinDir is the default bpffs directory every NAT66 map is pinned under,
+// deliberately distinct from every other datapath's, so each is fully
+// independent under bpffs even where map names do not collide.
 const PinDir = "/sys/fs/bpf/galactic-nat66"
 
-// Load loads nat66prog's compiled object with every map pinned under
-// pinDir. A map already pinned there from a previous process is reused
-// as-is; see internal/plumbing/ebpf/edgeattach.Load's identical doc
-// comment for the full rationale (schema-mismatch recreation, pin-by-name
-// semantics) -- not repeated here, since it applies unchanged. See doc.go
-// for why, unlike edgeattach.Load, there is no kernel preflight check
-// here.
+// Load loads the compiled NAT66 object with every map pinned under pinDir. A
+// map already pinned there by a previous process is reused as-is. See the
+// package doc comment for why, unlike its sibling, there is no kernel preflight
+// check here.
 func Load(pinDir string) (*nat66prog.Nat66Objects, error) {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return nil, fmt.Errorf("nat66attach: remove memlock rlimit: %w", err)
@@ -53,13 +48,11 @@ func Load(pinDir string) (*nat66prog.Nat66Objects, error) {
 	opts := &ebpf.CollectionOptions{Maps: ebpf.MapOptions{PinPath: pinDir}}
 	loadErr := spec.LoadAndAssign(&loaded, opts)
 	if loadErr != nil && errors.Is(loadErr, ebpf.ErrMapIncompatible) {
-		// Every map here is either control-plane-owned and reconstructable
-		// (shard_config_table is rewritten once at process startup by
-		// cmd/galactic-nat66's setupNat66Datapath) or datapath-owned and
-		// self-managed (nat66_conn_table is an LRU that self-evicts;
-		// drop_reasons is a pure counter array) -- a stale pin from an
-		// older, incompatible map layout is safe to recreate rather than
-		// fatal.
+		// Every map here is either control-plane-owned and reconstructable,
+		// the shard config being rewritten at process startup, or
+		// datapath-owned and self-managing, the connection table being an
+		// LRU that self-evicts and the drop counters a pure array. A stale
+		// pin from an incompatible layout is safe to recreate.
 		slog.Warn("nat66attach: pinned eBPF map incompatible with the newly compiled map spec, recreating "+
 			"(control-plane state will repopulate at next startup)", "pinDir", pinDir, "err", loadErr)
 		if unpinErr := unpinIncompatibleMaps(spec, pinDir); unpinErr != nil {
@@ -99,11 +92,10 @@ func unpinIncompatibleMaps(spec *ebpf.CollectionSpec, pinDir string) error {
 	return errors.Join(errs...)
 }
 
-// Attach attaches program (nat66prog.Nat66Objects.Nat66Ingress) to
-// ifaceName's XDP hook in native (driver) mode, returning the resulting
-// link.Link for the caller to hold open and Close on shutdown -- see
-// doc.go for why native mode is required, not merely preferred, and why no
-// pinning or Watch-style re-attachment is needed here.
+// Attach attaches program to ifaceName's XDP hook in native driver mode,
+// returning the link for the caller to hold open and close on shutdown. See the
+// package doc comment for why native mode is required and why no pinning or
+// re-attachment is needed.
 func Attach(program *ebpf.Program, ifaceName string) (link.Link, error) {
 	if program == nil {
 		return nil, errors.New("nat66attach: program is nil")

--- a/internal/plumbing/ebpf/nat66attach/doc.go
+++ b/internal/plumbing/ebpf/nat66attach/doc.go
@@ -2,32 +2,26 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nat66attach loads internal/plumbing/ebpf/nat66prog's compiled XDP
-// program and attaches it to one interface -- one NAT66 shard's own
-// fabric-facing uplink -- mirroring internal/plumbing/ebpf/edgeattach's
-// mechanics almost verbatim (pinned maps, verifier-error unwrapping,
-// incompatible-map recreation on a schema change; native-driver-mode-only
-// XDP attach with no generic-mode fallback). See edgeattach's own doc
-// comment for the full rationale behind each of those choices -- it
-// applies unchanged here, this package is not repeating it.
+// Package nat66attach loads the compiled NAT66 XDP program and attaches it to
+// one interface, a shard's fabric-facing uplink.
 //
-// # No kernel preflight check here
+// It mirrors the edge attach package's mechanics almost verbatim: pinned maps,
+// verifier-error unwrapping, incompatible-map recreation on a schema change, and
+// native-driver-mode attach with no generic-mode fallback. See that package for
+// the rationale behind each, which applies here unchanged.
 //
-// Unlike edgeattach.Load, this package's Load does not run a kernel
-// preflight check before loading: internal/plumbing/ebpf/edgepreflight is
-// scoped specifically to edgeprog's own map types (its own doc comment
-// lists BPF_MAP_TYPE_HASH, not BPF_MAP_TYPE_LRU_HASH -- nat66_conn_table's
-// actual type), and internal/plumbing/ebpf/preflight is scoped to the SRv6
-// uSID TC-BPF datapath. Neither is a correct fit, and inventing a third,
-// nat66-specific preflight package is out of scope for this phase --
-// LoadAndAssign's own verifier-error unwrapping already surfaces "this
-// kernel can't load this program" clearly at load time, just later than a
-// dedicated preflight check would.
+// # No kernel preflight check
 //
-// # One attach target, no Watch-style re-attachment
+// Unlike its sibling, Load runs no preflight check first. The edge preflight
+// package is scoped to that datapath's own map types, which do not include the
+// LRU hash this connection table uses, and the uSID preflight package is scoped
+// to the TC-BPF datapath. Neither fits, and a third package is out of scope for
+// now. Loading already surfaces "this kernel cannot load this program" clearly,
+// just later than a dedicated check would.
 //
-// Same as edgeattach: this program has exactly one attach target (a fixed,
-// operator-configured interface name, config.NAT66Config.UplinkInterface),
-// attached once at process startup by cmd/galactic-nat66. There is no
-// external network event this package needs to notice on its own.
+// # One attach target, no re-attachment
+//
+// This program has exactly one target, a fixed operator-configured interface,
+// attached once at process startup. There is no external event this package
+// needs to notice on its own.
 package nat66attach

--- a/internal/plumbing/ebpf/nat66map/conntable.go
+++ b/internal/plumbing/ebpf/nat66map/conntable.go
@@ -14,23 +14,19 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
 )
 
-// beU16 converts v between host and big-endian ("network") representation
-// by a full 2-byte swap -- its own inverse, so this same function is used
-// for both directions. Required because nat66prog's generated Go structs
-// store a C __be16 field as a plain uint16, and cilium/ebpf's BTF-based
-// marshalling writes it using the host's native (little-endian, on every
-// architecture this repo targets) byte order with no swap of its own. This
-// duplicates edgemap's identically-named helper rather than importing it --
-// see doc.go for why this package does not depend on edgemap.
+// beU16 swaps a uint16 between host and network byte order. A full 2-byte swap
+// is its own inverse, so one function serves both directions. Needed because the
+// generated Go structs store a big-endian C field as a plain uint16, which the
+// marshalling writes in host order with no swap. Duplicated rather than imported
+// from a sibling map package; see the package doc comment for why this package
+// depends on none of them.
 func beU16(v uint16) uint16 {
 	return v<<8 | v>>8
 }
 
-// ConnKey identifies one nat66_conn_table row -- see nat66.c's struct
-// conn_key doc comment for the forward/reverse row layout this mirrors.
-// TenantArg is host-order (nat66.c's read_argument already returns it in
-// host order, not wire order, so unlike Sport/Dport it needs no beU16
-// swap); Sport/Dport are the packet's own wire-order (__be16) ports.
+// ConnKey identifies one nat66_conn_table row, mirroring the datapath's forward
+// and reverse row layout. TenantArg is in host order, the datapath already
+// returning it that way; the ports are the packet's own wire-order values.
 type ConnKey struct {
 	Proto     uint8
 	TenantArg uint16
@@ -45,9 +41,8 @@ type ConnKey struct {
 type ConnEntry struct {
 	ConnKey
 
-	// BackendAddr/BackendPort are the tenant backend's own facing
-	// address/port -- present in both the forward and reverse row's value
-	// (nat66.c's struct conn_value comment).
+	// BackendAddr and BackendPort are the tenant backend's facing address and
+	// port, present in both the forward and reverse row's value.
 	BackendAddr netip.Addr
 	BackendPort uint16
 
@@ -63,24 +58,21 @@ type ConnEntry struct {
 	// to re-encapsulate a reply back toward it (handle_return).
 	BackendUSID netip.Addr
 
-	// Proto is the value's own copy of the protocol, read back
-	// independently of ConnKey.Proto (both are always equal by
-	// construction -- nat66.c never writes them differently -- exposed
-	// separately only because Nat66ConnValue carries its own field).
+	// Proto is the value's own copy of the protocol, always equal to the key's
+	// by construction and exposed separately only because the kernel value
+	// carries its own field.
 	Proto uint8
 }
 
-// ConnTable is the read-only accessor for nat66_conn_table -- see doc.go
-// for why this package never writes to it. Get/List exist purely for
-// observability/metrics (e.g. a future admin CLI or diagnostics endpoint);
-// nothing in this codebase's control plane depends on reading it today.
+// ConnTable is the read-only accessor for nat66_conn_table; see the package doc
+// comment for why this package never writes it. Get and List exist for
+// observability, and nothing in the control plane depends on reading them.
 type ConnTable struct {
 	table Table
 }
 
-// NewConnTable wraps table as a ConnTable. Production callers pass a
-// KernelTable wrapping a loaded *nat66prog.Nat66Objects's Nat66ConnTable
-// map; tests pass a fake Table.
+// NewConnTable wraps table as a ConnTable. Production callers pass a kernel
+// table over the loaded map; tests pass a fake.
 func NewConnTable(table Table) *ConnTable {
 	return &ConnTable{table: table}
 }
@@ -144,10 +136,9 @@ func (t *ConnTable) Get(key ConnKey) (ConnEntry, bool, error) {
 	return fromWireConnValue(key, value), true, nil
 }
 
-// List returns every entry currently in nat66_conn_table, in unspecified
-// order. Since this is an LRU-evicting map under live traffic, the result
-// is only ever a point-in-time snapshot -- a row present in one List call
-// may be gone (evicted, or aged out) by the next.
+// List returns every entry currently in nat66_conn_table, in unspecified order.
+// The map evicts under live traffic, so the result is a point-in-time snapshot:
+// a row present in one call may be gone by the next.
 func (t *ConnTable) List() ([]ConnEntry, error) {
 	var (
 		entries []ConnEntry

--- a/internal/plumbing/ebpf/nat66map/doc.go
+++ b/internal/plumbing/ebpf/nat66map/doc.go
@@ -2,57 +2,34 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nat66map implements the read/write API for
-// internal/plumbing/ebpf/nat66prog's two control-plane-facing maps
-// (shard_config_table, a single-entry write target this shard's own
-// operator-supplied identity is stamped into; drop_reasons, a per-CPU
-// counter array) plus a read-only accessor for nat66_conn_table, the
-// datapath's own self-managed LRU flow-state table.
+// Package nat66map implements the read/write API for the NAT66 datapath's two
+// control-plane-facing maps, shard_config_table and drop_reasons, plus a
+// read-only accessor for nat66_conn_table, the datapath's self-managed LRU flow
+// table.
 //
 // # nat66_conn_table is never written here
 //
-// nat66_conn_table (a BPF_MAP_TYPE_LRU_HASH) is written ONLY by
-// nat66.c's own handle_forward/handle_return -- it allocates masquerade
-// ports, claims rows via BPF_NOEXIST, and self-evicts under memory
-// pressure with no GC needed, entirely inside the datapath. This mirrors
-// the identical "never write conn_table, only read for observability"
-// boundary internal/plumbing/ebpf/edgemap's now-removed edgenat.c-era
-// ruletable.go doc comment described for that program's own conn_table:
-// ConnTable in this package exposes Get/List only, no Register/Unregister/
-// Reconcile at all -- there is no control-plane liveness set to reconcile
-// this table against in the first place.
+// The datapath alone writes that table: it allocates masquerade ports, claims
+// rows, and self-evicts under memory pressure, with no GC needed. ConnTable
+// exposes only Get and List, since there is no control-plane liveness set to
+// reconcile it against.
 //
-// # shard_config_table is the one thing the control plane does write
+// # shard_config_table is what the control plane does write
 //
-// shard_config_table (a single-entry BPF_MAP_TYPE_ARRAY, key uint32(0))
-// carries this shard's own identity -- shard_sid and shard_pub_addr,
-// both operator-supplied (see internal/config.NAT66Config) -- and is
-// written exactly once, at process startup, by cmd/galactic-nat66's
-// setupNat66Datapath. ShardConfigTable's Set/Get mirror
-// internal/plumbing/ebpf/edgemap/doc.go's own reasoning for why
-// encap_config_table (edgeprog's analogous single-entry map) doesn't get a
-// dedicated wrapper there: unlike that case, this package does give
-// shard_config_table one, because unlike edgeprog's encap_config_table
-// (a single field, written directly by internal/gateway.NewKernelDatapath)
-// this map's value has two fields and benefits from the same
-// netip.Addr-typed, validated API every other table in this codebase's
-// eBPF map layer already offers -- see internal/plumbing/ebpf/prog's own
-// locator_table/vrf_table wrappers (internal/plumbing/ebpf/usidmap) for the
-// precedent this package follows instead.
+// A single-entry array carrying this shard's identity, its SID and public
+// address, both operator-supplied, written once at process startup.
+// ShardConfigTable gives it a typed, validated wrapper rather than a raw Put,
+// as the other map layers here do, because the value has two address fields.
 //
-// # Reusing usidmap's or edgemap's Table/KernelTable/Iterator? No.
+// # Its own Table interface, not usidmap's or edgemap's
 //
-// nat66prog.nat66.c is its own standalone datapath -- no map or key layout
-// shared with usid.c (usidmap) or edgedsr.c (edgemap) -- so, following
-// edgemap's own doc comment's precedent for why it does not import
-// usidmap's identical interface, this package declares its own Table/
-// KernelTable/Iterator (table.go) rather than importing either.
+// This is a standalone datapath sharing no map or key layout with the others, so
+// this package declares its own Table, KernelTable, and Iterator rather than
+// importing either neighbor's.
 //
 // # Testability
 //
-// Every table type here is built against the Table interface (table.go),
-// not directly against *ebpf.Map: KernelTable adapts a real, loaded map
-// (e.g. nat66prog.Nat66Objects.ShardConfigTable) for production use, while
-// this package's own tests substitute an in-memory fake to exercise every
-// code path without a kernel or root privileges.
+// Every table type is built against the Table interface rather than directly
+// against a loaded map: KernelTable adapts a real map for production, and tests
+// substitute an in-memory fake to exercise every path without a kernel or root.
 package nat66map

--- a/internal/plumbing/ebpf/nat66map/dropreasons.go
+++ b/internal/plumbing/ebpf/nat66map/dropreasons.go
@@ -10,23 +10,16 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
 )
 
-// DropReasonsReader abstracts drop_reasons's per-CPU lookup (a
-// BPF_MAP_TYPE_PERCPU_ARRAY keyed by drop reason index) down to the one
-// operation this package needs, so tests can substitute an in-memory fake
-// instead of a real, kernel-loaded map -- same interface shape as
-// internal/plumbing/ebpf/edgemetrics.DropReasonsReader and
-// internal/plumbing/ebpf/metrics's identical type. *ebpf.Map already
-// satisfies this interface structurally.
+// DropReasonsReader narrows the drop-reason map, a per-CPU array keyed by
+// reason index, to the one operation this package needs, so tests can substitute
+// an in-memory fake. A real loaded map already satisfies it structurally.
 type DropReasonsReader interface {
 	Lookup(key, valueOut any) error
 }
 
-// SumDropReason reads drop_reasons[index] (one per-CPU counter slice) and
-// returns the sum across every CPU -- the per-CPU-array summing idiom
-// internal/plumbing/ebpf/prog's test helpers and
-// internal/plumbing/ebpf/edgemetrics.Collector.collectDrops both already
-// use, duplicated here rather than imported for the same "no shared
-// datapath" reasoning doc.go gives for Table/KernelTable/Iterator.
+// SumDropReason reads one drop-reason counter and returns the sum across every
+// CPU. Duplicated here rather than imported, for the same no-shared-datapath
+// reasoning the package doc comment gives for the map interfaces.
 func SumDropReason(reader DropReasonsReader, index uint32) (uint64, error) {
 	var perCPU []uint64
 	if err := reader.Lookup(index, &perCPU); err != nil {
@@ -39,11 +32,9 @@ func SumDropReason(reader DropReasonsReader, index uint32) (uint64, error) {
 	return total, nil
 }
 
-// DropReasonTotals reads every drop reason index
-// (nat66prog.DropReasonNat66Count of them) and returns the per-CPU-summed
-// total for each, keyed by its DropReasonNat66* index -- the shape a
-// Prometheus collector (or any other caller) reads a full snapshot from in
-// one call rather than looping SumDropReason itself.
+// DropReasonTotals reads every drop reason index and returns the per-CPU summed
+// total for each, keyed by index: a full snapshot in one call rather than a
+// caller looping over SumDropReason.
 func DropReasonTotals(reader DropReasonsReader) (map[uint32]uint64, error) {
 	totals := make(map[uint32]uint64, nat66prog.DropReasonNat66Count)
 	for i := range nat66prog.DropReasonNat66Count {

--- a/internal/plumbing/ebpf/nat66map/shardconfig.go
+++ b/internal/plumbing/ebpf/nat66map/shardconfig.go
@@ -14,24 +14,21 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/nat66prog"
 )
 
-// shardConfigKey is shard_config_table's single, fixed key (nat66.c's
-// `__u32 cfg_key = 0`) -- this map is a BPF_MAP_TYPE_ARRAY with
-// max_entries=1, so there is exactly one valid key, ever.
+// shardConfigKey is shard_config_table's single fixed key. The map is a
+// one-entry array, so there is exactly one valid key.
 const shardConfigKey uint32 = 0
 
-// ShardConfig is shard_config_table's fully decoded single row: this
-// shard's own operator-supplied identity (internal/config.NAT66Config's
-// ShardSID/ShardPubAddr, already validated there). See nat66.c's header
-// comment for what each address is used for.
+// ShardConfig is shard_config_table's decoded single row: this shard's
+// operator-supplied identity, already validated by config parsing. See the
+// datapath's header comment for what each address is used for.
 type ShardConfig struct {
-	// ShardSID is this shard's own SRv6 uSID (uFMT 48+16) -- the outer
-	// destination a tenant's egress packet is encapsulated toward, and the
-	// re-encap source handle_return uses on the way back.
+	// ShardSID is this shard's own SRv6 uSID: the outer destination a tenant's
+	// egress packet is encapsulated toward, and the re-encapsulation source used
+	// on the way back.
 	ShardSID netip.Addr
 
-	// ShardPubAddr is this shard's own publicly-routable masquerade source
-	// address -- every flow this shard NATs is SNAT'd to an address:port
-	// within it.
+	// ShardPubAddr is this shard's publicly routable masquerade source. Every
+	// flow this shard translates is given an address and port within it.
 	ShardPubAddr netip.Addr
 }
 
@@ -40,16 +37,14 @@ type ShardConfigTable struct {
 	table Table
 }
 
-// NewShardConfigTable wraps table as a ShardConfigTable. Production callers
-// pass a KernelTable wrapping a loaded *nat66prog.Nat66Objects's
-// ShardConfigTable map; tests pass a fake Table.
+// NewShardConfigTable wraps table as a ShardConfigTable. Production callers pass
+// a kernel table over the loaded map; tests pass a fake.
 func NewShardConfigTable(table Table) *ShardConfigTable {
 	return &ShardConfigTable{table: table}
 }
 
-// validateAddr rejects anything that isn't a native IPv6 address --
-// phase 1 is IPv6-only, matching every other table in this codebase's own
-// convention (e.g. edgemap.toWireKey's identical check).
+// validateAddr rejects anything that is not a native IPv6 address, this datapath
+// being IPv6-only.
 func validateAddr(field string, addr netip.Addr) error {
 	if !addr.Is6() || addr.Is4In6() {
 		return fmt.Errorf("%s %s is not a native IPv6 address (phase 1 is IPv6-only)", field, addr)
@@ -57,13 +52,10 @@ func validateAddr(field string, addr netip.Addr) error {
 	return nil
 }
 
-// Set writes (or overwrites) shard_config_table's single entry with cfg.
-// This is a blind overwrite, not a read-modify-write: shard_config_table
-// carries no counters or other datapath-owned fields to preserve across a
-// re-write (unlike, e.g., edgemap.VIPTable's own vip_table/vip_stats_table
-// split -- see that package's Register doc comment for the race a
-// read-modify-write would otherwise risk here; shard_config_table has no
-// such risk because it has nothing the datapath itself increments).
+// Set writes, or overwrites, the single entry with cfg. A blind overwrite
+// rather than a read-modify-write: this map carries no counters or other
+// datapath-owned fields to preserve, and so has none of the race a
+// read-modify-write would risk on a map the datapath itself increments.
 func (t *ShardConfigTable) Set(cfg ShardConfig) error {
 	if err := validateAddr("shard SID", cfg.ShardSID); err != nil {
 		return fmt.Errorf("nat66map: shard_config_table: set: %w", err)
@@ -82,9 +74,8 @@ func (t *ShardConfigTable) Set(cfg ShardConfig) error {
 	return nil
 }
 
-// Get reads shard_config_table's single entry, reporting whether it has
-// been written yet (nat66_ingress fails open -- XDP_PASS, not claimed --
-// on every packet until it has, per nat66.c's header comment).
+// Get reads the single entry and reports whether it has been written yet. Until
+// it has, the datapath fails open and claims no packets.
 func (t *ShardConfigTable) Get() (ShardConfig, bool, error) {
 	var value nat66prog.Nat66ShardConfig
 	if err := t.table.Lookup(shardConfigKey, &value); err != nil {

--- a/internal/plumbing/ebpf/nat66map/table.go
+++ b/internal/plumbing/ebpf/nat66map/table.go
@@ -6,49 +6,42 @@ package nat66map
 
 import "github.com/cilium/ebpf"
 
-// Table is the minimal map-operation surface every table type in this
-// package is written against, instead of directly against *ebpf.Map. Its
-// method set matches *ebpf.Map's own Put/Lookup/Delete/Iterate closely
-// enough that KernelTable (below) is a one-line adapter; this package's own
-// tests substitute a fake, in-memory implementation to exercise
-// shard-config/read-accessor logic without a kernel or root privileges --
-// see doc.go for why this is its own declaration rather than an import of
-// edgemap's or usidmap's identical interface.
+// Table is the minimal map-operation surface every table type in this package is
+// written against, rather than a loaded map directly. Its method set is close
+// enough to the real map's that KernelTable is a one-line adapter, and tests
+// substitute an in-memory fake to exercise this package's logic without a kernel
+// or root. See the package doc comment for why it is declared here rather than
+// imported from a sibling.
 type Table interface {
 	// Put creates or overwrites the map entry at key with value.
 	Put(key, value any) error
 
-	// Lookup reads the map entry at key into valueOut. It returns
-	// ebpf.ErrKeyNotExist (or, for a fake Table, an error satisfying
-	// errors.Is(err, ebpf.ErrKeyNotExist)) if key is absent.
+	// Lookup reads the entry at key into valueOut, returning an error matching
+	// ebpf.ErrKeyNotExist when key is absent.
 	Lookup(key, valueOut any) error
 
 	// Delete removes the map entry at key. It returns ebpf.ErrKeyNotExist
 	// (see Lookup) if key is already absent.
 	Delete(key any) error
 
-	// Iterate returns an Iterator walking every entry currently in the
-	// map, in unspecified order -- matching *ebpf.Map.Iterate's own
-	// documented behavior.
+	// Iterate returns an Iterator over every entry currently in the map, in
+	// unspecified order.
 	Iterate() Iterator
 }
 
 // Iterator matches *ebpf.MapIterator's own Next/Err method set.
 type Iterator interface {
-	// Next decodes the next key/value pair into keyOut/valueOut and
-	// reports whether one was available. Callers must check Err after Next
-	// returns false to distinguish "iteration finished" from "an error
-	// interrupted iteration."
+	// Next decodes the next pair into keyOut and valueOut and reports whether
+	// one was available. Callers must check Err after it returns false, to tell
+	// a finished iteration from an interrupted one.
 	Next(keyOut, valueOut any) bool
 
 	// Err returns the first error encountered during iteration, if any.
 	Err() error
 }
 
-// KernelTable adapts a real, loaded *ebpf.Map -- e.g.
-// nat66prog.Nat66Objects's ShardConfigTable/Nat66ConnTable/DropReasons map
-// fields, once loaded by internal/plumbing/ebpf/nat66attach -- to the
-// Table interface every table type in this package is written against.
+// KernelTable adapts a real, loaded map to the Table interface every table type
+// in this package is written against.
 type KernelTable struct {
 	Map *ebpf.Map
 }

--- a/internal/plumbing/ebpf/nat66prog/doc.go
+++ b/internal/plumbing/ebpf/nat66prog/doc.go
@@ -2,45 +2,32 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nat66prog holds the compiled XDP program that implements one
-// shard of galactic-nat66's sharded, stateful NAT66 egress tier (design
-// plan §3) -- deliberately its own standalone datapath, not a personality
-// bolted onto galactic-gateway's own edgedsr.c: tenant egress traffic
-// (backend -> arbitrary internet destination) is a different pattern from
-// ingress (fixed VIP, fixed backend pool) and needs its own placement
-// ring, own state, own maps, with nothing shared between the two tiers.
+// Package nat66prog holds the compiled XDP program implementing one shard of
+// the sharded, stateful NAT66 egress tier.
 //
-// nat66.c is the single source of truth for the packet path; see its
-// header comment for the full walkthrough. `go generate` (via bpf2go)
-// compiles it with clang into a CO-RE-portable BPF object and generates
-// matching Go bindings (Nat66Objects, LoadNat66, LoadNat66Objects, plus
-// per-map/per-program fields) in this package.
+// It is deliberately its own datapath rather than a second personality on the
+// edge gateway's: tenant egress toward an arbitrary internet destination is a
+// different pattern from ingress toward a fixed VIP and backend pool, and needs
+// its own placement ring, state, and maps, sharing nothing with that tier.
 //
-// Same not-committed-generated-artifacts convention as
-// internal/plumbing/ebpf/prog and internal/plumbing/ebpf/edgeprog: see
-// either's doc.go for the full rationale (a compiled binary blob risks
-// silently drifting out of sync with its own source with nothing to catch
-// the mismatch short of a byte-diff).
+// nat66.c is the single source of truth for the packet path; its header comment
+// walks it. `go generate` compiles it with clang into a CO-RE-portable BPF
+// object and generates the matching Go bindings here.
 //
-// Placement: sibling of internal/plumbing/ebpf/edgeprog under the shared
-// internal/plumbing/ebpf/ umbrella, its own package rather than a second
-// program in edgeprog -- same "different datapath domain, no shared
-// map/key layout" reasoning edgeprog's own doc.go gives for not folding
-// into internal/plumbing/ebpf/prog.
+// The generated files are gitignored rather than committed, as in the sibling
+// datapath packages: a committed binary blob can drift out of sync with its
+// source with nothing short of a byte-diff to catch it.
 //
-// This package does not itself load or attach the compiled program to any
-// interface -- that is internal/plumbing/ebpf/nat66attach's job (mirroring
-// edgeattach's shape), driven by cmd/galactic-nat66.
+// This package neither loads nor attaches the program; internal/plumbing/ebpf/
+// nat66attach does, driven by cmd/galactic-nat66.
 package nat66prog
 
-// See internal/plumbing/ebpf/prog/doc.go for why -idirafter lists both
-// multiarch directories and why -cc is omitted.
+// See the uSID program package's doc.go for why the include flags list both
+// multiarch directories and why the compiler is not named explicitly.
 //
-// -Wno-address-of-packed-member: same known clang false positive
-// edgenat.c's own doc.go documented -- struct l4_view's sport_ptr/
-// dport_ptr/check_ptr fields all sit at compile-time-fixed *even* offsets
-// within their packed struct (nat66_tcphdr's source/dest/check are
-// 0/2/16; nat66_udphdr's are 0/2/6), genuinely 2-byte aligned despite the
+// The packed-member warning is suppressed for a known false positive: the
+// pointer fields into the L4 view all sit at compile-time-fixed even offsets
+// within their packed structs, so they are genuinely 2-byte aligned despite the
 // packed attribute.
 //
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -Wno-address-of-packed-member -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type conn_key -type conn_value -type shard_config Nat66 nat66.c

--- a/internal/plumbing/ebpf/nat66prog/dropreason.go
+++ b/internal/plumbing/ebpf/nat66prog/dropreason.go
@@ -4,12 +4,10 @@
 
 package nat66prog
 
-// Drop reason indices into the drop_reasons map (nat66.c's `enum
-// nat66_drop_reason`), exported for callers outside this package --
-// mirroring internal/plumbing/ebpf/edgeprog/dropreason.go and
-// internal/plumbing/ebpf/prog/dropreason.go's identical rationale:
-// bpf2go's -type flag cannot generate a Go type for a C enum that is only
-// ever used as a literal constant.
+// Drop reason indices into the drop_reasons map, mirroring the datapath's own
+// enum and exported for callers outside this package. Hand-kept in sync with the
+// C source, because the generator cannot produce a Go type for an enum used only
+// as a literal constant.
 const (
 	DropReasonNat66NoReturnConn     uint32 = 0
 	DropReasonNat66MalformedReturn  uint32 = 1

--- a/internal/plumbing/ebpf/nat66prog/nat66.c
+++ b/internal/plumbing/ebpf/nat66prog/nat66.c
@@ -4,73 +4,50 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// nat66.c implements the XDP datapath for one shard of galactic-nat66's
-// sharded, stateful NAT66 egress tier (design plan §3) -- a component
-// deliberately kept off galactic-gateway's own ingress datapath (edgedsr.c)
-// entirely: tenant egress (backend -> arbitrary internet destination) is a
-// different traffic pattern from ingress (fixed VIP, fixed backend pool)
-// and gets its own placement ring, own state, own self-routing return
-// path, with no shared map or hash ring between the two tiers.
+// nat66.c implements the XDP datapath for one shard of the sharded, stateful
+// NAT66 egress tier. It is deliberately separate from the gateway's ingress
+// datapath: tenant egress toward an arbitrary internet destination is a
+// different traffic pattern from ingress toward a fixed VIP and backend pool,
+// and gets its own placement ring, state, and return path, sharing no map or
+// hash ring with the other tier.
 //
-// This shard's own identity is two addresses (shard_config_table):
-// shard_sid, a real SRv6 uSID (uFMT 48+16, same encoding
-// internal/plumbing/ebpf/prog/usid.c's own decap already uses) other nodes'
-// tenant-VRF default routes encapsulate toward, with the Argument nibble
-// carrying the *requesting tenant's own VRFID* -- reusing the existing
-// per-node Argument-allocation mechanism rather than inventing a second
-// one, and giving this program tenant isolation for free, the same way
-// usid_ingress's own vrf_table lookup does; and shard_pub_addr, a plain
-// publicly-routable address used as the masquerade source for every flow
-// this shard NATs -- ordinary unicast routing delivers a reply to
-// shard_pub_addr back to this exact shard with no hashing or cross-shard
-// lookup needed on the return path at all (design plan §3.3's "the
-// destination address already names the owner").
+// A shard's identity is two addresses. shard_sid is a real SRv6 uSID that other
+// nodes' tenant-VRF default routes encapsulate toward, with the Argument
+// carrying the requesting tenant's VRFID: that reuses the existing per-node
+// Argument allocation rather than inventing a second one, and gives this
+// program tenant isolation the same way the ingress datapath's vrf_table lookup
+// does. shard_pub_addr is a publicly routable address used as the masquerade
+// source for every flow this shard translates, so ordinary unicast routing
+// returns a reply to this exact shard with no hashing or cross-shard lookup on
+// the return path.
 //
-// Packet path -- one program, dispatched on the outer IPv6 destination:
+// One program, dispatched on the outer IPv6 destination:
 //
-//  1. Parse the outer Ethernet + IPv6 header (bounds-checked). Not IPv6 --
+//  1. Parse the outer Ethernet and IPv6 header, bounds-checked. Not IPv6:
 //     XDP_PASS.
-//  2. daddr == shard_pub_addr: this is a reply arriving from the internet,
-//     addressed to a masquerade source this shard itself allocated --
-//     handle_return(): reverse nat66_conn_table lookup by the packet's own
-//     (proto, dest-facing tuple), un-SNAT back to the tenant backend's own
-//     view, and re-encapsulate toward that backend's worker node via SRv6
-//     (the same push_outer_header push/FIB-lookup mechanic
-//     internal/plumbing/ebpf/edgeprog/edgedsr.c already uses for its own
-//     encap -- copied here for the identical reason edgedsr.c's own header
-//     comment gives for copying it from edgenat.c: proven, unchanging
-//     mechanism, not worth threading through a shared header neither file
-//     otherwise needs). No matching conn_table row -- drop (this address
-//     is claimed).
-//  3. Outer daddr's top 64 bits (Block+Node-ID) match this shard's own
-//     shard_sid, and nexthdr is 41 (IPv6-in-IPv6, no SRH) -- this is a
-//     tenant's own outbound egress packet, encapsulated the same way any
-//     other cross-node SRv6 destination is (RouteEgressAdd's own
-//     SEG6_IPTUN_MODE_ENCAP_RED wire format). handle_forward(): strip the
-//     outer header, read the Argument nibble as this flow's tenant_arg
-//     (isolation key -- two tenants' colliding backend ULA addresses never
-//     share a nat66_conn_table row, because tenant_arg is part of the
-//     forward key), allocate (or reuse) a masquerade port via the same
-//     probe-then-BPF_NOEXIST-claim technique
-//     internal/plumbing/ebpf/edgeprog/edgedsr.c's Full-NAT predecessor
-//     used for SNAT-port allocation, SNAT the source to
-//     shard_pub_addr:allocated_port, fix the checksum via bpf_csum_diff
-//     (this is XDP, no __sk_buff, so bpf_l4_csum_replace is unavailable --
-//     same constraint edgenat.c's own header comment documents), and
-//     XDP_PASS: once SNAT'd to a real public address, this is an ordinary
-//     internet-routable packet needing no further SRv6 handling -- the
-//     kernel's own default route takes it from here, so this program does
-//     not do its own bpf_fib_lookup for the general-internet leg the way
-//     it does for the encap-back-to-tenant leg in handle_return.
-//  4. Anything else -- XDP_PASS (not this shard's traffic at all).
+//  2. Destination equal to shard_pub_addr is a reply from the internet
+//     addressed to a masquerade source this shard allocated. Look up the
+//     connection table in reverse, undo the translation back to the tenant
+//     backend's view, and re-encapsulate toward that backend's worker node. No
+//     matching row is a drop, this address being claimed.
+//  3. Destination whose top 64 bits match shard_sid, with an IPv6-in-IPv6 next
+//     header and no routing header, is a tenant's outbound packet encapsulated
+//     the way any cross-node SRv6 destination is. Strip the outer header, read
+//     the Argument as this flow's tenant key so two tenants' colliding backend
+//     addresses never share a row, allocate or reuse a masquerade port,
+//     translate the source to shard_pub_addr and that port, fix the checksum
+//     with a checksum diff, since XDP has no sk_buff and the incremental helper
+//     is unavailable, and XDP_PASS. Once translated to a public address this is
+//     an ordinary internet-routable packet and the kernel's default route takes
+//     it from there, so no FIB lookup of this program's own is needed on that
+//     leg.
+//  4. Anything else: XDP_PASS.
 //
-// No tenant-identity check beyond the Argument nibble itself: a forged
-// Argument only misdirects the forger's *own* isolation bucket, never a
-// legitimate tenant's, but this program trusts that only legitimate
-// SRv6-fabric-internal traffic ever reaches it at all -- the same
-// trust-boundary/anti-spoofing question the design plan's §5 already
-// flags as needing its own security pass before real traffic, not
-// something this file's own logic resolves.
+// There is no tenant-identity check beyond the Argument itself. A forged
+// Argument misdirects only the forger's own isolation bucket, never a
+// legitimate tenant's, but this program trusts that only fabric-internal
+// traffic reaches it at all. The trust boundary is a separate security
+// question, not something this file resolves.
 #include <linux/bpf.h>
 
 #define SEC(name) __attribute__((section(name), used))
@@ -78,12 +55,10 @@
 #define __type(name, val) typeof(val) *name
 #define NAT66_ALWAYS_INLINE inline __attribute__((always_inline))
 
-// NAT66_BARRIER_VAR: same verifier bounds-narrowing gotcha as
-// edgedsr.c/edgenat.c's EDGE_BARRIER_VAR -- see either file's header
-// comment. Reused here under this file's own naming convention rather
-// than importing a macro from either (each file is deliberately
-// self-contained, one external header dependency, per this codebase's
-// established convention).
+// NAT66_BARRIER_VAR handles the same verifier bounds-narrowing behavior the
+// other datapath files document under their own names. Each file is
+// self-contained with one external header dependency, so the macro is repeated
+// rather than imported.
 #define NAT66_BARRIER_VAR(var) asm volatile("" : "=r"(var) : "0"(var))
 
 // ---------------------------------------------------------------------
@@ -114,8 +89,7 @@ static long (*bpf_fib_lookup)(void *ctx, struct bpf_fib_lookup *params, __s32 pl
 #define NAT66_PAT_PORT_RANGE 28000
 
 // ---------------------------------------------------------------------
-// Minimal, self-contained header structs -- byte-exact to the wire
-// formats, matching usid.c/edgedsr.c's own convention.
+// Minimal, self-contained header structs, byte-exact to the wire formats.
 // ---------------------------------------------------------------------
 
 struct nat66_ethhdr {
@@ -156,16 +130,13 @@ struct nat66_udphdr {
 // Map key/value types.
 // ---------------------------------------------------------------------
 
-// struct conn_key: the forward row is keyed by the tenant backend's
-// own facing tuple (proto, tenant_arg, backend_addr:backend_port ->
-// dest_addr:dest_port) -- tenant_arg (this flow's VRFID, read from the
-// SRv6 Argument nibble) is part of the key specifically so two tenants
-// presenting the identical backend ULA never collide on this row, the
-// same reasoning component 2 (NPTv6)'s VRFID-keyed nptv6_table already
-// uses. The reverse row is keyed by (proto, tenant_arg=0,
-// dest_addr:dest_port -> shard_pub_addr:masq_port) -- tenant_arg is
-// unused/zero there, since shard_pub_addr:masq_port is already globally
-// unique by construction (this shard allocated it, from its own address).
+// struct conn_key. The forward row is keyed by the tenant backend's facing
+// tuple, with tenant_arg, this flow's VRFID read from the SRv6 Argument, part
+// of the key so two tenants presenting the same backend address never collide.
+// The reverse row is keyed by the internet peer's tuple against
+// shard_pub_addr and the masquerade port, with tenant_arg zero: that pair is
+// already globally unique, this shard having allocated it from its own
+// address.
 struct conn_key {
 	__u8 proto;
 	__u8 pad[1];
@@ -250,32 +221,23 @@ static NAT66_ALWAYS_INLINE int addr6_eq(const __u8 a[16], const __u8 b[16])
 	return 1;
 }
 
-// locator_matches checks only the top 64 bits (Block(48)+Node-ID(16)) of
-// daddr against this shard's own shard_sid -- the same "is this mine"
-// granularity internal/plumbing/ebpf/prog/usid.c's own locator_table
-// match uses, since the Argument nibble below it varies per tenant (see
-// this file's own header comment: the Argument nibble is read afterward,
-// in handle_forward, as the requesting tenant's own VRFID -- it is
-// deliberately not part of "is this addressed to me" at all).
+// locator_matches checks only the top 64 bits of daddr against this shard's
+// shard_sid, the same "is this mine" granularity the ingress datapath's locator
+// match uses. The Argument below it varies per tenant and is read afterward, so
+// it is deliberately not part of the question.
 //
-// This 64-bit granularity requires shard_sid's own (Block, Node-ID) to be
-// reserved and disjoint from every *other* uSID identity sharing this
-// node's uplink -- in particular, a shard's own Node-ID must differ from
-// the Node-ID any co-located tenant-delivery BGPRouter on this same node
-// already uses (see GALACTIC_NAT66_SHARD_SID's own deployment-side doc
-// comment, e.g. deploy/containerlab/resources/galactic-nat66/*/node-patch.yaml).
-// Confirmed live: an earlier lab config reused a co-located tenant
-// worker's own real Node-ID for that same node's shard placeholder SID,
-// which meant ordinary tenant ingress traffic addressed to that node's
-// real delivery uSID (same Block+Node-ID, nexthdr also 41 since
-// SEG6_IPTUN_MODE_ENCAP_RED uses that for every IPv6-inner packet, tenant
-// delivery included) was silently hijacked here, before it ever reached
-// usid_ingress's own TC hook -- not a bug in this 64-bit match itself
-// (widening it to a full 128-bit compare was tried and reverted: it broke
-// the correct, intentional case of two different tenants' egress packets
-// legitimately sharing this exact shard_sid with two different Argument
-// values), but an address-allocation conflict this function has no way
-// to detect on its own.
+// That granularity requires shard_sid's Block and Node-ID to be reserved and
+// disjoint from every other uSID identity sharing this node's uplink. In
+// particular, a shard's Node-ID must differ from the one any co-located
+// tenant-delivery BGPRouter on the same node uses. Reusing it means ordinary
+// tenant ingress traffic addressed to that node's real delivery uSID, which
+// shares the Block and Node-ID and also carries an IPv6-in-IPv6 next header, is
+// silently hijacked here before reaching the ingress hook.
+//
+// That is an address-allocation conflict this function cannot detect, not a
+// flaw in the 64-bit match. Widening to a full 128-bit compare breaks the
+// intended case of two tenants' egress packets sharing this shard_sid with
+// different Argument values.
 static NAT66_ALWAYS_INLINE int locator_matches(const __u8 daddr[16], const __u8 shard_sid[16])
 {
 	for (int i = 0; i < 8; i++) {
@@ -285,10 +247,8 @@ static NAT66_ALWAYS_INLINE int locator_matches(const __u8 daddr[16], const __u8 
 	return 1;
 }
 
-// read_argument extracts the 12-bit Argument nibble from a uFMT 48+16
-// address at bits 69-80 (daddr bytes 8-9) -- identical bit positions and
-// composition to internal/plumbing/ebpf/uformat's Go-side encoding and
-// usid.c's own step 5 read.
+// read_argument extracts the 12-bit Argument from a uFMT 48+16 address at bits
+// 69-80, the same bit positions the Go encoding and the ingress datapath use.
 static NAT66_ALWAYS_INLINE __u16 read_argument(const __u8 daddr[16])
 {
 	return ((__u16) (daddr[8] & 0x0F) << 8) | daddr[9];
@@ -317,10 +277,8 @@ static NAT66_ALWAYS_INLINE __be16 csum_fold_add(__be16 check, __s64 diff)
 	return (__be16) ~((__u16) sum);
 }
 
-// struct l4_view mirrors edgenat.c's identical type and identical
-// rationale (see that file's own doc comment): direct, already-typed
-// pointers to the L4 fields a rewrite needs, resolved exactly once,
-// adjacent to the bounds check that proves them safe.
+// struct l4_view holds already-typed pointers to the L4 fields a rewrite needs,
+// resolved exactly once, adjacent to the bounds check that proves them safe.
 struct l4_view {
 	__be16 sport;
 	__be16 dport;
@@ -356,13 +314,10 @@ static NAT66_ALWAYS_INLINE int parse_l4(__u8 proto, void *l4, void *data_end, st
 	return -1;
 }
 
-// fix_l4_checksum applies the combined address+port checksum delta for a
-// masquerade rewrite (one address, one port changed; the peer's own
-// address/port are unchanged) -- edgenat.c's identical fix_l4_checksum
-// covered a full 4-tuple rewrite (both addresses, both ports); this one is
-// simplified to the 2-field case NAT66 masquerade actually needs, still
-// via the same bpf_csum_diff technique (XDP has no __sk_buff, so
-// bpf_l4_csum_replace is unavailable).
+// fix_l4_checksum applies the combined address and port checksum delta for a
+// masquerade rewrite, where one address and one port change and the peer's are
+// unchanged. It uses a checksum diff because XDP has no sk_buff and the
+// incremental L4 helper is unavailable.
 static NAT66_ALWAYS_INLINE void fix_l4_checksum(__be16 *check_ptr, const __u8 old_addr[16], __be16 old_port,
 						 const __u8 new_addr[16], __be16 new_port)
 {
@@ -416,10 +371,9 @@ static NAT66_ALWAYS_INLINE void count_fib_drop(long fib_rc)
 		count_drop(DROP_REASON_NAT66_FIB_LOOKUP_FAILED);
 }
 
-// push_outer_header: identical mechanism to edgedsr.c/edgenat.c's own
-// function of the same name -- see either's header comment for the full
-// byte-level rationale. Copied, not shared, per this codebase's existing
-// convention (each program's surrounding types are independently defined).
+// push_outer_header uses the same mechanism as the other datapath programs'
+// function of the same name. Copied rather than shared, since each program
+// defines its own surrounding header structs.
 static NAT66_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 src[16], const __u8 dst[16],
 						  __be16 inner_payload_len_plus_ip6hdr)
 {
@@ -438,11 +392,9 @@ static NAT66_ALWAYS_INLINE int push_outer_header(struct xdp_md *ctx, const __u8 
 	struct nat66_ethhdr *eth = data;
 	struct nat66_ip6hdr *outer = (void *) (eth + 1);
 
-	// vtc_flow[0]'s high nibble is the IPv6 version field -- see
-	// edgedsr.c's identical fix (push_outer_header) for the full story:
-	// a real, previously uncaught bug inherited from the removed
-	// edgenat.c, found via live-kernel investigation, not
-	// BPF_PROG_TEST_RUN (which never validates this field).
+	// The high nibble of vtc_flow[0] is the IPv6 version and must be set: a
+	// zeroed default produces a header receivers parse as invalid IPv6, which a
+	// synthetic program run never validates.
 	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
 	outer->vtc_flow[0] = 0x60;
 	outer->payload_len = inner_payload_len_plus_ip6hdr;
@@ -477,23 +429,19 @@ static NAT66_ALWAYS_INLINE int strip_outer_header(struct xdp_md *ctx, struct nat
 	return 0;
 }
 
-// handle_forward: a tenant's own outbound egress packet, SRv6-encapsulated
-// toward this shard. Strips the outer header, resolves tenant_arg from the
-// Argument nibble, allocates (or reuses) a masquerade port, SNATs the
-// source, and passes the now-plain-internet-routable packet to the
-// kernel's own routing (XDP_PASS) -- see this file's header comment for
-// why no FIB lookup of its own is needed on this leg.
+// handle_forward processes a tenant's outbound packet encapsulated toward this
+// shard. It strips the outer header, resolves the tenant key from the Argument,
+// allocates or reuses a masquerade port, translates the source, and hands the
+// now internet-routable packet to the kernel's routing.
 static NAT66_ALWAYS_INLINE int handle_forward(struct xdp_md *ctx, struct nat66_ip6hdr *outer,
 					       struct shard_config *cfg)
 {
 	__u16 tenant_arg = read_argument(outer->daddr);
-	// outer->saddr (the tenant's own worker-node uSID, needed below to
-	// build the reply's own re-encap destination) must be captured now,
-	// into a plain local array -- strip_outer_header calls
-	// bpf_xdp_adjust_head twice, which invalidates every packet pointer
-	// derived before it, `outer` included; reading outer->saddr *after*
-	// the strip is a stale-pointer access the verifier rejects (confirmed
-	// empirically: "R9 invalid mem access 'scalar'" without this).
+	// The tenant's worker-node uSID, needed below to build the reply's
+	// re-encapsulation destination, must be captured into a local now. Stripping
+	// the outer header adjusts the packet head twice, which invalidates every
+	// pointer derived before it, so reading it afterward is a stale access the
+	// verifier rejects.
 	__u8 tenant_usid[16];
 	__builtin_memcpy(tenant_usid, outer->saddr, 16);
 
@@ -615,20 +563,17 @@ static NAT66_ALWAYS_INLINE int handle_return(struct xdp_md *ctx, struct nat66_ip
 	__builtin_memcpy(ip6->daddr, cv->backend_addr, 16);
 	*l4v.dport_ptr = cv->backend_port;
 
-	// Must include the inner IPv6 header's own 40 bytes, not just its
-	// payload -- see edgedsr.c's identical fix (its handle_forward call
-	// site) for the full story: a real, previously uncaught bug
-	// inherited from the removed edgenat.c, found via live-kernel
-	// investigation, not BPF_PROG_TEST_RUN.
+	// Must include the inner IPv6 header's own 40 bytes, not just its payload.
+	// Passing the inner payload length alone undercounts the outer header's
+	// declared length on every packet, which a validating receiver rejects.
 	__be16 inner_payload_len_plus_ip6hdr =
 		__builtin_bswap16((__u16) sizeof(struct nat66_ip6hdr) + __builtin_bswap16(ip6->payload_len));
 
-	// Outer source is this shard's own SRv6-reachable identity
-	// (shard_sid), not any field of cv -- the tenant's worker node
-	// decaps this exactly like any other cross-node SRv6 packet, and
-	// does not care about (or validate) the encap source, but it must
-	// still be a real, this-node address, not the internet peer's own
-	// address cv->dest_addr holds.
+	// The outer source is this shard's own SRv6-reachable identity, not any
+	// field of the connection row. The tenant's worker node decapsulates this
+	// like any cross-node SRv6 packet and does not validate the encapsulation
+	// source, but it must still be a real address on this node rather than the
+	// internet peer's.
 	if (push_outer_header(ctx, cfg->shard_sid, cv->backend_usid, inner_payload_len_plus_ip6hdr) != 0)
 		return XDP_DROP;
 

--- a/internal/plumbing/ebpf/nptv6map/clock.go
+++ b/internal/plumbing/ebpf/nptv6map/clock.go
@@ -6,17 +6,13 @@ package nptv6map
 
 import "golang.org/x/sys/unix"
 
-// monotonicNow returns a nanosecond CLOCK_MONOTONIC reading, used to stamp
-// this process's own in-memory Generation bookkeeping (see doc.go and
-// NPTv6Table.Register). This is a small, deliberate duplicate of
-// usidmap's own unexported monotonicNow (internal/plumbing/ebpf/usidmap/
-// table.go) rather than an exported/imported dependency on it: it is five
-// lines wrapping one syscall, and usidmap's own egresskind.go/
-// prog/dropreason.go already establish the precedent in this codebase of
-// hand-keeping a tiny piece of logic in sync across packages rather than
-// introducing a shared-but-barely-used export for it. See table.go's
-// monotonicNow for the full reasoning on why CLOCK_MONOTONIC, not
-// wall-clock time.Now(), is used here.
+// monotonicNow returns a nanosecond reading from the monotonic clock, stamping
+// this process's in-memory generation bookkeeping.
+//
+// A deliberate small duplicate of the uSID map layer's unexported equivalent,
+// rather than an exported dependency on it: it is a few lines wrapping one
+// syscall. See that function for why the monotonic clock rather than a wall
+// clock.
 func monotonicNow() uint64 {
 	var ts unix.Timespec
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)

--- a/internal/plumbing/ebpf/nptv6map/doc.go
+++ b/internal/plumbing/ebpf/nptv6map/doc.go
@@ -2,71 +2,38 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nptv6map implements the read/write API for the eBPF uSID
-// datapath's nptv6_table map (internal/plumbing/ebpf/prog/usid.c's struct
-// nptv6_value comment) -- one row per VRF configuring stateless RFC 6296
-// Network Prefix Translation (internal/plumbing/nptv6), keyed identically to
-// vrf_table: Block(48)<<12 | Argument(12) (internal/plumbing/ebpf/uformat's
-// NewVRFKey).
+// Package nptv6map implements the read/write API for the eBPF uSID datapath's
+// nptv6_table map: one row per VRF configuring stateless RFC 6296 prefix
+// translation, keyed identically to vrf_table on Block and Argument.
 //
-// # Reusing usidmap.Table/KernelTable/Iterator instead of duplicating them
+// # Reusing usidmap's map interfaces
 //
-// nptv6_table is defined in the exact same usid.c/prog package as vrf_table
-// (internal/plumbing/ebpf/usidmap), not a second, independent datapath --
-// unlike internal/plumbing/ebpf/edgemap (a different eBPF program entirely,
-// with no shared map layout at all, which is usidmap/doc.go's own stated
-// reason for NOT importing edgemap's duplicate Table/KernelTable/Iterator
-// definitions). Because nptv6_table and vrf_table are two maps of the one
-// uSID datapath, the map-operation seam usidmap.Table already defines (plus
-// its KernelTable adapter over a real *ebpf.Map, and its Iterator interface)
-// applies unchanged here: this package imports and depends on usidmap
-// directly rather than re-declaring an identical interface, which would
-// only invite the two to drift.
+// nptv6_table belongs to the same datapath program as vrf_table, not a separate
+// one, so the map-operation seam usidmap already defines, its kernel adapter
+// and its iterator, applies unchanged. This package imports them rather than
+// re-declaring an identical interface that would only drift.
 //
-// # Why this table has no Generation/monotonic-clock kernel field, unlike vrf_table
+// # No kernel-persisted generation, unlike vrf_table
 //
-// vrf_table's value (struct vrf_value) carries a real `generation` field,
-// because vrf_table has two independent, unsynchronized OS-process writers
-// that can race each other: the kubelet-invoked galactic-cni plugin binary
-// (VRFTable.Register, on the CNI ADD path) and the long-lived "run"
-// container's periodic GC sweep (VRFTable.Reconcile) -- see usidmap/doc.go's
-// "plugin-binary-vs-run-container race" section. nptv6_table's value
-// (struct nptv6_value) was deliberately not given an equivalent field: this
-// milestone's only writer of nptv6_table is that same "run" container's own
-// periodic sweep (gc.SweepEBPFNPTv6Table, called from
-// internal/installer.Run's ebpfGCSweepTicker, exactly where
-// gc.SweepEBPFVRFTable already runs -- see that function's own doc comment
-// for why eBPF map access is confined to this one container: galactic-router's
-// DaemonSet has no /sys/fs/bpf hostPath mount or CAP_BPF at all, so the
-// BGPVRFInstance reconciler (internal/controller) cannot open a pinned eBPF
-// map to register anything into directly, regardless of how the CRD's own
-// NPTv6 field is validated). A single writer, ticking sequentially in one
-// goroutine, cannot race itself between listing BGPVRFInstance CRDs and
-// reconciling nptv6_table against them -- there is no second process able to
-// register a brand-new mapping in the gap the way a concurrent CNI ADD can
-// for vrf_table.
+// vrf_table carries a generation in its kernel value because two unsynchronized
+// processes write it and can race. nptv6_table has one writer: the periodic
+// sweep in the same container that owns eBPF map access, since the CRD
+// reconciler's own DaemonSet has neither the bpffs mount nor CAP_BPF to open a
+// pinned map. A single writer ticking sequentially cannot race itself between
+// listing CRDs and reconciling against them.
 //
-// NPTv6Table still exposes Generation/Reconcile with the same method shape
-// as usidmap.VRFTable, for interface parity and because a future second
-// writer is not inconceivable, but the generation value itself is tracked
-// only in this process's own memory (an internal map keyed by NPTv6Key),
-// not persisted into the kernel value the way vrf_table's is. This means a
-// process restart forgets every previously-registered entry's generation
-// (it reads back as zero, "older than any cutoff"), unlike vrf_table's
-// kernel-persisted field, which survives a control-daemon restart within
-// the same boot. This is an accepted, intentional tradeoff, not an
-// oversight: gc.SweepEBPFNPTv6Table's own caller (internal/installer.Run)
-// re-registers every currently-live NPTv6 mapping on every tick before
-// reconciling stale ones away, so a post-restart Reconcile call only ever
-// mis-judges an entry's freshness for at most one sweep interval before the
-// same tick's own Register calls (which run first) re-stamp it -- see
-// SweepEBPFNPTv6Table's own doc comment for the exact ordering.
+// NPTv6Table still exposes Generation and Reconcile with usidmap.VRFTable's
+// method shape, for parity and against a future second writer, but the value is
+// tracked only in this process's memory. A restart therefore forgets every
+// entry's generation, which reads back as zero and so older than any cutoff.
+// That is an accepted tradeoff: the sweep re-registers every live mapping on
+// each tick before reconciling stale ones away, so a post-restart Reconcile
+// misjudges freshness for at most one interval before the same tick re-stamps
+// it.
 //
-// # No counter-preservation
+// # No counter preservation
 //
-// Unlike vrf_table's per-Argument hit counters (packets/bytes/last_seen_ns/
-// dropped_packets), nptv6_table carries no counters at all -- its value is
-// purely the two prefixes and the precomputed RFC 6296 adjustment. Register
-// therefore has no read-modify-write step to carry anything forward from an
-// existing entry; every call is a plain overwrite.
+// Unlike vrf_table, nptv6_table carries no counters: its value is the two
+// prefixes and the precomputed adjustment. Register therefore has no
+// read-modify-write step, and every call is a plain overwrite.
 package nptv6map

--- a/internal/plumbing/ebpf/nptv6map/nptv6.go
+++ b/internal/plumbing/ebpf/nptv6map/nptv6.go
@@ -20,18 +20,16 @@ import (
 )
 
 // NPTv6Key identifies one nptv6_table row: the uSID Block that matched in
-// locator_table, plus the 12-bit Argument -- the identical composition
-// usidmap.VRFKey uses, kept as its own type here (rather than reusing
-// usidmap.VRFKey directly) purely so this package's own exported API never
-// forces a caller to import usidmap just to build a key.
+// locator_table plus the 12-bit Argument. The same composition usidmap.VRFKey
+// uses, kept as its own type so a caller need not import that package just to
+// build a key.
 type NPTv6Key struct {
 	Block    uint64
 	Argument uint16
 }
 
-// NPTv6Entry is one fully decoded nptv6_table row, decoupled from
-// prog.UsidNptv6Value's cilium/ebpf/BTF-generated field layout -- mirrors
-// usidmap.VRFEntry's own reasoning.
+// NPTv6Entry is one decoded nptv6_table row, kept separate from the generated
+// kernel layout, as usidmap.VRFEntry is.
 type NPTv6Entry struct {
 	NPTv6Key
 
@@ -39,16 +37,13 @@ type NPTv6Entry struct {
 	// internal/plumbing/nptv6's doc comment for the translation itself.
 	Mapping nptv6.Mapping
 
-	// Adjustment is the precomputed RFC 6296 §3.6 checksum-neutral
-	// adjustment (nptv6.Mapping.Adjustment), stored in the kernel value so
-	// the datapath never recomputes it per packet.
+	// Adjustment is the precomputed RFC 6296 checksum-neutral adjustment, stored
+	// in the kernel value so the datapath never recomputes it per packet.
 	Adjustment uint16
 
-	// Generation is this process's own in-memory bookkeeping of when this
-	// entry was last (re-)registered by Register -- see doc.go's "no
-	// Generation/monotonic-clock kernel field" section for why this is not
-	// persisted in the kernel value the way usidmap.VRFEntry's own
-	// Generation is.
+	// Generation is this process's in-memory record of when Register last wrote
+	// this entry. See the package doc comment for why it is not persisted in
+	// the kernel value the way vrf_table's is.
 	Generation uint64
 }
 
@@ -61,22 +56,17 @@ type NPTv6Table struct {
 	generation map[NPTv6Key]uint64
 }
 
-// NewNPTv6Table wraps table as an NPTv6Table. Production callers pass a
-// usidmap.KernelTable wrapping a loaded *prog.UsidObjects's Nptv6Table map
-// (or OpenPinned, below, for a process that did not itself load the
-// datapath); tests pass a fake usidmap.Table.
+// NewNPTv6Table wraps table as an NPTv6Table. Production callers pass a kernel
+// table over the loaded map, or use OpenPinned in a process that did not load
+// the datapath; tests pass a fake.
 func NewNPTv6Table(table usidmap.Table) *NPTv6Table {
 	return &NPTv6Table{table: table, clock: monotonicNow, generation: make(map[NPTv6Key]uint64)}
 }
 
-// OpenPinned opens nptv6_table from its pinned path under pinDir
-// (internal/plumbing/ebpf/attach.Load pins each map at
-// <pinDir>/<map name>) and returns an NPTv6Table wrapping it, mirroring
-// usidmap.OpenPinnedRegistry -- for a process (internal/gc's periodic
-// sweep, via internal/installer.Run) that did not itself load the
-// datapath but needs to read/write this one map. The returned io.Closer
-// (the opened *ebpf.Map itself) must be closed once the caller is done; it
-// does not affect the map's pinned lifetime.
+// OpenPinned opens nptv6_table from its pinned path under pinDir and returns an
+// NPTv6Table wrapping it, for a process that did not itself load the datapath
+// but needs to read and write this one map. The returned map must be closed
+// when the caller is done, which does not affect its pinned lifetime.
 func OpenPinned(pinDir string) (*NPTv6Table, *ebpf.Map, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapNptv6Table), nil)
 	if err != nil {
@@ -91,15 +81,14 @@ func (t *NPTv6Table) Generation() uint64 {
 	return t.clock()
 }
 
-// Register writes (or overwrites) the nptv6_table entry for (block,
-// argument): computes m.Adjustment() internally and converts m's two
-// prefixes into the fixed 16-byte zero-padded arrays prog.UsidNptv6Value
-// expects, mirroring exactly how internal/plumbing/nptv6.prefixChecksum/
-// Translate already read prefix bytes (net.IPNet.IP, as produced by
-// net.ParseCIDR, is already zero-padded beyond its own prefix length). There
-// is no read-modify-write step here (unlike usidmap.VRFTable.Register):
-// nptv6_table carries no per-entry counters to preserve across a
-// re-registration, so every call is a plain overwrite.
+// Register writes, or overwrites, the nptv6_table entry for (block, argument).
+// It computes the adjustment from m and converts m's prefixes into the fixed
+// 16-byte zero-padded arrays the kernel value expects, which parsed CIDRs
+// already are beyond their own prefix length.
+//
+// There is no read-modify-write step, unlike vrf_table's Register: this table
+// carries no per-entry counters to preserve, so every call is a plain
+// overwrite.
 func (t *NPTv6Table) Register(block uint64, argument uint16, m nptv6.Mapping) error {
 	if err := uformat.ValidateArgument(argument); err != nil {
 		return fmt.Errorf("nptv6map: nptv6_table: register block=%#x argument=%#x: %w", block, argument, err)
@@ -130,9 +119,8 @@ func (t *NPTv6Table) Register(block uint64, argument uint16, m nptv6.Mapping) er
 	return nil
 }
 
-// Unregister removes the nptv6_table entry for (block, argument), if
-// present. Not an error to unregister an already-absent entry, matching
-// usidmap.VRFTable.Unregister's own idempotent contract.
+// Unregister removes the nptv6_table entry for (block, argument) if present. An
+// already-absent entry is not an error.
 func (t *NPTv6Table) Unregister(block uint64, argument uint16) error {
 	key, err := uformat.NewVRFKey(block, argument)
 	if err != nil {
@@ -188,14 +176,11 @@ func (t *NPTv6Table) List() ([]NPTv6Entry, error) {
 	return entries, nil
 }
 
-// Reconcile brings nptv6_table into agreement with live -- the caller's
-// current set of (Block, Argument) pairs that should have an entry --
-// removing every entry whose key is absent from live, except an entry whose
-// Generation is >= cutoff. Mirrors usidmap.VRFTable.Reconcile's exact
-// semantics; see doc.go for why this table's own writer (a single,
-// sequential periodic sweep) makes the race that mechanism guards against
-// far narrower here than for vrf_table, and why Generation is nonetheless
-// still tracked and honored the same way.
+// Reconcile brings nptv6_table into agreement with live, the caller's current
+// set of keys that should have an entry, removing every entry whose key is
+// absent except one whose generation is at or above cutoff. The same semantics
+// as vrf_table's; see the package doc comment for why this table's single
+// sequential writer makes the race that guards against far narrower here.
 func (t *NPTv6Table) Reconcile(live map[NPTv6Key]struct{}, cutoff uint64) (removed []NPTv6Entry, err error) {
 	entries, err := t.List()
 	if err != nil {
@@ -220,10 +205,9 @@ func (t *NPTv6Table) Reconcile(live map[NPTv6Key]struct{}, cutoff uint64) (remov
 	return removed, errors.Join(errs...)
 }
 
-// decode converts a raw kernel value plus its (block, argument) key into an
-// NPTv6Entry, filling in Generation from this process's own in-memory
-// bookkeeping (zero if this entry was never registered by this process
-// instance -- see doc.go).
+// decode converts a raw kernel value and its key into an NPTv6Entry, filling in
+// the generation from this process's own bookkeeping, or zero when this process
+// never registered the entry.
 func (t *NPTv6Table) decode(block uint64, argument uint16, value prog.UsidNptv6Value) NPTv6Entry {
 	nk := NPTv6Key{Block: block, Argument: argument}
 
@@ -248,12 +232,10 @@ func (t *NPTv6Table) decode(block uint64, argument uint16, value prog.UsidNptv6V
 	}
 }
 
-// toValue converts m (plus its precomputed adjustment) into the fixed
-// 16-byte zero-padded arrays prog.UsidNptv6Value expects. m.ULAPrefix/
-// m.PublicPrefix.IP are already 16-byte, zero-padded-beyond-prefix-length
-// slices by construction of net.ParseCIDR (the same assumption
-// nptv6.prefixChecksum documents), so this only needs a To16 conversion, no
-// further masking.
+// toValue converts m and its precomputed adjustment into the fixed 16-byte
+// zero-padded arrays the kernel value expects. A parsed CIDR's address is
+// already 16 bytes and zero-padded beyond its prefix length, so this needs only
+// a conversion and no further masking.
 func toValue(m nptv6.Mapping, adjustment uint16) (prog.UsidNptv6Value, error) {
 	ulaIP := m.ULAPrefix.IP.To16()
 	if ulaIP == nil {

--- a/internal/plumbing/ebpf/preflight/kernel_prober.go
+++ b/internal/plumbing/ebpf/preflight/kernel_prober.go
@@ -15,30 +15,22 @@ import (
 )
 
 // fibLookupStructName and tbidMemberName identify the kernel BTF type and
-// member this package's FIBLookupTBID check looks for. Named constants so
-// both the lookup and its error messages stay in sync if either ever needs
-// to change.
+// member the FIB lookup check looks for. Named so the lookup and its error
+// messages stay in sync.
 const (
 	fibLookupStructName = "bpf_fib_lookup"
 	tbidMemberName      = "tbid"
 )
 
-// KernelProber is the real, kernel-backed [Prober] implementation used in
-// production. It probes the actual running kernel via
-// github.com/cilium/ebpf's features package (for BPF_PROG_TYPE_SCHED_CLS
-// and BPF_MAP_TYPE_HASH -- both of which that package detects by actually
-// attempting the create/load syscall, the same technique any BPF loader
-// uses) and via kernel BTF introspection (for BTF presence and the
-// bpf_fib_lookup tbid member specifically -- see this package's doc
-// comment for why a struct-field check, not a version-string parse).
+// KernelProber is the real Prober implementation. It probes the running kernel
+// by attempting the create and load syscalls for the program and map types, the
+// same technique any BPF loader uses, and by introspecting kernel BTF for BTF
+// presence and the FIB lookup's table-id member.
 //
-// The zero value is not ready to use; construct with [NewKernelProber].
-// A *KernelProber may be reused across multiple Check/CheckWith calls --
-// its one piece of internal state (the loaded kernel BTF spec) is cached
-// after the first probe that needs it, since re-parsing the kernel's BTF
-// blob (several megabytes) on every call would make repeated preflight
-// checks (e.g. a health-check loop re-running this at Milestone 3.1/4)
-// needlessly expensive.
+// The zero value is not ready to use; construct with NewKernelProber. One may
+// be reused across calls: its only internal state, the loaded BTF spec, is
+// cached after the first probe that needs it, since re-parsing a multi-megabyte
+// blob on every call would make a repeated check needlessly expensive.
 type KernelProber struct {
 	specOnce sync.Once
 	spec     *btf.Spec
@@ -50,9 +42,8 @@ func NewKernelProber() *KernelProber {
 	return &KernelProber{}
 }
 
-// SchedCLS implements [Prober] by attempting to create a minimal
-// BPF_PROG_TYPE_SCHED_CLS program and reporting whether the kernel accepted
-// the program type.
+// SchedCLS reports whether the kernel accepts the TC-BPF program type, by
+// attempting to create a minimal program of that type.
 func (k *KernelProber) SchedCLS() error {
 	if err := ensureMemlockRemoved(); err != nil {
 		return err
@@ -63,9 +54,8 @@ func (k *KernelProber) SchedCLS() error {
 	return nil
 }
 
-// HashMap implements [Prober] by attempting to create a minimal
-// BPF_MAP_TYPE_HASH map and reporting whether the kernel accepted the map
-// type.
+// HashMap reports whether the kernel accepts the hash map type, by attempting
+// to create a minimal map of that type.
 func (k *KernelProber) HashMap() error {
 	if err := ensureMemlockRemoved(); err != nil {
 		return err
@@ -85,15 +75,14 @@ func (k *KernelProber) BTF() error {
 	return nil
 }
 
-// FIBLookupTBID implements [Prober] by loading the running kernel's BTF
-// description of `struct bpf_fib_lookup` and checking, recursively (the
-// real struct nests `tbid` inside an anonymous union -- see
-// hasMemberNamed), for a member literally named `tbid`. Presence of that
-// field is a direct, version-string-independent proof that this kernel's
-// bpf_fib_lookup() understands the BPF_FIB_LOOKUP_TBID flag and the
-// VRF-table-id lookup R5 depends on, since the kernel's BTF is generated
-// from the exact same struct definition its bpf_fib_lookup()
-// implementation reads.
+// FIBLookupTBID reports whether this kernel's bpf_fib_lookup understands the
+// VRF-table-id parameter, by loading the kernel's BTF description of the lookup
+// struct and searching it recursively for a member named tbid, which the real
+// struct nests inside an anonymous union.
+//
+// Presence of that field is version-string-independent proof, the kernel's BTF
+// being generated from the same struct definition the helper implementation
+// reads.
 func (k *KernelProber) FIBLookupTBID() error {
 	spec, err := k.kernelSpec()
 	if err != nil {
@@ -124,19 +113,15 @@ func (k *KernelProber) kernelSpec() (*btf.Spec, error) {
 	return k.spec, k.specErr
 }
 
-// maxMemberSearchDepth bounds hasMemberNamed's recursion. struct
-// bpf_fib_lookup nests at most one level deep (a handful of anonymous
-// unions directly inside the outer struct); this ceiling is generous
-// headroom against any deeper nesting a future kernel might introduce,
-// while still guaranteeing termination against unexpected/malformed BTF.
+// maxMemberSearchDepth bounds the recursive member search. The real struct
+// nests at most one level deep, so this is headroom against deeper nesting in a
+// future kernel while still guaranteeing termination against malformed BTF.
 const maxMemberSearchDepth = 8
 
-// hasMemberNamed reports whether t (expected to be a *btf.Struct or
-// *btf.Union) has a member named name, searching recursively into any
-// nested anonymous struct/union members -- required here because the real
-// kernel's `struct bpf_fib_lookup` places `tbid` inside an anonymous
-// `union { struct { ... vlan fields ... }; __u32 tbid; }`, not as a
-// top-level member.
+// hasMemberNamed reports whether t, a struct or union, has a member named name,
+// searching recursively into nested anonymous members. That is required because
+// the kernel places the field this checks for inside an anonymous union rather
+// than at the top level.
 func hasMemberNamed(t btf.Type, name string, depth int) bool {
 	if depth > maxMemberSearchDepth {
 		return false
@@ -163,13 +148,10 @@ func hasMemberNamed(t btf.Type, name string, depth int) bool {
 	return false
 }
 
-// ensureMemlockRemoved lifts the memlock rlimit that older kernels (pre-5.11
-// cgroup-based BPF memory accounting) enforce against BPF map/program
-// creation. It is safe and cheap to call repeatedly -- github.com/cilium/
-// ebpf's rlimit package makes the underlying setrlimit call idempotent --
-// and is required here because this package's probes may be the first BPF
-// syscalls a process makes (Milestone 3.1's control daemon is expected to
-// call [Check] before doing any other BPF setup of its own).
+// ensureMemlockRemoved lifts the memlock limit older kernels enforce against
+// BPF map and program creation. Safe and cheap to call repeatedly, the
+// underlying call being idempotent, and required here because these probes may
+// be the first BPF syscalls a process makes.
 func ensureMemlockRemoved() error {
 	if err := rlimit.RemoveMemlock(); err != nil {
 		return fmt.Errorf("remove memlock rlimit: %w", err)

--- a/internal/plumbing/ebpf/preflight/preflight.go
+++ b/internal/plumbing/ebpf/preflight/preflight.go
@@ -3,43 +3,31 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package preflight implements the startup kernel-capability check for the
-// `uFMT 48+16` eBPF/TC-BPF uSID datapath (design plan
-// .local/plan-ebpf-xdp-usid-datapath.md §6 "Preflight capability check";
-// Milestone 2.3 of .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+// eBPF uSID datapath.
 //
-// Before Milestone 3.1's control daemon attempts to load and attach
-// internal/plumbing/ebpf/prog's compiled BPF object, it must confirm the
-// running kernel actually supports everything that object needs:
+// Before the control daemon loads and attaches the compiled BPF object, the
+// running kernel must be confirmed to support everything that object needs:
 //
-//   - BPF_PROG_TYPE_SCHED_CLS (the TC-BPF ingress hook usid.c attaches as,
-//     design plan §4.1).
-//   - BPF_MAP_TYPE_HASH (locator_table/function_table/vrf_table are all
-//     this type, design plan §4.4).
-//   - Kernel BTF (usid.c is compiled CO-RE -- Compile Once, Run Everywhere
-//     -- and needs /sys/kernel/btf/vmlinux to load at all, design plan §6).
-//   - bpf_fib_lookup()'s VRF-table-id (tbid) parameter, specifically --
-//     not just that the bpf_fib_lookup helper exists at all. That
-//     parameter (the BPF_FIB_LOOKUP_TBID flag plus struct bpf_fib_lookup's
-//     `tbid` field) was added to the kernel in a later release than the
-//     base helper. A kernel that has bpf_fib_lookup but predates tbid
-//     support would pass a naive "is the helper present" check and then
-//     either fail the load (if usid.c's struct layout doesn't match what
-//     the running kernel expects) or, worse, silently misroute traffic at
-//     runtime -- R5 of the design plan depends on FIB lookups being scoped
-//     to the resolved Argument's Linux VRF table via exactly this
-//     parameter. This package detects tbid support by walking the running
-//     kernel's own BTF description of `struct bpf_fib_lookup` (via
-//     [KernelProber], see kernel_prober.go) for a member literally named
-//     `tbid`, rather than parsing a kernel version string: the kernel's
-//     BTF is generated directly from the same struct definition its
-//     bpf_fib_lookup() implementation reads, so if the field isn't there,
-//     the running kernel provably doesn't support it, independent of
-//     whatever version string /proc/version reports (backports/vendor
-//     kernels routinely change what a given "version" supports).
+//   - The TC-BPF program type usid.c attaches as.
+//   - The hash map type all three lookup maps use.
+//   - Kernel BTF, without which a CO-RE-compiled object cannot load at all.
+//   - bpf_fib_lookup's VRF-table-id parameter specifically, not merely that
+//     the helper exists.
 //
-// This check must never produce a partial pass: any missing capability
-// fails the whole check, and the caller must not fall back to a
-// degraded/unsafe mode (design plan §6). See [Check] and [CheckWith].
+// That last one needs its own check. The table-id flag and struct field were
+// added later than the base helper, so a kernel with the helper but without
+// them passes a naive presence check and then either fails the load or, worse,
+// silently misroutes traffic, since scoping the FIB lookup to the resolved
+// Argument's VRF table depends on exactly that parameter.
+//
+// Support is detected by walking the running kernel's own BTF for a member
+// named tbid rather than parsing a version string. The BTF is generated from
+// the same struct definition the helper implementation reads, so its absence is
+// proof, whatever version the kernel reports: backports and vendor kernels
+// routinely change what a given version supports.
+//
+// This check never passes partially. Any missing capability fails the whole
+// check, and the caller must not fall back to a degraded mode.
 package preflight
 
 import (
@@ -47,42 +35,33 @@ import (
 	"fmt"
 )
 
-// Prober is the kernel-capability probe interface this package's checks run
-// against. [NewKernelProber] returns the real, kernel-backed implementation
-// used in production; tests substitute a mocked/stubbed implementation (see
-// preflight_test.go) to exercise the pass case and each individual failure
-// case in [CheckWith] without touching the real kernel (Milestone 2.3 exit
-// criteria).
+// Prober is the kernel-capability probe interface the checks run against.
+// NewKernelProber returns the real implementation; tests substitute a stub to
+// exercise the pass case and each failure case without a kernel.
 type Prober interface {
-	// SchedCLS reports whether the running kernel supports
-	// BPF_PROG_TYPE_SCHED_CLS. Returns nil if supported, a non-nil error
-	// otherwise.
+	// SchedCLS reports whether the kernel supports the TC-BPF program type,
+	// returning nil when it does.
 	SchedCLS() error
 
-	// HashMap reports whether the running kernel supports
-	// BPF_MAP_TYPE_HASH. Returns nil if supported, a non-nil error
-	// otherwise.
+	// HashMap reports whether the kernel supports the hash map type, returning
+	// nil when it does.
 	HashMap() error
 
-	// BTF reports whether the running kernel exposes BTF type
-	// information (required for usid.c's CO-RE compilation to resolve
-	// against this kernel). Returns nil if available, a non-nil error
-	// otherwise.
+	// BTF reports whether the kernel exposes BTF type information, which a
+	// CO-RE-compiled object needs to resolve against it. Returns nil when
+	// available.
 	BTF() error
 
-	// FIBLookupTBID reports whether this kernel's bpf_fib_lookup()
-	// supports the VRF-table-id (tbid) parameter specifically -- not
-	// merely that the base helper exists. Returns nil if supported, a
-	// non-nil error otherwise.
+	// FIBLookupTBID reports whether this kernel's bpf_fib_lookup supports the
+	// VRF-table-id parameter, not merely that the helper exists. Returns nil
+	// when supported.
 	FIBLookupTBID() error
 }
 
-// capabilityCheck names one required capability, binds it to its probe
-// function, and carries a one-line, actionable "why this matters" note used
-// to build [CheckWith]'s aggregate error. The why text is independent of
-// whatever detail the underlying Prober error carries, so the aggregate
-// error is equally actionable regardless of which Prober implementation
-// (real or stubbed) produced it.
+// capabilityCheck names one required capability, binds it to its probe, and
+// carries a one-line actionable note used to build the aggregate error. That
+// note is independent of whatever detail the probe's own error carries, so the
+// aggregate stays equally actionable whichever Prober produced it.
 type capabilityCheck struct {
 	name string
 	fn   func() error
@@ -117,27 +96,21 @@ func capabilityChecks(p Prober) []capabilityCheck {
 }
 
 // Check runs every capability probe this datapath depends on against the
-// real running kernel (via [NewKernelProber]) and returns a clear,
-// actionable error if any is missing. It is the entry point Milestone
-// 3.1's control daemon calls before attempting to load
-// internal/plumbing/ebpf/prog's compiled object.
+// running kernel and returns an actionable error if any is missing. It is what
+// the control daemon calls before attempting to load the compiled object.
 func Check() error {
 	return CheckWith(NewKernelProber())
 }
 
-// CheckWith runs the same checks as [Check] against an arbitrary [Prober],
-// so tests can substitute a mocked/stubbed kernel-feature-probe
-// implementation and exercise the pass case and each individual failure
-// case without touching the real kernel.
+// CheckWith runs the same probes as Check against an arbitrary Prober, so tests
+// can exercise the pass case and each failure case without a kernel.
 //
-// Every check always runs, even after an earlier one fails, so a caller
-// sees every missing capability at once rather than one at a time across
-// repeated fix-and-rerun cycles. If nothing is missing, CheckWith returns
-// nil. If anything is missing, CheckWith returns a single non-nil error
-// (built with [errors.Join]) describing every failure -- there is no
-// partial-pass return value, and callers must treat any non-nil error as
-// "do not load the datapath on this node," never as a signal to fall back
-// to a degraded or unsafe mode (design plan §6).
+// Every check runs even after an earlier one fails, so a caller sees every
+// missing capability at once rather than one per fix-and-rerun cycle. It
+// returns nil when nothing is missing, and otherwise a single joined error
+// describing every failure. There is no partial-pass return: any non-nil error
+// means do not load the datapath on this node, never fall back to a degraded
+// mode.
 func CheckWith(p Prober) error {
 	checks := capabilityChecks(p)
 

--- a/internal/plumbing/ebpf/prog/doc.go
+++ b/internal/plumbing/ebpf/prog/doc.go
@@ -2,69 +2,42 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package prog holds the compiled TC-BPF program that implements the
-// `uFMT 48+16` uSID decode/forward datapath (design plan
-// .local/plan-ebpf-xdp-usid-datapath.md §4.2/§4.4; Milestone 2.2 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+// Package prog holds the compiled TC-BPF program implementing the uFMT 48+16
+// uSID decode and forward datapath.
 //
-// usid.c is the single source of truth for the packet path; see its
-// header comment for the full 9-step walkthrough. `go generate` (via
-// bpf2go, github.com/cilium/ebpf's code generator) compiles it with clang
-// into a CO-RE-portable BPF object and generates matching Go bindings
-// (UsidObjects, LoadUsid, LoadUsidObjects, plus per-map/per-program
-// fields) in this package -- run `go generate ./...` from the repo root,
-// or `go generate` from this directory, after editing usid.c.
+// usid.c is the single source of truth for the packet path; its header comment
+// walks the nine steps. `go generate` compiles it with clang into a
+// CO-RE-portable BPF object and generates the matching Go bindings in this
+// package. Run it after editing usid.c.
 //
-// Unlike this repo's other generated code (e.g. *.pb.go, committed
-// per CLAUDE.md: "Generated protobuf files ... are committed; never
-// hand-edit them"), the generated *_bpfel.go/*_bpfel.o and
-// *_bpfeb.go/*_bpfeb.o files are gitignored, not committed: they embed a
-// compiled binary blob rather than plain Go source, and committing a
-// compiled artifact risks it silently drifting out of sync with usid.c
-// with nothing to catch the mismatch short of a byte-diff. Instead, every
-// build site regenerates them fresh via `task build:ebpf` -- a hard
-// dependency of `task build`/`lint`/`test:unit`/`test:unit-root`/`test:e2e`
-// (see Taskfile.yaml), and of containers/galactic-cni/Dockerfile and
-// containers/galactic-router/Dockerfile's builder stages -- so clang must
-// be on PATH (or $BPF2GO_CC) to build or test this module at all; there is
-// no fallback to a checked-in copy.
+// The generated Go and object files are gitignored rather than committed,
+// unlike this repo's other generated code: they embed a compiled binary blob,
+// and a committed artifact can drift out of sync with usid.c with nothing short
+// of a byte-diff to catch it. Every build site regenerates them, which the
+// build, lint, and test tasks and both container builder stages all depend on,
+// so clang must be on PATH or named by $BPF2GO_CC to build or test this module.
+// There is no fallback to a checked-in copy.
 //
-// Placement: sibling of internal/plumbing/ebpf/uformat (Milestone 2.1)
-// under the shared internal/plumbing/ebpf/ umbrella -- uformat is the
-// pure-Go bit-layout library with no kernel dependency; this package is
-// the compiled BPF program itself. The two intentionally share the exact
-// same key-composition arithmetic (locator_key = top 8 bytes of the
-// address as-is; function_key = Block<<4|Function; vrf_key =
-// Block<<12|Argument) so the kernel program and the Go control plane
-// (Milestone 3.x, which will populate these maps) can never drift on bit
-// positions -- see usid.c's map-key comment block for the details.
+// This package neither loads nor attaches the program. It exposes typed handles
+// to the maps and program for the loader package and for this package's own
+// tests.
 //
-// This package does not itself load or attach the compiled program to any
-// interface -- that is Milestone 3.1's job (extending galactic-cni's `run`
-// subcommand). This package only builds the object and exposes typed Go
-// handles to its maps and program, via bpf2go's generated loader
-// functions, for that later milestone (and this milestone's own
-// BPF_PROG_TEST_RUN-based tests) to use.
+// It sits beside internal/plumbing/ebpf/uformat, the pure-Go bit-layout library
+// with no kernel dependency. The two share the same key-composition arithmetic
+// deliberately, so the kernel program and the Go control plane cannot drift on
+// bit positions.
 package prog
 
-// The -idirafter flags below work around a clang quirk specific to
-// Debian/Ubuntu-style multiarch layouts (confirmed via the `build` job's
-// real run of this directive in .github/workflows/ci.yaml, on
-// ubuntu-latest): with `-target bpfel`/`bpfeb`, clang's default header
-// search list drops `/usr/include/<triple>` (present for the host GNU
-// target, absent for the BPF virtual target), so `<linux/bpf.h>`'s own
-// `<asm/types.h>` include goes unresolved even though
-// `linux-libc-dev`/`libc6-dev` did install it -- just not somewhere the
-// BPF target's search path looks. Listing both the amd64 and arm64
-// multiarch directories explicitly covers this repo's two supported
-// architectures; -idirafter silently skips whichever one doesn't exist on
-// the host, so this is harmless on non-Debian systems (Fedora, Alpine,
-// macOS) that resolve these headers without any multiarch subdirectory.
+// The -idirafter flags work around a clang quirk on Debian-style multiarch
+// layouts: with a BPF target, clang's default header search drops
+// /usr/include/<triple>, which exists for the host GNU target and not for the
+// BPF virtual one, so <linux/bpf.h>'s own <asm/types.h> goes unresolved even
+// though the libc headers are installed. Listing both supported architectures
+// covers it, and -idirafter silently skips whichever is absent, so this is
+// harmless on distributions that resolve these headers without a multiarch
+// subdirectory.
 //
-// -cc is deliberately omitted: bpf2go's own default is
-// getEnv("BPF2GO_CC", "clang"), so CI can pin an exact clang version by
-// setting $BPF2GO_CC (see .github/workflows/ci.yaml) without this
-// directive needing to change, while everyone else keeps getting plain
-// "clang" off their PATH.
+// -cc is deliberately omitted: bpf2go defaults to $BPF2GO_CC or "clang", so CI
+// can pin an exact version without this directive changing.
 //
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -Wall -idirafter /usr/include/x86_64-linux-gnu -idirafter /usr/include/aarch64-linux-gnu" -target bpfel,bpfeb -type locator_value -type function_value -type vrf_value -type ifindex_vrf_value -type nptv6_value -type vip_xlat_key -type vip_xlat_value -type egress_route_key -type egress_route_value -type public_uplink_value Usid usid.c

--- a/internal/plumbing/ebpf/prog/dropreason.go
+++ b/internal/plumbing/ebpf/prog/dropreason.go
@@ -4,18 +4,14 @@
 
 package prog
 
-// Drop reason indices into the drop_reasons map (usid.c's `enum
-// drop_reason`), exported for callers outside this package -- notably
-// internal/plumbing/ebpf/metrics's Prometheus collector (Milestone 4 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md), which needs a
-// stable, human-readable label per index. Hand-kept in sync with usid.c
-// for the same reason usidmap's BehaviorEndDT46/BehaviorEndDT2 constants
-// are (see usidmap/function.go's identical comment): bpf2go's -type flag
-// cannot generate a Go type for a C enum that is only ever used as a
-// literal constant, never as a typed variable/field the compiler retains
-// distinct BTF for. usid_test.go (this package) uses these same exported
-// constants directly rather than keeping its own copy -- if usid.c's enum
-// drop_reason ever changes, update both this file and usid_test.go.
+// Drop reason indices into the drop_reasons map, mirroring the datapath's own
+// enum and exported for callers outside this package, notably the Prometheus
+// collector, which needs a stable label per index.
+//
+// Hand-kept in sync with the C source, because the generator cannot produce a Go
+// type for an enum used only as a literal constant. This package's own tests use
+// these same constants rather than keeping a copy, so a change to the enum means
+// updating both this file and those tests.
 const (
 	DropReasonUnknownFunction            uint32 = 0
 	DropReasonUnknownArgument            uint32 = 1
@@ -36,10 +32,9 @@ const (
 	DropReasonCount                      uint32 = 16
 )
 
-// DropReasonNames maps each DropReason* index to a short, stable,
-// metrics/log-friendly name, decoupling Prometheus label values (Milestone
-// 4) and any other external representation from usid.c's C identifier
-// spelling.
+// DropReasonNames maps each index to a short, stable, metrics-friendly name,
+// decoupling label values and any other external representation from the C
+// identifier spelling.
 var DropReasonNames = map[uint32]string{
 	DropReasonUnknownFunction:            "unknown_function",
 	DropReasonUnknownArgument:            "unknown_argument",

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -4,115 +4,63 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// usid.c implements the TC-BPF ingress datapath for the `uFMT 48+16` SRv6
-// uSID carrier format described in .local/plan-ebpf-xdp-usid-datapath.md
-// (design plan) §4.2/§4.4, and sequenced as Milestone 2.2 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md.
+// usid.c implements the TC-BPF ingress datapath for the uFMT 48+16 SRv6 uSID
+// carrier format.
 //
-// Packet path (design plan §4.2, steps 1-9; every lookup here is an exact
-// hash match -- R1 forbids matching anything looser than a full /64, and
-// none of the three lookup maps below are BPF_MAP_TYPE_LPM_TRIE, per the
-// design plan's §4.4 map inventory):
+// Packet path. Every lookup is an exact hash match; nothing here matches looser
+// than a full /64, and none of the lookup maps below is an LPM trie:
 //
-//  1. Parse the outer Ethernet + IPv6 header (bounds-checked). Not IPv6,
-//     or too short to parse -- TC_ACT_UNSPEC (hand off to the next tc
-//     filter on this device unmodified, R6).
-//  2. Exact-match the destination address's top 64 bits (uSID Block(48) +
-//     Node-ID(16), read with no shift) against locator_table. No match --
-//     TC_ACT_UNSPEC (not one of this node's uSID Blocks, R6).
-//  3. Read Function directly from the unmutated packet at its fixed
-//     offset (bits 65-68) -- no shift, no mutation (R2).
-//  4. Exact-match (matched Block, Function) against function_table. No
-//     match -- drop, counted (DROP_REASON_UNKNOWN_FUNCTION): this packet
-//     was already claimed by step 2's locator match, so silent
-//     pass-through here would duplicate-deliver it to the normal stack. A
-//     match whose behavior isn't BEHAVIOR_END_DT46 (i.e.
-//     BEHAVIOR_END_DT2, reserved for a future L2 uEnd.DT2 path this
-//     program does not implement yet) is dropped and counted separately
-//     (DROP_REASON_UNSUPPORTED_BEHAVIOR) rather than falling through to
-//     DT46 decap -- #740 makes 0xE and 0xF fully independent service
-//     universes, so a DT2 entry reaching steps 5-9 below would parse an
-//     L2 frame as an inner IP packet against the wrong table entirely.
-//  5. Read Argument directly from the unmutated packet at its fixed
-//     offset (bits 69-80) -- no shift, no mutation (R2, R4). Argument
-//     0x000 is reserved and never registered into vrf_table (R4, design
-//     plan §5.1), so it always misses step 6 -- no special-cased check
-//     needed here.
-//  6. Exact-match (matched Block, Argument) against vrf_table. No match --
-//     drop, counted (DROP_REASON_UNKNOWN_ARGUMENT). Per-Argument hit
-//     counters (packets, bytes, last_seen) are updated in vrf_table's
-//     value on every match that reaches this step, supporting R8's
-//     dual-key migration counters -- these count packets *claimed* by
-//     this Argument, not packets successfully forwarded: a claimed packet
-//     can still be dropped by any of steps 7-9 below (malformed inner,
-//     strip failure, FIB failure, redirect failure), in which case it
-//     also bumps that same vrf_table entry's dropped_packets counter, so
-//     "packets - dropped_packets" is what actually left via step 9.
-//  7. Strip the outer IPv6 header (bpf_skb_adjust_room, BPF_ADJ_ROOM_MAC),
-//     exposing the inner IPv4/IPv6 packet (dual-stack, uEnd.DT46 -- R5).
-//  8. bpf_fib_lookup() against the resolved Linux VRF table id
-//     (vrf_table's value), using BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID
-//     so the lookup is scoped to that VRF's routing table exactly like the
-//     kernel's own SEG6_LOCAL_ACTION_END_DT46 does today (§4.3).
-//  9. Redirect to the resolved egress interface: bpf_redirect_peer() for a
-//     veth attachment (the pod's host-side veth, whose container-side peer
-//     lives in a different netns -- design plan §4.1), or plain
-//     bpf_redirect() for a tap attachment (the tap device already sits in
-//     the same netns this program runs in -- internal/cni/tap never moves
-//     it -- so no netns-crossing redirect is needed or possible). Which one
-//     to use is read from vrf_table's own egress_kind field, set at
-//     registration time from the CNI's InterfaceType (Milestone 6.1's
-//     tap-mode redirect fix).
+//  1. Parse the outer Ethernet and IPv6 header, bounds-checked. Not IPv6, or
+//     too short to parse: TC_ACT_UNSPEC, handed to the next tc filter
+//     unmodified.
+//  2. Exact-match the destination's top 64 bits, Block and Node-ID read with no
+//     shift, against locator_table. No match: TC_ACT_UNSPEC.
+//  3. Read Function from the unmutated packet at its fixed offset.
+//  4. Exact-match (Block, Function) against function_table. No match: drop,
+//     counted, because step 2 already claimed this packet and passing it
+//     through would duplicate-deliver it to the normal stack. A match whose
+//     behavior is not End.DT46 is dropped and counted separately rather than
+//     falling through: the two Function values are independent service
+//     universes, so a DT2 entry reaching the steps below would parse an L2
+//     frame as an inner IP packet.
+//  5. Read Argument from the unmutated packet at its fixed offset. Argument
+//     0x000 is reserved and never registered, so it always misses step 6 and
+//     needs no special case.
+//  6. Exact-match (Block, Argument) against vrf_table. No match: drop, counted.
+//     Per-Argument counters are updated on every match reaching this step.
+//     They count packets claimed, not forwarded: a claimed packet can still be
+//     dropped by steps 7 through 9, which also bumps that entry's
+//     dropped_packets, so packets minus dropped_packets is what left via step
+//     9.
+//  7. Strip the outer IPv6 header, exposing the inner IPv4 or IPv6 packet.
+//  8. bpf_fib_lookup against the resolved Linux VRF table, scoped to that
+//     table exactly as the kernel's own End.DT46 does.
+//  9. Redirect to the resolved egress interface: bpf_redirect_peer for a veth
+//     attachment, whose container-side peer is in another namespace, or plain
+//     bpf_redirect for a tap, which already sits in this namespace. Which one
+//     comes from vrf_table's egress_kind, set at registration time.
 //
-// This file intentionally has no dependency on libbpf's bpf_helpers.h /
-// bpf_helper_defs.h: it declares only the handful of BPF helper functions
-// it actually calls (using the enum bpf_func_id constants from the
-// system's own <linux/bpf.h>, not hand-picked magic numbers), and defines
-// its own minimal Ethernet/IPv4/IPv6 header structs rather than pulling in
-// <linux/if_ether.h>/<linux/ip.h>/<linux/ipv6.h>. This keeps the build's
-// only external dependency on the kernel-headers package's <linux/bpf.h>
-// (present on any distro that ships BPF/BTF support at all), and keeps the
-// datapath's exact wire-format assumptions visible in one file instead of
-// spread across vendored third-party headers.
+// This file depends on no libbpf headers. It declares only the helpers it
+// calls, using the enum constants from the system's <linux/bpf.h>, and defines
+// its own minimal header structs. That keeps the build's only external
+// dependency on the kernel headers package and keeps the wire-format
+// assumptions visible in one file.
 //
-// Compiled with CO-RE (Compile Once - Run Everywhere) via BTF: clang is
-// invoked with `-g`, which emits a .BTF section into the object alongside
-// the program/map definitions below (all of which already use the
-// BTF-defined-map convention -- `__uint`/`__type` inside an anonymous
-// struct tagged SEC(".maps") -- rather than the legacy fixed
-// `struct bpf_map_def`). This program does not read any unstable
-// kernel-internal struct fields (no BPF_CORE_READ of `struct sk_buff`
-// internals, etc.), so it needs no `vmlinux.h`: the packet fields it reads
-// are all stable, wire-format bytes accessed via direct bounds-checked
-// pointer arithmetic on skb->data/skb->data_end, not BTF relocations
-// against a kernel struct layout.
+// Compiled with CO-RE through BTF. It reads no unstable kernel-internal struct
+// fields, so it needs no vmlinux.h: every packet field it touches is stable
+// wire-format bytes read through bounds-checked pointer arithmetic.
 //
-// The BPF ELF "license" section below is a kernel-required
-// self-declaration for the compiled bytecode: the verifier's
-// license_is_gpl_compatible() check reads it to decide whether this
-// program may call a gpl_only helper -- and it already does: the VRF FIB
-// lookup below calls bpf_fib_lookup(), which the kernel implements as
-// gpl_only (net/core/filter.c's bpf_fib_lookup_proto). That check accepts
-// only a fixed whitelist of exact strings ("GPL", "GPL v2", "GPL and
-// additional rights", "Dual MIT/GPL", "Dual BSD/GPL"); this file's own
-// AGPL-3.0-or-later SPDX identifier (above) is not on it, so declaring
-// the ELF section as literally "AGPL-3.0-or-later" makes the program
-// fail to load at all (verifier: "cannot call GPL-restricted function
-// from non-GPL compatible program"), not merely a hypothetical future
-// tradeoff. "GPL" is used instead (not "Dual BSD/GPL" -- this program
-// isn't itself dual-licensed, so it declares plain "GPL" rather than a
-// disjunction it doesn't mean), same as Cilium, Katran, and every other
-// AGPL/Apache/BSD-licensed project embedding a BPF datapath: the ELF
-// license section governs which helpers the verifier allows and says
-// nothing about the licensing of the surrounding Go project, so this is
-// independent of (and doesn't relicense) the file's own
-// AGPL-3.0-or-later SPDX header.
+// The ELF license section is a kernel-required declaration that gates which
+// helpers the verifier allows. bpf_fib_lookup, called below, is GPL-only, and
+// the verifier accepts only a fixed whitelist of strings, which this file's own
+// SPDX identifier is not on. Declaring it verbatim makes the program fail to
+// load, so "GPL" is declared instead. That section governs helper access and
+// says nothing about the licensing of the surrounding project.
 
 #include <linux/bpf.h>
 
-// __u8/__u16/__u32/__u64/__s16/__s32/__be16/__be32 all come transitively
-// from <linux/bpf.h> -> <linux/types.h> -> <asm-generic/int-ll64.h>; no
-// separate include or manual typedef needed.
+// The fixed-width integer types all come transitively from <linux/bpf.h>; no
+// separate include or typedef is needed.
 
 // ---------------------------------------------------------------------
 // Minimal BTF-map-definition and section macros (the same idiom used by
@@ -126,9 +74,8 @@
 #define __type(name, val) typeof(val) *name
 #define USID_ALWAYS_INLINE inline __attribute__((always_inline))
 
-// USID_OFFSETOF reproduces <stddef.h>'s offsetof -- not otherwise available,
-// since this file deliberately includes no headers beyond <linux/bpf.h>
-// (see the file header comment).
+// USID_OFFSETOF reproduces offsetof, which is not otherwise available since
+// this file includes no headers beyond <linux/bpf.h>.
 #define USID_OFFSETOF(type, member) ((__u32) (unsigned long) &((type *) 0)->member)
 
 // ---------------------------------------------------------------------
@@ -140,61 +87,54 @@
 
 static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *) BPF_FUNC_map_lookup_elem;
 
-// Called once, unconditionally, at the top of usid_ingress -- see its call
-// site for why a defensive linearization pass runs before any direct
-// data/data_end read in this program.
+// Called once, unconditionally, at the top of usid_ingress. See its call site
+// for why a defensive linearization pass runs before any direct packet read.
 static long (*bpf_skb_pull_data)(struct __sk_buff *skb, __u32 len) = (void *) BPF_FUNC_skb_pull_data;
 
 static long (*bpf_skb_adjust_room)(struct __sk_buff *skb, __s32 len_diff, __u32 mode,
 				    __u64 flags) = (void *) BPF_FUNC_skb_adjust_room;
 
-// Clears the outer transit VLAN off a decapsulated packet -- see its call
-// site (step 7) for why the inner packet must not inherit it, and why a
-// helper is needed rather than zeroing a field: skb->vlan_tci is not
-// writable from BPF, and the tag lives there rather than in packet data
-// whenever the NIC strips it on receive.
+// Clears the outer transit VLAN off a decapsulated packet. A helper is needed
+// rather than zeroing a field: skb->vlan_tci is not writable from BPF, and the
+// tag lives there rather than in packet data whenever the NIC strips it on
+// receive. See its call site in step 7.
 static long (*bpf_skb_vlan_pop)(struct __sk_buff *skb) = (void *) BPF_FUNC_skb_vlan_pop;
 
-// Only used on the IPv4-inner decap path, to retag skb->protocol -- see
-// the long comment at its call site (step 7) for why a helper is needed
-// here at all instead of a plain assignment.
+// Used only on the IPv4-inner decap path, to retag skb->protocol. See step 7
+// for why a helper is needed rather than a plain assignment.
 static long (*bpf_skb_change_proto)(struct __sk_buff *skb, __be16 proto,
 				     __u64 flags) = (void *) BPF_FUNC_skb_change_proto;
 
 static long (*bpf_fib_lookup)(void *ctx, struct bpf_fib_lookup *params, __s32 plen,
 			       __u32 flags) = (void *) BPF_FUNC_fib_lookup;
 
-// Step 9 calls one of these two, chosen per-entry via vrf_table's
-// egress_kind field: bpf_redirect_peer for a veth attachment (crosses into
-// the peer's netns, per design plan §4.1), bpf_redirect for a tap
-// attachment (same-netns egress -- see its call site for why).
+// Step 9 calls one of these two, chosen per entry through vrf_table's
+// egress_kind: bpf_redirect_peer for a veth attachment, which crosses into the
+// peer's namespace, and bpf_redirect for a tap, which does not.
 static long (*bpf_redirect_peer)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redirect_peer;
 static long (*bpf_redirect)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redirect;
 
 static __u64 (*bpf_ktime_get_ns)(void) = (void *) BPF_FUNC_ktime_get_ns;
 
-// vip_xlat_table's rewrite (unlike nptv6_table's, see struct
-// vip_xlat_value's comment) is a genuine address+port substitution with no
-// checksum-neutral shortcut, so it needs the real incremental L4 checksum
-// update every stateful NAT uses -- available here because both
-// usid_ingress and usid_egress are TC-BPF (a real struct __sk_buff),
-// unlike edgenat.c's XDP context, which is exactly why that program needs
-// the heavier bpf_csum_diff approach instead.
+// vip_xlat_table's rewrite is a genuine address and port substitution with no
+// checksum-neutral shortcut, so it needs the incremental L4 checksum update any
+// stateful NAT uses. Available here because both programs are TC-BPF with a
+// real sk_buff, unlike an XDP context, which needs the heavier checksum-diff
+// approach.
 static long (*bpf_l4_csum_replace)(struct __sk_buff *skb, __u32 offset, __u64 from, __u64 to,
 				    __u64 flags) = (void *) BPF_FUNC_l4_csum_replace;
 static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const void *from, __u32 len,
 				    __u64 flags) = (void *) BPF_FUNC_skb_store_bytes;
 
-// BPF_F_PSEUDO_HDR/BPF_F_MARK_MANGLED_0 (uapi/linux/bpf.h) reproduced as
-// plain constants for the same reason the TC_ACT_*/USID_AF_INET* constants
-// above are -- avoiding a second header dependency for a couple of flags.
+// Two checksum flags reproduced as plain constants, for the same reason as the
+// TC verdict and address-family constants below: avoiding a second header
+// dependency.
 #define USID_BPF_F_PSEUDO_HDR (1U << 4)
 #define USID_BPF_F_MARK_MANGLED_0 (1U << 5)
 
 // ---------------------------------------------------------------------
-// TC verdicts (uapi/linux/pkt_cls.h) -- reproduced as plain constants to
-// avoid pulling in that header's transitive netlink dependencies for three
-// integers.
+// TC verdicts, reproduced as plain constants to avoid pulling in that header's
+// transitive netlink dependencies for three integers.
 // ---------------------------------------------------------------------
 
 #define TC_ACT_UNSPEC (-1)
@@ -203,8 +143,7 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 #define TC_ACT_REDIRECT 7
 
 // ---------------------------------------------------------------------
-// Address-family constants (uapi asm-generic/socket.h). These values are
-// fixed kernel ABI and never change.
+// Address-family constants. Fixed kernel ABI.
 // ---------------------------------------------------------------------
 
 #define USID_AF_INET 2
@@ -213,17 +152,15 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 #define USID_ETH_P_IP 0x0800
 #define USID_ETH_P_IPV6 0x86DD
 
-// IPv6 Next Header values (RFC 8200 §4 / IANA protocol numbers) that name
-// an inner IPv4 or IPv6 packet directly -- i.e. no extension header sits
-// between the outer uSID header and the real inner packet. Fixed kernel
-// ABI, never change.
+// IPv6 Next Header values naming an inner IPv4 or IPv6 packet directly, that
+// is, with no extension header between the outer uSID header and the real inner
+// packet. Fixed kernel ABI.
 #define USID_IPPROTO_IPIP 4
 #define USID_IPPROTO_IPV6 41
 
-// Transport protocol numbers, needed by the DSR/Maglev redesign's
-// vip_xlat_table lookup (both TCP and UDP headers place source/destination
-// port at the identical offset -- struct usid_l4ports below -- so no
-// separate struct is needed per protocol for the fields this file touches).
+// Transport protocol numbers, needed for the vip_xlat_table lookup. TCP and UDP
+// place source and destination port at the same offset, so one struct covers
+// both for the fields this file touches.
 #define USID_IPPROTO_TCP 6
 #define USID_IPPROTO_UDP 17
 
@@ -233,34 +170,25 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 #define USID_UDP_CSUM_OFFSET 6
 
 // USID_EGRESS_HOP_LIMIT is the hop limit usid_egress writes into the outer
-// IPv6 header it pushes for a resolved egress route -- a fixed, reasonable
-// default (matching this lab's/most Linux hosts' own default unicast hop
-// limit), not read from the inner packet's own hop limit: the outer
-// header's hop count only needs to survive the underlay's own hop count
-// (a handful of hops in every topology this program runs on), not mirror
-// whatever budget the inner packet's original sender picked.
+// header it pushes. A fixed default rather than a copy of the inner packet's
+// own: the outer header only needs to survive the underlay's hop count, not
+// mirror whatever budget the original sender chose.
 #define USID_EGRESS_HOP_LIMIT 64
 
-// USID_L3_OFFSET is the fixed byte offset of the L3 (IPv6) header from
-// skb->data -- always sizeof(struct usid_ethhdr), a compile-time constant.
-// apply_vip_xlat's csum_off/addr_off/port_off arguments must be this kind
-// of compile-time-constant-derived offset, not a runtime pointer
-// subtraction: bpf_skb_store_bytes (inside apply_vip_xlat) invalidates the
-// verifier's tracked bounds on every previously-derived packet pointer,
-// and a scalar computed by subtracting two packet pointers loses precise
-// range tracking across that call boundary, which then fails the bounds
-// check on the *next* direct packet dereference after the call --
-// confirmed empirically via BPF_PROG_TEST_RUN (the verifier rejected the
-// pointer-subtraction version with "R5 min value is outside of the
-// allowed memory range"). A literal constant offset sidesteps the problem
-// entirely rather than working around it.
+// USID_L3_OFFSET is the fixed byte offset of the IPv6 header from skb->data, a
+// compile-time constant.
+//
+// apply_vip_xlat's offset arguments must be constant-derived like this rather
+// than computed by pointer subtraction. bpf_skb_store_bytes invalidates the
+// verifier's tracked bounds on every previously derived packet pointer, and a
+// scalar produced by subtracting two packet pointers loses precise range
+// tracking across that boundary, which then fails the bounds check on the next
+// dereference after the call.
 #define USID_L3_OFFSET (sizeof(struct usid_ethhdr))
 
 // ---------------------------------------------------------------------
-// Minimal, self-contained header structs. Byte-exact to the real wire
-// formats; hand-rolled (rather than <linux/if_ether.h>/<linux/ip.h>/
-// <linux/ipv6.h>) so this file has exactly one external header dependency
-// (<linux/bpf.h>, for the map/program/helper/fib-lookup definitions).
+// Minimal, self-contained header structs, byte-exact to the wire formats.
+// Hand-rolled so this file has exactly one external header dependency.
 // ---------------------------------------------------------------------
 
 struct usid_ethhdr {
@@ -269,10 +197,9 @@ struct usid_ethhdr {
 	__be16 h_proto;
 } __attribute__((packed));
 
-// struct usid_ip6hdr is deliberately NOT the kernel's bitfield-based
-// struct ipv6hdr (whose version/traffic-class bitfield layout is
-// endian-dependent) -- this program never reads version/traffic-class/flow
-// label, so vtc_flow is left as an opaque 4-byte blob.
+// struct usid_ip6hdr is deliberately not the kernel's bitfield-based ipv6hdr,
+// whose version and traffic-class layout is endian-dependent. This program
+// never reads those fields, so vtc_flow stays an opaque 4-byte blob.
 struct usid_ip6hdr {
 	__u8 vtc_flow[4];
 	__be16 payload_len;
@@ -282,12 +209,10 @@ struct usid_ip6hdr {
 	__u8 daddr[16];
 } __attribute__((packed));
 
-// struct usid_l4ports mirrors the first 4 bytes shared by a TCP and a UDP
-// header (source port, destination port) -- the only L4 fields
-// vip_xlat_table's rewrite touches directly; the checksum field itself is
-// updated via bpf_l4_csum_replace, never read/written as a struct field
-// here (its offset differs between TCP/UDP -- see USID_TCP_CSUM_OFFSET/
-// USID_UDP_CSUM_OFFSET above).
+// struct usid_l4ports mirrors the first 4 bytes a TCP and a UDP header share,
+// the source and destination ports, which are the only L4 fields the rewrite
+// touches directly. The checksum is updated through a helper rather than as a
+// struct field, since its offset differs between the two protocols.
 struct usid_l4ports {
 	__be16 source;
 	__be16 dest;
@@ -307,26 +232,20 @@ struct usid_iphdr {
 } __attribute__((packed));
 
 // ---------------------------------------------------------------------
-// Map value types (design plan §4.4).
+// Map value types.
 // ---------------------------------------------------------------------
 
-// struct locator_value is locator_table's value: `{ generation }`.
-// generation is a __u64, not __u32: userspace (Milestone 3.3's
-// internal/plumbing/ebpf/usidmap) stamps it with a nanosecond-resolution
-// CLOCK_MONOTONIC reading, which overflows a 32-bit field in a few
-// seconds. This program never reads generation's contents itself (the
-// locator_table lookup below only tests the returned pointer for a match,
-// never dereferences a field of it), so widening this field has no effect
-// on the packet path.
+// struct locator_value is locator_table's value. generation is 64-bit because
+// userspace stamps it with a nanosecond-resolution monotonic reading, which
+// overflows 32 bits in seconds. This program never reads it: the lookup only
+// tests the returned pointer for a match.
 struct locator_value {
 	__u64 generation;
 };
 
-// struct function_value is function_table's value: `{ behavior_enum }`.
-// BEHAVIOR_END_DT46 is the only behavior this program implements (design
-// plan R3); BEHAVIOR_END_DT2 is reserved for a future L2 uEnd.DT2 path.
-// usid_ingress reads this field (step 4) only to reject anything that
-// isn't BEHAVIOR_END_DT46 -- it does not itself implement DT2 decap.
+// struct function_value is function_table's value. End.DT46 is the only
+// behavior this program implements; End.DT2 is reserved for a future L2 path.
+// Step 4 reads this field only to reject anything that is not End.DT46.
 enum function_behavior {
 	BEHAVIOR_END_DT46 = 1,
 	BEHAVIOR_END_DT2 = 2,
@@ -336,52 +255,34 @@ struct function_value {
 	__u32 behavior;
 };
 
-// enum egress_kind indexes vrf_value's egress_kind field (Milestone 6.1's
-// tap-mode redirect fix): which redirect helper step 9 must use for this
-// entry's resolved egress interface. EGRESS_KIND_VETH (the zero value, so
-// an entry registered before this field existed -- there are none, since
-// nothing has shipped to production yet -- would default correctly) uses
+// enum egress_kind selects which redirect helper step 9 uses for an entry's
+// resolved egress interface. EGRESS_KIND_VETH, the zero value, uses
 // bpf_redirect_peer; EGRESS_KIND_TAP uses plain bpf_redirect, since a tap
-// device never has a netns-crossing peer (internal/cni/tap creates it in
-// the same netns this program runs in and never moves it).
+// device never has a namespace-crossing peer.
 enum egress_kind {
 	EGRESS_KIND_VETH = 0,
 	EGRESS_KIND_TAP = 1,
 };
 
-// struct vrf_value is vrf_table's value: `{ linux_vrf_table_id, packets,
-// bytes, last_seen }` per the design plan's §4.4 map inventory, plus
-// `generation` (design plan §4.2 step 6's earlier, value-shape description
-// of this same map -- `{linux_vrf_table_id, generation, hit counter}` --
-// which §4.4's table narrowed to the counter fields alone; this field
-// reconciles the two by carrying generation as an actual struct member,
-// same as locator_value already does) and `egress_kind` (Milestone 6.1's
-// tap-mode redirect fix, above). generation is written only by userspace
-// (internal/plumbing/ebpf/usidmap, Milestone 3.3) at registration time --
-// this program never reads or writes it -- and lets the GC sweep
-// (Milestone 7.3) distinguish "existed before this sweep's CRD-list
-// snapshot was taken" from "registered after," so a Register call landing
-// between the sweep's list-CRDs and delete-stale-entries steps is never
-// reaped as stale (design plan §5.4's closing paragraph). egress_kind
-// occupies what was previously an explicit alignment-only pad field
-// between vrf_table_id and packets; generation is placed last so every
-// pre-existing field keeps its original offset.
+// struct vrf_value is vrf_table's value: the Linux VRF table ID this Argument
+// resolves to, per-Argument counters, an egress_kind, and a generation.
 //
-// `bytes` is bumped by skb->len as read at step 6, i.e. before step 7's
-// strip -- it counts the whole tunneled frame (outer IPv6 header +
-// Ethernet included), not just the inner payload that eventually reaches
-// the egress interface.
+// generation is written only by userspace, at registration time, and never read
+// here. It lets the GC sweep tell "existed before this sweep's snapshot" from
+// "registered after", so a registration landing mid-sweep is never reaped.
 //
-// dropped_packets counts packets that matched this vrf_table entry
-// (bumping `packets` above) but were then dropped by one of steps 7-9
-// (malformed inner, strip failure, FIB failure, redirect failure) rather
-// than actually forwarded -- so `packets` alone is a *claimed* count, not
-// a *forwarded* one, and `packets - dropped_packets` is what actually left
-// via step 9. Added after ecv's review of #281 pointed out that a VRF
-// dropping everything still showed healthy per-Argument packets/bytes
-// with no per-tenant signal in drop_reasons (which has no Block/Argument
-// dimension). Placed last, like generation, so every pre-existing field
-// keeps its original offset.
+// bytes is bumped by skb->len as read at step 6, before the strip, so it counts
+// the whole tunneled frame including the outer header and Ethernet, not the
+// inner payload that reaches the egress interface.
+//
+// dropped_packets counts packets that matched this entry, bumping packets, but
+// were then dropped by steps 7 through 9 rather than forwarded. packets alone
+// is a claimed count, and packets minus dropped_packets is what actually left.
+// Without it, a VRF dropping everything still shows healthy per-Argument
+// counters, since drop_reasons has no Block or Argument dimension.
+//
+// egress_kind occupies what was an alignment pad, and generation and
+// dropped_packets are placed last, so every other field keeps its offset.
 struct vrf_value {
 	__u32 vrf_table_id;
 	__u32 egress_kind;
@@ -393,41 +294,29 @@ struct vrf_value {
 };
 
 // ---------------------------------------------------------------------
-// DSR/Maglev redesign additions (design plan §0.1, §2): per-VRF stateless
-// NPTv6 (RFC 6296) and the tap-backend VIP-boundary substitution. Both are
-// consulted from two places: usid_ingress (this file, below -- inbound,
-// after step 7's strip, before step 8's FIB lookup, using the (block,
-// argument) already resolved locally by steps 2-6) and usid_egress (this
-// file, below -- outbound, on a tenant's own not-yet-encapsulated reply,
-// intercepted per-attachment before the kernel's SEG6 encap route ever
-// runs -- see usid_egress's own header comment for why that attach point,
-// not "TC egress of the shared physical uplink", is the only place that
-// can resolve the sending VRF unambiguously).
+// Per-VRF stateless NPTv6 and the VIP-boundary substitution. Both are consulted
+// from two places: usid_ingress, inbound, after the strip and before the FIB
+// lookup, using the (block, argument) steps 2 through 6 already resolved; and
+// usid_egress, outbound, on a tenant's not-yet-encapsulated reply, intercepted
+// per attachment. See usid_egress's header comment for why that attach point is
+// the only one that can resolve the sending VRF unambiguously.
 // ---------------------------------------------------------------------
 
-// struct ifindex_vrf_value is ifindex_vrf_table's value: the (Block,
-// Argument) the attachment on this ifindex belongs to. usid_egress runs
-// per-attachment on plain, not-yet-encapsulated tenant traffic -- it has no
-// outer uSID destination to decode (block,argument) from the way
-// usid_ingress does -- so this is written once per attachment (alongside
-// the existing vrf_table.Register call, which already has both values) at
-// CNI ADD time, keyed by the attachment's own host-side veth/tap ifindex,
-// and removed at CNI DEL.
+// struct ifindex_vrf_value is ifindex_vrf_table's value: the (Block, Argument)
+// the attachment on this ifindex belongs to. usid_egress runs on plain,
+// not-yet-encapsulated traffic and has no outer destination to decode them
+// from, so they are written once per attachment at CNI ADD time, keyed by that
+// attachment's host-side ifindex, and removed at DEL.
 struct ifindex_vrf_value {
 	__u64 block;
 	__u16 argument;
 };
 
-// struct nptv6_value is nptv6_table's value: one VRF's RFC 6296 mapping,
-// mirroring internal/plumbing/nptv6.Mapping/Adjustment on the control-plane
-// side -- see that package's doc comment for the checksum-neutral math this
-// applies. ula_prefix/public_prefix are zero-padded beyond prefix_len,
-// exactly like internal/plumbing/nptv6.prefixChecksum assumes. adjustment
-// is the precomputed RFC 6296 §3.6 value (Mapping.Adjustment), stored in
-// ordinary host-endian layout like every other non-wire-format field in
-// this file -- unlike vip_xlat_value's addr/port fields below, this value
-// is never copied directly onto the wire, so no explicit byte-order
-// convention is needed here.
+// struct nptv6_value is nptv6_table's value: one VRF's RFC 6296 mapping. The
+// prefixes are zero-padded beyond prefix_len, as the control-plane side
+// assumes. adjustment is the precomputed RFC 6296 value, in host-endian layout
+// like every other non-wire field here, since it is never copied onto the
+// wire.
 struct nptv6_value {
 	__u8 ula_prefix[16];
 	__u8 public_prefix[16];
@@ -435,44 +324,29 @@ struct nptv6_value {
 	__u16 adjustment;
 };
 
-// struct vip_xlat_key keys vip_xlat_table: (block, argument) identify the
-// tenant VRF (same composition as vrf_table's own key, kept as separate
-// fields here rather than pre-folded, since a struct key -- unlike
-// vrf_table's plain __u64 -- has room to also carry proto/port). port's
-// meaning is direction-dependent: the *ingress*-direction lookup (in
-// usid_ingress) keys on the packet's own destination port, i.e. the VIP
-// port a client dialed; the *egress*-direction lookup (in usid_egress)
-// keys on the packet's own source port, i.e. the backend's real port --
-// each ServiceVIPBinding writes one row under each key (vip_xlat.go),
-// since the two directions substitute in opposite directions and are
-// looked up via different fields of the same packet.
+// struct vip_xlat_key keys vip_xlat_table. block and argument identify the
+// tenant VRF, kept as separate fields rather than pre-folded because a struct
+// key has room to carry proto and port as well.
 //
-// direction disambiguates those two rows when their ports coincide -- a
-// common, unremarkable case (e.g. a binding that keeps port 80 on both the
-// VIP and the backend), not a rare one, and one this struct originally had
-// no way to handle: (block, argument, proto, port) alone collapses the
-// ingress row (keyed on the VIP port) and the egress row (keyed on the
-// backend port) into the *same* map entry whenever those two ports match,
-// so registering the second row silently overwrote the first -- found live
-// in containerlab, where ns60's binding uses port 80 both ways and the
-// ingress row (VIP -> backend) never survived RegisterEgress's later
-// write, leaving every packet correctly matched by the edge gateway but
-// silently undeliverable at the backend. usid_ingress always sets
-// direction to USID_VIP_XLAT_DIR_INGRESS on the key it builds;
-// usid_egress always sets USID_VIP_XLAT_DIR_EGRESS -- see vipxlatmap.go's
-// mirroring register()/unregister() split for the control-plane side.
+// port's meaning is direction-dependent: the ingress lookup keys on the
+// packet's destination port, the VIP port a client dialed, and the egress
+// lookup on its source port, the backend's real port. Each binding writes one
+// row under each key.
 //
-// The trailing pad2 exists only to eliminate the struct's own compiler-
-// inserted alignment padding: block's __u64 alignment rounds this struct
-// up to 16 bytes, but block+argument+proto+direction+port only account for
-// 14 of them, leaving 2 bytes no initializer touches. C99 zero-initializes
-// an *omitted named member* (like direction, when a caller doesn't set it)
-// but says nothing about true structural padding, and clang's BPF backend
-// does not zero it -- bpf_map_lookup_elem() then reads all 16 key bytes
-// and the verifier rejects the two never-written ones as "invalid read
-// from stack" (caught live via a real containerlab deploy). Naming the
-// last 2 bytes as a real member makes them a normal omitted-member zero,
-// not padding.
+// direction disambiguates those two rows when their ports coincide, which is
+// ordinary rather than rare: a binding keeping port 80 on both sides would
+// otherwise collapse them into one entry, and registering the second would
+// silently overwrite the first, leaving traffic correctly matched at the edge
+// and undeliverable at the backend. usid_ingress always builds its key with the
+// ingress direction and usid_egress with the egress one.
+//
+// The trailing pad2 exists only to remove the struct's compiler-inserted
+// padding. block's alignment rounds the struct to 16 bytes while the named
+// members account for 14, and C zero-initializes an omitted named member but
+// says nothing about true padding, which clang's BPF backend does not zero. The
+// lookup then reads all 16 key bytes and the verifier rejects the two never
+// written as an invalid stack read. Naming them as a member makes them an
+// ordinary omitted-member zero.
 #define USID_VIP_XLAT_DIR_INGRESS 0
 #define USID_VIP_XLAT_DIR_EGRESS 1
 
@@ -485,71 +359,50 @@ struct vip_xlat_key {
 	__u16 pad2;
 };
 
-// struct vip_xlat_value is vip_xlat_table's value: unlike nptv6_value, this
-// is a genuine address+port rewrite with no reserved "elsewhere" bits to
-// absorb a checksum-neutral adjustment into (a real substitution, not a
-// prefix-preserving one) -- applying it needs bpf_l4_csum_replace, not a
-// plain word add/subtract. addr/port are stored in on-wire byte order
-// (network order for port; the 16 address bytes are already wire-order by
-// construction) since both are copied and diffed directly against packet
-// bytes.
+// struct vip_xlat_value is vip_xlat_table's value. Unlike nptv6_value this is a
+// genuine substitution with no reserved bits to absorb a checksum-neutral
+// adjustment into, so applying it needs an incremental checksum update rather
+// than a plain add or subtract. addr and port are stored in wire byte order,
+// since both are copied and diffed directly against packet bytes.
 struct vip_xlat_value {
 	__u8 addr[16];
 	__be16 port;
 };
 
 // ---------------------------------------------------------------------
-// TC-BPF egress-routing extension (docs/plans/tc-bpf-egress-srv6-encap.md):
-// replaces internal/plumbing/srv6's kernel-native SEG6 lwtunnel route
-// encapsulation (RouteEgressAdd/EgressDefaultRouteAdd) with an in-program
-// header push, closing CVE-2026-31668 (seg6 lwtunnel shares one dst_cache
-// per route between its input and output resolution paths, and reuses a
-// stale cached result across different routing contexts -- the upstream
-// fix's own writeup names VRF table separation, this codebase's own
-// per-tenant-VRF architecture, as a trigger). See that plan document for
-// the full mechanism and its own §3's explanation of why this is a plain
-// tunnel-header prepend, not a general SRH pusher: every existing call
-// site installs exactly one segment, and SEG6_IPTUN_MODE_ENCAP_RED
-// already omits the SRH entirely for that case (usid_ingress's own
-// decap side already requires and depends on exactly this shape).
+// TC-BPF egress-routing extension: an in-program header push replacing kernel
+// SEG6 lwtunnel encapsulation, which reuses one dst_cache per route across its
+// input and output resolution paths and returns a stale cached result once
+// those contexts differ, as they do under per-tenant VRFs.
+//
+// A plain tunnel-header prepend, not a general SRH pusher: every call site
+// installs exactly one segment, and the reduced encap mode already omits the
+// SRH for that case, which is the shape usid_ingress's decap side requires.
 // ---------------------------------------------------------------------
 
-// struct egress_route_key is egress_route_table's LPM_TRIE key. Keyed on
-// the Linux VRF table id (table_id), not (block, argument): every one of
-// RouteEgressAdd/EgressDefaultRouteAdd/RouteMainAdd's own Go-side callers
-// (internal/runtime/gobgp/monitor.go, internal/cnibgp/bgp.go) already has
-// the Linux table id in hand -- that is the identity BGP path processing
-// and NAT66 shard-SID resolution are already scoped by -- and none of them
-// otherwise need to resolve a uSID (block, argument) identity at all. This
-// program itself has no direct route from its own per-attachment identity
-// (ifindex_vrf_table's block/argument) to a Linux table id either, so it
-// takes one extra vrf_table lookup (already keyed by the vrf_key this
-// program computes for the NPTv6/vip_xlat lookups above) to read
-// vrf->vrf_table_id, rather than teaching ifindex_vrf_table or
-// egress_route_table a second, redundant identity scheme.
+// struct egress_route_key is egress_route_table's LPM trie key.
 //
-// family disambiguates an IPv4 VPC prefix from an IPv6 one sharing the
-// same leading bytes when addr's low bytes happen to coincide (e.g. an
-// IPv4 /24 stored zero-extended into addr's first 4 bytes could otherwise
-// collide with an IPv6 prefix whose own first 4 bytes are identical by
-// coincidence) -- placed inside the LPM-matched region (never past
-// table_id, always matched in full) specifically so this can never happen:
-// two entries can only ever compare equal on their address bits once
+// Keyed on the Linux VRF table ID rather than (block, argument): every Go-side
+// caller already holds the table ID, that being the identity BGP path
+// processing and shard resolution are scoped by, and none of them resolves a
+// uSID identity at all. This program has no direct route from its own
+// per-attachment identity to a table ID either, so it takes one extra vrf_table
+// lookup rather than teaching a second, redundant identity scheme to two maps.
+//
+// family separates an IPv4 prefix from an IPv6 one whose leading bytes
+// coincide, for instance a zero-extended IPv4 /24 against an IPv6 prefix with
+// the same first four bytes. It sits inside the matched region and is always
+// matched in full, so two entries can compare equal on address bits only once
 // table_id and family already match exactly.
 //
-// prefixlen is bits, not bytes, per LPM_TRIE's own convention -- always at
-// least 40 (the fixed table_id(32)+family(8) portion, matching
-// EgressDefaultRouteAdd's own ::/0 entries) and up to 40+128=168 for a
-// full IPv6 host route or 40+32=72 for a full IPv4 host route.
+// prefixlen is in bits, per the trie's convention: at least 40 for the fixed
+// table_id and family portion, up to 168 for a full IPv6 host route or 72 for a
+// full IPv4 one.
 //
-// __attribute__((packed)), unlike vrf_value/nptv6_value/vip_xlat_value
-// above: an LPM_TRIE's matching semantics only ever compare the first
-// prefixlen *bits*, so (unlike vip_xlat_key's HASH-map full-key-equality
-// requirement, which forced that struct's own explicit pad2 field)
-// trailing compiler-inserted padding here would never affect a lookup's
-// correctness either way -- packed is used anyway to make the exact byte
-// layout this comment's own bit-offset reasoning depends on unambiguous,
-// rather than relying on it holding incidentally.
+// Packed, unlike the structs above. A trie compares only the first prefixlen
+// bits, so trailing padding could not affect a lookup either way, but packing
+// makes the byte layout this comment's bit offsets depend on unambiguous rather
+// than incidental.
 struct egress_route_key {
 	__u32 prefixlen;
 	__u32 table_id;
@@ -557,56 +410,39 @@ struct egress_route_key {
 	__u8 addr[16];
 } __attribute__((packed));
 
-// USID_EGRESS_ROUTE_FAMILY_INET6/INET4 are egress_route_key.family's two
-// values -- deliberately not reusing USID_AF_INET/USID_AF_INET6 (which are
-// the kernel's real AF_INET/AF_INET6 values, sized and spaced for a
-// different purpose, struct bpf_fib_lookup.family) for a field whose only
-// job is disambiguating two prefixes within this one map, not naming a
-// real address family to any kernel API.
+// The two values egress_route_key.family takes. Deliberately not the kernel's
+// real address-family constants, which are sized and spaced for a different
+// purpose: this field only disambiguates two prefixes within this map and names
+// no address family to any kernel API.
 #define USID_EGRESS_ROUTE_FAMILY_INET6 0
 #define USID_EGRESS_ROUTE_FAMILY_INET4 1
 
-// struct egress_route_value is egress_route_table's value: the resolved
-// SRv6 SID (or NAT66 shard SID, for a default-route entry) to
-// encapsulate toward, plus the fully precomputed link/L2 information
-// needed to actually deliver that encapsulated packet.
+// struct egress_route_value is egress_route_table's value: the SID to
+// encapsulate toward, plus the precomputed link and L2 information needed to
+// deliver that encapsulated packet.
 //
-// An earlier version of this struct carried only sid, on the theory that
-// usid_egress could resolve link_ifindex/dmac/smac itself, fresh, via a
-// per-packet bpf_fib_lookup() -- both simpler for the Go side (no
-// next-hop resolution logic of its own) and self-healing (a next-hop
-// change on the underlay takes effect on the very next packet). That
-// theory doesn't hold: confirmed live, bpf_fib_lookup() called from
-// usid_egress's own attach point (the tenant's own VRF-enslaved veth)
-// unconditionally returns BPF_FIB_LKUP_RET_BLACKHOLE for a main-table
-// destination that resolves just fine via `ip -6 route get` outside BPF --
-// tried with/without BPF_FIB_LOOKUP_TBID, with/without BPF_FIB_LOOKUP_DIRECT,
-// and with fib_params.ifindex set to both skb->ifindex and a neutral
-// non-VRF-enslaved ifindex; all four combinations blackholed identically.
-// This is the kernel's own VRF/l3mdev isolation boundary asserting itself
-// against the *attaching* skb's real device, independent of any
-// bpf_fib_lookup parameter -- not something tunable from inside this
-// program at all. The Go control plane must resolve link/L2 information
-// the same way the netlink-route mechanism this replaces always did
-// (RouteEgressAdd's own resolveNextHop, run once at route-install time),
-// and store it here -- see egressroutemap.EgressRouteTable.Register.
+// The link and L2 information is resolved by the Go control plane at
+// registration time rather than by a per-packet bpf_fib_lookup here. That would
+// be simpler and self-healing, but it does not work: a lookup from this
+// program's attach point, the tenant's VRF-enslaved veth, unconditionally
+// returns BPF_FIB_LKUP_RET_BLACKHOLE for a main-table destination that resolves
+// fine outside BPF. With and without the direct and table-ID flags, and with
+// fib_params.ifindex set to both skb->ifindex and a neutral non-enslaved index,
+// all four combinations blackhole identically. That is the kernel's VRF and
+// l3mdev isolation boundary asserting itself against the attaching skb's real
+// device, independent of any lookup parameter.
 //
-// link_ifindex == 0 is a reserved sentinel meaning "local pass-through":
-// this entry exists in the trie purely to win the LPM lookup over a
-// shorter, less specific entry (in practice, always a tenant VRF's own
-// ::/0 NAT66 default), not to encapsulate anything -- usid_egress checks
-// for it and returns TC_ACT_UNSPEC (defer to the kernel) before doing any
-// of the encap work below, the same way it already special-cases
-// multicast/link-local destinations. 0 is never a legitimate Linux
-// ifindex (the kernel reserves it for "no interface", same convention
-// netlink itself uses), so it collides with no real registration.
-// Installed by egressroutemap.EgressRouteTable.RegisterPassThrough for
-// every attachment's own IPAM-assigned prefix, at CNI ADD time -- see
-// that function's own doc comment for why: two attachments sharing one
-// VRF on the same node have a kernel connected route between them that
-// this program's own ::/0 default entry would otherwise hijack, exactly
-// like the multicast/link-local bug below, just for ordinary unicast
-// intra-VRF peers instead of NDP.
+// link_ifindex == 0 is a reserved sentinel meaning local pass-through: the
+// entry exists only to win the longest-prefix lookup over a shorter one, in
+// practice a VRF's ::/0 NAT66 default, and not to encapsulate anything.
+// usid_egress checks for it and defers to the kernel before doing any encap
+// work, as it already does for multicast and link-local destinations. 0 is
+// never a legitimate ifindex, so it collides with no real registration.
+//
+// Such an entry is installed for every attachment's IPAM-assigned prefix at CNI
+// ADD time. Without it, two attachments sharing a VRF on one node have the
+// connected route between them hijacked by the ::/0 default, the same shape as
+// the multicast carve-out below but for ordinary unicast peers.
 struct egress_route_value {
 	__u8 sid[16];
 	__u32 link_ifindex;
@@ -616,8 +452,7 @@ struct egress_route_value {
 
 // ---------------------------------------------------------------------
 
-// enum drop_reason indexes drop_reasons (design plan §4.4's fourth map,
-// observability only).
+// enum drop_reason indexes drop_reasons, which is observability only.
 enum drop_reason {
 	DROP_REASON_UNKNOWN_FUNCTION = 0,
 	DROP_REASON_UNKNOWN_ARGUMENT = 1,
@@ -629,48 +464,32 @@ enum drop_reason {
 	DROP_REASON_FIB_NO_NEIGH = 7,
 	DROP_REASON_FIB_UNREACHABLE = 8,
 	DROP_REASON_FIB_FRAG_NEEDED = 9,
-	// Outer ip6->nexthdr names neither IPIP(4) nor IPv6-in-IPv6(41) --
-	// an extension header (Routing header/SRH, Fragment header, etc.)
-	// sits between the outer header and the real inner packet, so byte
-	// 40 is that extension header, not the inner packet's version
-	// nibble. Counted apart from DROP_REASON_UNKNOWN_INNER_VERSION,
-	// which this case would otherwise be silently folded into.
+	// The outer next header names neither IPIP nor IPv6-in-IPv6, so an
+	// extension header sits between the outer header and the real inner
+	// packet and byte 40 is that header, not a version nibble. Counted apart
+	// from UNKNOWN_INNER_VERSION, which it would otherwise fold into.
 	DROP_REASON_UNEXPECTED_NEXTHDR = 10,
-	// function_table matched, but the entry's behavior isn't
-	// BEHAVIOR_END_DT46 (i.e. it's BEHAVIOR_END_DT2, reserved for a
-	// future L2 path this program doesn't implement) -- step 4, see its
-	// comment above.
+	// function_table matched, but the entry's behavior is not End.DT46, that
+	// is, it is the L2 behavior this program does not implement. See step 4.
 	DROP_REASON_UNSUPPORTED_BEHAVIOR = 11,
-	// usid_egress's own egress-routing extension (docs/plans/
-	// tc-bpf-egress-srv6-encap.md): egress_route_table matched (a route
-	// was configured for this destination) but bpf_skb_adjust_room
-	// failed to grow room for the new outer header -- essentially never
-	// expected to fire (the same helper's shrink direction is
-	// unconditionally trusted by usid_ingress above), kept as its own
-	// reason rather than folded into an unrelated one so it's visible if
-	// it ever does.
+	// egress_route_table matched, so a route was configured, but growing room
+	// for the new outer header failed. Essentially never expected, since the
+	// same helper's shrink direction is trusted unconditionally on the ingress
+	// side, and kept as its own reason so it is visible if it ever fires.
 	DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED = 12,
-	// Unused: an earlier version of usid_egress's egress-routing
-	// extension ran its own per-packet bpf_fib_lookup() to resolve the
-	// matched SID's link/L2 next-hop, and this counted that call
-	// failing. That approach doesn't work at all from this program's own
-	// attach point (see struct egress_route_value's own comment for why
-	// -- a real kernel VRF/l3mdev isolation boundary, not a parameter
-	// bug) and was replaced with Go-side precomputation
-	// (egressroutemap.EgressRouteTable.Register), which has nothing left
-	// to fail in the same way at packet-processing time. Kept
-	// undeleted rather than renumbering every index after it.
+	// Unused. An earlier egress path resolved the matched SID's next hop with
+	// its own per-packet FIB lookup and counted that failing. That does not
+	// work from this attach point at all, for the reason struct
+	// egress_route_value gives, and was replaced by Go-side precomputation,
+	// which has nothing left to fail at packet time. Kept rather than
+	// renumbering every slot after it.
 	DROP_REASON_EGRESS_ROUTE_FIB_LOOKUP_FAILED = 13,
 	// The redirect out the resolved physical interface failed.
 	DROP_REASON_EGRESS_ROUTE_REDIRECT_FAILED = 14,
-	// usid_egress's own VIP-sourced-reply redirect (struct
-	// public_uplink_value's own doc comment): public_uplink_table
-	// matched (it's always populated once the node has converged, this
-	// is a real registration miss or a redirect failure) but the
-	// redirect to the resolved fabric-uplink interface failed.
+	// public_uplink_table matched, but the redirect to the resolved
+	// fabric-uplink interface failed. See struct public_uplink_value.
 	DROP_REASON_PUBLIC_UPLINK_REDIRECT_FAILED = 15,
-	// TEMPORARY diagnostic checkpoints for an ongoing bpf_redirect
-	// investigation -- not counted drops, just markers of how far
+	// TEMPORARY diagnostic checkpoints, not counted drops: markers of how far
 	// usid_egress's egress-routing extension got. Remove once resolved.
 	DROP_REASON_TRACE_MULTICAST_LL_BAIL = 16,
 	DROP_REASON_TRACE_MISS_VRF = 17,
@@ -679,75 +498,61 @@ enum drop_reason {
 	DROP_REASON_TRACE_ADJUST_ROOM_OK = 20,
 	DROP_REASON_TRACE_REACHED_REDIRECT = 21,
 	DROP_REASON_TRACE_REDIRECT_OK = 22,
-	// bpf_trace_printk is unavailable to sched_cls programs on this
-	// kernel (verifier: "program of this type cannot use helper
-	// bpf_trace_printk#6", confirmed live) -- this checkpoint exists
-	// because that discovery ruled out adding a print at the one
-	// early-return in usid_egress that DROP_REASON_TRACE_MULTICAST_LL_BAIL
-	// through DROP_REASON_TRACE_REDIRECT_OK don't cover: the
-	// ifindex_vrf_table miss immediately above, in the function's own
-	// entry sequence.
+	// bpf_trace_printk is unavailable to this program type on this kernel, so
+	// this checkpoint covers the one early return in usid_egress's entry
+	// sequence that the checkpoints below do not: the ifindex_vrf_table miss
+	// immediately above.
 	DROP_REASON_TRACE_IFINDEX_MISS = 23,
-	// Full entry-sequence bracketing: usid_egress's own prefix (before
-	// DROP_REASON_TRACE_MULTICAST_LL_BAIL) has four more early-return
-	// paths with no counter at all -- these close every remaining gap so
+	// Full entry-sequence bracketing. usid_egress's prefix has four more early
+	// returns with no counter, so these close every remaining gap and
 	// "nothing incremented" can no longer mean either "never invoked" or
-	// "always took the uninstrumented path".
+	// "always took an uninstrumented path".
 	DROP_REASON_TRACE_ENTRY = 24,
 	DROP_REASON_TRACE_PULL_DATA_FAILED = 25,
 	DROP_REASON_TRACE_ETH_BOUNDS_FAILED = 26,
 	DROP_REASON_TRACE_ETHERTYPE_MISMATCH = 27,
 	DROP_REASON_TRACE_IFINDEX_HIT = 28,
-	// TEMPORARY diagnostic checkpoints for usid_ingress's step 8/9, the
-	// mirror of DROP_REASON_TRACE_* above for usid_egress. Remove once
-	// resolved.
+	// TEMPORARY diagnostic checkpoints for usid_ingress's steps 8 and 9, the
+	// mirror of the egress ones above. Remove once resolved.
 	//
-	// The ingress path has no success counter at all, so a packet that
-	// is claimed at step 6 and then lost has the same signature as one
-	// delivered: the per-vrf_table packets counter moves, no drop
-	// counter moves, and nothing distinguishes the two. Measured on a
-	// live tap attachment: packets=+5 per 5 sent, dropped_packets flat,
-	// and the target tap's own tx_packets flat, so the packet is neither
-	// dropped by this program nor delivered.
+	// The ingress path has no success counter, so a packet claimed at step 6
+	// and then lost looks exactly like one delivered: the per-entry packets
+	// counter moves, no drop counter moves, and nothing separates the two. On
+	// a live tap attachment, packets moved by the number sent, dropped_packets
+	// stayed flat, and the target tap's own transmit counter stayed flat, so
+	// the packet was neither dropped here nor delivered.
 	//
-	// Everything between step 6 and the redirect is already counted, so
-	// what is left is the redirect itself and what the kernel does with
-	// it after this program returns. skb_do_redirect runs post-return
-	// and can discard the packet with nothing here to observe it, which
-	// a zero or otherwise unusable fib_params.ifindex would cause.
+	// Everything between step 6 and the redirect is already counted, so what
+	// remains is the redirect and what the kernel does with it after this
+	// program returns. That discard happens post-return with nothing here able
+	// to observe it, which a zero or otherwise unusable resolved ifindex would
+	// cause.
 	DROP_REASON_TRACE_ING_REACHED_REDIRECT = 29,
 	DROP_REASON_TRACE_ING_REDIRECT_OK = 30,
-	// Not a counter: SET to the ifindex bpf_fib_lookup resolved, so the
-	// redirect target itself is observable rather than inferred. Read it
-	// as a value, never as a count.
+	// Not a counter: set to the ifindex the FIB lookup resolved, so the
+	// redirect target is observable rather than inferred. Read as a value.
 	DROP_REASON_TRACE_ING_LAST_IFINDEX = 31,
-	// A real drop, not a trace: bpf_fib_lookup returned SUCCESS with an
-	// ifindex that cannot be redirected to. Sitting in the temporary
-	// block rather than with the other FIB reasons at 0-15 only to avoid
-	// renumbering slots 16-30, which the Go mirror's DropReasonCount and
-	// hack/returnpath-lab's name table both key off. It should graduate
-	// into the real block when the temporary slots around it are
-	// removed.
+	// A real drop, not a trace: the FIB lookup returned success with an
+	// ifindex that cannot be redirected to. It sits in the temporary block
+	// only to avoid renumbering the slots around it, which the Go mirror and
+	// the lab tool's name table both key off, and should move into the real
+	// block when those slots are removed.
 	DROP_REASON_FIB_NO_IFINDEX = 32,
-	// TEMPORARY, and the ingress mirror of DROP_REASON_TRACE_ENTRY
-	// through DROP_REASON_TRACE_IFINDEX_HIT above, added for the same
-	// reason those were: usid_ingress's own entry sequence has five
-	// exits with no counter at all, so "nothing incremented" cannot
-	// currently distinguish "never invoked" from "always took an
-	// uninstrumented path".
+	// TEMPORARY, the ingress mirror of the egress entry-sequence checkpoints
+	// above and added for the same reason: usid_ingress's entry sequence has
+	// five exits with no counter, so "nothing incremented" cannot distinguish
+	// "never invoked" from "always took an uninstrumented path".
 	//
-	// Two of the five are live hypotheses rather than completeness for
-	// its own sake. ETHERTYPE_MISMATCH is where a VLAN tag left in the
-	// packet data by a NIC that does not strip it would land, silently.
-	// LOCATOR_MISS is where a Block or Node-ID that does not match this
-	// node's own registration would land, equally silently, and it is
-	// the one miss in the lookup chain with no counter (function_table
-	// and vrf_table misses are already DROP_REASON_UNKNOWN_FUNCTION and
-	// DROP_REASON_UNKNOWN_ARGUMENT).
+	// Two of the five are live hypotheses rather than completeness for its own
+	// sake. ETHERTYPE_MISMATCH is where a VLAN tag left in packet data by a NIC
+	// that does not strip it would land, silently. LOCATOR_MISS is where a
+	// Block or Node-ID not matching this node's registration would land,
+	// equally silently, and it is the one miss in the lookup chain with no
+	// counter of its own.
 	//
-	// drop_reasons is a PERCPU_ARRAY, so the unconditional entry counter
-	// is a per-CPU increment with no cross-CPU contention, on a program
-	// that already runs for every packet arriving on the fabric NICs.
+	// drop_reasons is a per-CPU array, so the unconditional entry counter is a
+	// per-CPU increment with no cross-CPU contention, on a program that already
+	// runs for every packet arriving on the fabric NICs.
 	DROP_REASON_TRACE_ING_ENTRY = 33,
 	DROP_REASON_TRACE_ING_PULL_DATA_FAILED = 34,
 	DROP_REASON_TRACE_ING_ETH_BOUNDS_FAILED = 35,
@@ -758,23 +563,18 @@ enum drop_reason {
 };
 
 // ---------------------------------------------------------------------
-// Maps (design plan §4.4). All three lookup maps are BPF_MAP_TYPE_HASH --
-// no BPF_MAP_TYPE_LPM_TRIE anywhere in this program, since R1/R2 mean
-// every lookup here is a fixed-width exact match, never a variable-length
-// prefix match.
+// Maps. All three uSID lookup maps are hash maps, never LPM tries, since every
+// uSID lookup is a fixed-width exact match rather than a prefix match.
 //
-// Keys are plain u64 exact-match keys, matching
-// internal/plumbing/ebpf/uformat's LocatorKey/FunctionKey composition
-// (Milestone 2.1):
-//   locator_key  = top 8 bytes of the destination address, as-is
-//                  (Block(48) << 16 | Node-ID(16)).
-//   function_key = matched Block(48) << 4 | Function(4) (52 significant
-//                  bits) -- Block and Function are never adjacent in the
-//                  wire address (Node-ID sits between them), so this key
-//                  is always composed from two independently-read values,
-//                  never read as one contiguous span.
-//   vrf_key      = matched Block(48) << 12 | Argument(12) (60 significant
-//                  bits), the same composition pattern as function_key.
+// Keys are plain u64 exact-match keys, matching the control plane's own key
+// composition:
+//   locator_key  = top 8 bytes of the destination address, as-is.
+//   function_key = Block << 4 | Function, 52 significant bits. Block and
+//                  Function are never adjacent in the wire address, with
+//                  Node-ID between them, so this is composed from two
+//                  independently read values.
+//   vrf_key      = Block << 12 | Argument, 60 significant bits, composed the
+//                  same way.
 // ---------------------------------------------------------------------
 
 struct {
@@ -793,15 +593,13 @@ struct {
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
-	// Design plan §2: Option 2 caps each uSID Block at 4,095 usable
-	// Argument values; R8 needs up to 2x that per Block during a
-	// make-before-break migration. 8192 covers one Block's worst case
-	// with headroom -- i.e. this map is deliberately sized for ~2 uSID
-	// Blocks' worth of Argument space today, not #740's full 64-Block
-	// range that locator_table/function_table already support. A third
-	// concurrent Block exhausts this map at registration time (surfacing
-	// as a failed CNI ADD, not a datapath drop) before R7's multi-Block
-	// work revisits this map's sizing alongside theirs.
+	// One uSID Block caps at 4,095 usable Argument values, and a
+	// make-before-break migration needs up to twice that per Block. 8192 covers
+	// one Block's worst case with headroom, that is, roughly two Blocks' worth
+	// of Argument space rather than the format's full Block range that
+	// locator_table and function_table already support. A third concurrent
+	// Block exhausts this map at registration time, surfacing as a failed CNI
+	// ADD rather than a datapath drop.
 	__uint(max_entries, 8192);
 	__type(key, __u64);
 	__type(value, struct vrf_value);
@@ -814,9 +612,9 @@ struct {
 	__type(value, __u64);
 } drop_reasons SEC(".maps");
 
-// ifindex_vrf_table: see struct ifindex_vrf_value's comment above. Sized
-// generously above vrf_table's own 8192 -- one row per *attachment*
-// (potentially several veths/taps per VRF), not one row per VRF.
+// ifindex_vrf_table: see struct ifindex_vrf_value. Sized above vrf_table
+// because it holds one row per attachment, potentially several per VRF, not one
+// per VRF.
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 16384);
@@ -824,10 +622,9 @@ struct {
 	__type(value, struct ifindex_vrf_value);
 } ifindex_vrf_table SEC(".maps");
 
-// nptv6_table: one row per VRF with NPTv6 configured, keyed identically to
-// vrf_table (block<<12|argument) -- both usid_ingress (which already has
-// this key locally) and usid_egress (via ifindex_vrf_table above) resolve
-// it the same way.
+// nptv6_table: one row per VRF with NPTv6 configured, keyed like vrf_table.
+// usid_ingress already holds that key locally, and usid_egress resolves it
+// through ifindex_vrf_table.
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 8192);
@@ -843,22 +640,15 @@ struct {
 	__type(value, struct vip_xlat_value);
 } vip_xlat_table SEC(".maps");
 
-// egress_route_table: see struct egress_route_key's comment above. The
-// first (and, as of this writing, only) BPF_MAP_TYPE_LPM_TRIE in this
-// file -- everything above is deliberately BPF_MAP_TYPE_HASH (uSID
-// decode is always a fixed-width exact match, per R1/R2), but egress
-// routing is inherently a longest-prefix-match problem (an intra-VPC
-// peer's specific prefix must win over a tenant VRF's own ::/0 default),
-// exactly what locator_table/function_table/vrf_table's own doc comment
-// says this format never needs -- that reasoning is scoped to uSID
-// decode, not to this unrelated map. BPF_F_NO_PREALLOC is required by the
-// kernel for this map type (lpm_trie_alloc rejects any other map_flags
-// value outright), not an optional tuning choice.
+// egress_route_table: see struct egress_route_key. The only LPM trie in this
+// file. Everything above is a hash map because uSID decode is always a
+// fixed-width exact match, but egress routing is inherently a longest-prefix
+// problem: an intra-VPC peer's specific prefix must win over a VRF's ::/0
+// default. BPF_F_NO_PREALLOC is required by the kernel for this map type, not a
+// tuning choice.
 //
-// Sized well above vrf_table's own 8192: this map holds routes, not VRFs
-// -- one VRF can have several intra-VPC-peer entries (RouteEgressAdd) plus
-// one default (EgressDefaultRouteAdd), so entries-per-VRF is not 1:1 the
-// way locator_table/vrf_table's own sizing reasoning assumes.
+// Sized well above vrf_table because it holds routes, not VRFs: one VRF can
+// have several peer entries plus a default, so entries per VRF are not 1:1.
 struct {
 	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
 	__uint(map_flags, BPF_F_NO_PREALLOC);
@@ -867,15 +657,13 @@ struct {
 	__type(value, struct egress_route_value);
 } egress_route_table SEC(".maps");
 
-// node_src_addr_table: this node's own SRv6/underlay-facing source
-// address, the single value usid_egress's egress-routing extension writes
-// into the outer IPv6 header it pushes -- a per-node constant, not
-// per-VRF/per-route, hence the single-entry BPF_MAP_TYPE_ARRAY rather than
-// folding it into egress_route_value (which would mean every route entry
-// redundantly carrying the same 16 bytes, and Go's writer needing to know
-// this node's own address just to register an unrelated destination
-// route). Populated once, at CNI datapath registration time (mirroring
-// attachUsidEgress's own once-per-node lifecycle), not per CNI ADD/DEL.
+// node_src_addr_table: this node's underlay-facing source address, the value
+// usid_egress writes into the outer header it pushes. A per-node constant
+// rather than a per-route one, hence a single-entry array rather than a field
+// on every egress_route_table entry, which would mean every route carrying the
+// same 16 bytes and the Go writer needing this node's address just to register
+// an unrelated destination. Rewritten idempotently on every CNI ADD, since it
+// is cheap and there is no once-per-node hook.
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);
@@ -884,50 +672,35 @@ struct {
 } node_src_addr_table SEC(".maps");
 
 // struct public_uplink_value is public_uplink_table's value: this node's
-// own fabric-uplink interface's real, physical next hop -- the link
-// index to redirect out plus the L2 (destination and source MAC)
-// addressing needed to actually reach it. Resolved once, Go-side
-// (egressroutemap.PublicUplink.Set), the same "resolve at registration
-// time, redirect blindly at packet time" pattern egress_route_value
-// itself already uses and for the identical reason: a live
-// bpf_fib_lookup() from this program's own attach point (the tenant's
-// own VRF-enslaved veth) unconditionally blackholes (see
-// egress_route_value's own doc comment), so there is no way to resolve
-// this fresh, per packet, from inside usid_egress at all.
+// fabric-uplink next hop, the link index to redirect out plus the destination
+// and source MAC needed to reach it. Resolved Go-side, the same
+// resolve-at-registration, redirect-blindly-at-packet-time pattern
+// egress_route_value uses and for the same reason: a live FIB lookup from this
+// program's attach point unconditionally blackholes, so there is no way to
+// resolve this per packet from inside usid_egress.
 //
-// Used by usid_egress's own VIP-sourced-reply handling, below: once
-// apply_vip_xlat has rewritten a packet's source address from a DSR
-// backend's real address to its own ServiceVIPBinding's VIP -- a real,
-// globally-routable, BGP-advertised address, needing no further
-// translation -- that packet must never reach egress_route_table's own
-// LPM lookup (whose only entries, in a VRF with NAT66 configured, would
-// otherwise treat it as an ordinary ULA-sourced tenant packet and
-// wrongly re-SNAT it through a NAT66 shard: found live, a real curl
-// through a DSR-served VIP timed out because of exactly this -- the
-// reply reached the client with the wrong source address and was
-// silently discarded as unrecognized). Instead, it's redirected here,
-// unconditionally, regardless of its own real destination: the single
-// physical (or, in this lab, ContainerLab-simulated point-to-point)
-// neighbor one hop off this node's own fabric interface is always the
-// correct next hop for a plainly-routable packet, the same property a
-// real host's own default gateway has -- from there, ordinary BGP
-// routing (once a genuine external client's own reachability is wired
-// up -- docs/plans/405-service-vip-route-provider.md, a separate,
-// orthogonal gap) takes over exactly like it would for any other host
-// on the network.
+// Used by usid_egress's VIP-sourced-reply handling. Once apply_vip_xlat has
+// rewritten a packet's source from a DSR backend's real address to its
+// binding's VIP, a globally routable, BGP-advertised address needing no further
+// translation, that packet must never reach egress_route_table's lookup: in a
+// VRF with NAT66 configured, the ::/0 default would treat it as an ordinary
+// ULA-sourced tenant packet and re-translate it through a shard, and the client
+// discards the reply as unrecognised.
+//
+// It is redirected here instead, whatever its own destination. The single
+// neighbor one hop off this node's fabric interface is always the correct next
+// hop for a plainly routable packet, the same property a host's default gateway
+// has, and ordinary routing takes over from there.
 struct public_uplink_value {
 	__u32 link_ifindex;
 	__u8 dmac[6];
 	__u8 smac[6];
 };
 
-// public_uplink_table: see struct public_uplink_value's own doc comment.
-// Single-entry BPF_MAP_TYPE_ARRAY, matching node_src_addr_table's
-// identical per-node-constant lifecycle and key convention (key 0,
-// always present once populated) -- a separate map, not folded into
-// node_src_addr_table, since the value shape is entirely different
-// (link/L2 info here vs. a plain address there) and the two are read at
-// different points in usid_egress for different reasons.
+// public_uplink_table: see struct public_uplink_value. A single-entry array
+// matching node_src_addr_table's per-node lifecycle and key convention. A
+// separate map rather than a field on that one, since the value shape differs
+// entirely and the two are read at different points for different reasons.
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);
@@ -947,12 +720,11 @@ static USID_ALWAYS_INLINE void count_drop(__u32 reason)
 		__sync_fetch_and_add(count, 1);
 }
 
-// record_value overwrites a drop_reasons slot instead of incrementing it,
-// for the TEMPORARY diagnostic slots documented as values rather than
-// counts (DROP_REASON_TRACE_ING_LAST_IFINDEX). A counter cannot carry an
-// ifindex, and the alternative -- a second map -- would need its own
-// pinning and control-plane wiring for a slot that exists only until this
-// investigation closes.
+// record_value overwrites a drop_reasons slot instead of incrementing it, for
+// the temporary slots documented as values rather than counts. A counter cannot
+// carry an ifindex, and a second map would need its own pinning and
+// control-plane wiring for a slot that exists only until this investigation
+// closes.
 static USID_ALWAYS_INLINE void record_value(__u32 slot, __u64 value)
 {
 	__u64 *cell = bpf_map_lookup_elem(&drop_reasons, &slot);
@@ -961,21 +733,19 @@ static USID_ALWAYS_INLINE void record_value(__u32 slot, __u64 value)
 		*cell = value;
 }
 
-// count_claimed_drop is count_drop plus the per-vrf_table-entry
-// dropped_packets bump (struct vrf_value's comment above) -- used for
-// every drop that occurs after step 6's vrf_table match, i.e. every drop
-// of a packet already claimed by a specific (Block, Argument) tenant.
+// count_claimed_drop is count_drop plus the per-entry dropped_packets bump, for
+// every drop after step 6's vrf_table match, that is, every drop of a packet
+// already claimed by a specific tenant.
 static USID_ALWAYS_INLINE void count_claimed_drop(__u32 reason, struct vrf_value *vrf)
 {
 	count_drop(reason);
 	__sync_fetch_and_add(&vrf->dropped_packets, 1);
 }
 
-// read_be64 composes an 8-byte big-endian (network order) buffer into a
-// host-native __u64, byte by byte -- deliberately not a `*(__u64 *)p`
-// cast, since p is not guaranteed to be 8-byte aligned (it points 38
-// bytes into the packet, right after a 14-byte Ethernet header) and some
-// architectures reject unaligned wide loads at verification time.
+// read_be64 composes an 8-byte big-endian buffer into a host-native u64 byte by
+// byte, rather than casting: p is not guaranteed 8-byte aligned, pointing 38
+// bytes into the packet, and some architectures reject unaligned wide loads at
+// verification time.
 static USID_ALWAYS_INLINE __u64 read_be64(const __u8 *p)
 {
 	return ((__u64) p[0] << 56) | ((__u64) p[1] << 48) | ((__u64) p[2] << 40) |
@@ -983,15 +753,12 @@ static USID_ALWAYS_INLINE __u64 read_be64(const __u8 *p)
 	       ((__u64) p[6] << 8) | (__u64) p[7];
 }
 
-// apply_nptv6 rewrites addr's first v->prefix_len bits to the destination
-// prefix's own bits (public_prefix if outbound, ula_prefix otherwise), then
-// adds (outbound) or subtracts (!outbound) v->adjustment into the fixed
-// word at byte offset 6 (bits 48-63) -- see internal/plumbing/nptv6's
-// identical algorithm and doc comment. No checksum helper call is needed:
-// this is the entire point of RFC 6296's construction -- the adjustment
-// already offsets the prefix change's own contribution to addr's
-// 1's-complement checksum, so the packet's existing L4 checksum stays
-// valid untouched.
+// apply_nptv6 rewrites addr's first prefix_len bits to the destination prefix,
+// public if outbound and ULA otherwise, then adds or subtracts the adjustment
+// in the word at byte offset 6. No checksum helper is needed: that is the point
+// of the RFC 6296 construction, since the adjustment already offsets the prefix
+// change's contribution to the address checksum and the packet's L4 checksum
+// stays valid untouched.
 static USID_ALWAYS_INLINE void apply_nptv6(__u8 *addr, const struct nptv6_value *v, int outbound)
 {
 	const __u8 *new_prefix = outbound ? v->public_prefix : v->ula_prefix;
@@ -1018,67 +785,39 @@ static USID_ALWAYS_INLINE void apply_nptv6(__u8 *addr, const struct nptv6_value 
 	*word = __builtin_bswap16((__u16) sum);
 }
 
-// apply_vip_xlat rewrites the packet's addr_off/port_off fields (16-byte
-// address, 2-byte port) to new_val's own address/port, fixing up the L4
-// checksum at csum_off via three incremental bpf_l4_csum_replace calls (the
-// 16-byte address in two 8-byte halves, both BPF_F_PSEUDO_HDR since address
-// is a pseudo-header field; the port directly, no PSEUDO_HDR, since port is
-// a real L4 header field) -- unlike apply_nptv6, this is a genuine
-// substitution (see struct vip_xlat_value's comment), so there is no
-// checksum-neutral shortcut available. is_udp preserves a zero UDP checksum
-// (meaning "no checksum", RFC 768) as zero rather than "fixing" it into a
-// spurious nonzero value (BPF_F_MARK_MANGLED_0) -- TCP has no such
-// zero-means-disabled convention, so that flag is only ever passed for UDP.
+// apply_vip_xlat rewrites the 16-byte address at addr_off and the 2-byte port
+// at port_off to new_val's, fixing up the L4 checksum at csum_off with
+// incremental replace calls: the address as pseudo-header words, the port
+// directly, since a port is a real L4 header field. Unlike apply_nptv6 this is
+// a genuine substitution with no checksum-neutral shortcut.
 //
-// Validated against a real kernel via BPF_PROG_TEST_RUN
-// (TestUsidIngress_VIPXlatRewritesAddrPortAndChecksum): a synthetic UDP
-// packet's destination address/port are rewritten and the resulting
-// checksum matches an independent full recompute, not just "the verifier
-// accepted it" -- an earlier draft's 8-byte-at-a-time csum_replace calls
-// failed at runtime with EINVAL (BPF_F_HDR_FIELD_MASK only supports 2/4-byte
-// fields, confirmed against net/core/filter.c), and a second draft's
-// interleaved packet-pointer reads between helper calls failed verification
-// outright (bpf_l4_csum_replace/bpf_skb_store_bytes both invalidate
-// previously-derived packet pointers) -- both fixed, see this function's own
-// structure below. What remains unvalidated is real traffic through a real
-// tap/VM attachment (no such containerlab fixture exists yet -- design plan
-// §8); this function's own byte-level correctness is no longer speculative.
+// is_udp preserves a zero UDP checksum, which means "no checksum", as zero
+// rather than fixing it into a spurious nonzero value. TCP has no such
+// convention, so that flag is only ever passed for UDP.
 static USID_ALWAYS_INLINE long apply_vip_xlat(struct __sk_buff *skb, __u32 addr_off, __u32 port_off,
 					       __u32 csum_off, __u8 proto, const __u8 *old_addr,
 					       __be16 old_port, const struct vip_xlat_value *new_val)
 {
-	// bpf_l4_csum_replace's BPF_F_HDR_FIELD_MASK only accepts field sizes
-	// 2 or 4 (net/core/filter.c's switch on flags & BPF_F_HDR_FIELD_MASK
-	// has no `case 8` at all) -- an 8-byte-at-a-time replace, this
-	// function's first working draft, unconditionally fails with EINVAL.
-	// The 16-byte address is therefore updated as four 4-byte words, not
-	// two 8-byte halves. Confirmed empirically via BPF_PROG_TEST_RUN.
+	// The checksum helper's field-size mask accepts only 2 or 4 bytes, with no
+	// 8-byte case at all, so an 8-byte-at-a-time replace fails with EINVAL. The
+	// 16-byte address is updated as four 4-byte words.
 	//
-	// Every packet/map read this function needs happens *before* the
-	// first helper call, into plain scalar locals, and every
-	// bpf_l4_csum_replace/bpf_skb_store_bytes call below only ever
-	// touches those locals afterward -- bpf_l4_csum_replace and
-	// bpf_skb_store_bytes are both on the verifier's
-	// bpf_helper_changes_pkt_data() list (same reason usid_ingress's own
-	// steps re-read data/data_end after bpf_skb_adjust_room/
-	// bpf_skb_change_proto): calling one invalidates every
-	// previously-derived *packet* pointer -- old_addr included, since
-	// it's a live pointer into this same packet, not a copy -- and a
-	// later helper call's own argument evaluation dereferencing it again
-	// is rejected outright ("invalid mem access"). This isn't merely
-	// tidier code; interleaving reads and calls as the first draft did
-	// is rejected by the verifier, confirmed empirically.
+	// Every packet and map read this function needs happens before the first
+	// helper call, into plain scalar locals, and the calls below touch only
+	// those locals. Both the checksum-replace and store helpers invalidate
+	// every previously derived packet pointer, old_addr included, since it
+	// points into this same packet rather than being a copy. Interleaving reads
+	// and calls is rejected outright by the verifier.
 	__u32 from_w[4], to_w[4];
 #pragma unroll
 	for (int i = 0; i < 4; i++) {
 		__builtin_memcpy(&from_w[i], old_addr + i * 4, 4);
 		__builtin_memcpy(&to_w[i], new_val->addr + i * 4, 4);
 	}
-	// old_port/new_val->port are passed as-is (no byte-swap): unlike
-	// apply_nptv6's arithmetic on a word (which needs host-order values
-	// to add/subtract), bpf_l4_csum_replace's from/to are a raw
-	// "what used to be there, what's there now" pair in the same
-	// wire-order representation the address words above already use.
+	// The ports are passed as-is, with no byte swap. Unlike apply_nptv6's
+	// arithmetic on a word, which needs host order, the checksum helper's
+	// from and to are a raw "what used to be there, what is there now" pair in
+	// the same wire order the address words use.
 	__be16 new_port = new_val->port;
 
 	__u64 flags = USID_BPF_F_PSEUDO_HDR | 4;
@@ -1094,11 +833,10 @@ static USID_ALWAYS_INLINE long apply_vip_xlat(struct __sk_buff *skb, __u32 addr_
 				 (__u64) new_port, 2 | (is_udp ? USID_BPF_F_MARK_MANGLED_0 : 0)))
 		return -1;
 
-	// Store from the same from_w/to_w/new_port locals snapshotted above,
-	// not new_val directly -- new_val is a map-value pointer, not a
-	// packet pointer, so it isn't subject to the same invalidation rule,
-	// but using the locals already in hand removes any doubt rather than
-	// relying on that distinction holding.
+	// Store from the locals snapshotted above rather than from new_val
+	// directly. new_val is a map-value pointer, not a packet pointer, so it is
+	// not subject to the same invalidation, but using the locals already in
+	// hand removes any doubt.
 	if (bpf_skb_store_bytes(skb, addr_off, to_w, 16, 0))
 		return -1;
 	if (bpf_skb_store_bytes(skb, port_off, &new_port, 2, 0))
@@ -1113,19 +851,16 @@ static USID_ALWAYS_INLINE long apply_vip_xlat(struct __sk_buff *skb, __u32 addr_
 SEC("tc")
 int usid_ingress(struct __sk_buff *skb)
 {
-	// Defensive linearization (ecv's review of #281): every read below
-	// is direct data/data_end pointer access, never bpf_skb_load_bytes,
-	// so a non-linear skb (fragmented linear head -- GRO normally avoids
-	// this for tunnel headers, but nothing here depends on that holding)
-	// would fail its bounds check and misreport as
-	// DROP_REASON_MALFORMED_INNER instead of actually being malformed.
-	// bpf_skb_pull_data(skb, 0) pulls the entire packet into the linear
-	// area unconditionally, up front, so every direct read below is safe
-	// regardless of the skb's arriving layout. A failure here is treated
-	// like "not applicable to us" per R6 -- hand off to the next tc
-	// filter on this device unmodified (TC_ACT_UNSPEC, not TC_ACT_OK: see
-	// the note below step 2) rather than drop traffic this program hasn't
-	// even determined is a uSID packet yet.
+	// Defensive linearization. Every read below is a direct data pointer
+	// access, so a non-linear skb would fail its bounds check and misreport as
+	// a malformed inner packet instead of actually being malformed. Pulling the
+	// whole packet into the linear area up front makes every read below safe
+	// whatever the arriving layout.
+	//
+	// A failure is treated as "not applicable to us": hand off to the next tc
+	// filter unmodified rather than drop traffic this program has not yet
+	// determined is a uSID packet. TC_ACT_UNSPEC, not TC_ACT_OK; see the note
+	// below step 2.
 	count_drop(DROP_REASON_TRACE_ING_ENTRY); // TEMPORARY
 
 	if (bpf_skb_pull_data(skb, 0)) {
@@ -1136,9 +871,8 @@ int usid_ingress(struct __sk_buff *skb)
 	void *data = (void *) (long) skb->data;
 	void *data_end = (void *) (long) skb->data_end;
 
-	// Step 1: parse the outer Ethernet + IPv6 header (fixed 40B,
-	// bounds-checked). Not a match -- TC_ACT_UNSPEC, hand off unmodified
-	// (R6; see the note below step 2).
+	// Step 1: parse the outer Ethernet and IPv6 header, bounds-checked. Not a
+	// match: hand off unmodified. See the note below step 2.
 	struct usid_ethhdr *eth = data;
 
 	if ((void *) (eth + 1) > data_end) {
@@ -1158,28 +892,22 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_UNSPEC;
 	}
 
-	// Step 2: exact-match the destination address's top 64 bits
-	// (Block(48) + Node-ID(16), read with no shift) against
-	// locator_table. No match -- TC_ACT_UNSPEC, hand off unmodified (R6).
+	// Step 2: exact-match the destination's top 64 bits, Block and Node-ID read
+	// with no shift, against locator_table. No match: hand off unmodified.
 	//
-	// TC_ACT_UNSPEC, not TC_ACT_OK, on every fail-open path through this
-	// point (ecv's review of #283): this filter attaches direct-action at
-	// a fixed tc priority, and Cilium attaches its own tc/bpf programs to
-	// the same native-device ingress hook on these hosts. In direct-action
-	// mode TC_ACT_OK is a final verdict that ends the qdisc's filter
-	// chain, so a packet this program doesn't claim would never reach a
-	// colocated Cilium filter at a later priority; TC_ACT_UNSPEC instead
-	// tells tc "not matched here," letting the next filter run exactly as
-	// if this program weren't attached at all. Every fail-open path from
-	// here through the rest of the program is before step 2's
-	// locator_table match, i.e. before this program has claimed the
-	// packet as one of its own uSID Blocks at all -- once a packet is
-	// claimed (this locator_table lookup hits), every subsequent failure
-	// (unknown Function/Argument, malformed inner, FIB miss, redirect
-	// failure) is still TC_ACT_SHOT: this program is the packet's only
-	// intended handler past this point, so silently falling through to
-	// Cilium (or the normal stack) would misdeliver it, not just fail to
-	// accelerate it.
+	// TC_ACT_UNSPEC, not TC_ACT_OK, on every fail-open path through this point.
+	// This filter attaches direct-action at a fixed priority, and a cluster CNI
+	// may attach its own programs to the same hook. In direct-action mode
+	// TC_ACT_OK is a final verdict that ends the filter chain, so a packet this
+	// program does not claim would never reach a filter at a later priority.
+	// TC_ACT_UNSPEC instead means "not matched here", letting the next filter
+	// run as if this program were not attached.
+	//
+	// Every fail-open path is before this locator match, that is, before the
+	// packet has been claimed as one of this node's Blocks. Once claimed, every
+	// later failure is TC_ACT_SHOT: this program is the packet's only intended
+	// handler past that point, so falling through would misdeliver it rather
+	// than merely fail to accelerate it.
 	__u64 locator_key = read_be64(&ip6->daddr[0]);
 
 	struct locator_value *loc = bpf_map_lookup_elem(&locator_table, &locator_key);
@@ -1191,16 +919,14 @@ int usid_ingress(struct __sk_buff *skb)
 
 	__u64 block = locator_key >> 16;
 
-	// Step 3: read Function directly from the unmutated packet at its
-	// fixed offset -- bits 65-68, the high nibble of daddr byte 8. No
-	// shift, no mutation (R2).
+	// Step 3: read Function from the unmutated packet at its fixed offset, the
+	// high nibble of destination byte 8.
 	__u8 fn_arg_byte = ip6->daddr[8];
 	__u8 function = fn_arg_byte >> 4;
 
-	// Step 4: exact-match (matched Block, Function) against
-	// function_table. No match -- drop, counted: this packet was
-	// already claimed by step 2, so silent pass-through here would
-	// duplicate-deliver it to the normal stack.
+	// Step 4: exact-match (Block, Function) against function_table. No match:
+	// drop, counted, since step 2 already claimed this packet and passing it
+	// through would duplicate-deliver it to the normal stack.
 	__u64 function_key = (block << 4) | function;
 
 	struct function_value *fn = bpf_map_lookup_elem(&function_table, &function_key);
@@ -1210,25 +936,23 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	// #740 makes Function 0xE (uEnd.DT46: VRF ID, L3 route lookup) and
-	// 0xF (uEnd.DT2: EVI ID, Bridge Domain MAC lookup) fully independent
-	// service universes. This program only implements DT46 -- a DT2
-	// entry falling through to steps 5-9 below would parse an L2 frame
-	// as an inner IP packet against the wrong table entirely, not a
-	// near-miss, so it's rejected here instead.
+		// Function 0xE and 0xF are fully independent service universes: an
+		// L3 route lookup and an L2 bridge-domain lookup. This program
+		// implements only the former, and a DT2 entry falling through would
+		// parse an L2 frame as an inner IP packet against the wrong table
+		// entirely, so it is rejected here.
 	if (fn->behavior != BEHAVIOR_END_DT46) {
 		count_drop(DROP_REASON_UNSUPPORTED_BEHAVIOR);
 		return TC_ACT_SHOT;
 	}
 
-	// Step 5: read Argument directly from the unmutated packet at its
-	// fixed offset -- bits 69-80, the low nibble of daddr byte 8 plus
-	// all of byte 9. No shift, no mutation (R2, R4).
+	// Step 5: read Argument from the unmutated packet at its fixed offset, the
+	// low nibble of destination byte 8 plus byte 9.
 	__u16 argument = ((__u16) (fn_arg_byte & 0x0F) << 8) | ip6->daddr[9];
 
-	// Step 6: exact-match (matched Block, Argument) against vrf_table.
-	// Argument 0x000 is reserved and never registered (R4, design plan
-	// §5.1), so it always misses here -- no special-cased check.
+	// Step 6: exact-match (Block, Argument) against vrf_table. Argument 0x000
+	// is reserved and never registered, so it always misses here and needs no
+	// special case.
 	__u64 vrf_key = (block << 12) | argument;
 
 	struct vrf_value *vrf = bpf_map_lookup_elem(&vrf_table, &vrf_key);
@@ -1244,32 +968,24 @@ int usid_ingress(struct __sk_buff *skb)
 
 	__u32 vrf_table_id = vrf->vrf_table_id;
 
-	// The packet is claimed past this point: any failure from here on
-	// is a drop, never a silent pass-through (the vrf_table hit already
-	// committed this packet to the datapath).
+	// The packet is claimed past this point: every failure from here is a drop,
+	// never a silent pass-through.
 	//
-	// ip6->nexthdr must name the inner packet's AF directly (IPIP=4 or
-	// IPv6-in-IPv6=41) for byte 40 to legitimately be the inner packet's
-	// version nibble. Any other value means an extension header --
-	// Routing header/SRH (43, e.g. from a peer still on full encap
-	// rather than uSID reduced encap), Fragment header (44), Destination
-	// Options (60), etc. -- sits between the outer header and the real
-	// inner packet, so byte 40 is that extension header's own first
-	// byte, not a version nibble. Reading it as one anyway would
-	// silently fold every such packet into DROP_REASON_UNKNOWN_INNER_VERSION,
-	// masking a distinct, actionable failure mode -- checked and counted
-	// apart here, before that peek. ip6->nexthdr itself is already
-	// covered by the `(void *) (ip6 + 1) > data_end` bounds check above,
-	// so no further bounds check is needed to read it.
+	// The outer next header must name the inner packet's family directly for
+	// byte 40 to be the inner version nibble. Any other value means an
+	// extension header sits between them, so byte 40 is that header's first
+	// byte. Reading it as a version nibble would fold every such packet into
+	// UNKNOWN_INNER_VERSION and mask a distinct, actionable failure, so it is
+	// checked and counted apart before that peek. The field is already covered
+	// by the bounds check above.
 	if (ip6->nexthdr != USID_IPPROTO_IPIP && ip6->nexthdr != USID_IPPROTO_IPV6) {
 		count_claimed_drop(DROP_REASON_UNEXPECTED_NEXTHDR, vrf);
 		return TC_ACT_SHOT;
 	}
 
-	// Peek the inner packet's version nibble now, on the still-unmutated
-	// outer header, rather than after stripping (as a prior version of
-	// this function did) -- step 7 below needs to know the AF *before*
-	// it decides how to strip, not after.
+	// Peek the inner version nibble now, on the still-unmutated outer header:
+	// step 7 needs to know the family before it decides how to strip, not
+	// after.
 	if ((void *) (ip6 + 1) + 1 > data_end) {
 		count_claimed_drop(DROP_REASON_MALFORMED_INNER, vrf);
 		return TC_ACT_SHOT;
@@ -1283,56 +999,33 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	// Step 7: strip the outer IPv6 header, exposing the inner
-	// IPv4/IPv6 packet (dual-stack, per uEnd.DT46 -- R5).
+	// Step 7: strip the outer IPv6 header, exposing the inner IPv4 or IPv6
+	// packet.
 	//
-	// An IPv6 inner packet is a plain 40-byte carve: outer and inner
-	// share the same skb->protocol (ETH_P_IPV6), so nothing else is
-	// needed -- this is the path a prior version of this function
-	// always took.
+	// An IPv6 inner packet is a plain 40-byte carve, since outer and inner share
+	// skb->protocol.
 	//
-	// An IPv4 inner packet needs skb->protocol changed from ETH_P_IPV6
-	// to ETH_P_IP, and there is no direct way to do that: __sk_buff's
-	// protocol field is not in tc_cls_act_is_valid_access's BPF_WRITE
-	// whitelist (mark, tc_index, priority, tc_classid, cb[0..4], tstamp,
-	// queue_mapping -- confirmed against upstream net/core/filter.c;
-	// protocol is deliberately absent, and a direct `skb->protocol = ...`
-	// here is rejected at load with "invalid bpf_context access"). Left
-	// stale at ETH_P_IPV6, step 9's bpf_redirect_peer() hands the skb to
-	// the peer netns via skb_do_redirect()'s BPF_F_PEER branch, which
-	// only does skb->dev = dev and skb_scrub_packet() -- no
-	// eth_type_trans() to re-derive skb->protocol from the Ethernet
-	// header this function rewrites below (also confirmed against
-	// upstream: __netif_receive_skb_core()'s "another_round" re-entry on
-	// the peer device reuses skb->protocol as-is). The peer's IP stack
-	// then dispatches the IPv4 payload to ipv6_rcv(), which drops it on
-	// the version-nibble mismatch -- invisible to every counter in this
-	// file, since the packet has already left via a *successful*
-	// redirect. Confirmed live: an IPv4 uSID packet lands on the peer
-	// device (its RX byte/packet counters advance, and a raw AF_PACKET
-	// capture there shows a well-formed IPv4 frame) while
-	// Ip6InReceives/Ip6InHdrErrors in that netns's /proc/net/snmp6 both
-	// advance by exactly the same count, and the pod never sees it at
-	// the socket layer -- IPv4 InMsgs/InEchos in /proc/net/snmp never
-	// move.
+	// An IPv4 inner packet needs skb->protocol changed, and there is no direct
+	// way to do that: the field is not in the context's write whitelist, and a
+	// plain assignment is rejected at load. Left stale, step 9's peer redirect
+	// hands the skb to the peer namespace through a path that only reassigns
+	// the device and scrubs the packet, with no call to re-derive protocol from
+	// the Ethernet header this function rewrites. The peer's stack then
+	// dispatches an IPv4 payload to the IPv6 receive path, which drops it on
+	// the version mismatch, invisibly to every counter here because the packet
+	// already left through a successful redirect. The signature is a peer
+	// device whose receive counters advance and whose capture shows a
+	// well-formed IPv4 frame, while that namespace's IPv6 receive and header
+	// error counters advance by the same amount and the pod never sees it.
 	//
-	// bpf_skb_change_proto() is the one BPF-legal way to update
-	// skb->protocol, but it is built for in-place v4<->v6 header
-	// translation (NAT64-style, RFC 6145), not encap/decap: called here
-	// while skb->protocol is still ETH_P_IPV6 (i.e. before any stripping
-	// -- exactly the point we're at), it removes
-	// sizeof(usid_ip6hdr)-sizeof(usid_iphdr) (20) bytes from the *front*
-	// of the current L3 header -- the first 20 bytes of our 40-byte
-	// outer header -- shifts everything after (the outer header's last
-	// 20 bytes, then our untouched real inner packet) up by 20 to fill
-	// the gap, and sets skb->protocol = ETH_P_IP. That leaves exactly
-	// sizeof(usid_iphdr) (20) bytes of outer-header leftover sitting in
-	// front of our real inner IPv4 header; the plain carve below removes
-	// exactly that leftover, exposing the real header at offset 0 same
-	// as the IPv6 case. Net bytes removed is sizeof(usid_ip6hdr) (40)
-	// either way -- change_proto's 20 plus this carve's 20 for the v4
-	// case, this carve's 40 alone for the v6 case -- only the
-	// skb->protocol side effect differs.
+	// bpf_skb_change_proto is the one legal way to update the field, but it is
+	// built for in-place v4/v6 header translation rather than decap. Called
+	// here, before any stripping, it removes 20 bytes from the front of the
+	// current L3 header, shifts everything after it up to fill the gap, and
+	// sets the protocol. That leaves exactly 20 bytes of outer-header remnant
+	// in front of the real inner header, which the plain carve below removes,
+	// exposing it at offset 0 as in the IPv6 case. Net bytes removed is 40
+	// either way; only the protocol side effect differs.
 	__s32 strip_len = (__s32) sizeof(struct usid_ip6hdr);
 
 	if (inner_version == 4) {
@@ -1348,46 +1041,38 @@ int usid_ingress(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	// Drop the outer transit VLAN, which the decapsulated inner packet
-	// must not inherit.
+	// Drop the outer transit VLAN, which the decapsulated inner packet must not
+	// inherit.
 	//
-	// When the uSID packet arrives on a VLAN whose tag the NIC strips
-	// into skb metadata (hardware VLAN offload, the ordinary case), the
-	// tag lives in skb->vlan_tci rather than in packet data, so the
-	// ethertype check at the top of this function sees IPv6 and the
-	// carve above never touches the tag. Stripping the outer IPv6
-	// header therefore leaves the tag attached to a packet it has
-	// nothing to do with: the tag describes the segment the *outer*
-	// packet crossed to reach this node, while the inner packet is
-	// addressed inside a tenant VRF and never belonged to that segment.
+	// When the packet arrives on a VLAN whose tag the NIC strips into skb
+	// metadata, the ordinary case, the tag lives in skb->vlan_tci rather than
+	// packet data, so the ethertype check above sees IPv6 and the carve never
+	// touches it. Stripping the outer header then leaves the tag on a packet it
+	// has nothing to do with: it describes the segment the outer packet
+	// crossed, while the inner packet is addressed inside a tenant VRF and
+	// never belonged to that segment.
 	//
-	// Carrying it forward breaks the redirect in step 9 two ways. A tap
-	// re-inserts a metadata tag into the frame on transmit, so the guest
-	// would receive a tagged frame it has no VLAN interface to accept;
-	// and any other egress program on the resolved interface that
-	// filters by VLAN id sees a tag from a segment that interface is not
-	// on, and is entitled to drop the packet before it is ever
-	// transmitted -- a discard that happens after this program has
-	// already returned TC_ACT_REDIRECT, so no counter here can see it.
+	// Carrying it forward breaks step 9 two ways. A tap re-inserts a metadata
+	// tag on transmit, so the guest receives a tagged frame it has no VLAN
+	// interface to accept; and any other egress program on the resolved
+	// interface that filters by VLAN id sees a tag from a segment that
+	// interface is not on and may drop the packet, after this program has
+	// already returned a redirect verdict and with no counter here to see it.
 	//
-	// Unconditional and idempotent: with no tag present this is a no-op
-	// returning success, so it needs no guard of its own. It is placed
-	// here, immediately after the carve, so the existing pointer re-read
-	// below covers this helper's invalidation too.
+	// Unconditional and idempotent: with no tag present it is a no-op returning
+	// success. Placed immediately after the carve so the pointer re-read below
+	// covers this helper's invalidation too.
 	//
-	// A failure counts as DROP_REASON_STRIP_FAILED rather than earning a
-	// reason of its own: removing the tag is part of the same carve step
-	// as removing the outer header, and the only way this helper fails
-	// is the allocation the carve above can equally fail on, so the two
-	// share a cause as well as a step.
+	// A failure counts as STRIP_FAILED rather than earning its own reason:
+	// removing the tag is part of the same carve step, and the only way it
+	// fails is the allocation the carve can equally fail on.
 	if (bpf_skb_vlan_pop(skb)) {
 		count_claimed_drop(DROP_REASON_STRIP_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}
 
-	// bpf_skb_change_proto/bpf_skb_adjust_room/bpf_skb_vlan_pop can all
-	// change the underlying packet buffer: all previously derived
-	// data/data_end pointers are invalidated and must be re-read.
+	// All three of the helpers above can change the underlying packet buffer, so
+	// every previously derived pointer is invalid and must be re-read.
 	data = (void *) (long) skb->data;
 	data_end = (void *) (long) skb->data_end;
 
@@ -1411,32 +1096,25 @@ int usid_ingress(struct __sk_buff *skb)
 			return TC_ACT_SHOT;
 		}
 
-		// DSR/Maglev redesign (design plan §2, §0.1): translate the
-		// inner packet's *destination* before the FIB lookup below, so
-		// the lookup resolves against the tenant's real, routed
-		// address -- not the public/VIP address an external
-		// client/gateway actually addressed the packet to. Both
-		// lookups key on (block, argument), already resolved locally
-		// by steps 2-6 above -- no new per-packet identity resolution
-		// needed on this (ingress/decap) side.
+		// Translate the inner packet's destination before the FIB lookup
+		// below, so the lookup resolves against the tenant's real, routed
+		// address rather than the public or VIP address the client addressed.
+		// Both lookups key on (block, argument), already resolved by steps 2
+		// through 6, so no per-packet identity resolution is needed here.
 		struct nptv6_value *npt = bpf_map_lookup_elem(&nptv6_table, &vrf_key);
 
 		if (npt)
 			apply_nptv6(inner6->daddr, npt, 0 /* inbound: public -> ULA */);
 
-		// Component 0.1's tap-VIP substitution needs the inner L4
-		// destination port to key vip_xlat_table -- read it now
-		// (TCP/UDP only; anything else has no port to substitute on
-		// and is left alone) before the strip-relative offsets below
-		// are computed. This is inner6->nexthdr (the freshly-stripped
-		// *inner* header's own next-header field), deliberately not
-		// the outer ip6->nexthdr checked above -- that field only
-		// ever names IPIP(4)/IPv6-in-IPv6(41) (the outer encap
-		// format), never the inner packet's own L4 protocol; ip6 is
-		// also no longer a valid pointer here regardless; the strip
-		// above (bpf_skb_adjust_room/bpf_skb_change_proto) can
-		// relocate the underlying buffer, invalidating every pointer
-		// derived before it, and the verifier enforces this.
+			// The VIP substitution needs the inner L4 destination port to key
+			// vip_xlat_table, read now, before the strip-relative offsets
+			// below are computed. TCP and UDP only; anything else has no port
+			// to substitute on.
+			//
+			// This is the freshly stripped inner header's next-header field,
+			// not the outer one checked above, which only ever names the encap
+			// format. The outer pointer is invalid here regardless, since the
+			// strip can relocate the buffer.
 		if (inner6->nexthdr == USID_IPPROTO_TCP || inner6->nexthdr == USID_IPPROTO_UDP) {
 			struct usid_l4ports *ports = (void *) (inner6 + 1);
 
@@ -1463,12 +1141,10 @@ int usid_ingress(struct __sk_buff *skb)
 						count_claimed_drop(DROP_REASON_MALFORMED_INNER, vrf);
 						return TC_ACT_SHOT;
 					}
-					// apply_vip_xlat's bpf_skb_store_bytes calls
-					// invalidate every previously-derived packet
-					// pointer -- re-read data/data_end and
-					// re-derive inner6 the same fixed-offset way
-					// it was originally computed (new_eth+1), not
-					// via the now-stale pointer.
+					// The store calls invalidate every previously derived
+					// packet pointer, so re-read and re-derive the inner
+					// header the same fixed-offset way it was originally
+					// computed rather than through the stale pointer.
 					data = (void *) (long) skb->data;
 					data_end = (void *) (long) skb->data_end;
 					new_eth = data;
@@ -1486,13 +1162,11 @@ int usid_ingress(struct __sk_buff *skb)
 		__builtin_memcpy(fib_params.ipv6_dst, inner6->daddr, sizeof(fib_params.ipv6_dst));
 		new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IPV6);
 
-		// fib_params.tot_len is the L3 length the kernel's MTU check
-		// (step 8, below) compares against the egress route's MTU --
-		// but only if it's nonzero; left at memset's zero, that check
-		// is silently skipped and BPF_FIB_LKUP_RET_FRAG_NEEDED can
-		// never fire. IPv6 has no total-length field of its own, so
-		// this is the fixed 40-byte header plus payload_len (host
-		// order; the wire field is big-endian).
+		// fib_params.tot_len is the L3 length the kernel's MTU check compares
+		// against the route's MTU, but only when nonzero: left at zero that
+		// check is skipped and a fragmentation-needed result can never fire.
+		// IPv6 has no total-length field, so this is the fixed 40-byte header
+		// plus payload_len, in host order.
 		fib_params.tot_len = (__u16) sizeof(struct usid_ip6hdr) +
 				     __builtin_bswap16(inner6->payload_len);
 	} else {
@@ -1508,20 +1182,19 @@ int usid_ingress(struct __sk_buff *skb)
 		__builtin_memcpy(&fib_params.ipv4_dst, inner4->daddr, sizeof(fib_params.ipv4_dst));
 		new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IP);
 
-		// Same fib_params.tot_len requirement as the IPv6 branch
-		// above, except IPv4 already carries its own total-length
-		// field (host order; the wire field is big-endian) -- no
-		// header-size arithmetic needed.
+		// The same tot_len requirement as the IPv6 branch, except IPv4 carries
+		// its own total-length field, in host order, so no arithmetic is
+		// needed.
 		fib_params.tot_len = __builtin_bswap16(inner4->tot_len);
 	}
 
 	fib_params.ifindex = skb->ingress_ifindex;
 	fib_params.tbid = vrf_table_id;
 
-	// Step 8: bpf_fib_lookup() against the resolved Linux VRF table id
-	// -- a normal FIB lookup scoped to that VRF, exactly like the
-	// kernel's stock End.DT46 does today, reached via a dynamic
-	// Argument-keyed lookup instead of a static per-/128 route (§4.3).
+	// Step 8: bpf_fib_lookup against the resolved Linux VRF table, an ordinary
+	// FIB lookup scoped to that table exactly as the kernel's stock End.DT46
+	// does, reached through a dynamic Argument-keyed lookup rather than a
+	// static per-address route.
 	long fib_rc = bpf_fib_lookup(skb, &fib_params, sizeof(fib_params),
 				      BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 
@@ -1531,19 +1204,17 @@ int usid_ingress(struct __sk_buff *skb)
 		else if (fib_rc == BPF_FIB_LKUP_RET_UNREACHABLE || fib_rc == BPF_FIB_LKUP_RET_BLACKHOLE || fib_rc == BPF_FIB_LKUP_RET_PROHIBIT)
 			count_claimed_drop(DROP_REASON_FIB_UNREACHABLE, vrf);
 		else if (fib_rc == BPF_FIB_LKUP_RET_FRAG_NEEDED)
-			// No ICMPv6 Packet Too Big is generated here, unlike the
-			// static-route SEG6 decap path this replaces -- an
-			// accepted PMTUD gap for this milestone; see
-			// docs/agents/ARCHITECTURE-CNI.md's Known Constraints.
+			// No ICMPv6 Packet Too Big is generated here, unlike the static
+			// route path this replaces: an accepted PMTUD gap, recorded in
+			// the CNI architecture doc's known constraints.
 			count_claimed_drop(DROP_REASON_FIB_FRAG_NEEDED, vrf);
 		else
 			count_claimed_drop(DROP_REASON_FIB_LOOKUP_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}
 
-	// TEMPORARY (see DROP_REASON_TRACE_ING_REACHED_REDIRECT): record the
-	// resolved redirect target before using it. A lookup that returns
-	// SUCCESS is not required to hand back a usable ifindex, and
+	// TEMPORARY: record the resolved redirect target before using it. A lookup
+	// returning success is not required to hand back a usable ifindex, and
 	// redirecting to a zero one is a silent post-return discard.
 	record_value(DROP_REASON_TRACE_ING_LAST_IFINDEX, (__u64) fib_params.ifindex);
 
@@ -1555,26 +1226,19 @@ int usid_ingress(struct __sk_buff *skb)
 	__builtin_memcpy(new_eth->h_dest, fib_params.dmac, sizeof(new_eth->h_dest));
 	__builtin_memcpy(new_eth->h_source, fib_params.smac, sizeof(new_eth->h_source));
 
-	// Step 9: redirect to the resolved egress interface. A veth
-	// attachment's egress interface is the pod's host-side veth, whose
-	// container-side peer lives in a different netns, so
-	// bpf_redirect_peer is required to cross into it (§4.1). A tap
-	// attachment has no peer at all -- internal/cni/tap creates a plain
-	// netlink.Tuntap in this same netns and never moves it -- so plain
-	// bpf_redirect (same-netns egress) is required instead;
-	// bpf_redirect_peer against a tap ifindex always fails
-	// (DROP_REASON_REDIRECT_FAILED), which is exactly the tap-mode
-	// blackhole this per-entry egress_kind field (registered by
-	// internal/cni's registerEBPFDatapath from the CNI's own
-	// InterfaceType) fixes.
+	// Step 9: redirect to the resolved egress interface.
 	//
-	// Verification note: this branch is exercised by unit tests only up
-	// through egress_kind's control-plane wiring (internal/cni's
-	// TestEgressKindForInterfaceType) -- a real FIB-lookup-then-redirect
-	// success/failure by egress kind needs a live route/interface
-	// (a real net_device) that BPF_PROG_TEST_RUN cannot fabricate, so
-	// that part is a live-cluster (ContainerLab/e2e) concern, same as
-	// this file's other FIB-lookup tests already document.
+	// A veth attachment's egress interface is the pod's host-side veth, whose
+	// container-side peer is in another namespace, so bpf_redirect_peer is
+	// required to cross into it. A tap has no peer at all, being created in this
+	// namespace and never moved, so plain bpf_redirect is required instead.
+	// bpf_redirect_peer against a tap always fails, which is the tap-mode
+	// blackhole this per-entry egress_kind fixes.
+	//
+	// Unit tests cover egress_kind's control-plane wiring only. A real
+	// lookup-then-redirect by egress kind needs a live route and net device
+	// that a synthetic program run cannot fabricate, so that part is a
+	// live-cluster concern like this file's other FIB-lookup tests.
 	long redirect_rc;
 
 	count_drop(DROP_REASON_TRACE_ING_REACHED_REDIRECT); // TEMPORARY
@@ -1594,45 +1258,31 @@ int usid_ingress(struct __sk_buff *skb)
 	return redirect_rc;
 }
 
-// usid_egress (design plan §0.1, §2) is usid_ingress's outbound companion:
-// a tenant's own reply/outbound traffic needs the reverse NPTv6 rewrite
-// (ULA -> public, on the packet's *source*) and/or the reverse tap-VIP
-// substitution (real addr:port -> VIP addr:port, also on *source*), and
-// (docs/plans/tc-bpf-egress-srv6-encap.md) the tenant VRF's own egress
-// SRv6 encapsulation, before the packet leaves this node at all.
+// usid_egress is usid_ingress's outbound companion. A tenant's outbound traffic
+// needs the reverse NPTv6 rewrite and the reverse VIP substitution, both on the
+// packet's source, and the tenant VRF's own SRv6 encapsulation, before the
+// packet leaves this node.
 //
-// Attach point, and why it is NOT the shared physical/fabric-facing
-// interface usid_ingress attaches to: this program's whole job (both its
-// original NPTv6/VIP-xlat responsibilities and its egress-routing
-// extension below) is to run *before* anything has yet decided how to
-// route this packet onward -- once a packet reaches the physical uplink,
-// that decision has already been made and the SID this program itself now
-// resolves would have to be un-done and re-done. There is also nothing at
-// that shared attach point to key a per-sender-VRF lookup on without
-// decoding the inner packet's own (potentially colliding across tenants,
-// per the same reasoning usidresolver.go's tenant-ownership fix already
-// closed for a different lookup) ULA source address.
+// The attach point is TC ingress of the tenant's own host-side veth or tap, the
+// interface usid_ingress's step 9 redirects to, which is the standard
+// from-container interception point. At that point the packet is still plain,
+// unencapsulated, and per-attachment, so (block, argument) resolves through
+// ifindex_vrf_table keyed on skb->ifindex rather than being decoded from packet
+// content.
 //
-// Correct attach point: TC *ingress* of the tenant's own host-side veth (or
-// tap, for a VM), the exact interface usid_ingress's own step 9 already
-// redirects packets *to* -- the standard "from-container" interception
-// point (mirroring e.g. Cilium's own per-endpoint egress hook). At that
-// point the packet is still a plain, unencapsulated, per-attachment
-// (so VRF-unambiguous) tenant packet -- (block, argument) is resolved via
-// ifindex_vrf_table (keyed on skb->ifindex, this interface's own identity),
-// not decoded from packet content at all.
+// Not the shared fabric interface usid_ingress attaches to. This program's whole
+// job is to run before anything has decided how to route the packet onward:
+// once it reaches the uplink that decision is made and the SID resolved here
+// would have to be undone and redone. There is also nothing at that shared
+// point to key a per-sender-VRF lookup on without decoding the inner packet's
+// own ULA source address, which can collide across tenants.
 //
-// This program never "claims" a packet the way usid_ingress does for its
-// NPTv6/VIP-xlat responsibilities: an attachment with no NPTv6 mapping and
-// no active ServiceVIPBinding is common and expected (most VRFs/backends
-// need neither), so a miss on either lookup is not an error. The
-// egress-routing extension below is different: once egress_route_table
-// has a matching entry, this program *is* that packet's only path off
-// this node (the kernel-native SEG6 route this extension replaces is
-// being removed, not left as a fallback -- see the design plan's own §5
-// migration-ordering note for why it's still safe to leave both mechanisms
-// briefly installed together during rollout), so a failure past that
-// point is a drop, not a pass-through.
+// This program never claims a packet for its NPTv6 and VIP responsibilities: an
+// attachment with neither a mapping nor an active binding is common, so a miss
+// on either lookup is not an error. The egress-routing extension is different:
+// once egress_route_table has a matching entry, this program is that packet's
+// only path off the node, so a failure past that point is a drop rather than a
+// pass-through.
 SEC("tc")
 int usid_egress(struct __sk_buff *skb)
 {
@@ -1653,14 +1303,11 @@ int usid_egress(struct __sk_buff *skb)
 		return TC_ACT_UNSPEC;
 	}
 
-	// NPTv6/VIP-xlat remain IPv6-only by design (component 2/0.1); the
-	// egress-routing extension below does not share that restriction --
-	// RouteEgressAdd/EgressDefaultRouteAdd have always supported IPv4 VPC
-	// prefixes egressing over this IPv6-only underlay (egress.go's own
-	// Via-attribute handling) -- so an IPv4 packet still needs to reach
-	// that logic even though it skips the two IPv6-only rewrites above.
-	// Anything that's neither passes through unmodified, same as any
-	// packet this program has no mapping for.
+	// NPTv6 and the VIP substitution are IPv6-only by design. The
+	// egress-routing extension below is not: IPv4 VPC prefixes have always
+	// egressed over this IPv6-only underlay, so an IPv4 packet still reaches
+	// that logic while skipping the two rewrites above. Anything that is
+	// neither passes through unmodified.
 	__be16 h_proto = eth->h_proto;
 
 	if (h_proto != __builtin_bswap16(USID_ETH_P_IPV6) && h_proto != __builtin_bswap16(USID_ETH_P_IP)) {
@@ -1714,19 +1361,16 @@ int usid_egress(struct __sk_buff *skb)
 					__u32 port_off = USID_L3_OFFSET + (__u32) sizeof(struct usid_ip6hdr) +
 							  USID_OFFSETOF(struct usid_l4ports, source);
 
-					// A checksum/store failure here is not
-					// this program's packet to drop --
-					// only the rewrite itself is
-					// abandoned; the egress-routing
-					// extension below still runs.
+					// A checksum or store failure here is not this
+					// program's packet to drop. Only the rewrite is
+					// abandoned; the egress-routing extension below still
+					// runs.
 					apply_vip_xlat(skb, addr_off, port_off, csum_off, ip6->nexthdr, ip6->saddr,
 							ports->source, vv);
 
-					// apply_vip_xlat's bpf_skb_store_bytes
-					// calls invalidate every
-					// previously-derived packet pointer --
-					// re-derive before reading ip6->daddr
-					// below.
+					// The store calls invalidate every previously derived
+					// packet pointer, so re-derive before reading the
+					// destination below.
 					data = (void *) (long) skb->data;
 					data_end = (void *) (long) skb->data_end;
 					eth = data;
@@ -1736,22 +1380,19 @@ int usid_egress(struct __sk_buff *skb)
 					if ((void *) (ip6 + 1) > data_end)
 						return TC_ACT_SHOT;
 
-					// This packet's source is now a DSR backend's
-					// own ServiceVIPBinding VIP, not its real address
-					// -- see public_uplink_table's own doc comment for
-					// why it must be redirected there immediately,
-					// unconditionally, rather than ever reaching
-					// egress_route_table's lookup below (found live:
-					// without this, a VRF with NAT66 configured wrongly
-					// re-SNATs an already-correctly-VIP-addressed reply
-					// through a NAT66 shard, and the real client
-					// silently discards it as unrecognized). No
-					// count_claimed_drop on failure here (unlike the
-					// egress_route_table redirect failure path below)
-					// -- vrf_table's own per-VRF vrf_value isn't
-					// resolved yet at this point in the function, and
-					// this failure path is expected to essentially
-					// never fire in practice, the same as that one.
+					// This packet's source is now a binding's VIP rather
+					// than the backend's real address, so it must be
+					// redirected out the fabric uplink immediately and
+					// unconditionally, rather than reach the
+					// egress_route_table lookup below. In a VRF with NAT66
+					// configured, that lookup re-translates an
+					// already-correctly-addressed reply through a shard and
+					// the client silently discards it.
+					//
+					// No claimed-drop count on failure here, unlike the
+					// egress route redirect path below: vrf_table's value is
+					// not resolved yet at this point, and this path is
+					// expected essentially never to fire.
 					__u32 pu_key = 0;
 					struct public_uplink_value *pu = bpf_map_lookup_elem(&public_uplink_table, &pu_key);
 
@@ -1767,36 +1408,33 @@ int usid_egress(struct __sk_buff *skb)
 						}
 						return redirect_rc;
 					}
-					// public_uplink_table not configured yet (this
-					// node hasn't converged) -- fall through to the
-					// pre-existing behavior below rather than dropping
-					// outright; egress_route_table's own NAT66 default
-					// may still misroute this reply, but that's no
-					// worse than before this redirect existed.
+					// public_uplink_table is not configured yet, so this node
+					// has not converged. Fall through rather than drop
+					// outright: the NAT66 default below may still misroute
+					// this reply, which is no worse than before this redirect
+					// existed.
 				}
 			}
 		}
 
-		// Multicast (ff00::/8) and link-local (fe80::/10) destinations
-		// must never be matched against egress_route_table, no matter
-		// how broad a registered entry is (in particular
-		// EgressDefaultRouteAdd's own ::/0 default, which -- being a
-		// literal catch-all -- otherwise matches these exactly like any
-		// other destination). Found live: a tenant pod's own Neighbor
-		// Discovery traffic for resolving its *own default gateway's*
-		// link-layer address (an NS targeting a solicited-node
-		// multicast address) was being caught by the ::/0 default entry
-		// and redirected toward a NAT66 shard SID instead of ever
-		// reaching the normal kernel/host-side NDP handling that must
-		// answer it -- the container's own gateway neighbor entry went
-		// to FAILED and every packet through it silently died with a
-		// locally-synthesized "Destination unreachable", never sending
-		// anything at all, let alone anything usid_egress's own drop
-		// counters could see. The kernel's own routing has an equivalent
-		// carve-out by construction (link-local/multicast destinations
-		// are always handled by dedicated local-scope routing, never an
-		// application's own default route); this replicates it here,
-		// since nothing else in this program's own routing model does.
+		// Multicast and link-local destinations must never be matched against
+		// egress_route_table, however broad a registered entry is, and in
+		// particular not by the ::/0 default, which as a literal catch-all
+		// matches them like anything else.
+		//
+		// Without this carve-out, a pod's Neighbor Discovery traffic for
+		// resolving its own default gateway is caught by that default and
+		// redirected toward a NAT66 shard instead of reaching the host-side
+		// NDP handling that must answer it. The container's gateway neighbor
+		// entry then goes to FAILED and every packet through it dies with a
+		// locally synthesized unreachable, never sending anything this
+		// program's drop counters could see.
+		//
+		// The kernel's own routing has an equivalent carve-out by construction,
+		// link-local and multicast destinations always being handled by
+		// local-scope routing rather than an application's default route. This
+		// replicates it, since nothing else in this program's routing model
+		// does.
 		if (ip6->daddr[0] == 0xFF || (ip6->daddr[0] == 0xFE && (ip6->daddr[1] & 0xC0) == 0x80)) {
 			count_drop(DROP_REASON_TRACE_MULTICAST_LL_BAIL);
 			return TC_ACT_UNSPEC;
@@ -1814,10 +1452,9 @@ int usid_egress(struct __sk_buff *skb)
 		__builtin_memcpy(dst_addr, ip4->daddr, sizeof(ip4->daddr));
 	}
 
-	// Resolve this attachment's Linux VRF table id via vrf_table --
-	// already populated identically to ifindex_vrf_table at CNI ADD
-	// time -- see struct egress_route_key's own comment for why this,
-	// not (block, argument), is egress_route_table's key.
+	// Resolve this attachment's Linux VRF table ID through vrf_table, populated
+	// alongside ifindex_vrf_table at CNI ADD time. See struct egress_route_key
+	// for why that, and not (block, argument), is egress_route_table's key.
 	struct vrf_value *vrf = bpf_map_lookup_elem(&vrf_table, &vrf_key);
 
 	if (!vrf) {
@@ -1841,25 +1478,21 @@ int usid_egress(struct __sk_buff *skb)
 		return TC_ACT_UNSPEC; // no configured route for this destination -- defer to the kernel (still-installed netlink route during migration, or genuinely none)
 	}
 
-	// A local pass-through entry (struct egress_route_value's own comment
-	// above) -- it exists only to out-match a shorter default entry via
-	// LPM, not to be encapsulated toward. Defer to the kernel exactly like
-	// a genuine miss above, before touching node_src_addr_table or doing
-	// any encap work below.
+	// A local pass-through entry: it exists only to out-match a shorter default
+	// through the trie, not to be encapsulated toward. Defer to the kernel like
+	// a genuine miss, before touching node_src_addr_table or doing any encap
+	// work.
 	if (rv->link_ifindex == 0) {
 		count_drop(DROP_REASON_TRACE_PASSTHROUGH_ENTRY);
 		return TC_ACT_UNSPEC;
 	}
 
-	// node_src_addr_table is BPF_MAP_TYPE_ARRAY, not BPF_MAP_TYPE_HASH:
-	// every one of its (here, exactly one) slots always exists from map
-	// creation onward, pre-zeroed -- bpf_map_lookup_elem on an in-range
-	// array index can never itself signal "not configured yet" the way a
-	// HASH map miss (a null return) can. An all-zero address is
-	// otherwise never a legitimate value here (the unspecified address
-	// convention internal/plumbing/srv6's own RouteEgressAdd/RouteMainAdd
-	// already use for "not a usable address"), so it's checked
-	// explicitly below as this map's own "not yet configured" signal.
+	// node_src_addr_table is an array, not a hash: its single slot always exists
+	// from map creation, pre-zeroed, so a lookup on an in-range index can never
+	// signal "not configured yet" the way a hash miss can. An all-zero address
+	// is never a legitimate value here, following the same unspecified-address
+	// convention the Go route installers use, so it is checked explicitly below
+	// as this map's not-configured signal.
 	__u32 src_key = 0;
 	__u8 *src = bpf_map_lookup_elem(&node_src_addr_table, &src_key);
 
@@ -1875,11 +1508,10 @@ int usid_egress(struct __sk_buff *skb)
 	if (src_or == 0)
 		return TC_ACT_UNSPEC; // this node's own source address isn't registered yet -- fail open rather than encapsulate with an all-zero source
 
-	// Push room for a new outer IPv6 header. Positive len_diff grows
-	// room (usid_ingress's own strip, above, is this same call with a
-	// negative len_diff) -- BPF_ADJ_ROOM_MAC keeps the Ethernet header
-	// at the very front and opens the new space directly after it,
-	// exactly where the outer header being pushed here belongs.
+	// Push room for a new outer IPv6 header. A positive length difference grows
+	// room, the ingress strip being the same call with a negative one, and the
+	// MAC-anchored mode keeps the Ethernet header at the front and opens the
+	// space directly after it, where the outer header belongs.
 	if (bpf_skb_adjust_room(skb, (__s32) sizeof(struct usid_ip6hdr), BPF_ADJ_ROOM_MAC, 0)) {
 		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
 		return TC_ACT_SHOT;
@@ -1905,10 +1537,9 @@ int usid_egress(struct __sk_buff *skb)
 
 	__builtin_memset(outer->vtc_flow, 0, sizeof(outer->vtc_flow));
 	outer->vtc_flow[0] = 0x60; // version 6, traffic class/flow label left zero
-	// skb->len is now the full grown frame (Ethernet + new outer header +
-	// original inner packet); the inner payload length this header's own
-	// payload_len must carry is that minus the Ethernet and outer-header
-	// bytes just added.
+	// skb->len is now the full grown frame, Ethernet plus new outer header plus
+	// the original inner packet, so the payload length this header must carry
+	// is that minus the Ethernet and outer-header bytes just added.
 	__u16 inner_len = (__u16) (skb->len - (__u32) sizeof(struct usid_ethhdr) - (__u32) sizeof(struct usid_ip6hdr));
 
 	outer->payload_len = __builtin_bswap16(inner_len);
@@ -1918,31 +1549,25 @@ int usid_egress(struct __sk_buff *skb)
 	__builtin_memcpy(outer->daddr, rv->sid, 16);
 	new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IPV6);
 
-	// L2 (dmac/smac) and the real egress interface all come straight from
-	// rv -- resolved once by the Go control plane at Register time, not
-	// via a runtime bpf_fib_lookup() here. This is a deliberate departure
-	// from usid_ingress's own step 8 (which *does* call bpf_fib_lookup()
-	// per packet): confirmed live, bpf_fib_lookup() called from this
-	// program's own attach point (the tenant's own VRF-enslaved veth)
-	// unconditionally returns BPF_FIB_LKUP_RET_BLACKHOLE for a
-	// main-table destination -- tried with BPF_FIB_LOOKUP_TBID, without
-	// it, with BPF_FIB_LOOKUP_DIRECT, without it, and with fib_params.ifindex
-	// set to both skb->ifindex and a neutral non-VRF-enslaved ifindex,
-	// all four combinations identically blackholed a destination `ip -6
-	// route get` resolves just fine outside BPF. This is the kernel's own
-	// VRF/l3mdev isolation boundary asserting itself against the
-	// *attaching* skb's real device (skb->dev), independent of anything
-	// bpf_fib_lookup's own params can override -- not a parameter bug.
-	// usid_ingress never hits this because its own attach point (the
-	// physical uplink) was never VRF-enslaved to begin with.
+	// The L2 addresses and the egress interface come straight from the matched
+	// entry, resolved once by the Go control plane at registration time rather
+	// than by a FIB lookup here. That is a deliberate departure from
+	// usid_ingress's step 8, which does call one per packet: from this
+	// program's attach point, the tenant's VRF-enslaved veth, the lookup
+	// unconditionally blackholes a main-table destination that resolves fine
+	// outside BPF. Every combination of the direct and table-ID flags, and of
+	// skb->ifindex against a neutral non-enslaved index, blackholes
+	// identically. That is the kernel's VRF and l3mdev isolation boundary
+	// asserting itself against the attaching skb's real device, not a parameter
+	// bug. usid_ingress never hits it because its attach point was never
+	// VRF-enslaved.
 	__builtin_memcpy(new_eth->h_dest, rv->dmac, sizeof(new_eth->h_dest));
 	__builtin_memcpy(new_eth->h_source, rv->smac, sizeof(new_eth->h_source));
 
-	// Same-netns redirect: this program's attach point (the tenant's own
-	// host-side veth) and the resolved physical uplink both live in the
-	// root/host netns, unlike usid_ingress's step 9 veth-mode branch
-	// (which crosses into a *different* netns and needs
-	// bpf_redirect_peer for exactly that reason).
+	// Same-namespace redirect: this program's attach point and the resolved
+	// uplink both live in the host namespace, unlike usid_ingress's veth branch,
+	// which crosses into a different one and needs the peer helper for exactly
+	// that reason.
 	count_drop(DROP_REASON_TRACE_REACHED_REDIRECT);
 	long redirect_rc = bpf_redirect(rv->link_ifindex, 0);
 

--- a/internal/plumbing/ebpf/uformat/uformat.go
+++ b/internal/plumbing/ebpf/uformat/uformat.go
@@ -2,24 +2,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package uformat implements the pure-Go bit-layout primitives for the
-// `uFMT 48+16` SRv6 uSID carrier format specified in
-// datum-cloud/enhancements#740 ("Option 2 — Shared 16-bit Slot") and
-// consumed by the eBPF/TC-BPF datapath described in
-// .local/plan-ebpf-xdp-usid-datapath.md. It has no kernel, cgo, or BPF
-// dependency: it only encodes/decodes the fixed-bit-offset fields inside a
-// 128-bit uSID address and derives the map keys the datapath's
-// locator_table and function_table use.
+// Package uformat implements the pure-Go bit-layout primitives for the uFMT
+// 48+16 SRv6 uSID carrier format. It has no kernel, cgo, or BPF dependency: it
+// encodes and decodes the fixed-offset fields inside a 128-bit uSID address and
+// derives the map keys the datapath's locator_table and function_table use.
 //
-// Bit layout (RFC 9800 REPLACE-CSID flavor; see the design plan's R2 and
-// its "why R2 departs from PR #740's original shift wording" call-out for
-// why nothing here ever shifts the address):
+// Bit layout, in the RFC 9800 REPLACE-CSID flavor:
 //
 //	bit  1                  48 49              64 65   68 69          80 81                  128
 //	     |------ uSID Block (48) ------|-- Node-ID (16) --|-Fn(4)-|-- Argument (12) --|------ Padding (48, zero) ------|
 //
-// Byte layout of the 16-byte address (bit 1 is the MSB of byte 0, matching
-// [net/netip.Addr.As16]'s network-byte-order convention):
+// Byte layout of the 16-byte address, bit 1 being the most significant bit of
+// byte 0:
 //
 //	bytes 0-5   (48 bits) Block
 //	bytes 6-7   (16 bits) Node-ID
@@ -27,26 +21,11 @@
 //	byte 8 lo + byte 9 (12 bits) Argument
 //	bytes 10-15 (48 bits) Padding (must be zero)
 //
-// Every accessor in this package reads (or writes) its field at that
-// field's fixed offset only. There is deliberately no shift that relocates
-// one field's bits into another field's frame (design plan R2): Block,
-// Node-ID, Function, and Argument are always independently readable at
-// their fixed offsets from an unmutated address, and locator_table/
-// function_table keys are built by directly copying or composing those
-// fixed-offset reads, never by shifting the address to bring a field into
-// some other field's canonical position. A field's own minimal,
-// right-justifying shift out of its fixed offset -- e.g. Block()'s
-// `>> NodeIDBits` -- is not what this rules out.
-//
-// Placement note: this package lives under internal/plumbing/ebpf/ rather
-// than as a sibling of internal/plumbing/{srv6,vrf,intf,sysctl} directly,
-// because the eBPF datapath work is a multi-milestone effort (design plan
-// §4, §6) that needs more than one package — this one (pure-Go bit layout,
-// Milestone 2.1), the BPF program sources and generated bindings
-// (Milestone 2.2), and the load/attach/reconcile control daemon logic
-// (Milestone 3.x) all belong under one ebpf/ umbrella rather than
-// individually crowding internal/plumbing's top level. uformat has no
-// dependency on the other two and can be imported on its own.
+// Every accessor reads or writes its field at that field's fixed offset only.
+// Nothing here shifts one field's bits into another field's frame: all four
+// fields stay independently readable from an unmutated address, and map keys
+// are composed by copying those fixed-offset reads. A field's own
+// right-justifying shift out of its offset is not what that rules out.
 package uformat
 
 import (
@@ -69,30 +48,29 @@ const (
 	// BlockMax is the largest value that fits in the 48-bit Block field.
 	BlockMax = 1<<BlockBits - 1 // 0xFFFFFFFFFFFF
 
-	// NodeIDMin and NodeIDMax bound PR #740's reserved Node-ID range.
-	// 0xE000-0xFFFF belongs to the Function/Argument universe, not to
-	// Node-ID (design plan §10, "Node-ID range not validated anywhere").
+	// NodeIDMin and NodeIDMax bound the reserved Node-ID range. 0xE000-0xFFFF
+	// belongs to the Function and Argument universe, not to Node-ID.
 	NodeIDMin = 0x0001
 	NodeIDMax = 0xDFFF
 
-	// FunctionEndDT46 and FunctionEndDT2 are the only two Function values
-	// PR #740 defines today (design plan R3): 0xE selects the L3
-	// uEnd.DT46 behavior this plan builds; 0xF is reserved for a future
-	// uEnd.DT2 (L2) behavior and must not be blocked by this code.
+	// FunctionEndDT46 and FunctionEndDT2 are the only Function values defined:
+	// 0xE selects the L3 uEnd.DT46 behavior this datapath implements, and 0xF
+	// is reserved for a future L2 uEnd.DT2 behavior this code must not
+	// block.
 	FunctionEndDT46 = 0xE
 	FunctionEndDT2  = 0xF
 
-	// ArgumentMin and ArgumentMax bound the valid Argument range.
-	// Argument 0x000 is reserved by PR #740 and must never be registered
-	// into vrf_table (design plan R4, §5.1) — ValidateArgument rejects it.
+	// ArgumentMin and ArgumentMax bound the valid Argument range. 0x000 is
+	// reserved and must never be registered into vrf_table; ValidateArgument
+	// rejects it.
 	ArgumentMin = 0x001
 	ArgumentMax = 0xFFF // 12-bit max
 )
 
-// Fields is the fully decoded set of uFMT 48+16 fields carried by a single
-// uSID address. Block and NodeID occupy their full width (uint64/uint16);
-// Function and Argument are stored right-justified in wider integer types
-// with only their low 4 / 12 bits significant.
+// Fields is the decoded set of uFMT 48+16 fields carried by one uSID address.
+// Block and NodeID occupy their full width; Function and Argument are stored
+// right-justified in wider types with only their low 4 and 12 bits
+// significant.
 type Fields struct {
 	Block    uint64
 	NodeID   uint16
@@ -100,13 +78,12 @@ type Fields struct {
 	Argument uint16
 }
 
-// Validate returns a non-nil error if any field violates its documented
-// range: Block > BlockMax, Node-ID outside [NodeIDMin,NodeIDMax], Function
-// not one of the defined enum values, or Argument outside
-// [ArgumentMin,ArgumentMax] (which alone excludes the reserved zero value —
-// R4, §5.1). Decode does not call this automatically — callers validate
-// explicitly at the point a value is about to be registered into a map
-// (design plan §5.1), never on the datapath's packet-read path itself.
+// Validate returns an error if any field is out of range: Block above BlockMax,
+// Node-ID outside its bounds, Function not a defined value, or Argument outside
+// its bounds, which alone excludes the reserved zero.
+//
+// Decode does not call this. Callers validate at the point a value is about to
+// be registered into a map, never on the packet-read path.
 func (f Fields) Validate() error {
 	return errors.Join(
 		ValidateBlock(f.Block),
@@ -125,8 +102,8 @@ func ValidateBlock(block uint64) error {
 	return nil
 }
 
-// ValidateNodeID returns an error if nodeID falls outside PR #740's
-// reserved Node-ID range 0x0001-0xDFFF.
+// ValidateNodeID returns an error if nodeID falls outside the reserved Node-ID
+// range 0x0001-0xDFFF.
 func ValidateNodeID(nodeID uint16) error {
 	if nodeID < NodeIDMin || nodeID > NodeIDMax {
 		return fmt.Errorf("uformat: node-id %#x out of range [%#x,%#x]", nodeID, uint16(NodeIDMin), uint16(NodeIDMax))
@@ -134,12 +111,10 @@ func ValidateNodeID(nodeID uint16) error {
 	return nil
 }
 
-// ValidateFunction returns an error unless function is one of the two
-// Function values PR #740 defines today: FunctionEndDT46 (0xE) or
-// FunctionEndDT2 (0xF, reserved for future L2 use — design plan R3). This
-// is a registration-time check only — the datapath itself never validates
-// Function against this enum; an unrecognized Function is instead detected
-// as a function_table miss at forward time (design plan §4.2 step 4).
+// ValidateFunction returns an error unless function is one of the two defined
+// Function values. A registration-time check only: the datapath never validates
+// Function against this enum, and an unrecognised value shows up as a
+// function_table miss at forward time.
 func ValidateFunction(function uint8) error {
 	if function != FunctionEndDT46 && function != FunctionEndDT2 {
 		return fmt.Errorf("uformat: function %#x is not a defined Function value (want %#x or %#x)",
@@ -148,12 +123,10 @@ func ValidateFunction(function uint8) error {
 	return nil
 }
 
-// ValidateArgument returns an error if argument is outside
-// [ArgumentMin,ArgumentMax]. This includes rejecting the reserved value
-// 0x000, which PR #740 forbids ever registering into vrf_table (design
-// plan R4, §5.1). Per R4, the datapath's fixed-offset packet read
-// (Argument, below) never itself rejects any 12-bit value at forward
-// time — this validation applies only at registration time.
+// ValidateArgument returns an error if argument is outside its valid range,
+// which includes rejecting the reserved 0x000 that must never be registered
+// into vrf_table. A registration-time check only: the datapath's fixed-offset
+// read never rejects any 12-bit value.
 func ValidateArgument(argument uint16) error {
 	if argument < ArgumentMin || argument > ArgumentMax {
 		return fmt.Errorf("uformat: argument %#x out of range [%#x,%#x]", argument, uint16(ArgumentMin), uint16(ArgumentMax))
@@ -189,11 +162,10 @@ func NodeID(addr netip.Addr) (uint16, error) {
 	return binary.BigEndian.Uint16(b[6:8]), nil
 }
 
-// Function returns the 4-bit Function at bits 65-68 of addr — the upper
-// nibble of byte 8 — read directly from the unmutated address (design plan
-// R2). The returned value is not checked against ValidateFunction; callers
-// on the packet-read path should not reject it, only fail the subsequent
-// function_table lookup.
+// Function returns the 4-bit Function at bits 65-68 of addr, the upper nibble
+// of byte 8, read from the unmutated address. It is not checked against
+// ValidateFunction: a caller on the packet-read path should let the subsequent
+// function_table lookup fail rather than reject the value here.
 func Function(addr netip.Addr) (uint8, error) {
 	b, err := as16(addr)
 	if err != nil {
@@ -202,12 +174,10 @@ func Function(addr netip.Addr) (uint8, error) {
 	return b[8] >> 4, nil
 }
 
-// Argument returns the 12-bit Argument at bits 69-80 of addr — the lower
-// nibble of byte 8 plus all of byte 9 — read directly from the unmutated
-// address (design plan R2, R4). This value is never itself part of a match
-// key and this function never rejects any 12-bit value; callers that need
-// to reject the reserved 0x000 (e.g. before a vrf_table registration) call
-// ValidateArgument separately.
+// Argument returns the 12-bit Argument at bits 69-80 of addr, the lower nibble
+// of byte 8 plus byte 9, read from the unmutated address. It is never itself
+// part of a match key, and no 12-bit value is rejected here; a caller that must
+// reject the reserved 0x000 calls ValidateArgument.
 func Argument(addr netip.Addr) (uint16, error) {
 	b, err := as16(addr)
 	if err != nil {
@@ -216,11 +186,10 @@ func Argument(addr netip.Addr) (uint16, error) {
 	return uint16(b[8]&0x0F)<<8 | uint16(b[9]), nil
 }
 
-// Decode extracts every uFMT 48+16 field from addr at its fixed bit
-// offset. It returns an error if addr is not a 16-byte IPv6 address, or if
-// the 48-bit zero-padding tail (bits 81-128) is non-zero — a structural
-// format check, distinct from the semantic range checks in Validate*
-// (which Decode does not call).
+// Decode extracts every uFMT 48+16 field from addr at its fixed offset. It
+// returns an error if addr is not a 16-byte IPv6 address, or if the 48-bit
+// padding tail is non-zero. That is a structural check, distinct from the
+// semantic range checks Validate performs and Decode does not.
 func Decode(addr netip.Addr) (Fields, error) {
 	b, err := as16(addr)
 	if err != nil {
@@ -239,14 +208,12 @@ func Decode(addr netip.Addr) (Fields, error) {
 	}, nil
 }
 
-// Encode constructs a uFMT 48+16 IPv6 address from f, placing each field at
-// its fixed bit offset with zero padding in bits 81-128. It returns an
-// error if Block, Function, or Argument overflow their field width; it
-// does not enforce the narrower semantic ranges in Validate* (e.g.
-// Argument 0x000 or an out-of-range Node-ID), so callers can construct
-// synthetic/placeholder or intentionally-reserved test addresses through
-// this function and validate separately when a value is meant to be
-// registered for real.
+// Encode constructs a uFMT 48+16 address from f, placing each field at its
+// fixed offset with zero padding in the tail. It errors when Block, Function, or
+// Argument overflow their field width, but does not enforce the narrower
+// semantic ranges, so a caller can build a synthetic or deliberately reserved
+// address here and validate separately when the value is meant to be
+// registered.
 func Encode(f Fields) (netip.Addr, error) {
 	if err := ValidateBlock(f.Block); err != nil {
 		return netip.Addr{}, err
@@ -266,11 +233,10 @@ func Encode(f Fields) (netip.Addr, error) {
 	return netip.AddrFrom16(b), nil
 }
 
-// LocatorKey is the 64-bit exact-match key for the locator_table map: bits
-// 1-64 of a uSID address (Block(48) + Node-ID(16)), read directly with no
-// shift. Every address sharing the same Block and Node-ID produces the
-// same LocatorKey regardless of Function/Argument, which is exactly the
-// property R1's "/64 match, not /128" needs.
+// LocatorKey is the 64-bit exact-match key for locator_table: bits 1-64 of a
+// uSID address, Block and Node-ID, read with no shift. Every address sharing a
+// Block and Node-ID yields the same key whatever its Function and Argument,
+// which is what a /64 match needs.
 type LocatorKey uint64
 
 // LocatorKeyFromAddr composes the locator_table key directly from a uSID
@@ -283,10 +249,9 @@ func LocatorKeyFromAddr(addr netip.Addr) (LocatorKey, error) {
 	return LocatorKey(binary.BigEndian.Uint64(b[:8])), nil
 }
 
-// NewLocatorKey composes a locator_table key from a Block and Node-ID
-// value directly, without needing a full address — used by the control
-// daemon (Milestone 3.x) when registering a locator from BGPRouter CRD
-// state rather than from a packet.
+// NewLocatorKey composes a locator_table key from a Block and Node-ID directly,
+// without a full address, for registering a locator from CRD state rather than
+// from a packet.
 func NewLocatorKey(block uint64, nodeID uint16) (LocatorKey, error) {
 	if err := ValidateBlock(block); err != nil {
 		return 0, err
@@ -294,21 +259,19 @@ func NewLocatorKey(block uint64, nodeID uint16) (LocatorKey, error) {
 	return LocatorKey(block<<NodeIDBits | uint64(nodeID)), nil
 }
 
-// FunctionKey is the 52-bit exact-match key for the function_table map:
-// Block(48) in the high bits, Function(4) in the low bits, stored in the
-// low 52 bits of a uint64 (the top 12 bits are always zero). Block and
-// Function are never adjacent bit ranges in the wire address — Node-ID
-// sits between them at bits 49-64 — so this key is always composed from
-// two independently-obtained values, never read as a single contiguous
-// span (design plan §4.2 step 3/4; the Block value must be carried forward
-// as program state from the locator_table match, or re-read directly from
-// the still-unmutated packet, and combined with a freshly read Function).
+// FunctionKey is the 52-bit exact-match key for function_table: Block in the
+// high bits and Function in the low bits, in the low 52 bits of a uint64.
+//
+// Block and Function are not adjacent in the wire address, with Node-ID between
+// them, so this key is always composed from two independently read values
+// rather than one contiguous span. The Block must be carried forward from the
+// locator_table match, or re-read from the still-unmutated packet, and combined
+// with a freshly read Function.
 type FunctionKey uint64
 
-// FunctionKeyFromAddr composes the function_table key directly from a
-// uSID address, by independently reading Block (bits 1-48) and Function
-// (bits 65-68) at their fixed offsets and then combining them — never as a
-// single contiguous span.
+// FunctionKeyFromAddr composes the function_table key from a uSID address, by
+// reading Block and Function independently at their fixed offsets and combining
+// them.
 func FunctionKeyFromAddr(addr netip.Addr) (FunctionKey, error) {
 	block, err := Block(addr)
 	if err != nil {
@@ -333,28 +296,20 @@ func NewFunctionKey(block uint64, function uint8) (FunctionKey, error) {
 	return FunctionKey(block<<FunctionBits | uint64(function)), nil
 }
 
-// VRFKey is the composite exact-match key for the vrf_table map: uSID
-// Block(48) in the high bits, Argument(12) in the low bits, stored in the
-// low 60 bits of a uint64 (design plan §4.4; R8 -- Block is part of the
-// key, not Argument alone, so two Blocks can each hold an independently
-// counted, independently matched entry for the same Argument value during
-// a make-before-break migration). Block and Argument are never adjacent
-// bit ranges in the wire address either -- Node-ID and Function sit
-// between them at bits 49-68 -- so, like FunctionKey, this key is always
-// composed from two independently obtained values, never read as a single
-// contiguous span.
+// VRFKey is the composite exact-match key for vrf_table: Block in the high bits
+// and Argument in the low bits, in the low 60 bits of a uint64.
 //
-// Milestone 2.1 deliberately left this constructor unbuilt (see
-// prog/usid_test.go's own local vrfKey helper and its comment) for
-// whichever milestone needed a real, exported map-key constructor first --
-// Milestone 3.3's control-daemon read/write API (internal/plumbing/ebpf/
-// usidmap) is that first use.
+// Block is part of the key rather than Argument alone, so two Blocks can each
+// hold an independently matched entry for the same Argument during a
+// make-before-break migration.
+//
+// Block and Argument are not adjacent in the wire address either, with Node-ID
+// and Function between them, so like FunctionKey this is always composed from
+// two independently read values.
 type VRFKey uint64
 
-// VRFKeyFromAddr composes the vrf_table key directly from a uSID address,
-// by independently reading Block (bits 1-48) and Argument (bits 69-80) at
-// their fixed offsets and combining them -- never as a single contiguous
-// span.
+// VRFKeyFromAddr composes the vrf_table key from a uSID address, by reading
+// Block and Argument independently at their fixed offsets and combining them.
 func VRFKeyFromAddr(addr netip.Addr) (VRFKey, error) {
 	block, err := Block(addr)
 	if err != nil {
@@ -367,14 +322,11 @@ func VRFKeyFromAddr(addr netip.Addr) (VRFKey, error) {
 	return NewVRFKey(block, argument)
 }
 
-// NewVRFKey composes a vrf_table key from a Block and Argument value
-// directly, without needing a full address -- used by
-// internal/plumbing/ebpf/usidmap when registering/unregistering an entry
-// from CNI-supplied values rather than from a packet. Like NewFunctionKey,
-// this only bounds-checks that argument fits the 12-bit field; it does not
-// reject the reserved value 0x000 the way ValidateArgument does --
-// callers that must enforce that (usidmap.VRFTable.Register, design plan
-// R4/§5.1) validate separately before calling this.
+// NewVRFKey composes a vrf_table key from a Block and Argument directly,
+// without a full address, for registering from CNI-supplied values rather than
+// from a packet. It bounds-checks only that argument fits the 12-bit field and
+// does not reject the reserved 0x000; a caller that must enforce that calls
+// ValidateArgument first.
 func NewVRFKey(block uint64, argument uint16) (VRFKey, error) {
 	if err := ValidateBlock(block); err != nil {
 		return 0, err

--- a/internal/plumbing/ebpf/usidmap/doc.go
+++ b/internal/plumbing/ebpf/usidmap/doc.go
@@ -2,95 +2,48 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package usidmap implements the read/write API that populates and
-// reconciles the eBPF uSID datapath's three control-plane maps --
-// locator_table, function_table, and vrf_table (design plan
-// .local/plan-ebpf-xdp-usid-datapath.md §4.4; Milestone 3.3 of
-// .local/implementation-plan-ebpf-xdp-usid-datapath.md).
+// Package usidmap implements the read/write API that populates and reconciles
+// the eBPF uSID datapath's three control-plane maps: locator_table,
+// function_table, and vrf_table.
 //
-// This package does not itself decide *when* to register or reconcile
-// anything -- that is later milestones' job:
+// It decides nothing about when to register or reconcile. The CNI ADD path
+// registers a VRF entry and the rollback path unregisters it; the GC sweep
+// calls Generation then Reconcile, comparing vrf_table against live
+// BGPVRFInstance CRDs; the control daemon seeds locator_table and
+// function_table for this node's active uSID Blocks at startup and whenever the
+// router's locator changes.
 //
-//   - Milestone 7.1 (CNI registration) calls VRFTable.Register from the
-//     CNI ADD path (design plan §5.1) -- the only ingress/decap
-//     registration; the legacy srv6.RouteIngressAdd static-route path
-//     this originally ran alongside was deleted in the 2026-08-02 direct
-//     cutover. The design plan's placeholder signature,
-//     `usidmap.Register(argument, locatorBlock, vrfTableID)`, is
-//     VRFTable.Register below (argument order: block, then argument, to
-//     match Block-then-Argument ordering used throughout uformat).
-//   - Milestone 7.2 (explicit unregister) calls VRFTable.Unregister from
-//     the failed-ADD rollback path (internal/cni/resource.go's
-//     resourceTracker.cleanup).
-//   - Milestone 7.3 (GC sweep extension) calls VRFTable.Generation then
-//     VRFTable.Reconcile from internal/gc's controller, comparing vrf_table
-//     against live BGPVRFInstance CRDs.
-//   - Milestone 3.1's control daemon (internal/plumbing/ebpf/attach) is
-//     expected to call LocatorTable.Register/FunctionTable.Register at
-//     startup (and on BGPRouter.Spec.SRv6Locator change) to seed
-//     locator_table/function_table for this node's active uSID Block(s) --
-//     that wiring is not part of this milestone's scope either; this
-//     package only builds the API those call sites use.
+// # The two-writer race
 //
-// # The plugin-binary-vs-run-container race (design plan §5.4)
+// Map writes come from two unsynchronized processes: the kubelet-invoked CNI
+// plugin binary, on the ADD and rollback paths, and the long-lived control
+// container, on the GC sweep. Both hold independent handles on the same pinned
+// maps, so they race by construction.
 //
-// Map writes happen from two different, unsynchronized processes: the
-// kubelet-invoked galactic-cni plugin binary (Register/Unregister, on the
-// CNI ADD/rollback path) and the long-lived `run` container (GC's
-// reconciliation sweep). Because both hold an independent handle onto the
-// same pinned kernel maps, they race by construction. The specific failure
-// mode this package exists to prevent: a Register call for a brand new
-// VPCAttachment lands *between* the GC sweep's list-CRDs step (which
-// snapshots which Arguments currently have a live BGPVRFInstance) and its
-// delete-stale-entries step (which removes vrf_table entries absent from
-// that snapshot) -- without protection, the sweep would delete the
-// just-registered entry, even though it is not stale at all: the CRD
-// write and the map write are two different systems that can complete in
-// either order or with a delay between them.
+// The failure this package prevents: a Register for a new attachment lands
+// between the sweep's list-CRDs step, which snapshots which Arguments have a
+// live CRD, and its delete-stale-entries step. Without protection the sweep
+// deletes an entry that is not stale at all, the CRD write and the map write
+// being two systems that can complete in either order.
 //
-// The fix is a per-entry generation field, stamped by Register with the
-// table's own monotonic clock reading (VRFTable.Generation; CLOCK_MONOTONIC,
-// not wall-clock -- see table.go's monotonicNow for why). The GC controller
-// calls VRFTable.Generation immediately *before* listing CRDs and passes
-// the result to VRFTable.Reconcile as cutoff: any vrf_table entry with
-// Generation >= cutoff was written at or after that snapshot was taken, so
-// Reconcile always keeps it regardless of whether its key appears in the
-// live set -- it is simply re-evaluated, correctly, on the *next* sweep,
-// once the CRD has had a chance to actually appear in a fresh list. Only
-// entries older than the snapshot (Generation < cutoff) are ever eligible
-// for deletion, and then only if their key is genuinely absent from the
-// live set.
+// The fix is a per-entry generation, stamped by Register from the table's
+// monotonic clock. The sweep reads Generation immediately before listing CRDs
+// and passes it to Reconcile as a cutoff: an entry at or above the cutoff was
+// written at or after the snapshot, so it is always kept and re-evaluated on
+// the next sweep, once the CRD has had a chance to appear. Only older entries
+// whose key is genuinely absent from the live set are deleted.
 //
-// vrf_table's kernel-side value struct (prog.UsidVrfValue) carries this
-// generation field directly, alongside the per-Argument hit counters
-// (packets/bytes/last_seen_ns) that already existed from Milestone 2.2 --
-// see usid.c's struct vrf_value comment for why this reconciles an
-// apparent tension between the design plan's §4.2 (which described
-// vrf_table's value as `{linux_vrf_table_id, generation, hit counter}`)
-// and its later, narrower §4.4 map-inventory table (which listed only the
-// counter fields): this milestone treats §4.2's inclusion of generation as
-// the one this specific race requires, and implements it as a real
-// struct field rather than an out-of-band side table, so it survives a
-// control-daemon restart the same way the rest of vrf_table's state does
-// (pinned under bpffs, design plan §4.4/§9). locator_table's value
-// already had its own `generation` field from Milestone 2.2 (used for a
-// different purpose -- R7's multiple-concurrent-Block bookkeeping, not
-// this race -- since the GC sweep's scope, design plan §5.3, is vrf_table
-// only; locator_table/function_table are not swept, so LocatorTable and
-// FunctionTable below expose plain Register/Unregister/Get/List with no
-// Reconcile/race handling to match).
+// vrf_table's kernel value carries that generation directly, alongside the
+// per-Argument counters, so it survives a control-daemon restart the way the
+// rest of the table's state does. locator_table's value carries a generation of
+// its own for unrelated multi-Block bookkeeping. Neither locator_table nor
+// function_table is swept, so their table types expose no Reconcile.
 //
 // # Testability
 //
-// Every table type in this package (VRFTable, LocatorTable, FunctionTable)
-// is built against the Table interface (table.go), not directly against
-// *ebpf.Map -- KernelTable adapts a real, loaded map (e.g.
-// prog.UsidObjects.VrfTable) to that interface for production use, while
-// usidmap_test.go substitutes an in-memory fake implementation to exercise
-// register/unregister/reconcile logic, including the race scenario above,
-// without a kernel or root privileges (Milestone 3.3's own exit
-// criterion). Registry (registry.go) is the convenience entry point that
-// wires all three real, kernel-backed tables from a loaded
-// *prog.UsidObjects in one call, for whichever later milestone's
-// production code needs it.
+// Every table type is built against the Table interface rather than directly
+// against a loaded map. KernelTable adapts a real map for production, while
+// tests substitute an in-memory fake to exercise register, unregister, and
+// reconcile logic, including the race above, without a kernel or root. Registry
+// wires all three kernel-backed tables from a loaded object set in one call.
 package usidmap

--- a/internal/plumbing/ebpf/usidmap/egresskind.go
+++ b/internal/plumbing/ebpf/usidmap/egresskind.go
@@ -4,21 +4,15 @@
 
 package usidmap
 
-// Egress kind values for vrf_table's value field, mirroring usid.c's
-// `enum egress_kind` (EGRESS_KIND_VETH/EGRESS_KIND_TAP). Hand-kept in sync
-// with usid.c because bpf2go's -type flag cannot generate a Go type for a
-// C enum that is only ever used as a literal constant, never as a
-// variable/field the compiler retains distinct BTF for (see
-// usidmap/function.go's BehaviorEndDT46/BehaviorEndDT2 constants and
-// prog/dropreason.go for the identical reason/pattern).
+// Egress kind values for vrf_table's value field, mirroring the datapath's own
+// enum. Hand-kept in sync with the C source, because the generator cannot
+// produce a Go type for an enum used only as a literal constant.
 //
-// This selects which redirect helper usid_ingress's step 9 uses: a veth
-// attachment's egress interface has a peer in a different netns
-// (bpf_redirect_peer); a tap attachment (internal/cni/tap) never moves its
-// interface out of this netns, so it has no peer and needs plain
-// bpf_redirect instead. EgressKindVeth is the zero value so a Register call
-// that never sets it explicitly defaults to the pre-existing (and still
-// most common) veth behavior.
+// The value selects which redirect helper the datapath uses: a veth
+// attachment's egress interface has a peer in another namespace, while a tap
+// never leaves this one and so has no peer. EgressKindVeth is the zero value, so
+// a registration that never sets it explicitly defaults to the more common veth
+// behavior.
 const (
 	EgressKindVeth uint32 = 0
 	EgressKindTap  uint32 = 1

--- a/internal/plumbing/ebpf/usidmap/function.go
+++ b/internal/plumbing/ebpf/usidmap/function.go
@@ -14,23 +14,19 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 )
 
-// Behavior values for function_table's value field, mirroring usid.c's
-// `enum function_behavior` (BEHAVIOR_END_DT46/BEHAVIOR_END_DT2). These are
-// hand-kept in sync with usid.c because bpf2go's -type flag cannot
-// generate a Go type for a C enum that is only ever used as a literal
-// constant, never as a variable/field the compiler retains distinct BTF
-// for (see prog/doc.go's go:generate comment, and prog/usid_test.go's own
-// hand-kept drop_reason constants for the identical reason).
+// Behavior values for function_table's value field, mirroring the datapath's own
+// enum. They are hand-kept in sync because the generator cannot produce a Go
+// type for a C enum used only as a literal constant, never as a field the
+// compiler retains distinct type information for.
 const (
 	BehaviorEndDT46 uint32 = 1
 	BehaviorEndDT2  uint32 = 2
 )
 
-// behaviorForFunction returns the function_table Behavior value
-// corresponding to function, so FunctionTable.Register's caller supplies
-// only (block, function) -- never a Behavior directly -- making a
-// mismatched Function/Behavior pair (e.g. Function 0xE stored against
-// BEHAVIOR_END_DT2) structurally impossible to register through this API.
+// behaviorForFunction returns the Behavior value corresponding to function, so a
+// caller supplies only the block and function and never a Behavior directly.
+// That makes a mismatched pair structurally impossible to register through this
+// API.
 func behaviorForFunction(function uint8) (uint32, error) {
 	switch function {
 	case uformat.FunctionEndDT46:
@@ -55,17 +51,16 @@ type FunctionTable struct {
 	table Table
 }
 
-// NewFunctionTable wraps table as a FunctionTable. Production callers pass
-// a KernelTable wrapping a loaded *prog.UsidObjects's FunctionTable map (or
-// use NewRegistryFromObjects); tests pass a fake Table.
+// NewFunctionTable wraps table as a FunctionTable. Production callers pass a
+// kernel table over the loaded map, or use the registry constructor; tests pass
+// a fake.
 func NewFunctionTable(table Table) *FunctionTable {
 	return &FunctionTable{table: table}
 }
 
-// Register writes (or overwrites) the function_table entry for (block,
-// function), storing the Behavior value behaviorForFunction derives from
-// function -- one entry per (active uSID Block x defined Function), per
-// design plan §4.4.
+// Register writes, or overwrites, the function_table entry for (block,
+// function), storing the Behavior derived from function. There is one entry per
+// active Block and defined Function.
 func (t *FunctionTable) Register(block uint64, function uint8) error {
 	if err := uformat.ValidateBlock(block); err != nil {
 		return fmt.Errorf("usidmap: function_table: register block=%#x function=%#x: %w", block, function, err)
@@ -123,10 +118,8 @@ func (t *FunctionTable) Get(block uint64, function uint8) (FunctionEntry, bool, 
 	return FunctionEntry{Block: block, Function: function, Behavior: value.Behavior}, true, nil
 }
 
-// List returns every entry currently in function_table, in unspecified
-// order. Because function_table's key (Block<<4|Function, see
-// uformat.NewFunctionKey) folds Block and Function together, List decodes
-// both back out of each raw key.
+// List returns every entry in function_table, in unspecified order. The raw key
+// folds Block and Function together, so List decodes both back out of it.
 func (t *FunctionTable) List() ([]FunctionEntry, error) {
 	var (
 		entries []FunctionEntry

--- a/internal/plumbing/ebpf/usidmap/locator.go
+++ b/internal/plumbing/ebpf/usidmap/locator.go
@@ -19,17 +19,13 @@ type LocatorEntry struct {
 	Block  uint64
 	NodeID uint16
 
-	// Generation is bumped by Register on every (re-)registration of this
-	// Block/Node-ID pair -- e.g. on BGPRouter.Spec.SRv6Locator change --
-	// giving R7's multiple-concurrent-Block bookkeeping a way to tell a
-	// freshly (re-)confirmed locator apart from one that hasn't been
-	// touched by the control daemon in a while. Unlike vrf_table's
-	// generation (vrf.go), this is not currently consumed by any
-	// Reconcile-style staleness sweep -- the GC controller's scope (design
-	// plan §5.3) is vrf_table only -- so LocatorTable exposes no Reconcile
-	// method; this field exists because locator_value already carried it
-	// from Milestone 2.2, not because this milestone adds new sweep logic
-	// for it.
+	// Generation is bumped on every registration of this Block and Node-ID pair,
+	// such as on a locator change, so multi-Block bookkeeping can tell a freshly
+	// confirmed locator from one the control daemon has not touched in a while.
+	//
+	// Unlike vrf_table's, it is consumed by no staleness sweep, the GC scope
+	// being vrf_table alone, so this type exposes no Reconcile. The field exists
+	// because the kernel value already carries it.
 	Generation uint64
 }
 
@@ -40,16 +36,15 @@ type LocatorTable struct {
 }
 
 // NewLocatorTable wraps table as a LocatorTable. Production callers pass a
-// KernelTable wrapping a loaded *prog.UsidObjects's LocatorTable map (or
-// use NewRegistryFromObjects); tests pass a fake Table.
+// kernel table over the loaded map, or use the registry constructor; tests pass
+// a fake.
 func NewLocatorTable(table Table) *LocatorTable {
 	return &LocatorTable{table: table, clock: clockFn}
 }
 
-// Register writes (or overwrites) the locator_table entry for (block,
-// nodeID), stamping it with this table's current clock reading as its
-// Generation. Design plan §4.4: populated "at startup + on locator
-// change" by the control daemon, from BGPRouter.Spec.SRv6Locator/.NodeID.
+// Register writes, or overwrites, the locator_table entry for (block, nodeID),
+// stamping it with this table's current clock reading. The control daemon
+// populates it at startup and whenever the router's locator changes.
 func (t *LocatorTable) Register(block uint64, nodeID uint16) error {
 	if err := uformat.ValidateBlock(block); err != nil {
 		return fmt.Errorf("usidmap: locator_table: register block=%#x node-id=%#x: %w", block, nodeID, err)
@@ -104,10 +99,8 @@ func (t *LocatorTable) Get(block uint64, nodeID uint16) (LocatorEntry, bool, err
 	return LocatorEntry{Block: block, NodeID: nodeID, Generation: value.Generation}, true, nil
 }
 
-// List returns every entry currently in locator_table, in unspecified
-// order. Because locator_table's key (Block<<16|NodeID, see
-// uformat.NewLocatorKey) folds Block and Node-ID together, List decodes
-// both back out of each raw key.
+// List returns every entry in locator_table, in unspecified order. The raw key
+// folds Block and Node-ID together, so List decodes both back out of it.
 func (t *LocatorTable) List() ([]LocatorEntry, error) {
 	var (
 		entries []LocatorEntry

--- a/internal/plumbing/ebpf/usidmap/registry.go
+++ b/internal/plumbing/ebpf/usidmap/registry.go
@@ -13,20 +13,17 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
 )
 
-// Registry bundles the read/write API for all three of the eBPF uSID
-// datapath's control-plane maps, wired against a single loaded
-// *prog.UsidObjects. It exists purely as a convenience constructor for
-// production callers (Milestones 3.1/7.1/7.2/7.3) that otherwise have to
-// wrap each of the three maps in its own KernelTable individually.
+// Registry bundles the read/write API for all three of the uSID datapath's
+// control-plane maps against one loaded object set. A convenience constructor
+// for callers that would otherwise wrap each map individually.
 type Registry struct {
 	VRF      *VRFTable
 	Locator  *LocatorTable
 	Function *FunctionTable
 }
 
-// NewRegistryFromObjects builds a Registry backed by objs's real,
-// kernel-loaded maps (e.g. the *prog.UsidObjects returned by
-// internal/plumbing/ebpf/attach.Load or .Start).
+// NewRegistryFromObjects builds a Registry backed by objs's kernel-loaded
+// maps.
 func NewRegistryFromObjects(objs *prog.UsidObjects) *Registry {
 	return &Registry{
 		VRF:      NewVRFTable(KernelTable{Map: objs.VrfTable}),
@@ -35,12 +32,10 @@ func NewRegistryFromObjects(objs *prog.UsidObjects) *Registry {
 	}
 }
 
-// pinnedMaps is the io.Closer OpenPinnedRegistry returns: closing it closes
-// every *ebpf.Map handle this process itself opened (design plan §5.4 --
-// opening a pinned map hands back a new fd referencing the same
-// kernel-side map object the control daemon already loaded; that fd is
-// this process's own to close, and doing so does not affect the
-// underlying pinned map or any other process's handle to it).
+// pinnedMaps is the closer OpenPinnedRegistry returns. Closing it closes every
+// map handle this process opened: opening a pinned map hands back a new
+// descriptor onto the same kernel object the control daemon loaded, and closing
+// it affects neither the pinned map nor any other process's handle.
 type pinnedMaps []*ebpf.Map
 
 func (p pinnedMaps) Close() error {
@@ -50,15 +45,11 @@ func (p pinnedMaps) Close() error {
 	return nil
 }
 
-// OpenPinnedRegistry opens vrf_table, locator_table, and function_table
-// from their pinned paths under pinDir (internal/plumbing/ebpf/attach.Load
-// pins each map at <pinDir>/<map name>, e.g. <pinDir>/vrf_table) and
-// returns a Registry wrapping them, for a short-lived process -- namely
-// the galactic-cni plugin binary's ADD path (Milestones 7.1/7.2) -- that
-// did not itself load the datapath but needs to read/write its maps. The
-// returned io.Closer must be closed once the caller is done; it does not
-// affect the maps' pinned lifetime (design plan §4.4: maps stay pinned
-// across any single process's open/close cycle).
+// OpenPinnedRegistry opens the three control-plane maps from their pinned paths
+// under pinDir and returns a Registry wrapping them, for a short-lived process
+// that did not itself load the datapath but needs to read and write its maps.
+// The returned closer must be closed when the caller is done; the maps stay
+// pinned across any process's open and close cycle.
 func OpenPinnedRegistry(pinDir string) (*Registry, pinnedMaps, error) {
 	open := func(name string) (*ebpf.Map, error) {
 		m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, name), nil)

--- a/internal/plumbing/ebpf/usidmap/table.go
+++ b/internal/plumbing/ebpf/usidmap/table.go
@@ -9,49 +9,41 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Table is the minimal map-operation surface every table type in this
-// package (VRFTable, LocatorTable, FunctionTable) is written against,
-// instead of directly against *ebpf.Map. Its method set matches *ebpf.Map's
-// own Put/Lookup/Delete/Iterate closely enough that KernelTable (below) is
-// a one-line adapter; usidmap_test.go substitutes a fake, in-memory
-// implementation to exercise register/unregister/reconcile logic without a
-// kernel or root privileges (Milestone 3.3's own exit criterion: "unit
-// tests against a mocked map interface").
+// Table is the minimal map-operation surface every table type in this package is
+// written against, rather than a loaded map directly. Its method set is close
+// enough to the real map's that KernelTable is a one-line adapter, and tests
+// substitute an in-memory fake to exercise register, unregister, and reconcile
+// logic without a kernel or root.
 type Table interface {
 	// Put creates or overwrites the map entry at key with value.
 	Put(key, value any) error
 
-	// Lookup reads the map entry at key into valueOut. It returns
-	// ebpf.ErrKeyNotExist (or, for a fake Table, an error satisfying
-	// errors.Is(err, ebpf.ErrKeyNotExist)) if key is absent.
+	// Lookup reads the entry at key into valueOut, returning an error matching
+	// ebpf.ErrKeyNotExist when key is absent.
 	Lookup(key, valueOut any) error
 
 	// Delete removes the map entry at key. It returns ebpf.ErrKeyNotExist
 	// (see Lookup) if key is already absent.
 	Delete(key any) error
 
-	// Iterate returns an Iterator walking every entry currently in the
-	// map, in unspecified order -- matching *ebpf.Map.Iterate's own
-	// documented behavior.
+	// Iterate returns an Iterator over every entry currently in the map, in
+	// unspecified order.
 	Iterate() Iterator
 }
 
 // Iterator matches *ebpf.MapIterator's own Next/Err method set.
 type Iterator interface {
-	// Next decodes the next key/value pair into keyOut/valueOut and
-	// reports whether one was available. Callers must check Err after
-	// Next returns false to distinguish "iteration finished" from "an
-	// error interrupted iteration."
+	// Next decodes the next pair into keyOut and valueOut and reports whether
+	// one was available. Callers must check Err after it returns false, to tell
+	// a finished iteration from an interrupted one.
 	Next(keyOut, valueOut any) bool
 
 	// Err returns the first error encountered during iteration, if any.
 	Err() error
 }
 
-// KernelTable adapts a real, loaded *ebpf.Map -- e.g.
-// prog.UsidObjects.VrfTable, LocatorTable, or FunctionTable, once loaded
-// and pinned by internal/plumbing/ebpf/attach.Load -- to the Table
-// interface every table type in this package is written against.
+// KernelTable adapts a real, loaded map to the Table interface every table type
+// in this package is written against.
 type KernelTable struct {
 	Map *ebpf.Map
 }
@@ -61,45 +53,34 @@ func (k KernelTable) Lookup(key, valueOut any) error { return k.Map.Lookup(key, 
 func (k KernelTable) Delete(key any) error           { return k.Map.Delete(key) }
 func (k KernelTable) Iterate() Iterator              { return k.Map.Iterate() }
 
-// clockFn is a package-level override point so tests can control the
-// generation values Register/Generation observe deterministically, instead
-// of racing against a real, always-advancing clock. Production code always
-// leaves this at its default, monotonicNow.
+// clockFn is an override point so tests can control the generation values
+// deterministically instead of racing a real, always-advancing clock.
 var clockFn = monotonicNow
 
-// monotonicNow returns a nanosecond reading from CLOCK_MONOTONIC, used as
-// the generation value stamped into vrf_table (and locator_table) entries
-// at write time (see doc.go's "plugin-binary-vs-run-container race"
-// section).
+// monotonicNow returns a nanosecond reading from the monotonic clock, used as
+// the generation stamped into map entries at write time.
 //
-// CLOCK_MONOTONIC, not wall-clock time.Now(), deliberately: a wall-clock
-// reading can jump backwards (NTP step correction), which would let a
-// freshly Registered entry's generation compare as *older* than a cutoff
-// captured moments before in real chronological order -- exactly the
-// scenario this mechanism exists to prevent misjudging as stale. Go's
-// time.Now() does carry an internal monotonic reading, but it is only ever
-// comparable between two time.Time values from the same process and is not
-// exposed as a raw, storable integer -- unsuitable for a value that must be
-// written into a map entry and compared later, possibly by a different
-// process (design plan §5.4's two-actor split). unix.CLOCK_MONOTONIC gives
-// a raw, storable nanosecond count directly, immune to wall-clock jumps,
-// and -- critically -- stable across a control-daemon restart within the
-// same boot (it is not reset by a process restart, only by a reboot, and a
-// reboot also destroys every pinned bpffs map this generation value would
-// otherwise need to outlive, so that reset is harmless).
+// Monotonic rather than wall clock, deliberately: a wall-clock reading can jump
+// backwards under a time correction, which would let a freshly registered entry
+// compare as older than a cutoff captured moments earlier, exactly the
+// misjudgement this mechanism exists to prevent. Go's own time values do carry
+// an internal monotonic reading, but it is comparable only between two values
+// from the same process and is not exposed as a storable integer, which this
+// must be: it is written into a map entry and compared later, possibly by
+// another process.
+//
+// The raw clock is also stable across a control-daemon restart within one boot.
+// It resets only on reboot, which also destroys every pinned map the value
+// would otherwise need to outlive.
 func monotonicNow() uint64 {
 	var ts unix.Timespec
-	// CLOCK_MONOTONIC is a well-known, always-valid clock id on Linux; the
-	// only realistic failure mode is a syscall-filtering sandbox rejecting
-	// clock_gettime entirely, in which case ts stays zeroed and every call
-	// in this process -- both Register's generation stamp and Generation's
-	// own cutoff snapshot -- reads 0. Reconcile's "keep if Generation >=
-	// cutoff" check then becomes 0 >= 0, which is true: entries are kept,
-	// never reaped, for as long as the rejection persists. This fails
-	// toward a leak (stale entries pile up, requiring a later restart or
-	// manual cleanup once clock_gettime works again), not toward
-	// misdelivery -- an entry never gets reaped out from under live
-	// traffic just because this syscall is unavailable.
+	// The monotonic clock is always valid on Linux; the only realistic failure
+	// is a syscall-filtering sandbox rejecting the call, in which case every
+	// reading in this process is 0. Reconcile's "keep at or above cutoff" check
+	// then compares 0 against 0, which holds, so entries are kept and never
+	// reaped while the rejection persists. That fails toward a leak, cleaned up
+	// by a later restart, rather than toward reaping an entry out from under
+	// live traffic.
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
 }

--- a/internal/plumbing/ebpf/usidmap/vrf.go
+++ b/internal/plumbing/ebpf/usidmap/vrf.go
@@ -15,20 +15,16 @@ import (
 )
 
 // VRFKey identifies one vrf_table row: the uSID Block that matched in
-// locator_table, plus the 12-bit Argument. Block is part of the key, not
-// Argument alone (design plan R8), so two Blocks can each hold an
-// independently counted, independently matched entry for the same Argument
-// value during a make-before-break migration.
+// locator_table plus the 12-bit Argument. Block is part of the key rather than
+// Argument alone, so two Blocks can each hold an independently counted entry
+// for the same Argument during a make-before-break migration.
 type VRFKey struct {
 	Block    uint64
 	Argument uint16
 }
 
-// VRFEntry is one fully decoded vrf_table row, decoupled from
-// prog.UsidVrfValue's cilium/ebpf/BTF-generated field layout so callers
-// outside this package (the GC controller, Milestone 7.3; the CNI
-// registration call, Milestone 7.1) don't need to import prog or
-// cilium/ebpf directly.
+// VRFEntry is one decoded vrf_table row, kept separate from the generated
+// kernel layout so callers outside this package need not import it.
 type VRFEntry struct {
 	VRFKey
 
@@ -36,24 +32,20 @@ type VRFEntry struct {
 	// (internal/plumbing/vrf.TableID()) this Argument resolves to.
 	VRFTableID uint32
 
-	// EgressKind is EgressKindVeth or EgressKindTap -- which redirect
-	// helper usid_ingress's step 9 uses for this entry's resolved egress
-	// interface (Milestone 6.1's tap-mode redirect fix).
+	// EgressKind is EgressKindVeth or EgressKindTap: which redirect helper the
+	// datapath uses for this entry's resolved egress interface.
 	EgressKind uint32
 
-	// Generation is the table's monotonic-clock reading (table.go's
-	// monotonicNow) at the time this entry was last written by Register.
-	// See doc.go's "plugin-binary-vs-run-container race" section for how
-	// Reconcile uses it.
+	// Generation is the table's monotonic-clock reading when this entry was
+	// last written by Register. See the package doc comment for how Reconcile
+	// uses it.
 	Generation uint64
 
 	// Packets, Bytes, LastSeenNs, and DroppedPackets are the datapath's own
-	// per-Argument hit counters (design plan R8), updated by usid_ingress
-	// itself on every packet that matches this entry. Register carries
-	// these forward on a re-registration of an existing key rather than
-	// resetting them (see Register's doc comment) -- they only ever
-	// originate from a real map write by the datapath itself, and are read
-	// back here via Get/List/Reconcile.
+	// per-Argument counters, updated on every packet matching this entry.
+	// Register carries them forward on a re-registration rather than resetting
+	// them; they only ever originate from a datapath write and are read back
+	// here.
 	Packets        uint64
 	Bytes          uint64
 	LastSeenNs     uint64
@@ -66,50 +58,38 @@ type VRFTable struct {
 	clock func() uint64
 }
 
-// NewVRFTable wraps table as a VRFTable. Production callers pass a
-// KernelTable wrapping a loaded *prog.UsidObjects's VrfTable map (or use
-// NewRegistryFromObjects, which does this for all three tables at once);
-// tests pass a fake Table.
+// NewVRFTable wraps table as a VRFTable. Production callers pass a kernel table
+// over the loaded map, or use NewRegistryFromObjects for all three at once;
+// tests pass a fake.
 func NewVRFTable(table Table) *VRFTable {
 	return &VRFTable{table: table, clock: clockFn}
 }
 
-// Generation returns a snapshot of this table's monotonic clock. The GC
-// controller (Milestone 7.3) must call this immediately *before* listing
-// BGPVRFInstance CRDs for Reconcile's live set, and pass the result as
-// Reconcile's cutoff argument -- see doc.go's "plugin-binary-vs-run-
-// container race" section for why the ordering matters.
+// Generation returns a snapshot of this table's monotonic clock. A caller must
+// read it immediately before listing CRDs to build Reconcile's live set, and
+// pass the result as that call's cutoff. See the package doc comment for why the
+// ordering matters.
 func (t *VRFTable) Generation() uint64 {
 	return t.clock()
 }
 
-// Register writes (or overwrites) the vrf_table entry for (block,
-// argument), mapping it to vrfTableID and stamping it with this table's
-// current Generation (design plan §5.1, §5.4).
+// Register writes, or overwrites, the vrf_table entry for (block, argument),
+// mapping it to vrfTableID with egressKind and stamping it with this table's
+// current generation.
 //
-// Register rejects argument == 0 outright: PR #740 reserves Instance ID
-// 0x000, and the datapath is required to always miss vrf_table for it
-// (R4) -- rejecting it here means a caller bug upstream of Register
-// (whatever eventually allocates Arguments, out of this plan's scope)
-// cannot silently plant a live entry for the one value that must always
-// miss.
+// argument 0 is rejected: that value is reserved and the datapath must always
+// miss vrf_table for it, so rejecting it here stops an upstream allocator bug
+// from planting a live entry for the one value that must never match.
 //
-// Re-registering an existing (block, argument) key updates its
-// VRFTableID/EgressKind and bumps Generation, but preserves whatever
-// Packets/Bytes/LastSeenNs usid_ingress has already accumulated against it
-// (a read-modify-write: Register looks the key up first, and carries its
-// existing counter fields forward into the value it writes). This matters
-// because a repeat Register of the *same* key is not always a fresh
-// attachment lifecycle -- it is also, in the ordinary case, the CNI ADD
-// retry path re-registering after a transient k8s-op failure
-// (internal/cnibgp/bgp.go's retryK8sOps), which happens on an Argument that
-// may already be carrying live traffic. R8's make-before-break migration
-// gate reads these counters to prove an Argument carried no traffic before
-// cutover; a blind overwrite that zeroed them on every retry would make a
-// previously-live Argument read as untouched. A genuinely new key (no
-// prior entry) still starts every counter at zero, since there is nothing
-// to carry forward -- ebpf.ErrKeyNotExist from the Lookup below is exactly
-// that case, not a failure.
+// Re-registering an existing key updates its table ID and egress kind and bumps
+// the generation, but carries the accumulated counters forward through a
+// read-modify-write. A repeat Register of the same key is not always a fresh
+// attachment: in the ordinary case it is the CNI ADD retry path re-registering
+// after a transient API failure, on an Argument that may already be carrying
+// live traffic. A make-before-break migration reads those counters to prove an
+// Argument carried none before cutover, and a blind overwrite would make a
+// previously live Argument read as untouched. A genuinely new key starts every
+// counter at zero, there being nothing to carry forward.
 func (t *VRFTable) Register(block uint64, argument uint16, vrfTableID uint32, egressKind uint32) error {
 	if err := uformat.ValidateArgument(argument); err != nil {
 		return fmt.Errorf("usidmap: vrf_table: register block=%#x argument=%#x: %w", block, argument, err)
@@ -140,11 +120,10 @@ func (t *VRFTable) Register(block uint64, argument uint16, vrfTableID uint32, eg
 	return nil
 }
 
-// Unregister removes the vrf_table entry for (block, argument), if
-// present. It is not an error to unregister an already-absent entry --
-// design plan §5.1 requires this call at both the failed-ADD rollback path
-// (Milestone 7.2) and the GC sweep (Milestone 7.3), and either caller may
-// legitimately race with the other having already removed the same entry.
+// Unregister removes the vrf_table entry for (block, argument) if present. An
+// already-absent entry is not an error: both the failed-ADD rollback path and
+// the GC sweep call this, and either may race the other having already removed
+// it.
 func (t *VRFTable) Unregister(block uint64, argument uint16) error {
 	key, err := uformat.NewVRFKey(block, argument)
 	if err != nil {
@@ -186,11 +165,9 @@ func (t *VRFTable) Get(block uint64, argument uint16) (VRFEntry, bool, error) {
 	}, true, nil
 }
 
-// List returns every entry currently in vrf_table, in unspecified order.
-// Because vrf_table's key (Block<<12|Argument, see uformat.NewVRFKey)
-// folds Block and Argument together, List decodes both back out of each
-// raw key rather than needing a separate Block parameter the way
-// Get/Register/Unregister do.
+// List returns every entry in vrf_table, in unspecified order. The raw key folds
+// Block and Argument together, so List decodes both back out of it rather than
+// taking a Block parameter the way the single-entry methods do.
 func (t *VRFTable) List() ([]VRFEntry, error) {
 	var (
 		entries []VRFEntry
@@ -219,26 +196,19 @@ func (t *VRFTable) List() ([]VRFEntry, error) {
 	return entries, nil
 }
 
-// Reconcile brings vrf_table into agreement with live -- the caller's
-// current set of (Block, Argument) pairs that have a live BGPVRFInstance
-// CRD -- removing every vrf_table entry whose key is absent from live,
-// *except* an entry whose Generation is >= cutoff.
+// Reconcile brings vrf_table into agreement with live, the caller's current set
+// of (Block, Argument) pairs backed by a live BGPVRFInstance CRD. It removes
+// every entry whose key is absent from live, except one whose generation is at
+// or above cutoff, and returns the entries removed.
 //
-// cutoff must be a value returned by this table's own Generation, captured
-// by the caller *before* it lists CRDs to build live (see doc.go's
-// "plugin-binary-vs-run-container race" section, and Generation's own doc
-// comment). An entry with Generation >= cutoff was registered at or after
-// that snapshot was taken, so it is always kept here regardless of whether
-// its key is in live -- it is correctly re-evaluated on the caller's
-// *next* Reconcile call, once the CRD list has had a chance to catch up.
-// Only entries older than the snapshot (Generation < cutoff) are ever
-// candidates for deletion, and then only if their key is genuinely absent
-// from live.
+// cutoff must come from this table's Generation, read before the caller listed
+// CRDs. An entry at or above it was registered at or after that snapshot, so it
+// is kept whatever live says and re-evaluated on the next call, once the CRD
+// list has caught up. Only older entries whose key is genuinely absent are
+// candidates for deletion.
 //
-// Reconcile attempts every stale candidate even if deleting one fails,
-// joining every such error into the returned error with errors.Join;
-// removed lists every entry actually deleted, regardless of whether a
-// later deletion in the same call failed.
+// Every stale candidate is attempted even if deleting one fails, with the errors
+// joined; removed lists everything actually deleted regardless.
 func (t *VRFTable) Reconcile(live map[VRFKey]struct{}, cutoff uint64) (removed []VRFEntry, err error) {
 	entries, err := t.List()
 	if err != nil {
@@ -251,9 +221,9 @@ func (t *VRFTable) Reconcile(live map[VRFKey]struct{}, cutoff uint64) (removed [
 			continue // still has a live BGPVRFInstance per the CRD snapshot
 		}
 		if e.Generation >= cutoff {
-			// Registered at or after the CRD-list snapshot was taken --
-			// too new to judge against a live set captured before it
-			// existed. Leave it for the next sweep (design plan §5.4).
+			// Registered at or after the CRD snapshot, so too new to judge
+			// against a live set captured before it existed. Leave it for the
+			// next sweep.
 			continue
 		}
 		if err := t.Unregister(e.Block, e.Argument); err != nil {

--- a/internal/plumbing/ebpf/vipxlatmap/clock.go
+++ b/internal/plumbing/ebpf/vipxlatmap/clock.go
@@ -6,26 +6,19 @@ package vipxlatmap
 
 import "golang.org/x/sys/unix"
 
-// monotonicNow returns a nanosecond reading from CLOCK_MONOTONIC, used as
-// this table's in-memory Generation source (VipXlatTable.Generation) -- see
-// the package doc comment for why this is in-memory only, unlike
-// usidmap.VRFTable's kernel-stored generation field.
+// monotonicNow returns a nanosecond reading from the monotonic clock, this
+// table's in-memory generation source. See the package doc comment for why the
+// generation is in-memory only here.
 //
-// This is a deliberate, small duplicate of
-// internal/plumbing/ebpf/usidmap/table.go's own monotonicNow (identical
-// body, identical reasoning: CLOCK_MONOTONIC rather than wall-clock
-// time.Now(), for the same immune-to-NTP-step-corrections and
-// stable-across-a-restart-within-the-same-boot properties that function's
-// doc comment explains in full) -- that function is unexported inside a
-// different package, so it cannot be imported directly; copying roughly ten
-// lines here was judged simpler and clearer than exporting it solely for
-// this one cross-package reuse.
+// A deliberate small duplicate of the uSID map layer's identical function, which
+// is unexported in another package and so cannot be imported. Copying ten lines
+// was judged simpler than exporting it for one cross-package use.
 func monotonicNow() uint64 {
 	var ts unix.Timespec
-	// See usidmap/table.go's monotonicNow for the failure-mode reasoning if
-	// this syscall is ever rejected (e.g. a syscall-filtering sandbox):
-	// every reading in this process then reads 0, which fails toward never
-	// reaping an entry rather than reaping one out from under live state.
+	// See the uSID map layer's equivalent for the failure mode if this call is
+	// ever rejected: every reading in this process then reads 0, which fails
+	// toward never reaping an entry rather than reaping one out from under live
+	// state.
 	_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
 }

--- a/internal/plumbing/ebpf/vipxlatmap/pin.go
+++ b/internal/plumbing/ebpf/vipxlatmap/pin.go
@@ -15,28 +15,18 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
-// OpenPinnedVipXlatTable opens vip_xlat_table from its pinned path under
-// pinDir (internal/plumbing/ebpf/attach.Load pins every usid_ingress map at
-// <pinDir>/<map name>, e.g. <pinDir>/vip_xlat_table -- the same convention
-// usidmap.OpenPinnedRegistry already documents and relies on for
-// vrf_table/locator_table/function_table) and returns a *VipXlatTable
-// wrapping it.
+// OpenPinnedVipXlatTable opens vip_xlat_table from its pinned path under pinDir
+// and returns a table wrapping it. The datapath's maps are each pinned at
+// <pinDir>/<map name>, the same convention the uSID registry relies on.
 //
-// This is new plumbing: nothing in this codebase needed galactic-router to
-// reach any of usid.c's maps before the DSR/Maglev tap-VIP substitution --
-// galactic-router loads/attaches no eBPF program of its own (that happens
-// once, elsewhere, driven by galactic-cni/internal/plumbing/ebpf/attach on
-// the CNI side), so this function's only job is to open a *second* handle
-// onto maps some other, already-running process on this node pinned --
-// exactly usidmap.OpenPinnedRegistry's own established pattern, reused here
-// for the one additional map that pattern didn't yet cover.
+// The router loads and attaches no eBPF program of its own, that happening once
+// elsewhere on the CNI side, so this function's only job is to open a second
+// handle onto a map another running process on this node pinned.
 //
-// Unlike usidmap.OpenPinnedRegistry's intended caller (the short-lived
-// galactic-cni plugin binary, one process per CNI ADD/DEL), galactic-router
-// is a long-lived daemon: the returned io.Closer should be closed once at
-// process shutdown, not immediately after use -- it does not affect the
-// map's pinned lifetime either way (closing only releases this process's
-// own file descriptor onto the kernel-side map object).
+// Unlike the short-lived plugin binary the uSID registry serves, the router is a
+// long-lived daemon: the returned closer should be closed once at process
+// shutdown rather than immediately after use. Either way it does not affect the
+// map's pinned lifetime, closing only this process's own descriptor.
 func OpenPinnedVipXlatTable(pinDir string) (*VipXlatTable, io.Closer, error) {
 	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapVipXlatTable), nil)
 	if err != nil {

--- a/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
+++ b/internal/plumbing/ebpf/vipxlatmap/vipxlat.go
@@ -3,59 +3,42 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package vipxlatmap implements the read/write API for the eBPF uSID
-// datapath's vip_xlat_table map (usid.c's struct vip_xlat_key/
-// vip_xlat_value) -- the DSR/Maglev redesign's VIP-boundary substitution
-// (design plan §0.1, §2), originally built for the tap-backend case but
-// now driven by ServiceVIPBindingReconciler
-// (internal/controller/servicevipbinding_controller.go) for EgressKindVeth
-// too: a decapsulated ingress packet is delivered into the owning
-// tenant's own VRF routing table, which has no route to a veth binding's
-// address on internal/plumbing/vip's root-namespace dummy interface --
-// found live in containerlab (see ServiceVIPBindingReconciler's own doc
-// comment) -- and this package's ingress row, run unconditionally by
-// usid_ingress whenever a matching entry exists, rewrites the destination
-// to the backend's real, already-routed address before that VRF lookup
-// happens, closing exactly that gap. Mirrors
-// internal/plumbing/ebpf/usidmap's own Register/Unregister/Get/List/
-// Reconcile shape for vrf_table.
+// datapath's vip_xlat_table map, which substitutes addresses at the VIP
+// boundary.
+//
+// A decapsulated ingress packet is delivered into the owning tenant's VRF
+// routing table, which has no route to a binding's address on the root
+// namespace's dummy interface. The ingress row, applied whenever a matching
+// entry exists, rewrites the destination to the backend's real, already-routed
+// address before that lookup happens. The API mirrors usidmap's
+// Register/Unregister/Get/List/Reconcile shape for vrf_table.
 //
 // # Two independent rows per binding
 //
-// usid.c's struct vip_xlat_key doc comment describes vip_xlat_table's
-// direction convention precisely: the *ingress*-direction lookup (in
-// usid_ingress, on a client's inbound request) keys on the packet's own
-// destination port -- the VIP port a client dialed -- and rewrites the
-// packet's destination to the backend's real address:port; the
-// *egress*-direction lookup (in usid_egress, on the backend's own reply)
-// keys on the packet's own source port -- the backend's real port -- and
-// rewrites the packet's source back to the VIP's address:port. These are
-// two independent map entries, not a single symmetric pair sharing one key:
-// RegisterIngress and RegisterEgress each write exactly one row, with
-// reversed key/value roles (RegisterIngress keys on the VIP port and values
-// the backend address:port; RegisterEgress keys on the backend port and
-// values the VIP address:port).
+// The ingress lookup, on a client's inbound request, keys on the packet's
+// destination port, the VIP port the client dialed, and rewrites the
+// destination to the backend's address and port. The egress lookup, on the
+// backend's reply, keys on the packet's source port, the backend's real port,
+// and rewrites the source back to the VIP's address and port.
 //
-// # No on-disk generation field, unlike vrf_table
+// These are two independent entries, not one symmetric pair. RegisterIngress
+// and RegisterEgress each write exactly one row, with the key and value roles
+// reversed.
 //
-// usidmap.VRFTable's crash-safety Generation convention (see usidmap's own
-// doc comment, "The plugin-binary-vs-run-container race") relies on a
-// generation field stored directly in vrf_table's own kernel value struct
-// (prog.UsidVrfValue.Generation), so it survives a control-daemon restart.
-// struct vip_xlat_value (usid.c) has no equivalent field -- it is a bare
-// `{addr[16], port}` substitution target with no spare bytes for one, and
-// this package does not modify usid.c to add one (that file is a shared,
-// already-verified eBPF program; changing its value layout is out of this
-// package's scope). Generation/Reconcile below are therefore backed by an
-// in-memory, per-process map instead of a kernel-stored field: Reconcile
-// still protects against the intra-process race (a Register call landing
-// between a caller's live-snapshot and its own Reconcile call, within the
-// same running reconciler process -- the scenario GC-style sweeps care
-// about day to day), but a process restart resets the tracked generations
-// to unknown (surfaced as Generation 0 on every pre-existing entry), so
-// immediately after a restart Reconcile can only safely trust the caller's
-// live set, not an entry's staleness history. This is an accepted, smaller
-// guarantee than VRFTable's, forced by struct vip_xlat_value's fixed
-// layout -- see this package's own tests for the exact behavior.
+// # Generation is per-process here, unlike vrf_table
+//
+// usidmap.VRFTable stores its crash-safety generation in the kernel value
+// struct, so it survives a control-daemon restart. struct vip_xlat_value is a
+// bare address and port with no spare bytes for one, and adding a field to the
+// shared datapath program is out of this package's scope.
+//
+// Generation and Reconcile are therefore backed by an in-memory, per-process
+// map. Reconcile still protects against the intra-process race, a Register
+// landing between a caller's snapshot and its Reconcile, which is what a
+// GC-style sweep needs day to day. A restart resets the tracked generations, so
+// every pre-existing entry reports generation 0 and Reconcile can only trust
+// the caller's live set. That is a smaller guarantee than VRFTable's, forced by
+// the value layout.
 package vipxlatmap
 
 import (
@@ -73,24 +56,18 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 )
 
-// Supported transport protocols -- the only two vip_xlat_table's rewrite
-// path is ever consulted for (usid_ingress/usid_egress both gate the
-// vip_xlat_table lookup behind `nexthdr == USID_IPPROTO_TCP ||
-// USID_IPPROTO_UDP`, usid.c). Register rejects any other proto value
-// outright rather than silently writing a kernel entry the datapath can
-// never reach.
+// The transport protocols vip_xlat_table's rewrite path is consulted for. Both
+// datapath programs gate the lookup on TCP or UDP, so Register rejects any
+// other value rather than write an entry the datapath can never reach.
 const (
 	ProtoTCP = uint8(unix.IPPROTO_TCP)
 	ProtoUDP = uint8(unix.IPPROTO_UDP)
 )
 
-// Key identifies one vip_xlat_table row exactly as the kernel key is
-// composed (usid.c's struct vip_xlat_key): Block/Argument identify the
-// tenant VRF (same composition as vrf_table's own key), Proto is the
-// transport protocol, and Port is direction-dependent -- see this
-// package's doc comment. Port is host order here; RegisterIngress/
-// RegisterEgress/Get/List/Reconcile all convert to/from the kernel's
-// wire-order representation internally (see hostToNetwork16).
+// Key identifies one vip_xlat_table row as the kernel composes it. Block and
+// Argument identify the tenant VRF, Proto is the transport protocol, and Port
+// is direction-dependent: the VIP port for an ingress row, the backend port for
+// an egress row. Port is in host order here and converted internally.
 type Key struct {
 	Block    uint64
 	Argument uint16
@@ -98,9 +75,8 @@ type Key struct {
 	Port     uint16
 }
 
-// Entry is one fully decoded vip_xlat_table row, decoupled from
-// prog.UsidVipXlatKey/Value's cilium/ebpf/BTF-generated layout so callers
-// outside this package don't need to import prog or cilium/ebpf directly.
+// Entry is one decoded vip_xlat_table row, kept separate from the generated
+// kernel layout so callers outside this package need not import it.
 type Entry struct {
 	Key
 
@@ -112,10 +88,9 @@ type Entry struct {
 	// Addr.
 	RewritePort uint16
 
-	// Generation is this table wrapper's own in-memory registration
-	// sequence number (see the package doc comment) -- 0 for any entry this
-	// process did not itself Register (e.g. one pinned by a previous
-	// process incarnation, discovered only via List/Get).
+	// Generation is this wrapper's in-memory registration sequence number, 0
+	// for any entry this process did not itself Register, such as one pinned by
+	// a previous incarnation and discovered through List or Get.
 	Generation uint64
 }
 
@@ -129,8 +104,7 @@ type VipXlatTable struct {
 }
 
 // NewVipXlatTable wraps table as a VipXlatTable. Production callers pass a
-// usidmap.KernelTable wrapping a loaded vip_xlat_table map (see
-// OpenPinnedVipXlatTable); tests pass a fake usidmap.Table.
+// kernel table over the loaded map; tests pass a fake.
 func NewVipXlatTable(table usidmap.Table) *VipXlatTable {
 	return &VipXlatTable{
 		table:       table,
@@ -139,9 +113,8 @@ func NewVipXlatTable(table usidmap.Table) *VipXlatTable {
 	}
 }
 
-// Generation returns a snapshot of this table's own in-memory monotonic
-// clock -- see the package doc comment for how this differs from
-// usidmap.VRFTable.Generation.
+// Generation returns a snapshot of this table's in-memory monotonic clock. See
+// the package doc comment for how it differs from usidmap.VRFTable's.
 func (t *VipXlatTable) Generation() uint64 {
 	return t.clock()
 }
@@ -166,11 +139,9 @@ func validatePort(port uint16) error {
 }
 
 // addrTo16 returns addr's raw 16 bytes in wire order, or an error if addr is
-// not a genuine IPv6 address. Both usid_ingress's inner-packet path and
-// usid_egress are IPv6-only by design (usid_egress's own doc comment: "IPv6
-// only (component 2/0.1 are both IPv6-only by design)"), so an IPv4
-// (or IPv4-mapped) address is rejected here rather than silently truncated
-// or zero-padded into something the datapath would misinterpret.
+// not a genuine IPv6 address. Both datapath paths are IPv6-only by design, so
+// an IPv4 or IPv4-mapped address is rejected rather than silently truncated or
+// zero-padded into something the datapath would misread.
 func addrTo16(addr net.IP) ([16]byte, error) {
 	if addr == nil {
 		return [16]byte{}, errors.New("vipxlatmap: vip_xlat_table: address is nil")
@@ -187,29 +158,24 @@ func addrTo16(addr net.IP) ([16]byte, error) {
 	return a.As16(), nil
 }
 
-// directionIngress/directionEgress mirror usid.c's
-// USID_VIP_XLAT_DIR_INGRESS/USID_VIP_XLAT_DIR_EGRESS -- the byte value the
-// kernel key's Direction field must carry so usid_ingress's and
-// usid_egress's own, direction-fixed key constructions ever find the row
-// each is looking for. Needed because (block, argument, proto, port) alone
-// is not always unique: a binding that keeps the same port number on both
-// the VIP and the backend (an unremarkable, common case, not a rare one --
-// found live in containerlab, ns60's binding uses port 80 both ways) would
-// otherwise collapse the ingress and egress rows into the same map entry,
-// silently losing whichever was registered first. This package's own
-// exported API stays direction-implicit (RegisterIngress/RegisterEgress/
-// UnregisterIngress/UnregisterEgress/GetIngress/GetEgress each hard-code
-// the direction their own name implies) -- only the kernel key construction
-// below needs the actual byte value.
+// directionIngress and directionEgress mirror the datapath's direction
+// constants, the byte the kernel key must carry so each program's
+// direction-fixed key construction finds the row it is looking for.
+//
+// A direction field is needed because (block, argument, proto, port) is not
+// always unique: a binding that keeps the same port number on both the VIP and
+// the backend, an ordinary case, would otherwise collapse the two rows into one
+// entry and silently lose whichever was registered first. The exported API
+// stays direction-implicit, so only the key construction needs these values.
 const (
 	directionIngress = uint8(0)
 	directionEgress  = uint8(1)
 )
 
-// register is the shared primitive RegisterIngress/RegisterEgress build
-// their (key, value) pair around. keyPort is the port this row's kernel key
-// is composed with (direction-dependent -- see the package doc comment);
-// valAddr/valPort are the rewrite target this row substitutes in.
+// register is the shared primitive RegisterIngress and RegisterEgress build
+// their key and value around. keyPort is the port the kernel key is composed
+// with, which is direction-dependent; valAddr and valPort are the rewrite
+// target the row substitutes in.
 func (t *VipXlatTable) register(
 	direction uint8, block uint64, argument uint16, proto uint8, keyPort uint16, valAddr net.IP, valPort uint16,
 ) error {
@@ -255,19 +221,14 @@ func (t *VipXlatTable) register(
 	return nil
 }
 
-// RegisterIngress writes vip_xlat_table's ingress-direction row for one
-// ServiceVIPBinding: keyed on (block, argument, proto, vipPort) -- the
-// packet's own destination port on a client's inbound request, per
-// usid_ingress's lookup -- and rewriting to backendAddr:backendPort.
+// RegisterIngress writes the ingress-direction row for one binding, keyed on
+// (block, argument, proto, vipPort), the packet's destination port on an
+// inbound request, and rewriting to backendAddr and backendPort.
 //
-// vipAddr is accepted for call-site symmetry with RegisterEgress and with
-// ServiceVIPBindingSpec's own field set (so a caller can pass the binding's
-// VIPAddress/Port/BackendAddress/BackendPort straight through in the order
-// they appear on the CRD) and is validated for family consistency with
-// backendAddr, but it is not itself part of the kernel key or value:
-// usid.c's struct vip_xlat_key carries no address field at all (only
-// Proto+Port), and the ingress row's value is backendAddr:backendPort, not
-// vipAddr.
+// vipAddr is accepted for symmetry with RegisterEgress and with the CRD's field
+// order, and is validated for family consistency with backendAddr, but is not
+// part of the kernel key or value: the key carries no address field, and the
+// ingress row's value is the backend.
 func (t *VipXlatTable) RegisterIngress(
 	block uint64, argument uint16, proto uint8,
 	vipAddr net.IP, vipPort uint16,
@@ -279,12 +240,10 @@ func (t *VipXlatTable) RegisterIngress(
 	return t.register(directionIngress, block, argument, proto, vipPort, backendAddr, backendPort)
 }
 
-// RegisterEgress writes vip_xlat_table's egress-direction row for one
-// ServiceVIPBinding: keyed on (block, argument, proto, backendPort) -- the
-// packet's own source port on the backend's own reply, per usid_egress's
-// lookup -- and rewriting to vipAddr:vipPort. See RegisterIngress's doc
-// comment for why backendAddr is accepted but not itself part of the
-// kernel key.
+// RegisterEgress writes the egress-direction row for one binding, keyed on
+// (block, argument, proto, backendPort), the packet's source port on the
+// backend's reply, and rewriting to vipAddr and vipPort. backendAddr is
+// accepted but not part of the kernel key, as in RegisterIngress.
 func (t *VipXlatTable) RegisterEgress(
 	block uint64, argument uint16, proto uint8,
 	backendAddr net.IP, backendPort uint16,
@@ -296,9 +255,8 @@ func (t *VipXlatTable) RegisterEgress(
 	return t.register(directionEgress, block, argument, proto, backendPort, vipAddr, vipPort)
 }
 
-// unregister removes the vip_xlat_table entry keyed by (direction, block,
-// argument, proto, port), if present. Not an error if already absent,
-// mirroring usidmap.VRFTable.Unregister's identical idempotency contract.
+// unregister removes the entry keyed by (direction, block, argument, proto,
+// port) if present. An entry that is already absent is not an error.
 func (t *VipXlatTable) unregister(direction uint8, block uint64, argument uint16, proto uint8, port uint16) error {
 	key := prog.UsidVipXlatKey{
 		Block:     block,
@@ -332,9 +290,8 @@ func (t *VipXlatTable) UnregisterEgress(block uint64, argument uint16, proto uin
 	return t.unregister(directionEgress, block, argument, proto, backendPort)
 }
 
-// decodeEntry converts a raw kernel key/value pair into an Entry, attaching
-// this table's own in-memory Generation bookkeeping for key (0 if unknown --
-// see the package doc comment).
+// decodeEntry converts a raw kernel key and value into an Entry, attaching this
+// table's in-memory generation for that key, or 0 when unknown.
 func (t *VipXlatTable) decodeEntry(key prog.UsidVipXlatKey, value prog.UsidVipXlatValue) Entry {
 	t.mu.Lock()
 	gen := t.generations[key]
@@ -356,16 +313,14 @@ func (t *VipXlatTable) decodeEntry(key prog.UsidVipXlatKey, value prog.UsidVipXl
 	}
 }
 
-// GetIngress reads the ingress-direction vip_xlat_table entry for (block,
-// argument, proto, vipPort) -- the row RegisterIngress would have written --
-// reporting whether it exists.
+// GetIngress reads the ingress-direction entry for (block, argument, proto,
+// vipPort), the row RegisterIngress writes, and reports whether it exists.
 func (t *VipXlatTable) GetIngress(block uint64, argument uint16, proto uint8, vipPort uint16) (Entry, bool, error) {
 	return t.get(directionIngress, block, argument, proto, vipPort)
 }
 
-// GetEgress reads the egress-direction vip_xlat_table entry for (block,
-// argument, proto, backendPort) -- the row RegisterEgress would have
-// written -- reporting whether it exists.
+// GetEgress reads the egress-direction entry for (block, argument, proto,
+// backendPort), the row RegisterEgress writes, and reports whether it exists.
 func (t *VipXlatTable) GetEgress(block uint64, argument uint16, proto uint8, backendPort uint16) (Entry, bool, error) {
 	return t.get(directionEgress, block, argument, proto, backendPort)
 }
@@ -392,13 +347,10 @@ func (t *VipXlatTable) get(
 	return t.decodeEntry(key, value), true, nil
 }
 
-// List returns every entry currently in vip_xlat_table, in unspecified
-// order. There is no way to tell an ingress-direction row apart from an
-// egress-direction row purely from a raw entry -- both are just
-// (block, argument, proto, port) -> (addr, port) rows to the kernel; a
-// caller that needs to know which direction a given entry belongs to must
-// bring that context itself (e.g. from the ServiceVIPBinding it expects to
-// correspond to it).
+// List returns every entry in vip_xlat_table, in unspecified order. A raw entry
+// does not reveal its direction, since both are just (block, argument, proto,
+// port) to (addr, port) rows, so a caller needing that must bring the context
+// itself.
 func (t *VipXlatTable) List() ([]Entry, error) {
 	var (
 		entries []Entry
@@ -415,21 +367,17 @@ func (t *VipXlatTable) List() ([]Entry, error) {
 	return entries, nil
 }
 
-// Reconcile brings vip_xlat_table into agreement with live -- the caller's
-// current set of Keys that should exist -- removing every entry whose Key
-// is absent from live, except an entry whose Generation is >= cutoff.
+// Reconcile brings vip_xlat_table into agreement with live, the caller's
+// current set of keys, removing every entry whose key is absent from live
+// unless its generation is at or above cutoff. It returns the entries removed.
 //
-// cutoff must be a value returned by this table's own Generation, captured
-// by the caller immediately before it builds live, mirroring
-// usidmap.VRFTable.Reconcile's identical contract. See the package doc
-// comment for how this method's crash-safety differs from VRFTable's: an
-// entry this process did not itself Register (Generation 0, e.g. one left
-// by a previous process incarnation) is never treated as "too new to
-// judge" by this rule alone -- only entries this process has itself
-// Registered at or after the snapshot are protected. A fresh process
-// should let its own reconciler re-Register every live binding before ever
-// calling Reconcile, rather than relying on this method alone to preserve
-// state across a restart.
+// cutoff must come from this table's Generation, captured immediately before
+// the caller builds live.
+//
+// Only entries this process itself registered at or after the snapshot are
+// protected. An entry left by a previous incarnation reports generation 0 and
+// is not treated as too new to judge, so a fresh process should let its
+// reconciler re-register every live binding before calling this.
 func (t *VipXlatTable) Reconcile(live map[Key]struct{}, cutoff uint64) (removed []Entry, err error) {
 	entries, err := t.List()
 	if err != nil {
@@ -444,11 +392,9 @@ func (t *VipXlatTable) Reconcile(live map[Key]struct{}, cutoff uint64) (removed 
 		if e.Generation >= cutoff {
 			continue
 		}
-		// Key carries no Direction (List's own doc comment: a raw entry
-		// alone can't tell an ingress row from an egress row) -- try both;
-		// unregister is a no-op for whichever direction was never actually
-		// registered at this exact (block, argument, proto, port), so this
-		// never deletes anything that didn't already match e.
+		// Key carries no direction, so try both. unregister is a no-op for
+		// whichever direction was never registered at this exact key, so this
+		// never deletes anything that did not already match e.
 		delErr := errors.Join(
 			t.unregister(directionIngress, e.Block, e.Argument, e.Proto, e.Port),
 			t.unregister(directionEgress, e.Block, e.Argument, e.Proto, e.Port),
@@ -462,13 +408,8 @@ func (t *VipXlatTable) Reconcile(live map[Key]struct{}, cutoff uint64) (removed 
 	return removed, errors.Join(errs...)
 }
 
-// hostToNetwork16 converts a host-order uint16 to the network/big-endian
-// byte order struct vip_xlat_key.Port and struct vip_xlat_value.Port
-// require on the wire: bpf2go generates prog.UsidVipXlatKey/Value's Port
-// fields as a plain uint16 with no automatic byte-swap (mirroring
-// internal/plumbing/ebpf/prog/usid_test.go's own bswap16 helper, which
-// performs the identical swap for the same reason -- populating the same
-// map from a test). uint16 byte-swap is its own inverse, so this same
-// function also converts a wire-order value read back out of the kernel to
-// host order (see decodeEntry above).
+// hostToNetwork16 converts a host-order uint16 to the big-endian byte order the
+// kernel key and value ports use on the wire, since the generated structs
+// declare them as plain uint16 with no automatic swap. A uint16 byte swap is
+// its own inverse, so this also converts a value read back out to host order.
 func hostToNetwork16(v uint16) uint16 { return v<<8 | v>>8 }

--- a/internal/plumbing/intf/intf.go
+++ b/internal/plumbing/intf/intf.go
@@ -15,17 +15,15 @@ import (
 
 const interfaceNameTemplate = "G%09s%03s%s"
 
-// vrfInterfaceNameTemplate has no VPCAttachment segment: the VRF is shared
-// by every attachment (pod or VM) landing on a given VPC on a given node, so
-// it is keyed by VPC alone. Unlike the CRD-level VRF identity (see
-// crdnames.BGPVRFInstanceName), the node itself never needs to appear in the
-// name — kernel interface names only have to be unique within one host's own
-// namespace, and each host only ever creates VRF interfaces for itself.
+// vrfInterfaceNameTemplate has no attachment segment: the VRF is shared by every
+// attachment landing on a VPC on a node, so it is keyed by VPC alone. The node
+// never appears either, unlike the CRD-level identity, since kernel interface
+// names only have to be unique within one host and each host creates its own.
 const vrfInterfaceNameTemplate = "G%09s%s"
 
-// GenerateInterfaceNameVRF returns the kernel interface name for the VRF
-// associated with the given base62-encoded VPC. The VRF is per-VPC-per-node,
-// shared by every attachment on that VPC on this node — not per-attachment.
+// GenerateInterfaceNameVRF returns the kernel interface name for a
+// base62-encoded VPC's VRF. The VRF is per VPC per node, shared by every
+// attachment on that VPC here, rather than per attachment.
 func GenerateInterfaceNameVRF(vpc string) string {
 	return fmt.Sprintf(vrfInterfaceNameTemplate, vpc, "V")
 }
@@ -37,15 +35,15 @@ func GenerateInterfaceNameHost(vpc, vpcAttachment string) string {
 }
 
 // GenerateInterfaceNameGuest returns the kernel interface name for the
-// guest-side veth endpoint (moved into the container netns) for the given
-// base62-encoded VPC and VPCAttachment.
+// guest-side veth end, the one moved into the container namespace, for a
+// base62-encoded VPC and attachment.
 func GenerateInterfaceNameGuest(vpc, vpcAttachment string) string {
 	return fmt.Sprintf(interfaceNameTemplate, vpc, vpcAttachment, "G")
 }
 
-// HexToBase62 converts a hex string to base62. VPC and VPCAttachment
-// identifiers are hex in BGP artifacts but base62 in kernel interface names to
-// stay within the 15-character limit.
+// HexToBase62 converts a hex string to base62. Identifiers are hex in BGP
+// artifacts and base62 in kernel interface names, to stay within the
+// 15-character limit.
 func HexToBase62(value string) (string, error) {
 	return baseconv.Convert(strings.ToLower(value), baseconv.DigitsHex, baseconv.Digits62)
 }

--- a/internal/plumbing/loaddr/loaddr.go
+++ b/internal/plumbing/loaddr/loaddr.go
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Package loaddr detects the BGP local address by reading the global-unicast
-// IPv6 address assigned to the host's `lo` interface. galactic-router runs
-// with hostNetwork: true, so `lo` is the real host loopback, and an
-// underlay/fabric BGP daemon (e.g. FRR) is expected to have already assigned
-// an SRv6 loopback address to it (e.g. fc00:0:2::1/48) before galactic-router
-// starts.
+// IPv6 address on the host's loopback. The router runs with host networking, so
+// that is the real host loopback, and the underlay routing daemon is expected to
+// have assigned an SRv6 loopback address there before the router starts.
 package loaddr
 
 import (
@@ -17,10 +15,9 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-// Detect returns the first global-unicast IPv6 address assigned to the `lo`
-// interface, skipping the loopback address (::1) and link-local addresses
-// (fe80::/10). Returns an error if `lo` doesn't exist or has no qualifying
-// address.
+// Detect returns the first global-unicast IPv6 address on the loopback,
+// skipping ::1 and link-local addresses. It returns an error when the interface
+// does not exist or carries no qualifying address.
 func Detect() (string, error) {
 	link, err := netlink.LinkByName("lo")
 	if err != nil {

--- a/internal/plumbing/nptv6/doc.go
+++ b/internal/plumbing/nptv6/doc.go
@@ -2,51 +2,44 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package nptv6 implements RFC 6296 stateless IPv6-to-IPv6 Network Prefix
-// Translation for backends presenting a ULA that must appear as a different
-// (public/global) prefix. Unlike NAT66/masquerade (internal/maglev's
-// separately-sharded stateful tier), this is a pure 1:1 prefix rewrite with
+// Package nptv6 implements RFC 6296 stateless IPv6-to-IPv6 network prefix
+// translation, for backends presenting a ULA that must appear as a different,
+// globally routable prefix.
+//
+// Unlike the stateful NAT66 tier, this is a pure one-to-one prefix rewrite with
 // no connection table: the same source address always maps to the same
 // translated address, in both directions, with no per-flow state anywhere.
 //
 // # Checksum neutrality
 //
-// A naive prefix rewrite would invalidate every TCP/UDP checksum that
-// covers the address (the IPv6 pseudo-header includes both addresses) —
-// RFC 6296 avoids that without ever touching the L4 header by folding a
-// precomputed "adjustment" value into one 16-bit word of the address itself
-// (§3.4), chosen so the address's own 1's-complement checksum contribution
-// is unchanged end to end. Adjustment is a pure function of the two
-// configured prefixes (Mapping.Adjustment) — the same value applies to
-// every address sharing that Mapping and never needs recomputing per
-// packet; Translate then does one 1's-complement add/subtract of that
-// precomputed value into the fixed word, exactly the O(1)-per-packet cost
-// the design plan requires.
+// A naive prefix rewrite invalidates every transport checksum that covers the
+// address, the IPv6 pseudo-header including both. RFC 6296 avoids that without
+// touching the L4 header, by folding a precomputed adjustment into one 16-bit
+// word of the address itself, chosen so the address's own checksum contribution
+// is unchanged end to end.
 //
-// # Scope: /48-or-shorter prefixes only
+// The adjustment is a pure function of the two configured prefixes, so the same
+// value applies to every address sharing a mapping and never needs recomputing.
+// Translating is then one add or subtract into a fixed word, which is the
+// constant per-packet cost the datapath requires.
 //
-// RFC 6296 defines two placements for the adjustment word: §3.4 (MUST
-// support), for prefixes of length 48 or shorter, fixes it at bits 48..63 —
-// implemented here. §3.5 (SHOULD support), for prefixes of length 49..64,
-// instead scans the address's own Interface Identifier words (64..79,
-// 80..95, 96..111, 112..127, in that order) for the first word that isn't
-// already 0xFFFF and uses that — a genuinely per-address decision, not a
-// fixed location, and not implemented here: this repo's own VPC subnet
-// prefixes are /48 (see deploy/containerlab/resources/tenants/*/nad.yaml's
-// "ipv6_subnet" fields), so the §3.4 case is the one this design actually
-// needs. Mapping.Adjustment and Translate both reject a prefix longer than
-// /48 with a clear error rather than attempting the more complex §3.5
-// scheme incorrectly.
+// # Scope: prefixes of /48 or shorter
 //
-// # VRFID-keyed, never address-keyed
+// RFC 6296 defines two placements for the adjustment word. The mandatory one,
+// for prefixes of /48 or shorter, fixes it at bits 48 through 63, which is what
+// this implements. The optional one, for /49 through /64, instead scans the
+// interface identifier for the first word that is not already all ones, a
+// per-address decision rather than a fixed location.
 //
-// This package itself has no notion of a VRF or tenant at all — a Mapping
-// is just two prefixes. Scoping by VRFID (so two tenants may configure the
-// identical ULAPrefix without collision) is the caller's job: the eBPF-side
-// table this package's Adjustment feeds (a new nptv6map, mirroring
-// internal/plumbing/ebpf/edgemap's Register/Reconcile/Generation
-// crash-safety convention) is keyed by VRFID, consulted only after the
-// existing SRv6 uSID decap program (internal/plumbing/ebpf/prog/usid.c) has
-// already resolved which tenant VRF a packet belongs to — see the design
-// plan's §2.
+// That second scheme is not implemented: the VPC subnet prefixes here are /48,
+// so the mandatory case is the one this design needs. A prefix longer than /48
+// is rejected with a clear error rather than translated incorrectly.
+//
+// # Keyed by VRF, never by address
+//
+// This package has no notion of a VRF or tenant: a mapping is two prefixes.
+// Scoping by VRF, so two tenants may configure the same ULA prefix without
+// colliding, is the caller's job. The eBPF table this feeds is keyed by VRF and
+// consulted only after the uSID decap has already resolved which tenant a
+// packet belongs to.
 package nptv6

--- a/internal/plumbing/nptv6/nptv6.go
+++ b/internal/plumbing/nptv6/nptv6.go
@@ -11,33 +11,31 @@ import (
 	"net"
 )
 
-// maxSupportedPrefixLen is RFC 6296 §3.4's boundary: prefixes of this
-// length or shorter place the adjustment at a fixed word (bits 48..63).
-// Longer prefixes need §3.5's per-address IID-word scheme — see doc.go.
+// maxSupportedPrefixLen is the boundary RFC 6296 sets: prefixes this length or
+// shorter place the adjustment at a fixed word. Longer ones need the
+// per-address scheme this package does not implement.
 const maxSupportedPrefixLen = 48
 
-// adjustmentWordOffset is the byte offset of the 16-bit word (bits 48..63)
-// RFC 6296 §3.4 fixes the checksum adjustment into, for prefixes of length
-// maxSupportedPrefixLen or shorter.
+// adjustmentWordOffset is the byte offset of the 16-bit word the checksum
+// adjustment is folded into, for prefixes within the supported length.
 const adjustmentWordOffset = 6
 
-// Mapping is one VRF's stateless RFC 6296 prefix translation: backends
-// presenting an address in ULAPrefix are translated, checksum-neutrally and
-// bidirectionally, to the corresponding address in PublicPrefix.
+// Mapping is one VRF's stateless prefix translation: an address in ULAPrefix
+// translates, checksum-neutrally and in both directions, to the corresponding
+// address in PublicPrefix.
 type Mapping struct {
 	// ULAPrefix is the tenant-facing IPv6 ULA prefix, as presented by
 	// backends inside the VRF.
 	ULAPrefix *net.IPNet
 
-	// PublicPrefix is the externally-routable prefix ULAPrefix translates
-	// to/from. Must share ULAPrefix's own prefix length — RFC 6296
-	// translation only ever rewrites the shared prefix, never host bits.
+	// PublicPrefix is the externally routable prefix ULAPrefix translates to
+	// and from. It must share ULAPrefix's length, translation only ever
+	// rewriting the shared prefix and never host bits.
 	PublicPrefix *net.IPNet
 }
 
-// prefixLen validates that ULAPrefix/PublicPrefix are both set, both IPv6,
-// share an identical prefix length, and that length is within this
-// package's supported range (see doc.go). Returns the shared length.
+// prefixLen validates that both prefixes are set, both IPv6, share a length,
+// and that the length is supported, and returns that shared length.
 func (m Mapping) prefixLen() (int, error) {
 	if m.ULAPrefix == nil || m.PublicPrefix == nil {
 		return 0, errors.New("nptv6: ULAPrefix and PublicPrefix are both required")
@@ -58,9 +56,9 @@ func (m Mapping) prefixLen() (int, error) {
 	return ulaOnes, nil
 }
 
-// Adjustment precomputes the RFC 6296 §3.6 checksum-neutral adjustment
-// value for m, control-plane side, once — Translate applies it as a cheap
-// 1's-complement add/subtract, never recomputing it per packet.
+// Adjustment precomputes the checksum-neutral adjustment for m, once, on the
+// control plane. Translate applies it as a cheap add or subtract rather than
+// recomputing it per packet.
 func (m Mapping) Adjustment() (uint16, error) {
 	if _, err := m.prefixLen(); err != nil {
 		return 0, err
@@ -72,11 +70,10 @@ func (m Mapping) Adjustment() (uint16, error) {
 	return onesComplementAdd(pubChecksum, ^intChecksum), nil
 }
 
-// Translate applies m to addr. outbound=true translates a ULAPrefix address
-// to its PublicPrefix counterpart (the internal-to-external direction, RFC
-// 6296 §3.4 — adjustment is added); outbound=false translates the reverse
-// direction (adjustment is subtracted). Pure function, no state: the
-// identical (m, addr, outbound) input always produces the identical output.
+// Translate applies m to addr. outbound true translates a ULA address to its
+// public counterpart, adding the adjustment; false translates the reverse,
+// subtracting it. A pure function: the same inputs always produce the same
+// output.
 func Translate(m Mapping, addr net.IP, outbound bool) (net.IP, error) {
 	length, err := m.prefixLen()
 	if err != nil {
@@ -115,13 +112,12 @@ func Translate(m Mapping, addr net.IP, outbound bool) (net.IP, error) {
 	return result, nil
 }
 
-// prefixChecksum computes the RFC 1071-style 1's-complement checksum (sum
-// with end-around carry, then bitwise complement) of prefix's first 48
-// bits (3 big-endian 16-bit words) — RFC 6296 §3.6's "one's complement
-// checksum of the prefix". prefix is assumed already zero-padded beyond its
-// own configured length (true of any net.IPNet.IP produced by
-// net.ParseCIDR), so a prefix shorter than 48 bits contributes zero words
-// for its own unused high-order bits, matching the RFC's worked example.
+// prefixChecksum computes the one's-complement checksum of prefix's first 48
+// bits, summing with end-around carry and complementing.
+//
+// prefix is assumed already zero-padded beyond its configured length, which any
+// parsed CIDR is, so a prefix shorter than 48 bits contributes zero for its
+// unused high-order words.
 func prefixChecksum(prefix net.IP) uint16 {
 	ip := prefix.To16()
 	var sum uint32
@@ -134,11 +130,10 @@ func prefixChecksum(prefix net.IP) uint16 {
 	return ^uint16(sum)
 }
 
-// onesComplementAdd adds a and b using 1's-complement (end-around-carry)
-// arithmetic — the same construction an IP/TCP checksum update uses, and
-// what RFC 6296 §3.6 means by "using one's complement arithmetic" for both
-// the adjustment computation and its application (subtraction is addition
-// of the bitwise complement).
+// onesComplementAdd adds a and b with end-around carry, the same arithmetic a
+// checksum update uses and what the RFC means by one's-complement arithmetic
+// for both computing the adjustment and applying it. Subtraction is addition of
+// the complement.
 func onesComplementAdd(a, b uint16) uint16 {
 	sum := uint32(a) + uint32(b)
 	for sum>>16 != 0 {
@@ -147,9 +142,8 @@ func onesComplementAdd(a, b uint16) uint16 {
 	return uint16(sum)
 }
 
-// copyPrefixBits overwrites dst's first prefixLen bits with src's first
-// prefixLen bits, leaving every bit at position >= prefixLen in dst
-// untouched. Both dst and src must be 16-byte (net.IPv6len) slices.
+// copyPrefixBits overwrites dst's first prefixLen bits with src's, leaving every
+// later bit in dst untouched. Both must be 16-byte slices.
 func copyPrefixBits(dst, src net.IP, prefixLen int) {
 	fullBytes := prefixLen / 8
 	copy(dst[:fullBytes], src[:fullBytes])

--- a/internal/plumbing/radv/actor.go
+++ b/internal/plumbing/radv/actor.go
@@ -16,23 +16,20 @@ import (
 	"github.com/mdlayher/ndp"
 )
 
-// RunActor owns one tap attachment's entire Router Advertisement lifecycle
-// for as long as ctx is not canceled: it sends unsolicited RAs on the
-// jittered schedule NextInterval describes, and it replies to Router
-// Solicitations (RFC 4861 §6.2.6) so a freshly-booted or reconnected guest
-// doesn't have to wait out a full resend cycle to converge. Both jobs share
-// one Conn and one "when did we last send" clock, so a solicited reply also
-// reschedules the next unsolicited send — see the RFC 4861 §6.2.6 combining
-// behavior this mirrors — rather than the guest receiving a redundant
-// unsolicited RA moments after a solicited one.
+// RunActor owns one tap attachment's whole Router Advertisement lifecycle for
+// as long as ctx lives: it sends unsolicited advertisements on the jittered
+// schedule, and replies to solicitations so a freshly booted or reconnected
+// guest need not wait out a full resend cycle.
 //
-// Callers (internal/installer's reconciler) run one RunActor per currently
-// recorded attachment (state.go), start it when a new attachment appears,
-// and cancel ctx when the attachment disappears or the daemon shuts down.
-// RunActor returns nil on a clean ctx cancellation; a non-nil error means it
-// never got the Conn open in the first place (nothing to clean up, and the
-// reconciler is expected to retry on its next tick since the attachment
-// record is still there).
+// Both jobs share one connection and one last-sent clock, so a solicited reply
+// also reschedules the next unsolicited send rather than the guest receiving a
+// redundant advertisement moments later.
+//
+// Callers run one per recorded attachment, starting it when the attachment
+// appears and cancelling when it disappears or the daemon shuts down. It
+// returns nil on a clean cancellation; a non-nil error means it never got the
+// connection open, leaving nothing to clean up and the caller free to retry on
+// its next tick.
 func RunActor(ctx context.Context, iface string, mtu int) error {
 	ifi, err := net.InterfaceByName(iface)
 	if err != nil {
@@ -44,10 +41,10 @@ func RunActor(ctx context.Context, iface string, mtu int) error {
 		return fmt.Errorf("open NDP connection on %q: %w", iface, err)
 	}
 
-	// Without joining this group, the kernel never delivers multicast
-	// traffic addressed to ff02::2 to this socket at all — a guest's
-	// Router Solicitation is sent there (RFC 4861 §4.1), not to this
-	// interface's own unicast address.
+	// Without joining this group the kernel never delivers multicast
+	// traffic addressed to it to this socket at all, and a guest's Router
+	// Solicitation goes there rather than to this interface's unicast
+	// address.
 	if err := conn.JoinGroup(allRoutersMulticast); err != nil {
 		_ = conn.Close()
 		return fmt.Errorf("join all-routers multicast group on %q: %w", iface, err)
@@ -65,12 +62,10 @@ func RunActor(ctx context.Context, iface string, mtu int) error {
 	return nil
 }
 
-// readSolicitations is RunActor's blocking read loop, run on its own
-// goroutine since ndp.Conn.ReadFrom blocks and so can't share a select
-// statement with the resend timer in runActorLoop below. It exits as soon
-// as ReadFrom errors -- which is exactly what happens once runActorLoop
-// closes conn on shutdown, so no separate cancellation signal is needed
-// here.
+// readSolicitations is the blocking read loop, on its own goroutine since the
+// read blocks and so cannot share a select with the resend timer. It exits as
+// soon as the read errors, which is what happens once the main loop closes the
+// connection on shutdown, so it needs no separate cancellation signal.
 func readSolicitations(wg *sync.WaitGroup, conn *ndp.Conn, rsCh chan<- netip.Addr) {
 	defer wg.Done()
 
@@ -88,16 +83,16 @@ func readSolicitations(wg *sync.WaitGroup, conn *ndp.Conn, rsCh chan<- netip.Add
 		select {
 		case rsCh <- src:
 		case <-time.After(time.Second):
-			// The main loop only fails to receive here if it has already
-			// returned (about to close conn) -- drop rather than leak this
-			// goroutine waiting forever on a send nothing will ever read.
+			// The main loop only fails to receive here when it has already
+			// returned and is about to close the connection. Drop rather
+			// than leak this goroutine on a send nothing will read.
 		}
 	}
 }
 
-// runActorLoop is RunActor's own select loop, split out solely so RunActor
-// itself stays a short, readable setup/teardown wrapper. See RunActor's doc
-// comment for the combined resend/solicit behavior this implements.
+// runActorLoop is RunActor's select loop, split out so RunActor stays a short
+// setup and teardown wrapper. See RunActor for the combined behavior it
+// implements.
 func runActorLoop(
 	ctx context.Context, conn *ndp.Conn, iface string, mtu int, hwAddr net.HardwareAddr, rsCh <-chan netip.Addr,
 ) {
@@ -138,10 +133,9 @@ func runActorLoop(
 }
 
 // rateLimited reports whether now is too soon after lastSent to send another
-// advertisement, per RFC 4861 §6.2.6/§10 (MinDelayBetweenRAs): a router must
-// never send more than one advertisement -- solicited or not -- within that
-// window of the last one. A zero lastSent (no advertisement sent yet this
-// actor's lifetime) is never rate-limited.
+// advertisement: a router must never send more than one, solicited or not,
+// within the minimum delay. A zero lastSent, meaning none sent yet this
+// actor's lifetime, is never rate-limited.
 func rateLimited(lastSent, now time.Time) bool {
 	if lastSent.IsZero() {
 		return false
@@ -149,15 +143,14 @@ func rateLimited(lastSent, now time.Time) bool {
 	return now.Sub(lastSent) < MinDelayBetweenRAs
 }
 
-// responseDestination returns the address a solicited reply should be sent
-// to for a Router Solicitation whose source address was src. RFC 4861
-// §6.1.1: a solicitation with the unspecified source address (::) means the
-// guest hasn't self-configured any address yet, so there is nothing to
-// unicast a reply to -- fall back to the same all-nodes multicast address
-// unsolicited RAs use. Otherwise, unicast directly back to the soliciting
-// guest: cheaper than multicast, and correct here since there is exactly
-// one guest per tap link, not a shared segment with other listeners to also
-// serve.
+// responseDestination returns where a solicited reply should go for a
+// solicitation from src.
+//
+// An unspecified source means the guest has not self-configured any address, so
+// there is nothing to unicast to and the reply goes to the same all-nodes
+// address unsolicited advertisements use. Otherwise it goes straight back to
+// the guest: cheaper than multicast, and correct here since there is exactly
+// one guest per tap link rather than a shared segment.
 func responseDestination(src netip.Addr) netip.Addr {
 	if src.IsUnspecified() {
 		return allNodesMulticast

--- a/internal/plumbing/radv/radv.go
+++ b/internal/plumbing/radv/radv.go
@@ -2,24 +2,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package radv sends IPv6 Router Advertisements (RFC 4861) out a tap
-// interface's host side so a VM guest attached to it (Kata, Firecracker,
-// kraftlet/Unikraft) can learn a default route. A VM guest is an opaque
-// kernel this codebase has no netlink access into — unlike a veth-attached
-// container, whose guest netns galactic-veth configures directly (address
-// and default route both) via internal/cni/netns.go — so an RA is the only
-// channel available to tell it about a gateway at all.
+// Package radv sends IPv6 Router Advertisements out a tap interface's host
+// side, so a VM guest attached to it can learn a default route. A guest is an
+// opaque kernel this codebase has no netlink access into, unlike a
+// veth-attached container whose namespace the CNI configures directly, so an RA
+// is the only channel available to tell it about a gateway.
 //
-// Sending is deliberately split from tracking which tap interfaces need it:
-// this file only knows how to construct and send one RA, and how long to
-// wait before the next one (RFC 4861 §6.2.4's jittered interval). State.go
-// owns the durable, cross-process record of which host interfaces are
-// currently attached, which internal/cnitap (galactic-tap, short-lived, one
-// exec per CNI ADD/DEL) writes and internal/installer's long-lived daemon
-// (one process per node, for as long as the node has any tap attachments)
-// reads to keep resending on that jittered schedule — see state.go's own
-// doc comment for why a single send at ADD time is not sufficient on its
-// own.
+// Sending is deliberately split from tracking which taps need it. This file
+// knows only how to construct and send one RA and how long to wait before the
+// next. state.go owns the durable, cross-process record of which host
+// interfaces are attached: the short-lived tap plugin writes it, and the
+// long-lived node daemon reads it to keep resending on the jittered
+// schedule.
 package radv
 
 import (
@@ -32,86 +26,76 @@ import (
 	"github.com/mdlayher/ndp"
 )
 
-// MaxRtrAdvInterval and MinRtrAdvInterval bound the delay between
-// unsolicited RAs, per RFC 4861 §6.2.1 (valid range 4–1800s for Max; Min
-// MUST be no less than 3s and no greater than .75 * Max). radvd's own
-// widely-deployed default is Max=600s/Min≈198s (0.33 * Max) — this package
-// runs tighter than that: there is exactly one router (this node) per tap
-// link, so the multi-router synchronization concern the wider default range
-// guards against doesn't apply, and there's no meaningful bandwidth cost to
-// a shorter interval on a single point-to-point tap link. Min=220s keeps
-// comfortably under the .75 * Max = 225s ceiling while staying close to
-// Max, so a guest converges quickly without spending unsolicited RAs it
-// doesn't need. Package-level vars (not consts), matching
-// internal/installer's ebpfHealthCheckInterval override pattern, so tests
-// can shrink them.
+// MaxRtrAdvInterval and MinRtrAdvInterval bound the delay between unsolicited
+// RAs. RFC 4861 allows 4 to 1800 seconds for the maximum, and requires the
+// minimum to be at least 3 seconds and no more than three quarters of it.
+//
+// These run tighter than the widely deployed defaults. There is exactly one
+// router, this node, per tap link, so the multi-router synchronization concern
+// behind the wider range does not apply, and a shorter interval costs nothing
+// on a point-to-point link. The minimum stays just under the three-quarters
+// ceiling, so a guest converges quickly without spending RAs it does not need.
+//
+// Vars rather than consts so tests can shrink them.
 var (
 	MaxRtrAdvInterval = 300 * time.Second
 	MinRtrAdvInterval = 220 * time.Second
 )
 
-// RouterLifetime is the RouterLifetime advertised in every RA this package
-// sends (RFC 4861 §4.2) — how long a receiving guest should keep treating
-// the advertising link-local address as its default router absent another
-// RA. RFC 4861 §6.2.1 requires RouterLifetime >= MaxRtrAdvInterval (and <=
-// 9000s, the protocol's hard cap); 900s (3x MaxRtrAdvInterval) gives a
-// guest two full resend cycles of margin before its route would go stale,
-// while still expiring a guest's route reasonably soon after a tap
-// attachment disappears without a clean DEL (e.g. a hard node/VMM crash) —
-// unlike the one-shot version of this package, which used the 9000s hard
-// cap directly because nothing existed to refresh it before then.
+// RouterLifetime is advertised in every RA: how long a receiving guest keeps
+// treating the advertising link-local address as its default router without
+// another RA. RFC 4861 requires it to be at least MaxRtrAdvInterval and at most
+// 9000 seconds.
+//
+// Three times the maximum interval gives a guest two full resend cycles of
+// margin before its route goes stale, while still expiring it reasonably soon
+// after an attachment disappears without a clean teardown, such as a node or
+// VMM crash.
 var RouterLifetime = 900 * time.Second
 
-// allNodesMulticast is the RFC 4861 §6.2.3 destination for unsolicited RAs
-// and for solicited replies to a solicitation whose source address was
-// unspecified — every host on the link, not just one that solicited.
+// allNodesMulticast is the destination for unsolicited RAs, and for a reply to
+// a solicitation whose source was unspecified: every host on the link rather
+// than just the one that solicited.
 var allNodesMulticast = netip.MustParseAddr("ff02::1")
 
-// allRoutersMulticast is the RFC 4861 §4.1 destination a guest sends its
-// Router Solicitations to — an actor (actor.go) joins this group on its tap
-// host interface so its Conn actually receives them; ICMPv6 multicast
-// traffic isn't delivered to a socket that hasn't joined the group it's
-// addressed to.
+// allRoutersMulticast is the destination a guest sends Router Solicitations to.
+// An actor joins this group on its tap host interface so its socket actually
+// receives them, ICMPv6 multicast not being delivered to a socket that has not
+// joined the group.
 var allRoutersMulticast = netip.MustParseAddr("ff02::2")
 
-// NextInterval returns a random delay in [MinRtrAdvInterval,
-// MaxRtrAdvInterval) before the next unsolicited RA should be sent, per RFC
-// 4861 §6.2.4 — routers are required to jitter rather than fire on a fixed
-// clock specifically so that multiple routers on the same link don't
-// synchronize their RAs into bursts. Callers reschedule with a fresh call to
-// this function after every send (see actor.go's resend timer), rather than
-// using a fixed-period ticker.
+// NextInterval returns a random delay in [MinRtrAdvInterval, MaxRtrAdvInterval)
+// before the next unsolicited RA. Routers are required to jitter rather than
+// fire on a fixed clock, so several on one link do not synchronize into bursts.
+// Callers reschedule with a fresh call after every send rather than using a
+// fixed-period ticker.
 func NextInterval() time.Duration {
 	span := MaxRtrAdvInterval - MinRtrAdvInterval
 	return MinRtrAdvInterval + rand.N(span)
 }
 
-// MinDelayBetweenRAs and MaxRADelayTime are RFC 4861 §10's fixed protocol
-// constants governing solicited replies (actor.go): a router MUST NOT send
-// more than one advertisement within MinDelayBetweenRAs of the last one it
-// sent (solicited or not), and MUST wait a random delay in
-// [0, MaxRADelayTime) before replying to a solicitation, so that several
-// solicitations arriving close together don't each provoke an immediate,
-// synchronized reply. Package-level vars (not consts), matching
-// MaxRtrAdvInterval/MinRtrAdvInterval above, so tests can shrink them; unlike
-// those two, the RFC does not intend these to be tunable in production.
+// MinDelayBetweenRAs and MaxRADelayTime are the fixed protocol constants
+// governing solicited replies: no more than one advertisement within
+// MinDelayBetweenRAs of the last one sent, solicited or not, and a random delay
+// in [0, MaxRADelayTime) before replying, so several solicitations arriving
+// together do not each provoke a synchronized reply.
+//
+// Vars rather than consts so tests can shrink them; unlike the intervals above,
+// the RFC does not intend these to be tunable in production.
 var (
 	MinDelayBetweenRAs = 3 * time.Second
 	MaxRADelayTime     = 500 * time.Millisecond
 )
 
 // nextResponseDelay returns a random delay in [0, MaxRADelayTime) to wait
-// before replying to a Router Solicitation — see MaxRADelayTime's own doc
-// comment.
+// before replying to a Router Solicitation.
 func nextResponseDelay() time.Duration {
 	return rand.N(MaxRADelayTime)
 }
 
-// buildAdvertisement constructs the Router Advertisement both the
-// unsolicited resend path and the solicited-reply path (actor.go) send —
-// factored out so the two paths can never drift apart on hop
-// limit/lifetime/options. See SendRouterAdvertisement's doc comment for why
-// there is no Prefix Information option.
+// buildAdvertisement constructs the Router Advertisement both the unsolicited
+// resend and the solicited reply send, so the two paths cannot drift apart on
+// hop limit, lifetime, or options.
 func buildAdvertisement(mtu int, hwAddr net.HardwareAddr) *ndp.RouterAdvertisement {
 	return &ndp.RouterAdvertisement{
 		CurrentHopLimit: 64,
@@ -126,26 +110,21 @@ func buildAdvertisement(mtu int, hwAddr net.HardwareAddr) *ndp.RouterAdvertiseme
 	}
 }
 
-// SendRouterAdvertisement sends a single unsolicited Router Advertisement out
-// iface (a tap interface's host side), sourced from that interface's
-// kernel-assigned IPv6 link-local address. galactic-cni never programs a
-// link-local address of its own onto a veth or tap interface — see
-// internal/cni/tap's and internal/cni/veth's own doc comments — so this
-// relies entirely on the kernel's automatic fe80::/10 assignment as the RA's
-// source; ndp.Listen(ifi, ndp.LinkLocal) reads that address back rather than
-// creating one.
+// SendRouterAdvertisement sends one unsolicited Router Advertisement out iface,
+// a tap interface's host side, sourced from that interface's kernel-assigned
+// link-local address. Nothing in this codebase programs a link-local address
+// onto a veth or tap, so this relies on the kernel's automatic assignment; the
+// listen call reads that address back rather than creating one. mtu is
+// advertised as the link's MTU.
 //
-// The RA carries no Prefix Information option: a tap-attached guest gets its
-// address from IPAM, not IPv6 SLAAC, so the only thing being announced is
-// "this link-local address is your default router" plus the link's MTU —
-// nothing about how to self-assign an address.
+// The RA carries no prefix information option: a tap-attached guest gets its
+// address from IPAM rather than autoconfiguration, so the only things announced
+// are the default router and the MTU.
 //
-// This is a standalone, one-shot sender — production use is actor.go's
-// RunActor, which keeps one Conn open per attachment for its whole lifetime
-// (both the periodic resend and Router Solicitation replies) rather than
-// opening and closing a fresh Conn on every send. SendRouterAdvertisement
-// remains for callers that only need a single send with no RS-responsiveness
-// (e.g. a one-off diagnostic).
+// A standalone one-shot sender. Production use is RunActor, which keeps one
+// connection open per attachment for its whole lifetime, handling both the
+// periodic resend and solicitation replies. This remains for a caller needing a
+// single send with no solicitation handling.
 func SendRouterAdvertisement(iface string, mtu int) error {
 	ifi, err := net.InterfaceByName(iface)
 	if err != nil {

--- a/internal/plumbing/radv/state.go
+++ b/internal/plumbing/radv/state.go
@@ -11,39 +11,35 @@ import (
 	"path/filepath"
 )
 
-// DefaultStateDir is the well-known parent directory for the node-local
-// record of which tap host interfaces currently need periodic Router
-// Advertisements — mirrors internal/cni/ipam's DefaultLockDir and
-// internal/plumbing/vrf's lockDir: node-local state under /var/lib/cni that
-// must survive the process that wrote it exiting. A package-level var (not
-// a const, unlike its ipam/vrf counterparts): internal/installer's Run
-// reads it directly on every tick with no per-call parameter of its own to
-// override instead, so tests substitute a t.TempDir() here the same way
-// installer.go's own HostBinDir/HostConflist/etc. are overridden.
+// DefaultStateDir is the node-local parent directory recording which tap host
+// interfaces currently need periodic Router Advertisements: state that must
+// survive the process that wrote it exiting.
+//
+// A var rather than a const, unlike its counterparts elsewhere, because the
+// daemon reads it directly on every tick with no per-call parameter to override
+// instead, so tests substitute a temporary directory here.
 var DefaultStateDir = "/var/lib/cni/ra"
 
-// Record is one tap attachment's durable RA state: enough for
-// SendRouterAdvertisement to resend on it without anything else being
-// available (galactic-tap, the process that has the rest of the
-// attachment's context, is long gone by the time this is read).
+// Record is one tap attachment's durable advertisement state: enough to resend
+// on it with nothing else available, the process holding the rest of the
+// attachment's context being long gone by the time this is read.
 type Record struct {
-	// HostInterface is the tap's host-side interface name (see
-	// internal/plumbing/intf.GenerateInterfaceNameHost) — both the file's
-	// name under DefaultStateDir and the interface SendRouterAdvertisement
-	// is told to use, so it doubles as this record's own key.
+	// HostInterface is the tap's host-side interface name. It is both the
+	// record's filename and the interface to send on, so it doubles as this
+	// record's key.
 	HostInterface string `json:"hostInterface"`
 	// MTU is the host interface's MTU at ADD time, advertised via the RA's
 	// MTU option so the guest learns the same link MTU the host side has.
 	MTU int `json:"mtu"`
 }
 
-// RecordAttachment persists a tap attachment's RA state under stateDir,
-// keyed by hostInterface, so a long-lived reader (internal/installer's
-// resend ticker) can find it after the short-lived galactic-tap process
-// that created it has exited. Call on CNI ADD, only for attachments that
-// need an RA at all (an IPv6 gateway was allocated) — see
-// internal/cnitap's cmdAdd for that gating. Overwrites any existing record
-// for the same hostInterface, matching CNI's ADD-retry-is-safe contract.
+// RecordAttachment persists a tap attachment's advertisement state under
+// stateDir, keyed by hostInterface, so the long-lived resend ticker can find it
+// after the short-lived plugin process that created it has exited.
+//
+// Call it on ADD, only for attachments that need an advertisement at all, that
+// is, ones with an IPv6 gateway allocated. It overwrites any existing record for
+// the same interface, matching the ADD-retry-is-safe contract.
 func RecordAttachment(stateDir, hostInterface string, mtu int) error {
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return fmt.Errorf("create radv state dir %q: %w", stateDir, err)
@@ -62,11 +58,9 @@ func RecordAttachment(stateDir, hostInterface string, mtu int) error {
 	return nil
 }
 
-// RemoveAttachment deletes hostInterface's RA state record from stateDir, if
-// any. Call on CNI DEL, unconditionally (mirrors tap.Delete's own
-// best-effort, idempotent contract in internal/cnitap's cmdDel) — a missing
-// record (no IPv6 gateway was ever allocated for this attachment) is not an
-// error.
+// RemoveAttachment deletes hostInterface's record from stateDir, if any. Call it
+// on DEL unconditionally: a missing record, from an attachment that never had an
+// IPv6 gateway, is not an error.
 func RemoveAttachment(stateDir, hostInterface string) error {
 	err := os.Remove(filepath.Join(stateDir, hostInterface))
 	if err != nil && !os.IsNotExist(err) {
@@ -75,11 +69,10 @@ func RemoveAttachment(stateDir, hostInterface string) error {
 	return nil
 }
 
-// ListAttachments returns every currently-recorded tap attachment under
-// stateDir. A missing stateDir (no tap attachment has ever recorded RA state
-// on this node) is not an error — it returns an empty slice, the same as an
-// empty directory, since the resend ticker's caller has no useful reaction
-// to it beyond "nothing to do this tick" either way.
+// ListAttachments returns every recorded tap attachment under stateDir. A
+// missing directory, meaning no attachment has ever recorded state on this node,
+// returns an empty slice rather than an error, the caller having no useful
+// reaction beyond "nothing to do this tick" either way.
 func ListAttachments(stateDir string) ([]Record, error) {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {

--- a/internal/plumbing/srv6/egress.go
+++ b/internal/plumbing/srv6/egress.go
@@ -16,45 +16,28 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
 )
 
-// pinDir is the bpffs directory RouteEgressAdd/RouteEgressDel/
-// EgressDefaultRouteAdd/EgressDefaultRouteDel open egress_route_table
-// from -- a package var defaulting to attach.PinDir (the same seam
-// internal/cnibgp/cnibgp.go's own ebpfPinDir var provides), overridable in
-// this package's own tests so they don't depend on a real bpffs mount or
-// root privileges the way a live pinned-map integration test would.
+// pinDir is the bpffs directory the egress route helpers open
+// egress_route_table from. A package var so tests can redirect it and avoid
+// needing a real bpffs mount or root.
 var pinDir = attach.PinDir
 
-// RouteEgressAdd installs an egress_route_table entry for prefix in Linux
-// VRF table tableID, encapsulating toward the given SRv6 SID (gateway) --
-// the TC-BPF replacement for what used to be a kernel-native SEG6 encap
-// route (netlink.SEG6Encap). See docs/plans/tc-bpf-egress-srv6-encap.md
-// for why: that kernel mechanism is confirmed broken by CVE-2026-31668
-// under this codebase's own per-tenant-VRF architecture (seg6 lwtunnel's
-// dst_cache reused blindly across the input/output resolution paths'
-// differing routing contexts), not fixable by any change to how this
-// package calls it.
+// RouteEgressAdd installs an egress_route_table entry for prefix in Linux VRF
+// table tableID, so usid_egress encapsulates matching traffic toward the SRv6
+// SID gateway. It replaces a kernel SEG6 encap route, which is unusable here:
+// the seg6 lwtunnel reuses one dst_cache across the input and output
+// resolution paths, whose routing contexts differ once every tenant has its
+// own VRF.
 //
-// gateway must be a real SRv6 SID: an unspecified address (0.0.0.0 or ::,
-// including its IPv4-mapped ::ffff:0.0.0.0 form) means the caller never
-// resolved a real destination SID — installing it anyway would silently
-// blackhole traffic to prefix behind a route to nowhere, which is exactly
-// what happened before this check existed (an EVPN path with no usable SID
-// attribute was fed straight through). Fail loudly instead --
-// egressroutemap.EgressRouteTable.Register itself already enforces this.
-//
-// Unlike the netlink-route mechanism this replaces, this function no
-// longer resolves gateway's own link/next-hop at install time
-// (resolveNextHop, below, is no longer called from here): usid_egress's
-// own bpf_fib_lookup() resolves that fresh, per packet -- see
-// egress_route_value's doc comment in usid.c for why that's both simpler
-// and self-healing.
+// gateway must be a real SRv6 SID. An unspecified address (:: or 0.0.0.0,
+// including the IPv4-mapped form) means the caller never resolved a
+// destination SID, and installing it would blackhole prefix behind a route to
+// nowhere. Register resolves gateway's link and L2 addresses as part of the
+// write, so an unreachable gateway also fails here rather than at packet
+// time.
 func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
-	// Checked here, before ever touching bpffs, not left solely to
-	// egressroutemap.EgressRouteTable.Register's own identical guard: a
-	// caller passing a bad gateway shouldn't need a real pinned map (or
-	// root) on hand just to get the right error back -- matching this
-	// function's own pre-TC-BPF behavior, which failed this same check
-	// before its first netlink call.
+	// Checked before touching bpffs, duplicating Register's own guard, so a
+	// caller passing a bad gateway gets the right error without needing a
+	// pinned map or root.
 	if gateway == nil || gateway.IsUnspecified() {
 		return fmt.Errorf("refusing to install egress route for %s: gateway %s is not a usable SRv6 SID", prefix, gateway)
 	}
@@ -66,23 +49,15 @@ func RouteEgressAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	return table.Register(tableID, prefix, gateway)
 }
 
-// resolveNextHop resolves gateway's real, immediate next-hop -- the exact
-// link plus (unless gateway is itself on-link) the concrete address the
-// kernel would actually forward through right now -- via netlink.RouteGet.
+// resolveNextHop flattens gateway into the link index plus the concrete
+// next-hop address the kernel would forward through right now, via
+// netlink.RouteGet. nextHop is nil when gateway is itself on-link.
 //
-// This flattening matters because IPv6 route installation does not recurse
-// through an indirect gateway on its own: passing gateway straight through
-// as a route's Gw with no LinkIndex set fails with "no route to host"
-// whenever gateway is only reachable via its own separate route (e.g.
-// through a link-local next-hop) rather than being on-link itself --
-// confirmed empirically live in containerlab, where every BGP next-hop
-// used as a plain gateway (RouteMainAdd, below) is exactly this indirect
+// IPv6 route installation does not recurse through an indirect gateway:
+// passing gateway as a route's Gw with no LinkIndex set fails with "no route
+// to host" whenever gateway is reachable only via a separate route, such as
+// through a link-local next-hop. BGP next-hops are usually exactly that
 // shape.
-//
-// Only RouteMainAdd calls this today: RouteEgressAdd/EgressDefaultRouteAdd
-// used to (their own SEG6 encap routes needed the identical flattening),
-// but no longer do -- usid_egress's own per-packet bpf_fib_lookup replaces
-// that resolution entirely for both (see RouteEgressAdd's own doc comment).
 func resolveNextHop(gateway net.IP) (linkIndex int, nextHop net.IP, err error) {
 	routes, err := netlink.RouteGet(gateway)
 	if err != nil {
@@ -94,8 +69,8 @@ func resolveNextHop(gateway net.IP) (linkIndex int, nextHop net.IP, err error) {
 	return routes[0].LinkIndex, routes[0].Gw, nil
 }
 
-// RouteEgressDel removes the egress_route_table entry for prefix from
-// Linux VRF table tableID -- RouteEgressAdd's counterpart.
+// RouteEgressDel removes the egress_route_table entry for prefix from Linux
+// VRF table tableID. The counterpart to RouteEgressAdd.
 func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
 	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {
@@ -105,31 +80,19 @@ func RouteEgressDel(prefix *net.IPNet, tableID uint32) error {
 	return table.Unregister(tableID, prefix)
 }
 
-// RouteMainAdd installs a plain route for prefix in routing table tableID,
-// forwarding to gateway via ordinary recursive next-hop resolution -- no
-// SEG6 encapsulation, unlike RouteEgressAdd, and untouched by the
-// TC-BPF migration RouteEgressAdd/EgressDefaultRouteAdd underwent above:
-// this function never called netlink.SEG6Encap in the first place, so it
-// was never exposed to CVE-2026-31668 at all (see its own doc comment
-// below for why an anycast route specifically must not be SEG6-wrapped).
+// RouteMainAdd installs a plain kernel route for prefix in routing table
+// tableID, forwarding to gateway through ordinary recursive next-hop
+// resolution and no encapsulation at all.
 //
-// This exists for EVPN Type 5 paths that carry no Route Target extended
-// community at all (see matchTableID in internal/runtime/gobgp/monitor.go):
-// NetworkGatewayReconciler's anycast ingress-VIP advertisements are the one
-// case today, deliberately left VRFID/Function-less because they name no
-// tenant VRF (that reconciler's own package doc comment). Their EVPN path
-// therefore carries no Prefix-SID either, so gateway here is always the
-// path's plain BGP next-hop -- a real, already fabric-reachable node
-// address (how else could this path's own BGP session exist), not a uSID
-// decap SID. Wrapping the packet in another SEG6/IPv6-in-IPv6 header toward
-// that address the way RouteEgressAdd does for a tenant VRF prefix would
-// only make it undeliverable: nothing there is listening for that
-// encapsulation the way usid_ingress listens for a real uSID SID's traffic.
-// Ordinary recursive forwarding is what an anycast route actually needs.
+// It exists for EVPN Type 5 paths carrying no Route Target extended community,
+// which today means the anycast ingress-VIP advertisements that name no tenant
+// VRF. Such a path carries no Prefix-SID either, so gateway is the path's
+// plain BGP next-hop: a node address already reachable over the fabric, not a
+// uSID decap SID. Wrapping it in an outer IPv6 header the way RouteEgressAdd
+// does would make the packet undeliverable, because nothing at that address
+// listens for that encapsulation.
 //
-// gateway must be a real address for the same reason RouteEgressAdd
-// requires one: an unspecified gateway would silently blackhole prefix
-// behind a route to nowhere.
+// gateway must be a real address; an unspecified one would blackhole prefix.
 func RouteMainAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 	if gateway == nil || gateway.IsUnspecified() {
 		return fmt.Errorf("refusing to install route for %s: gateway %s is not a usable next-hop", prefix, gateway)
@@ -150,18 +113,15 @@ func RouteMainAdd(prefix *net.IPNet, gateway net.IP, tableID uint32) error {
 			route.Gw = nextHop
 		}
 	} else {
-		// gateway itself is on-link (RouteGet found no further next-hop of
-		// its own) -- unlike RouteEgressAdd's SEG6 encap case, where the
-		// segment list alone already fully specifies the destination, a
-		// plain route needs an explicit gateway here or the kernel would
-		// treat prefix itself as directly reachable on this link.
+		// gateway is on-link. A plain route still needs it stated explicitly,
+		// or the kernel treats prefix itself as directly reachable here.
 		route.Gw = gateway
 	}
 	return netlink.RouteReplace(route)
 }
 
-// RouteMainDel removes the plain route for prefix from routing table
-// tableID -- RouteMainAdd's counterpart, mirroring RouteEgressDel.
+// RouteMainDel removes the plain route for prefix from routing table tableID.
+// The counterpart to RouteMainAdd.
 func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 	return netlink.RouteDel(&netlink.Route{
 		Dst:   prefix,
@@ -169,50 +129,25 @@ func RouteMainDel(prefix *net.IPNet, tableID uint32) error {
 	})
 }
 
-// EgressDefaultRouteAdd installs egress_route_table's default (::/0)
-// entry for Linux VRF table tableID, encapsulating toward the first
-// usable address in shardSIDs -- the TC-BPF replacement for what used to
-// be a kernel-native SEG6 encap default route (see RouteEgressAdd's own
-// doc comment for why). This is the missing half of the design plan's §3
-// sharded NAT66 tier: nat66.c's own shard-receive side has always been
-// able to decap and NAT a packet addressed to its own shard_sid, but
-// nothing ever produced such a packet -- no code anywhere installed a
-// default route in a tenant VRF at all, so a backend with no more
-// specific destination simply had no route out (confirmed live: "no
-// route to host" from vrf60's own table). This closes that gap the same
-// way RouteEgressAdd closes it for a specific intra-VPC destination.
+// EgressDefaultRouteAdd installs egress_route_table's default (::/0) entry for
+// Linux VRF table tableID, encapsulating toward the first usable address in
+// shardSIDs. It gives a tenant VRF a route out for any destination with no
+// more specific entry, so traffic reaches the NAT66 shard tier that decaps and
+// translates it.
 //
-// Picking only the first usable shard, rather than spreading load across
-// all of them, is a deliberate simplification: design plan §3.2's own
-// per-flow hash (internal/maglev, or an earlier version of this
-// function's own kernel-ECMP-multipath approximation of it) was never a
-// hard requirement -- §3.5 treats shard-set-change disruption as a
-// property to prove, not one gating this mechanism's existence at all --
-// and correctness (a route exists, traffic flows) matters more here than
-// shard load distribution. Revisit with a real selection mechanism (a
-// second, larger LPM/hash map in usid.c, or per-flow hashing inside
-// usid_egress itself) if per-shard load spreading is ever needed.
+// shardSIDs lists the candidate NAT66 shards. An empty slice installs nothing
+// and returns nil, treating "nothing configured yet" as success. A nil or
+// unspecified entry is a misconfiguration and fails immediately.
 //
-// shardSIDs must be non-empty -- EgressDefaultRouteAdd installs nothing
-// and returns nil when it is, the same "nothing configured yet, not an
-// error" stance GALACTIC_CNI_NAT66_SHARD_SIDS's own doc comment takes. An
-// unspecified/nil entry is a real misconfiguration and fails loudly
-// (matching RouteEgressAdd's own guard, enforced by
-// egressroutemap.EgressRouteTable.Register).
-//
-// EgressDefaultRouteAdd still needs to skip a shard SID it cannot yet
-// resolve a route+neighbor for, and only fail if every one does: a real,
-// necessary case found live -- a compute node that is *also* one of the
-// configured shards itself (this lab's own "reuse the site workers as
-// shards" layout) can never resolve a route to its *own* advertised SID,
-// since GoBGP, like every BGP implementation, never reflects a
-// self-originated path back into that same node's received-path
-// processing. egressroutemap.EgressRouteTable.Register resolves
-// link/L2 information at registration time (see its own doc comment for
-// why), so this same resolvability constraint that applied to the
-// netlink-route mechanism's own resolveNextHop applies again here,
-// unlike an intermediate version of this function that (incorrectly)
-// assumed it no longer would.
+// Shards are tried in order and the first that registers wins, rather than
+// load being spread across them: correctness matters more here than
+// distribution, and per-flow selection would need a hash inside usid_egress.
+// A shard whose SID cannot be resolved is skipped, and only an exhausted list
+// is an error, because a node that is itself one of the configured shards can
+// never resolve a route to its own advertised SID: BGP does not reflect a
+// self-originated path back into the originating node's received paths.
+// Register resolves link and L2 information as part of the write, which is
+// what makes an unresolvable shard fail here.
 func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 	if len(shardSIDs) == 0 {
 		return nil
@@ -225,8 +160,7 @@ func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 
 	var unresolved []error
 	for _, sid := range shardSIDs {
-		// Checked here, before ever touching bpffs -- see RouteEgressAdd's
-		// identical guard for why.
+		// Checked before touching bpffs, as in RouteEgressAdd.
 		if sid == nil || sid.IsUnspecified() {
 			return fmt.Errorf("refusing to install NAT66 default route: shard SID %s is not a usable SRv6 SID", sid)
 		}
@@ -240,8 +174,8 @@ func EgressDefaultRouteAdd(tableID uint32, shardSIDs []net.IP) error {
 		len(shardSIDs), errors.Join(unresolved...))
 }
 
-// EgressDefaultRouteDel removes egress_route_table's default (::/0) entry
-// for Linux VRF table tableID -- EgressDefaultRouteAdd's counterpart.
+// EgressDefaultRouteDel removes egress_route_table's default (::/0) entry for
+// Linux VRF table tableID. The counterpart to EgressDefaultRouteAdd.
 func EgressDefaultRouteDel(tableID uint32) error {
 	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {
@@ -251,34 +185,17 @@ func EgressDefaultRouteDel(tableID uint32) error {
 	return table.Unregister(tableID, egressroutemap.DefaultPrefix)
 }
 
-// ResolveNodeSourceAddress resolves this node's own SRv6/underlay-facing
-// source address: the primary global IPv6 address on the same
-// interface(s) usid_ingress/usid_egress themselves are attached to
-// (attach.ResolveInterfaces).
+// ResolveNodeSourceAddress returns this node's underlay-facing source address:
+// the first global-scope IPv6 address on the interface usid_ingress and
+// usid_egress are attached to. usid_egress writes it as the source of every
+// outer header it pushes. A kernel-native encapsulation would pick it through
+// ordinary source-address selection; an in-program header push has to be told.
 //
-// This is the address usid_egress's egress-routing extension writes into
-// every outer header it pushes (via egressroutemap.NodeSourceAddress) --
-// the TC-BPF replacement's own analog of a property the kernel-native
-// SEG6 lwtunnel mechanism gave for free, via ordinary IPv6
-// source-address-selection (RTA_PREFSRC): confirmed live, `ip -6 route get
-// <SID>` reported `src 2001:db8:1:10::2` (this node's own fabric-facing
-// eth1 address) for every SEG6-encapsulated route this package ever
-// installed, with no explicit `src` ever configured anywhere in this
-// codebase.
-//
-// Deliberately reuses attach.ResolveInterfaces rather than re-deriving
-// "the fabric interface" via its own separate heuristic (an earlier
-// version of this function guessed from the main-table IPv6 default
-// route's own interface): found live, that guess is simply wrong on this
-// lab's own topology (and, in general, on any node where the default
-// route belongs to the cluster/pod network, not the SRv6 underlay) --
-// eth0 (the container network) carries the default route, while eth1
-// (the real fabric interface, attached to `GALACTIC_CNI_EBPF_INTERFACES`
-// or, in its absence, this same package's own auto-detected default-route
-// interface) does not. attach.ResolveInterfaces is the datapath's own,
-// already-correct answer to "which interface is the fabric one" -- reusing
-// it here guarantees this function can never disagree with wherever
-// usid_egress itself is actually attached.
+// The interface comes from attach.ResolveInterfaces rather than a separate
+// heuristic, so this can never disagree with where the datapath is actually
+// attached. Deriving it instead from the main-table default route would pick
+// the wrong interface on any node where the default route belongs to the
+// cluster network rather than the SRv6 underlay.
 func ResolveNodeSourceAddress() (net.IP, error) {
 	names, err := attach.ResolveInterfaces()
 	if err != nil {
@@ -304,25 +221,16 @@ func ResolveNodeSourceAddress() (net.IP, error) {
 	return nil, fmt.Errorf("no global-scope IPv6 address found on %s (the SRv6/underlay-facing interface)", names[0])
 }
 
-// ResolvePublicUplink resolves this node's own fabric-uplink interface's
-// real, physical next hop -- the link index plus the concrete L2
-// (destination and source MAC) address a DSR backend's VIP-sourced reply
-// must be redirected toward (egressroutemap.PublicUplink), unconditionally,
-// regardless of that reply's own real destination. See struct
-// public_uplink_value's own doc comment in usid.c for the full mechanism.
+// ResolvePublicUplink returns the fabric uplink's link index and the
+// destination and source MACs a DSR backend's VIP-sourced reply is redirected
+// toward, regardless of that reply's own destination. See struct
+// public_uplink_value in usid.c for how the datapath uses them.
 //
-// Deliberately reuses attach.ResolveInterfaces, the same as
-// ResolveNodeSourceAddress just above and for the identical reason: this
-// can never disagree with wherever usid_ingress/usid_egress are actually
-// attached. Every fabric uplink in this codebase's own topology (a
-// physical NIC on real hardware; a point-to-point veth to a transit
-// router in this repo's own containerlab lab) has exactly one real
-// neighbor, so -- unlike resolveLinkAndL2's own per-SID resolution,
-// which needs netlink.RouteGet to pick the right neighbor out of a link
-// with more than one -- this just takes whichever IPv6 neighbor entry on
-// that interface already has a resolved link-layer address, with no
-// destination-specific route lookup at all: there is only ever one
-// candidate to find.
+// The interface comes from attach.ResolveInterfaces, so this cannot disagree
+// with where the datapath is attached. A fabric uplink is point to point and
+// has exactly one real neighbor, so this takes the first resolved IPv6
+// neighbor on it instead of doing a destination-specific route lookup.
+// Returns an error when no neighbor has resolved yet.
 func ResolvePublicUplink() (linkIndex int, dmac, smac net.HardwareAddr, err error) {
 	names, err := attach.ResolveInterfaces()
 	if err != nil {
@@ -344,16 +252,10 @@ func ResolvePublicUplink() (linkIndex int, dmac, smac net.HardwareAddr, err erro
 		return 0, nil, nil, fmt.Errorf("list neighbors on %s: %w", names[0], err)
 	}
 	for _, n := range neighs {
-		// Every IPv6-enabled interface auto-populates a permanent,
-		// already-"resolved" multicast neighbor entry of its own (for its
-		// solicited-node/all-nodes group membership, MAC prefix 33:33::),
-		// regardless of whether any real unicast next hop has ever been
-		// discovered -- confirmed live, this is exactly what an earlier
-		// version of this loop (accepting any entry with a 6-byte
-		// HardwareAddr) matched first, on an interface with no genuine
-		// neighbor at all. n.IP.IsMulticast() excludes it; a real
-		// point-to-point uplink's only remaining entry is its one actual
-		// neighbor.
+		// Every IPv6 interface auto-populates a permanent, already-resolved
+		// multicast neighbor entry for its group memberships, whether or not
+		// any real next hop was ever discovered. Skipping multicast leaves
+		// only the genuine neighbor.
 		if len(n.HardwareAddr) == 6 && n.IP != nil && !n.IP.IsMulticast() {
 			return linkIndex, n.HardwareAddr, smac, nil
 		}

--- a/internal/plumbing/srv6/usid.go
+++ b/internal/plumbing/srv6/usid.go
@@ -12,15 +12,11 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// functionNibble maps an SRv6Function to its uFMT 48+16 Function value
-// (uformat.FunctionEndDT46 or FunctionEndDT2). End.DT46 is the only
-// officially supported value (go.datum.net/network's SRv6Function enum
-// dropped End.DT4/End.DT6 entirely -- neither was ever requested by any
-// caller in this codebase, and the uFMT shared Function/Argument slot has
-// no distinct wire code for a per-family variant anyway, design plan R3):
-// it is the only endpoint behavior the eBPF datapath's vrf_table ever
-// installs, regardless of pod-subnet address family (see
-// internal/cnibgp/bgp.go's registerEBPFDatapath/buildAdvertisementSpec).
+// functionNibble maps an SRv6Function to its 4-bit uFMT 48+16 Function value.
+// End.DT46 is the only accepted value: it is the only endpoint behavior the
+// eBPF datapath installs, whatever the pod subnet's address family, and the
+// shared Function/Argument slot has no distinct code for a per-family
+// variant. Any other function is an error.
 func functionNibble(fn bgpv1alpha1.SRv6Function) (uint8, error) {
 	if fn == bgpv1alpha1.SRv6FunctionEndDT46 {
 		return uformat.FunctionEndDT46, nil
@@ -29,9 +25,8 @@ func functionNibble(fn bgpv1alpha1.SRv6Function) (uint8, error) {
 }
 
 // ComputeSID derives the compressed SRv6 uSID for a (locator, nodeID,
-// argument, function) tuple in the `uFMT 48+16` REPLACE-CSID layout (RFC
-// 9800 §4.2.7; datum-cloud/enhancements#740 "Option 2 — Shared 16-bit
-// Slot"):
+// argument, function) tuple in the uFMT 48+16 REPLACE-CSID layout of RFC 9800
+// §4.2.7:
 //
 //	bits 1-48   uSID Block    (locator's network prefix; must be an IPv6 /48)
 //	bits 49-64  Node-ID       (nodeID; BGPRouterSpec.NodeID, this router's PoP-local slot)
@@ -42,8 +37,9 @@ func functionNibble(fn bgpv1alpha1.SRv6Function) (uint8, error) {
 //	                           from the VPCAttachment identifier)
 //	bits 81-128 Padding       (always zero)
 //
-// See internal/plumbing/ebpf/uformat for the field layout and the
-// encode/decode primitives this delegates to.
+// locator must be an IPv6 /48; nodeID and argument must fit their fields.
+// Returns the full 128-bit SID, or an error naming the field that is out of
+// range. See internal/plumbing/ebpf/uformat for the encode primitives.
 func ComputeSID(locator string, nodeID, argument int32, function bgpv1alpha1.SRv6Function) (netip.Addr, error) {
 	prefix, err := netip.ParsePrefix(locator)
 	if err != nil {

--- a/internal/plumbing/sysctl/sysctl.go
+++ b/internal/plumbing/sysctl/sysctl.go
@@ -28,10 +28,10 @@ var interfaceSettings = []struct {
 	{"net.ipv6.conf.%s.proxy_ndp", "1"},
 }
 
-// ConfigureInterfaceSysctls applies forwarding, rp_filter, and proxy ARP/NDP
-// sysctl settings to iface, which are required for correct VRF packet handling.
-// Silently skips sysctls that don't exist (e.g., in container environments
-// where dynamically created interfaces may not have all sysctl entries).
+// ConfigureInterfaceSysctls applies the forwarding, reverse-path filter, and
+// proxy ARP and NDP settings iface needs for correct VRF packet handling. A
+// sysctl that does not exist is skipped silently, as happens for dynamically
+// created interfaces in some container environments.
 func ConfigureInterfaceSysctls(iface string) error {
 	for _, entry := range interfaceSettings {
 		key := fmt.Sprintf(entry.format, iface)
@@ -42,29 +42,23 @@ func ConfigureInterfaceSysctls(iface string) error {
 	return nil
 }
 
-// ConfigureFIBLookupUplinkSysctls enables IPv6 forwarding on iface (a
-// galactic-gateway or galactic-nat66 node's public/fabric-facing uplink --
-// the interface edgedsr.c's edge_lb and nat66.c's nat66_ingress XDP
-// programs each attach to) and, needed alongside it,
-// net.ipv6.conf.all.forwarding.
+// ConfigureFIBLookupUplinkSysctls enables IPv6 forwarding on iface, a gateway
+// or NAT66 node's fabric-facing uplink, and alongside it the all-interfaces
+// forwarding sysctl.
 //
-// Without this, bpf_fib_lookup() (edgedsr.c's push_outer_header, and
-// nat66.c's identical mechanism in both its forward and return paths)
-// returns BPF_FIB_LKUP_RET_NOT_FWDED for every lookup -- the kernel
-// correctly refusing to resolve a forwarding route on an interface that
-// isn't configured as a router -- which neither datapath's own drop-reason
-// accounting could distinguish from a generic FIB lookup failure (see
-// edgedsr.c's DROP_REASON_FIB_LOOKUP_FAILED fallback and nat66.c's
-// equivalent). Found via live-kernel investigation of the containerlab
-// veth/XDP_TX blocker (deploy/containerlab/README.md): this sysctl gap,
-// not XDP_TX itself, is what actually prevented every gateway node's
-// bpf_fib_lookup from ever succeeding in that lab. Both the per-interface
-// and the "all" sysctl are set together because that combination is what
-// was empirically confirmed to unblock bpf_fib_lookup; per-interface alone
-// was not independently verified sufficient, and setting only "all" would
-// affect every interface on the node instead of just the uplink -- setting
-// both is the validated-safe choice, not a guess. Silently skips sysctls
-// that don't exist, matching ConfigureInterfaceSysctls's own convention.
+// Without them, bpf_fib_lookup returns not-forwarded for every lookup, the
+// kernel correctly refusing to resolve a forwarding route on an interface not
+// configured as a router. Neither datapath's drop accounting can tell that from
+// a generic lookup failure, so the symptom is a lookup that simply never
+// succeeds.
+//
+// Both the per-interface and the all-interfaces sysctl are set together because
+// that combination is what was confirmed to unblock the lookup. Per-interface
+// alone was not independently verified sufficient, and setting only the
+// all-interfaces one would affect every interface on the node rather than the
+// uplink.
+//
+// A sysctl that does not exist is skipped silently, as elsewhere here.
 func ConfigureFIBLookupUplinkSysctls(iface string) error {
 	settings := []struct{ key, value string }{
 		{fmt.Sprintf("net.ipv6.conf.%s.forwarding", iface), "1"},
@@ -78,11 +72,10 @@ func ConfigureFIBLookupUplinkSysctls(iface string) error {
 	return nil
 }
 
-// ConfigureTapSysctls applies sysctls appropriate for a tap interface
-// connected to a VM. Unlike ConfigureInterfaceSysctls, it skips
-// proxy_arp and proxy_ndp since the VM handles its own address resolution.
-// Silently skips sysctls that don't exist (e.g., in container environments
-// where dynamically created interfaces may not have all sysctl entries).
+// ConfigureTapSysctls applies the sysctls appropriate for a tap connected to a
+// VM. Unlike ConfigureInterfaceSysctls it skips proxy ARP and NDP, the VM
+// handling its own address resolution. A sysctl that does not exist is skipped
+// silently.
 func ConfigureTapSysctls(iface string) error {
 	settings := map[string]string{
 		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", iface):  "0",

--- a/internal/plumbing/vip/vip.go
+++ b/internal/plumbing/vip/vip.go
@@ -2,23 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package vip manages loopback-style VIP binding on backend nodes -- one
-// half of the DSR/Maglev gateway redesign's veth/container case (design
-// plan §0.1, §1): a backend node binds a service VIP to its own dedicated
-// dummy interface, letting the node itself verifiably answer on that
-// address (see Verify) without the reply ever passing back through
-// galactic-gateway. Requires CAP_NET_ADMIN, mirroring internal/plumbing/vrf.
+// Package vip manages loopback-style VIP binding on backend nodes: a node binds
+// a service VIP to its own dummy interface, letting the node verifiably answer
+// on that address without the reply passing back through the gateway. Requires
+// CAP_NET_ADMIN.
 //
-// This alone does not deliver anything to a VRF-isolated backend pod,
-// though: the dummy interface lives in the node's root network namespace,
-// not enslaved to any tenant VRF, and a DSR-forwarded ingress packet is
-// decapsulated straight into the owning tenant's own VRF routing table --
-// which has no route to an address that only exists outside it. The other
-// half, internal/plumbing/ebpf/vipxlatmap's vip_xlat_table translation
-// (originally built for the tap case only), now also runs for veth for
-// exactly this reason -- see
-// internal/controller.ServiceVIPBindingReconciler's own doc comment for
-// the live containerlab finding that surfaced this gap.
+// This alone delivers nothing to a VRF-isolated backend pod. The dummy interface
+// lives in the node's root namespace, enslaved to no tenant VRF, while a
+// forwarded ingress packet is decapsulated straight into the owning tenant's VRF
+// table, which has no route to an address existing only outside it. The address
+// translation in the eBPF map layer covers that half.
 package vip
 
 import (
@@ -31,23 +24,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// InterfaceName is the dedicated dummy link this package owns exclusively
-// for VIP addresses — not lo, since lo already carries the SRv6 locator
-// address internal/plumbing/loaddr.Detect reads; mixing VIP churn onto that
-// same interface risks disturbing the one address the fabric underlay
-// depends on.
+// InterfaceName is the dummy link this package owns exclusively for VIP
+// addresses. Not loopback, which already carries the SRv6 locator address the
+// underlay depends on: mixing VIP churn onto it risks disturbing that.
 const InterfaceName = "galactic-vip0"
 
-// vipMu serializes Bind/Unbind within a single process, mirroring
-// internal/plumbing/vrf's identical vrfMu — this package has no
-// cross-process lock file of its own because, unlike VRF creation (raced by
-// separate CNI plugin processes), every caller of this package runs inside
-// one long-lived galactic-router process.
+// vipMu serializes Bind and Unbind within one process. There is no
+// cross-process lock here because, unlike VRF creation, every caller runs inside
+// one long-lived process.
 var vipMu sync.Mutex
 
-// Bind idempotently assigns addr to InterfaceName, creating the interface
-// first if this is the first VIP ever bound on this node. Safe to call
-// repeatedly for the same address.
+// Bind idempotently assigns addr to InterfaceName, creating the interface if
+// this is the first VIP bound on this node. Safe to call repeatedly for the same
+// address.
 func Bind(addr net.IP) error {
 	vipMu.Lock()
 	defer vipMu.Unlock()
@@ -86,14 +75,13 @@ func Unbind(addr net.IP) error {
 	return nil
 }
 
-// Verify confirms addr is actually live: present in InterfaceName's address
-// list AND resolvable as a local (RTN_LOCAL) route via the kernel's own
-// route table -- not just "AddrAdd returned nil" (an address the kernel
-// duplicate-address-detection has since removed, for example, would still
-// have been accepted by AddrAdd at the time). Verify does not attempt to
-// contact any application-level listener on addr:port -- whether something
-// is actually listening on it is the workload's concern, not this
-// package's.
+// Verify confirms addr is live: present in the interface's address list and
+// resolvable as a local route in the kernel's own table. That is more than the
+// add having returned successfully, since an address duplicate-address detection
+// has since removed would still have been accepted at the time.
+//
+// It does not contact any listener on the address: whether something is
+// listening is the workload's concern.
 func Verify(addr net.IP) error {
 	link, err := netlink.LinkByName(InterfaceName)
 	if err != nil {
@@ -131,10 +119,8 @@ func Verify(addr net.IP) error {
 	return fmt.Errorf("vip: %s is not resolvable as a local route", addr)
 }
 
-// ensureInterface returns InterfaceName, creating it as a dummy link (and
-// bringing it up) the first time this is called on a node -- idempotent by
-// name, mirroring internal/plumbing/vrf.Add's identical
-// LinkByName-then-LinkAdd pattern.
+// ensureInterface returns InterfaceName, creating it as a dummy link and
+// bringing it up the first time this is called on a node. Idempotent by name.
 func ensureInterface() (netlink.Link, error) {
 	if link, err := netlink.LinkByName(InterfaceName); err == nil {
 		return link, nil
@@ -155,9 +141,8 @@ func ensureInterface() (netlink.Link, error) {
 	return link, nil
 }
 
-// hostNet returns addr expressed as its own host route (a /32 for IPv4, a
-// /128 for IPv6) -- the mask AddrAdd/AddrDel need to bind a single VIP
-// without claiming a whole subnet on InterfaceName.
+// hostNet returns addr as its own host route, the mask needed to bind a single
+// VIP without claiming a whole subnet on the interface.
 func hostNet(addr net.IP) *net.IPNet {
 	if v4 := addr.To4(); v4 != nil {
 		return &net.IPNet{IP: v4, Mask: net.CIDRMask(32, 32)}

--- a/internal/plumbing/vrf/lock.go
+++ b/internal/plumbing/vrf/lock.go
@@ -12,22 +12,21 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// lockDir is the well-known parent directory for the node-local flock that
-// serializes VRF table ID allocation across separate CNI plugin invocations.
-// Each CNI ADD/DEL is its own OS process, so two pods attaching to different
-// VPCs concurrently on the same node construct independent calls into this
-// package against the same node-wide VRF table ID space; an in-process
-// sync.Mutex (vrfMu) does nothing to serialize across those process
-// boundaries, which lets both processes race in findNextAvailableVRFID and
-// netlink.LinkAdd, surfacing as "device or resource busy" from the kernel.
+// lockDir is the node-local parent directory for the lock serializing VRF table
+// ID allocation across separate CNI invocations.
+//
+// Each ADD and DEL is its own process, so two pods attaching to different VPCs
+// concurrently on one node make independent calls into this package against the
+// same node-wide table ID space. An in-process mutex does nothing across those
+// boundaries, and both processes then race in ID selection and link creation,
+// surfacing as a busy-device error from the kernel.
 const lockDir = "/var/lib/cni/galactic-vrf"
 
 const lockFileName = "lock"
 
-// fileLock is a cross-process advisory lock backed by flock(2), mirroring
-// internal/cni/ipam's fileLock: flock(2) locks are held per open file
-// description, so any number of processes opening the same path contend for
-// the same lock.
+// fileLock is a cross-process advisory lock. Such locks are held per open file
+// description, so any number of processes opening the same path contend for the
+// same lock.
 type fileLock struct {
 	f *os.File
 }

--- a/internal/plumbing/vrf/vrf.go
+++ b/internal/plumbing/vrf/vrf.go
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package vrf manages Linux VRF interfaces for Galactic VPC network isolation.
-// Each VPC gets its own VRF with a unique routing table ID, per node — shared
-// by every attachment (pod or VM) landing on that VPC on that node, not
-// per-attachment. Requires CAP_NET_ADMIN.
+// Package vrf manages the Linux VRF interfaces that isolate Galactic VPC
+// networks. Each VPC gets one VRF with its own routing table ID per node,
+// shared by every attachment landing on that VPC on that node rather than one
+// per attachment. Requires CAP_NET_ADMIN.
 package vrf
 
 import (
@@ -24,32 +24,29 @@ import (
 const minVRFID = uint32(1)
 const maxVRFID = uint32(math.MaxUint32 - 1)
 
-// ErrNotFound is returned (wrapped) by TableID when no VRF interface for
-// that VPC exists in *this process's own* network namespace. Callers need
-// this distinguishable from a genuine netlink failure because "absent" is
-// an ordinary, expected condition for some callers rather than an error:
-// galactic-router runs in the host's root netns and legitimately cannot
-// see a VRF #855's ingress sidecar created inside Envoy's own pod netns
-// (see internal/runtime/gobgp's vrfTableID), while a failed
-// netlink.LinkList is a real problem worth surfacing either way.
+// ErrNotFound is wrapped by TableID when no VRF interface for that VPC exists
+// in this process's own network namespace.
+//
+// Callers need that distinguishable from a genuine netlink failure, because
+// absent is an ordinary condition for some of them: a process in the host's
+// root namespace legitimately cannot see a VRF the ingress sidecar created
+// inside a pod's namespace, while a failed link listing is a real problem
+// either way.
 var ErrNotFound = errors.New("vrf: no VRF interface for this VPC in this network namespace")
 
-// vrfMu serializes VRF creation/deletion within a single process (e.g.
-// concurrent goroutines in galactic-router's GC). It does not, by itself,
-// protect against two separate CNI ADD/DEL invocations racing on the same
-// node — each is its own OS process — so Add and Delete also take the
-// cross-process flock in lock.go.
+// vrfMu serializes VRF creation and deletion within one process. It does not by
+// itself protect two separate CNI invocations racing on the same node, each
+// being its own process, so Add and Delete also take a cross-process lock.
 var vrfMu sync.Mutex
 
-// Add creates a Linux VRF interface for the given base62-encoded VPC,
-// allocating the next available routing table ID and applying the required
-// sysctl settings. The VRF is shared by every attachment (pod or VM) on this
-// VPC on this node: concurrent calls — whether from goroutines in this
-// process, from separate CNI plugin processes attaching different pods to
-// the same VPC, or both — are serialized, and Add is idempotent by name. If
-// a VRF with the same name already exists (because another attachment on
-// this VPC already created it, or one was left behind by a previous failed
-// cmdAdd with no corresponding cmdDel), Add returns nil.
+// Add creates the Linux VRF interface for a base62-encoded VPC, allocating the
+// next available routing table ID and applying the required sysctls.
+//
+// The VRF is shared by every attachment on this VPC on this node, so concurrent
+// calls, from goroutines here or from separate plugin processes attaching
+// different pods, are serialized. It is idempotent by name: a VRF that already
+// exists, whether created by a sibling attachment or left behind by a failed
+// ADD, returns nil.
 func Add(vpc string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
@@ -93,14 +90,15 @@ func Add(vpc string) error {
 	return netlink.LinkSetUp(vrf)
 }
 
-// Delete flushes all routes from the VRF routing table and removes the VRF
-// interface for the given base62-encoded VPC. Delete is idempotent: if the
-// VRF interface does not exist, it returns nil. Callers must only invoke
-// Delete once no attachment on this VPC on this node remains live — deleting
-// out from under a still-live sibling attachment breaks it. galactic-veth's
-// own cmdDel never calls this directly for exactly that reason; only
-// galactic-router's GC controller does, after confirming via every
-// BGPAdvertisement for this VPC/node that none are still in use.
+// Delete flushes every route from the VRF's routing table and removes the
+// interface for a base62-encoded VPC. Idempotent: an absent interface returns
+// nil.
+//
+// Callers must only invoke it once no attachment on this VPC on this node
+// remains live, since deleting out from under a sibling breaks it. The CNI
+// teardown path never calls it for that reason; only garbage collection does,
+// after confirming through every advertisement for this VPC and node that none
+// is still in use.
 func Delete(vpc string) error {
 	vrfMu.Lock()
 	defer vrfMu.Unlock()
@@ -130,11 +128,10 @@ func Delete(vpc string) error {
 	return netlink.LinkDel(link)
 }
 
-// TableID returns the Linux routing table ID for the VRF associated with the
-// given base62-encoded VPC. The returned error wraps ErrNotFound when no
-// such interface exists in this process's own network namespace — see that
-// variable's doc comment for why callers may need to treat that case as
-// ordinary rather than as a failure.
+// TableID returns the Linux routing table ID for a base62-encoded VPC's VRF.
+// The error wraps ErrNotFound when no such interface exists in this process's
+// own network namespace, which some callers treat as ordinary rather than a
+// failure.
 func TableID(vpc string) (uint32, error) {
 	return getVRFIDForInterface(intf.GenerateInterfaceNameVRF(vpc))
 }
@@ -149,18 +146,15 @@ func Exists(vpc string) error {
 	return nil
 }
 
-// FlushTable removes every IPv4 and IPv6 route from the given Linux routing
-// table ID. Add calls this before creating a VRF on a reused table ID (a
-// table can be reused if a previous VRF using it was removed without going
-// through Delete, e.g. a hard node reboot), and Delete calls it before
-// removing the VRF interface — so a stale table is always cleared on reuse
-// rather than inherited.
+// FlushTable removes every IPv4 and IPv6 route from the given routing table.
+// Add calls it before creating a VRF on a reused table ID, which happens when a
+// previous VRF was removed without going through Delete, and Delete calls it
+// before removing the interface, so a stale table is always cleared rather than
+// inherited.
 //
-// Exported so internal/gc's legacy-name fallback in RemoveOrphanedVRFs (a
-// pre-rename VRF interface Delete can't resolve by name, so it removes the
-// link directly instead of going through Delete) can flush the table itself
-// before removing the link, and get the same guarantee Delete gives the
-// normal path — see RemoveOrphanedVRFs' own doc comment and #343.
+// Exported so garbage collection's fallback path, which removes a legacy-named
+// interface directly rather than through Delete, can flush the table itself and
+// get the same guarantee.
 func FlushTable(vrfID uint32) error {
 	for _, family := range []int{unix.AF_INET, unix.AF_INET6} {
 		routes, err := netlink.RouteListFiltered(

--- a/internal/reconcile/reconcile.go
+++ b/internal/reconcile/reconcile.go
@@ -23,12 +23,9 @@ import (
 	bgpv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// legacySRv6SIDAnnotation is the pre-VRFID/Function fallback annotation used
-// when a BGPAdvertisement or its BGPRouter has not yet been migrated to the
-// RFC 9800 NEXT-CSID uSID fields (VRFID/Function on the advertisement,
-// SRv6Locator/NodeID on the router). This keeps existing containerlab
-// labs/e2e fixtures working since their BGPRouter definitions may not yet set
-// NodeID.
+// legacySRv6SIDAnnotation carries a SID directly, for a BGPAdvertisement or
+// BGPRouter not yet migrated to the uSID fields. It keeps lab and test fixtures
+// working whose routers may not set a node ID.
 const legacySRv6SIDAnnotation = "galactic.datum.net/srv6-sid"
 
 // Reconciler assembles DesiredRouter values from BGP CRDs.
@@ -39,9 +36,9 @@ type Reconciler struct {
 }
 
 // New returns a Reconciler for the given node and local BGP address.
-// localAddress, when non-empty, is used as the EVPN next-hop instead of the
-// node's first IPv6 InternalIP — required when the node InternalIP is not
-// reachable via the SRv6 transit mesh (e.g. Kind/ContainerLab Docker bridge).
+// localAddress, when non-empty, is used as the EVPN next hop instead of the
+// node's first IPv6 internal address, which is required when that address is
+// not reachable over the SRv6 transit mesh.
 func New(c client.Client, nodeName, localAddress string) *Reconciler {
 	return &Reconciler{
 		client:       c,
@@ -50,9 +47,9 @@ func New(c client.Client, nodeName, localAddress string) *Reconciler {
 	}
 }
 
-// BuildDesiredRouter assembles the full DesiredRouter from BGP CRDs for
-// the given BGPRouter. It returns (nil, nil) if the router should be silently
-// skipped (wrong node). It returns (nil, err) on error.
+// BuildDesiredRouter assembles the full desired router from BGP CRDs for the
+// given BGPRouter. It returns nil with a nil error when the router targets
+// another node and should be silently skipped.
 func (r *Reconciler) BuildDesiredRouter(
 	ctx context.Context, router *bgpv1alpha1.BGPRouter,
 ) (*model.DesiredRouter, error) {
@@ -84,10 +81,9 @@ func (r *Reconciler) BuildDesiredRouter(
 		return nil, fmt.Errorf("list BGPAdvertisements for router %s/%s: %w", namespace, router.Name, err)
 	}
 
-	// Gather VRF instances. A node hosts one BGPVRFInstance per VPC that has
-	// at least one attachment here — shared by every attachment on that
-	// VPC/node, not one per attachment — so every instance targeting this
-	// router must be carried into DesiredRouter — not just the first.
+	// A node hosts one instance per VPC with at least one attachment here,
+	// shared by every attachment on that VPC, so every instance targeting this
+	// router must be carried through, not just the first.
 	vrfList := &bgpv1alpha1.BGPVRFInstanceList{}
 	if err := r.client.List(ctx, vrfList,
 		client.InNamespace(namespace),
@@ -100,10 +96,9 @@ func (r *Reconciler) BuildDesiredRouter(
 		vrfInstances[i] = buildVRFInstance(v)
 	}
 
-	// Resolve the EVPN next-hop. When localAddress is set (e.g. from
-	// BGP_LOCAL_ADDRESS), use it directly — it is the transit-reachable
-	// address. Fall back to the node's first IPv6 InternalIP only when
-	// localAddress is not configured.
+	// Resolve the EVPN next hop. A configured local address is used directly,
+	// being the transit-reachable one; otherwise fall back to the node's first
+	// IPv6 internal address.
 	var nextHop string
 	if r.localAddress != "" {
 		nextHop = r.localAddress
@@ -339,10 +334,9 @@ func policyTargetsRouter(policy *bgpv1alpha1.BGPPolicy, router *bgpv1alpha1.BGPR
 	return false
 }
 
-// buildVRFInstance converts a BGPVRFInstance CRD into a DesiredVRFInstance.
-// VRFID carries straight through; the runtime derives the RFC 4364 Type 1
-// route distinguisher ("routerID:vrfID") from it rather than the CRD storing
-// one directly.
+// buildVRFInstance converts a BGPVRFInstance into its desired-state form. The
+// VRFID carries straight through, and the runtime derives the route
+// distinguisher from it rather than the CRD storing one.
 func buildVRFInstance(v bgpv1alpha1.BGPVRFInstance) model.DesiredVRFInstance {
 	importRTs := make([]string, len(v.Spec.ImportRouteTargets))
 	for j, rt := range v.Spec.ImportRouteTargets {
@@ -360,11 +354,10 @@ func buildVRFInstance(v bgpv1alpha1.BGPVRFInstance) model.DesiredVRFInstance {
 	}
 }
 
-// resolveSRv6SID computes the SRv6 SID to place in the EVPN GWIPAddress field
-// for adv on router. When adv.Spec.VRFID and adv.Spec.Function are both set,
-// and router.Spec.SRv6Locator and router.Spec.NodeID are both configured, the
-// SID is derived via srv6.ComputeSID (RFC 9800 NEXT-CSID uSID compression).
-// Otherwise it falls back to the legacy srv6-sid annotation.
+// resolveSRv6SID computes the SID to advertise for adv on router. When the
+// advertisement carries both a VRFID and a function, and the router a locator
+// and a node ID, the SID is derived from them. Otherwise it falls back to the
+// legacy annotation.
 func resolveSRv6SID(router *bgpv1alpha1.BGPRouter, adv *bgpv1alpha1.BGPAdvertisement) (string, error) {
 	if adv.Spec.VRFID == nil || adv.Spec.Function == nil ||
 		router.Spec.SRv6Locator == "" || router.Spec.NodeID == 0 {

--- a/internal/runtime/gobgp/monitor.go
+++ b/internal/runtime/gobgp/monitor.go
@@ -26,27 +26,23 @@ import (
 	vrfpkg "go.datum.net/galactic/internal/plumbing/vrf"
 )
 
-// pinDir is the bpffs directory probeEgressRouteWrite opens egress_route_table
-// from -- a package var defaulting to attach.PinDir, the same test seam
-// internal/plumbing/srv6's own pinDir var provides, so this package's tests
-// don't depend on a real bpffs mount or root privileges either.
+// pinDir is the bpffs directory probeEgressRouteWrite opens
+// egress_route_table from. A package var so tests need no bpffs mount or
+// root.
 var pinDir = attach.PinDir
 
 // errVRFNotInThisNetns marks the one vrfTableID failure that is an ordinary
-// operating condition rather than a fault: the VRF exists, just not in this
-// process's own network namespace. applyVRFs skips such a VRF at debug
-// level instead of reporting that its routes will not be installed --
-// see vrfTableID's own History note for why there is nothing for this
-// process to install in that case anyway.
+// condition rather than a fault: the VRF exists, but not in this process's
+// network namespace. applyVRFs skips such a VRF at debug level, since there is
+// nothing for this process to install for it anyway.
 var errVRFNotInThisNetns = errors.New("kernel VRF interface is not in this process's network namespace")
 
-// startRIBMonitor starts the shared EVPN best-path watcher goroutine once per
-// GoBGPRuntime lifetime, regardless of how many VRFs exist. It installs and
-// removes kernel SEG6 encap routes in the relevant VRF routing table as
-// remote EVPN Type 5 paths are added or withdrawn, dispatching each path to
-// its VRF via rtIndex (kept current by applyVRFs) rather than being scoped to
-// one VRF — a node can host thousands of VRFs, one per VPC attachment, so a
-// dedicated goroutine and WatchEvent subscription per VRF would not scale.
+// startRIBMonitor starts the shared EVPN best-path watcher goroutine, once per
+// runtime lifetime however many VRFs exist. It installs and removes routes in
+// the relevant VRF routing table as remote EVPN Type 5 paths are added and
+// withdrawn, dispatching each path to its VRF through the route-target index.
+// One goroutine and subscription for all VRFs, because a node can host
+// thousands and one per VRF would not scale.
 func (r *GoBGPRuntime) startRIBMonitor(b *gobgpserver.BgpServer) {
 	if r.srvCtx == nil {
 		slog.Info("startRIBMonitor: skipping — srvCtx is nil")
@@ -75,20 +71,16 @@ func (r *GoBGPRuntime) watchEVPNRIB(ctx context.Context, b *gobgpserver.BgpServe
 	}
 }
 
-// backfillEVPNRoutes scans the current global EVPN RIB and (re)applies every
-// best path against rtIndex. It is called synchronously from applyVRFs right
-// after a new VRF is registered, to catch remote paths that were already
-// best-path before that VRF's route target existed in rtIndex.
+// backfillEVPNRoutes scans the current global EVPN RIB and reapplies every best
+// path against the route-target index. applyVRFs calls it synchronously right
+// after registering a new VRF, to catch remote paths that were already best
+// path before that VRF's route target was indexed.
 //
-// This matters because the shared watchEVPNRIB goroutine starts once for the
-// whole runtime and registers WatchBestPath(true), which only replays the
-// then-current RIB at that single moment. VRFs are registered incrementally
-// as BGPVRFInstance CRDs are reconciled (potentially thousands, arriving over
-// time), so a remote path that became best-path before its VRF's RT was
-// indexed would otherwise never be installed — WatchBestPath only notifies on
-// future changes, not on-demand re-delivery. Since RouteEgressAdd is a
-// netlink route replace, re-applying already-installed routes here is a
-// harmless no-op.
+// The shared watcher registers for best-path notifications once and replays the
+// RIB only at that moment, while VRFs are registered incrementally as CRDs are
+// reconciled. Without this, a path that became best before its route target was
+// indexed would never be installed, since the watch notifies only on future
+// changes. Reapplying an already-installed route is a harmless replace.
 func (r *GoBGPRuntime) backfillEVPNRoutes(b *gobgpserver.BgpServer) {
 	err := b.ListPath(apiutil.ListPathRequest{
 		TableType: api.TableType_TABLE_TYPE_GLOBAL,
@@ -106,9 +98,9 @@ func (r *GoBGPRuntime) backfillEVPNRoutes(b *gobgpserver.BgpServer) {
 	}
 }
 
-// processEVPNPath installs or withdraws the kernel SEG6 encap route for a
-// single EVPN Type 5 path if it matches a VRF in rtIndex. logPrefix names the
-// caller for log correlation (the shared watcher vs. a VRF-registration backfill).
+// processEVPNPath installs or withdraws the route for a single EVPN Type 5 path
+// when it matches a known VRF. logPrefix names the caller, the shared watcher
+// or a registration backfill, for log correlation.
 func (r *GoBGPRuntime) processEVPNPath(path *apiutil.Path, logPrefix string) {
 	if path.Family != bgp.RF_EVPN {
 		return
@@ -149,13 +141,12 @@ func (r *GoBGPRuntime) processEVPNPath(path *apiutil.Path, logPrefix string) {
 		return
 	}
 
-	// The destination SRv6 SID travels in the BGP Prefix-SID attribute (see
-	// prefixSIDAttr in paths.go), not the EVPN route's own Gateway IP field —
-	// that field can't carry an IPv6 SID for an IPv4 prefix (RFC 9136 requires
-	// the Gateway IP and Prefix to share an address family), so relying on it
-	// here silently installed a garbage seg6 segment for every IPv4 VPC
-	// prefix. Fall back to the transit next-hop when no Prefix-SID attribute
-	// is present (non-SRv6 advertisements — see buildEVPNPaths).
+	// The destination SID travels in the BGP Prefix-SID attribute, not the EVPN
+	// route's Gateway IP field. That field cannot carry an IPv6 SID for an IPv4
+	// prefix, since RFC 9136 requires the Gateway IP and Prefix to share an
+	// address family, so reading it installs a garbage segment for every IPv4
+	// VPC prefix. Fall back to the transit next hop for non-SRv6
+	// advertisements, which carry no Prefix-SID.
 	gw, ok := evpnPrefixSID(path.Attrs)
 	if !ok {
 		if nh := evpnMpReachNexthop(path.Attrs); nh != "" {
@@ -177,44 +168,32 @@ func (r *GoBGPRuntime) processEVPNPath(path *apiutil.Path, logPrefix string) {
 	}
 }
 
-// routeInstall is matchTableID's result: which kernel table processEVPNPath
-// should install path's route into, and which of srv6's two installers to
-// use -- RouteEgressAdd's SEG6 encap (a VRF-scoped tenant path, whose gw
-// always resolves to a real uSID decap SID) or RouteMainAdd's plain
-// next-hop route (plain is true; see RouteMainAdd's own doc comment for
-// why an RT-less path needs this instead).
+// routeInstall is matchTableID's result: which kernel table the route belongs
+// in, and which installer to use. plain selects an ordinary next-hop route for
+// a path with no route target; otherwise the route is encapsulated toward a
+// uSID decap SID.
 type routeInstall struct {
 	tableID uint32
 	plain   bool
 }
 
-// matchTableID resolves how to install one EVPN Type 5 path's route.
+// matchTableID resolves how to install one EVPN Type 5 path's route, and
+// reports false when the path belongs to no VRF this node participates in.
 //
-// A path carrying at least one Route Target extended community is a
-// tenant VRF route: matchTableID looks up the kernel VRF table that
-// imports one of those RTs, via the RT index maintained by applyVRFs, and
-// returns false if no VRF configured on this node imports any RT on the
-// path (a VRF this node doesn't participate in -- correctly skipped, not
-// installed anywhere). This is an O(1)-per-community lookup, not an
-// O(#VRFs) scan, so it stays cheap even with thousands of VRFs on the node.
+// A path carrying at least one route target is a tenant VRF route. It is looked
+// up in the route-target index applyVRFs maintains, an O(1) lookup per
+// community rather than a scan over VRFs, so it stays cheap with thousands on a
+// node.
 //
-// A path carrying no Route Target community at all is not VRF-scoped by
-// construction (buildEVPNPaths in paths.go only attaches the extended
-// communities attribute "if len(rts) > 0") -- e.g.
-// NetworkGatewayReconciler's anycast ingress-VIP advertisements, which
-// leave VRFID/Function unset for exactly this reason (that reconciler's
-// own package doc comment). Such a path is installed into the kernel's
-// main routing table (table ID 0, which both the kernel and this
-// vishvananda/netlink call resolve to RT_TABLE_MAIN when left unset) via
-// RouteMainAdd's plain routing, not RouteEgressAdd's SEG6 encap -- see that
-// function's own doc comment for why. This previously silently dropped
-// every anycast VIP path on every node in the mesh (found live: a
-// containerlab NetworkGateway/NetworkRule canary's VIP was never reachable
-// from any other site, even once BGP itself and the DSR/Maglev datapath
-// were both working correctly) -- gated on the absence of any RT
-// altogether, not merely a lookup miss, so a genuine unrecognized-VRF path
-// still correctly falls through to false above rather than being installed
-// into main by accident.
+// A path carrying no route target is not VRF-scoped by construction, since the
+// extended communities attribute is attached only when there is at least one.
+// The anycast ingress-VIP advertisements are the case today, and they leave
+// VRFID and Function unset for exactly this reason. Such a path goes into the
+// main routing table as a plain route rather than an encapsulated one.
+//
+// The distinction is on the absence of any route target, not on a lookup miss,
+// so a path naming a VRF this node does not have still returns false rather
+// than landing in the main table by accident.
 func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeInstall, bool) {
 	r.rtIndexMu.RLock()
 	defer r.rtIndexMu.RUnlock()
@@ -239,59 +218,30 @@ func (r *GoBGPRuntime) matchTableID(attrs []bgp.PathAttributeInterface) (routeIn
 }
 
 // vrfTableID resolves the kernel VRF table ID for a VRF named "{vpc}-{node}",
-// where vpc is hex-encoded per crdnames.BGPVRFInstanceName/VPCSegment. The
-// kernel VRF itself is keyed by the base62 vpc alone (it's shared by every
-// attachment on this VPC on this node — vrfpkg.TableID needs no node
-// component, since interface names only need to be unique within one host's
-// own namespace), so only the segment before the first '-' matters here;
-// node can itself contain '-' (e.g. "dfw-worker-control"), which is why this
-// splits into exactly 2 parts instead of parsing node back out too. The hex
-// segment has to be decoded back to base62 before it can be used to build
-// the kernel interface name — intf.HexToBase62 naturally errors out on the
-// SHA-256 hash fallback form (crdnames.nameSegment's "x..." prefix, for VPCs
-// that don't cleanly hex-encode), which is correct here too: that form was
-// never recoverable to a real interface name in the first place.
+// where vpc is hex-encoded.
 //
-// A VRF absent from this process's own netns is reported by wrapping
-// errVRFNotInThisNetns, so applyVRFs can treat it as an ordinary skip
-// rather than a failure -- see that variable's own doc comment.
+// The kernel VRF is keyed by the base62 vpc alone, since it is shared by every
+// attachment on this VPC on this node and interface names need only be unique
+// within one host. Only the segment before the first '-' matters, which is why
+// this splits into exactly two parts: a node name may itself contain '-'. The
+// hex segment is decoded back to base62 to build the interface name, which
+// naturally errors on the hash fallback form used for a VPC that does not
+// cleanly hex-encode. That form was never recoverable to an interface name.
 //
-// vrfpkg.TableID's own netlink.LinkList() call is scoped to this
-// process's own network namespace -- galactic-router runs
-// hostNetwork: true, so that's the host's root netns, correct for a VRF
-// galactic-cni created there directly for a real tenant pod's own CNI
-// attachment. It is structurally blind to a VRF #855's ingress sidecar
-// creates instead, which lives entirely inside Envoy's own pod netns by
-// design (so its own SO_BINDTODEVICE calls resolve there). Confirmed
-// live on us-central-1-staging-lab: a node running only the ingress
-// sidecar for a given VPC -- no real tenant CNI attachment for it at all
-// -- never has that VRF's interface visible in its own root netns, so
-// this lookup fails on every single reconcile, forever; not a race, not
-// something a restart or a longer wait fixes.
+// A VRF absent from this process's netns is reported by wrapping
+// errVRFNotInThisNetns, so applyVRFs treats it as an ordinary skip.
 //
-// History: that condition was previously handled by falling back to
-// reading the pinned vrf_table for the VPC's own (block, argument) row,
-// on the stated premise that "internal/ingresssidecar's own
-// ensureEgressDatapath already writes this exact (block, argument) ->
-// kernel table ID mapping there". It does not, on either half of the
-// key: that fallback derived block from the *VPC identifier*
-// (intf.Base62ToHex(vpc) parsed as hex) while every writer of that map
-// keys block off an SRv6 locator's own top 48 bits (uformat.Block, e.g.
-// internal/cnibgp's registerEBPFDatapath) or off the reserved
-// uformat.BlockMax the sidecar itself uses; and it looked up
-// BGPVRFInstance.Spec.VRFID as the argument while the sidecar registers
-// vrf.TableID(vpc) -- two unrelated allocators. The lookup therefore
-// could never hit any real row, and its "no vrf_table entry exists
-// either" error was reported for every sidecar-owned VRF regardless of
-// what the map actually held. Removed rather than re-keyed: on a node
-// whose only consumer of that VPC is Envoy, the egress_route_table
-// entries this table id would have been used to install are already
-// written per-EndpointSlice by the sidecar itself
-// (internal/ingresssidecar's kernelBackend.EnsureRoute ->
-// srv6.RouteEgressAdd), and Envoy only ever connects to backends those
-// same EndpointSlices published -- so there is nothing for this process
-// to add there, and the honest handling is to skip quietly rather than
-// to recover a table id for redundant work.
+// The underlying link lookup is scoped to this process's namespace. This
+// process runs with host networking, which is correct for a VRF the CNI created
+// there for a tenant pod, and structurally blind to one the ingress sidecar
+// creates inside an Envoy pod's namespace so its own socket binds resolve
+// there. On a node running only the sidecar for a VPC, that lookup fails on
+// every reconcile and no restart or wait changes it.
+//
+// Skipping quietly is the honest handling. On such a node the egress routes
+// this table ID would install are already written per-EndpointSlice by the
+// sidecar itself, and Envoy only connects to backends those slices published,
+// so there is nothing for this process to add.
 func vrfTableID(vrfName string) (uint32, error) {
 	parts := strings.SplitN(vrfName, "-", 2)
 	if len(parts) != 2 {
@@ -312,10 +262,9 @@ func vrfTableID(vrfName string) (uint32, error) {
 	return tableID, nil
 }
 
-// evpnMpReachNexthop returns the MpReachNLRI next-hop address string from path
-// attrs, or empty string if none is found. Used to identify locally-originated
-// EVPN paths, and as the non-SRv6 fallback gateway when no Prefix-SID
-// attribute is present (see evpnPrefixSID).
+// evpnMpReachNexthop returns the MpReachNLRI next-hop address from attrs, or ""
+// when none is found. It identifies locally-originated paths, and serves as the
+// gateway for a path carrying no Prefix-SID attribute.
 func evpnMpReachNexthop(attrs []bgp.PathAttributeInterface) string {
 	for _, attr := range attrs {
 		if mp, ok := attr.(*bgp.PathAttributeMpReachNLRI); ok {
@@ -325,12 +274,11 @@ func evpnMpReachNexthop(attrs []bgp.PathAttributeInterface) string {
 	return ""
 }
 
-// evpnPrefixSID extracts the destination SRv6 SID from a BGP Prefix-SID path
-// attribute's SRv6 L3 Service TLV (RFC 9252), if present. This is the sole
-// carrier for the SID in this design — see prefixSIDAttr in paths.go. Unlike
-// the EVPN Type 5 route's own Gateway IP field, the Prefix-SID attribute is a
-// separate path attribute independent of the NLRI's address family, so it
-// carries a SID correctly for both IPv4 and IPv6 VPC prefixes.
+// evpnPrefixSID extracts the destination SRv6 SID from a BGP Prefix-SID
+// attribute's SRv6 L3 Service TLV, reporting whether one was present. It is the
+// only carrier for the SID in this design. Being a separate path attribute,
+// independent of the NLRI's address family, it carries a SID correctly for both
+// IPv4 and IPv6 VPC prefixes.
 func evpnPrefixSID(attrs []bgp.PathAttributeInterface) (net.IP, bool) {
 	for _, attr := range attrs {
 		psid, ok := attr.(*bgp.PathAttributePrefixSID)
@@ -354,14 +302,13 @@ func evpnPrefixSID(attrs []bgp.PathAttributeInterface) (net.IP, bool) {
 	return nil, false
 }
 
-// addrToIPNet converts a netip.Addr and prefix length to a masked *net.IPNet.
-// IPv4 addresses are kept in native 4-byte form: netip.Addr.As16() returns an
-// IPv4-mapped 16-byte address, but pairing that with net.CIDRMask(bits, 128)
-// sets the mask's leading bits — the wrong end for a 4-in-16 address, whose
-// meaningful octets sit in the last 4 bytes — so consumers that reduce the IP
-// to 4 bytes (net.IP.To4(), as net.IPNet.String() and vishvananda/netlink's
-// family detection both do) see the mask's trailing, unset bits and read the
-// prefix length as 0 regardless of bits.
+// addrToIPNet converts addr and a prefix length of bits to a masked *net.IPNet.
+//
+// IPv4 addresses are kept in native 4-byte form. An IPv4-mapped 16-byte address
+// paired with a 128-bit mask sets the mask's leading bits, the wrong end for an
+// address whose meaningful octets are the last four, so any consumer that
+// reduces the address to 4 bytes reads the prefix length as 0 whatever bits
+// says.
 func addrToIPNet(addr netip.Addr, bits int) *net.IPNet {
 	masked := netip.PrefixFrom(addr, bits).Masked()
 	if masked.Addr().Is4() {
@@ -384,31 +331,21 @@ func addrToNetIP(addr netip.Addr) net.IP {
 	return ip
 }
 
-// probeEgressRouteWrite verifies that this process can actually write
-// egress_route_table entries for tableID before applyVRFs trusts this VRF's
-// routing to work at all. It installs a pass-through test entry for a
-// prefix from the RFC 3849 documentation range (2001:db8::/32) — which can
-// never conflict with real VPC traffic — then immediately removes it. A
-// pass-through entry (RegisterPassThrough, not Register) is deliberate:
-// unlike a real route, it needs no SID/next-hop resolution, so this probe
-// only exercises the one thing it exists to check -- the pinned bpffs map's
-// open+write path -- not incidentally depending on some other prefix
-// already having a resolvable neighbor.
+// probeEgressRouteWrite verifies that this process can write
+// egress_route_table entries for tableID, before applyVRFs trusts this VRF's
+// routing to work. It installs a pass-through entry for a prefix from the RFC
+// 3849 documentation range, which can never conflict with real traffic, then
+// removes it.
 //
-// This replaces an earlier version of this probe that wrote a real kernel
-// route via netlink instead (the same RFC 3849 prefix, same install/remove
-// shape) -- a leftover check from this codebase's pre-TC-BPF design, when
-// RouteEgressAdd really did write kernel SEG6 routes and so really did need
-// CAP_NET_ADMIN. Since the TC-BPF migration (see RouteEgressAdd's own doc
-// comment in internal/plumbing/srv6/egress.go), installing a VRF's routes
-// only ever writes into this pinned eBPF map — never the kernel FIB — so a
-// probe that tests kernel route-write capability instead tests a privilege
-// this path no longer needs, while never actually verifying the one this
-// path does need (a mounted bpffs at pinDir, readable/writable by this
-// process). galactic-router's DaemonSet happens to still grant NET_ADMIN
-// today (for the unrelated RouteMainAdd/anycast path), which is why the
-// old probe kept silently passing rather than ever catching this — but it
-// was verifying the wrong thing the whole time.
+// A pass-through entry rather than a real route: it needs no SID or next-hop
+// resolution, so the probe exercises only the pinned map's open and write path
+// and does not incidentally depend on some prefix having a resolvable
+// neighbor.
+//
+// Probing the map rather than the kernel FIB is the point. Installing a VRF's
+// routes writes only into this map, so a probe of kernel route-write capability
+// would test a privilege this path no longer needs while never checking the one
+// it does: a mounted bpffs at pinDir this process can read and write.
 func probeEgressRouteWrite(tableID uint32) error {
 	table, closer, err := egressroutemap.OpenPinnedEgressRouteTable(pinDir)
 	if err != nil {

--- a/internal/runtime/gobgp/paths.go
+++ b/internal/runtime/gobgp/paths.go
@@ -18,10 +18,10 @@ import (
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 )
 
-// deriveRD builds an RFC 4364 Type 1 route distinguisher from the router ID
-// and the advertisement's VRFID. When VRFID is set, the RD is "routerID:vrfID"
-// matching the per-VRF RD used by applyVRF during VRF registration. When VRFID
-// is nil (legacy advertisements without a VRFID), falls back to "routerID:0".
+// deriveRD builds an RFC 4364 Type 1 route distinguisher from the router ID and
+// the advertisement's VRFID. A set VRFID yields "routerID:vrfID", matching the
+// per-VRF distinguisher used at VRF registration; a nil one falls back to
+// "routerID:0".
 func deriveRD(routerID string, vrfID *int32) string {
 	if vrfID != nil {
 		return fmt.Sprintf("%s:%d", routerID, *vrfID)
@@ -38,19 +38,16 @@ func parseSIDAddr(sid string) (netip.Addr, error) {
 	return netip.ParseAddr(sid)
 }
 
-// gatewayForPrefix returns the EVPN Type 5 Gateway IP Address to pair with
-// prefix. This field is left unused — RFC-compliant per
-// draft-ietf-bess-evpn-prefix-advertisement ("the GW IP field SHOULD be zero
-// if it is not used as an Overlay Index") — always the zero address in
-// prefix's own family. The SRv6 SID travels in the BGP Prefix-SID path
-// attribute instead (see buildEVPNPaths), which is a separate attribute
-// independent of the NLRI's address family and so, unlike this field, can
-// carry a SID for an IPv4 prefix: RFC 9136 requires the Prefix and Gateway IP
-// Address fields to share an address family, and GoBGP's wire encoding for
-// this NLRI only recognizes an all-IPv4 or an all-IPv6 layout (see
-// EVPNIPPrefixRoute.Len/Serialize) — mixing families produces a route whose
-// declared length doesn't match its serialized bytes, so there was never a
-// way to fit a 16-byte IPv6 SID into an IPv4 prefix's Gateway field.
+// gatewayForPrefix returns the EVPN Type 5 gateway address to pair with prefix:
+// always the zero address in prefix's own family, the field being unused, which
+// the specification permits when it is not an overlay index.
+//
+// The SID travels in the Prefix-SID path attribute instead. That attribute is
+// independent of the NLRI's address family and so, unlike this field, can carry
+// a SID for an IPv4 prefix: the standard requires the prefix and gateway fields
+// to share a family, and the wire encoding recognises only an all-IPv4 or
+// all-IPv6 layout, so there was never a way to fit a 16-byte SID into an IPv4
+// prefix's gateway field.
 func gatewayForPrefix(prefix netip.Prefix) netip.Addr {
 	if prefix.Addr().Is4() {
 		return netip.IPv4Unspecified()
@@ -58,18 +55,14 @@ func gatewayForPrefix(prefix netip.Prefix) netip.Addr {
 	return netip.IPv6Unspecified()
 }
 
-// prefixSIDAttr builds the BGP Prefix-SID path attribute (RFC 9252 SRv6 L3
-// Service TLV) carrying sid as an End.DT46 SRv6 Information Sub-TLV. This is
-// the sole carrier for the destination SID in this design — see
-// gatewayForPrefix for why the EVPN route's own Gateway IP field can't be
-// used for this instead.
+// prefixSIDAttr builds the BGP Prefix-SID path attribute carrying sid as an
+// End.DT46 SRv6 information sub-TLV. It is the only carrier for the destination
+// SID in this design.
 //
-// The Information Sub-TLV also carries an RFC 9252 §3.2.1 SID Structure
-// Sub-Sub-TLV describing the uSID layout (uFMT 48+16, see
-// internal/plumbing/ebpf/uformat) already present in sid, with no
-// transposition (TL/TO = 0). The field widths are derived from uformat's own
-// constants rather than re-hardcoded, so the wire encoding and the eBPF
-// datapath's bit layout can't silently drift apart.
+// The sub-TLV also carries a structure descriptor for the uSID layout already
+// present in sid, with no transposition. The field widths come from the shared
+// format constants rather than being hardcoded again, so the wire encoding and
+// the datapath's bit layout cannot drift apart.
 func prefixSIDAttr(sid netip.Addr) bgp.PathAttributeInterface {
 	structure := bgp.NewSRv6SIDStructureSubSubTLV(
 		uformat.BlockBits,    // LBL = 48, uSID Block
@@ -87,17 +80,15 @@ func prefixSIDAttr(sid netip.Addr) bgp.PathAttributeInterface {
 }
 
 // buildEVPNPaths adds or withdraws EVPN Type 5 IP Prefix paths for each prefix
-// in adv into the local GoBGP RIB.
+// in adv, in the local RIB.
 //
-// routerID is the BGP router-ID (IPv4 dotted-decimal) and is used to derive the
-// per-VRF route distinguisher (Type 1 IP-address: routerID:vrfID) when adv.VRFID
-// is set, matching the RD used by applyVRF during VRF registration. adv.NextHop
-// is the transit-reachable BGP peering address placed in MpReachNLRI. adv.SRv6SID,
-// when set, is the End.DT46 SID placed in a BGP Prefix-SID path attribute (see
-// prefixSIDAttr) — this is the SRv6 segment that remote nodes install in their
-// seg6 encap kernel routes, for both IPv4 and IPv6 prefixes alike. When
-// adv.SRv6SID is empty, no Prefix-SID attribute is attached (non-SRv6 fallback);
-// remote nodes then fall back to the plain next-hop (see monitor.go).
+// routerID is the BGP router ID, used to derive the per-VRF route distinguisher
+// when the advertisement names a VRF, matching what VRF registration uses. The
+// advertisement's next hop is the transit-reachable peering address. Its SID,
+// when set, becomes a Prefix-SID attribute, and is the segment remote nodes
+// install in their own encapsulating routes, for IPv4 and IPv6 prefixes alike.
+// With no SID, no such attribute is attached and remote nodes fall back to the
+// plain next hop.
 func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, routerID string, withdraw bool) error {
 	nextHop, err := netip.ParseAddr(adv.NextHop)
 	if err != nil {
@@ -113,10 +104,9 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 		sidAttr = prefixSIDAttr(sid)
 	}
 
-	// Type 1 (IP-address:local-admin) RD, unique per VRF.
-	// When adv.VRFID is set, the RD matches the one used by applyVRF during
-	// VRF registration ("routerID:vrfID"), ensuring two VRFs on the same
-	// router never produce colliding NLRIs even for identical prefixes.
+	// A Type 1 distinguisher, unique per VRF. When the advertisement names a
+	// VRF it matches the one used at registration, so two VRFs on one router
+	// never produce colliding NLRIs even for identical prefixes.
 	rdStr := deriveRD(routerID, adv.VRFID)
 	rd, err := bgp.ParseRouteDistinguisher(rdStr)
 	if err != nil {
@@ -135,10 +125,9 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 			return fmt.Errorf("invalid prefix %q: %w", prefixStr, err)
 		}
 
-		// EVPN Type 5 IP Prefix route. ESI all-zeros (Type 0 = not multihomed),
-		// ETag 0, label 0 (SRv6 — MPLS label unused). The Gateway IP field is
-		// left unused (see gatewayForPrefix) — the SID travels in sidAttr
-		// instead, attached to attrs below.
+		// An EVPN Type 5 IP Prefix route: no ethernet segment, tag 0, label 0
+		// since the label is unused with SRv6. The gateway field is left
+		// unused; the SID travels in the attribute attached below.
 		gwIP := gatewayForPrefix(prefix)
 		nlri, err := bgp.NewEVPNIPPrefixRoute(
 			rd,
@@ -153,9 +142,9 @@ func buildEVPNPaths(b *gobgpserver.BgpServer, adv model.DesiredAdvertisement, ro
 			return fmt.Errorf("build EVPN NLRI for prefix %q: %w", prefixStr, err)
 		}
 
-		// apiutil2Path extracts the nexthop from MpReachNLRI then discards the
-		// attribute and reconstructs it from path.Nlri — include it here purely
-		// to carry the nexthop through.
+		// The path conversion extracts the next hop from this attribute and then
+		// discards it, rebuilding it from the NLRI, so this is included purely
+		// to carry the next hop through.
 		mpreach, err := bgp.NewPathAttributeMpReachNLRI(bgp.RF_EVPN, []bgp.PathNLRI{{NLRI: nlri}}, nextHop)
 		if err != nil {
 			return fmt.Errorf("build MpReachNLRI for prefix %q: %w", prefixStr, err)

--- a/internal/runtime/gobgp/peer_monitor.go
+++ b/internal/runtime/gobgp/peer_monitor.go
@@ -16,22 +16,16 @@ import (
 	"go.datum.net/galactic/internal/model"
 )
 
-// startPeerMonitor starts the shared peer FSM transition watcher goroutine
-// once per GoBGPRuntime lifetime, the same one-shared-goroutine-per-runtime
-// pattern startRIBMonitor uses for EVPN best-path — a node can host many
-// peers, so a dedicated goroutine per peer would not scale, and GoBGP's own
-// WatchEvent/WatchPeer API is already shared across all of a BgpServer's
-// peers.
+// startPeerMonitor starts the shared peer FSM watcher goroutine, once per
+// runtime lifetime, as startRIBMonitor does for best-path events. A node can
+// host many peers, so one goroutine per peer would not scale, and the watch API
+// is already shared across a server's peers.
 //
-// This exists because GALACTIC_ROUTER's LogLevel only controls GoBGP's
-// internal logger, which is wired to io.Discard regardless of level (see
-// buildServerOptions in server.go) — so without this watcher, peer session
-// transitions (Idle → Connect → ... → Established, and drops back down)
-// never appear in this process's log output at all. The periodic
-// (peerStatusRequeue-interval) BGPPeer.Status update in
-// internal/controller/bgprouter_controller.go's updatePeerStatuses reflects
-// the *current* state into the CR, but never logs a transition, and can miss
-// one entirely if it reverts between two polls.
+// It exists because the log level only controls GoBGP's internal logger, which
+// is discarded whatever the level, so without this watcher session transitions
+// never appear in this process's output at all. The periodic status update
+// reflects the current state into the CRD but never logs a transition, and can
+// miss one entirely if it reverts between two polls.
 func (r *GoBGPRuntime) startPeerMonitor(b *gobgpserver.BgpServer) {
 	if r.srvCtx == nil {
 		slog.Info("startPeerMonitor: skipping — srvCtx is nil")
@@ -58,23 +52,17 @@ func (r *GoBGPRuntime) watchPeerEvents(ctx context.Context, b *gobgpserver.BgpSe
 	}
 }
 
-// onPeerUpdate logs an FSM state transition for a single peer, diffing
-// against lastPeerState so a re-signal of the same state (GoBGP can emit
-// more than one event per state) doesn't produce a duplicate log line. It
-// also notifies r.observer (if set) of the same transition, which
-// PeerStateEventEmitter (internal/controller) uses to raise Kubernetes
-// Events on the corresponding BGPPeer — see docs/plans/router-bgp-peer-
-// session-events.md.
+// onPeerUpdate logs one peer's FSM transition, diffing against the last
+// observed state so a re-signal of the same state, which GoBGP can emit more
+// than once, produces no duplicate line. It also notifies the observer, which
+// raises Kubernetes events on the corresponding BGPPeer.
 //
-// PEER_EVENT_END_OF_INIT is skipped: it marks the end of GoBGP's initial
-// peer-list replay to a new watcher, not an FSM transition (mirrors how
-// bmp.go's own peer up/down detection filters it).
+// The end-of-init event is skipped: it marks the end of the initial peer-list
+// replay to a new watcher, not an FSM transition.
 //
-// The exported apiutil.WatchEventMessage_PeerEvent only carries the peer's
-// new state, not its old one (GoBGP's internal watchEventPeer has an
-// OldState field, but WatchEvent doesn't forward it through this callback)
-// — so lastPeerState is this runtime's own record of "what did we last see
-// for this peer," rather than something GoBGP hands us directly.
+// The event carries only the peer's new state, not its old one, so the
+// last-observed map is this runtime's own record of what it last saw rather
+// than something GoBGP hands over.
 func (r *GoBGPRuntime) onPeerUpdate(ev *apiutil.WatchEventMessage_PeerEvent, ts time.Time) {
 	if ev == nil || ev.Type == apiutil.PEER_EVENT_END_OF_INIT {
 		return
@@ -124,9 +112,8 @@ func (r *GoBGPRuntime) onPeerUpdate(ev *apiutil.WatchEventMessage_PeerEvent, ts 
 		Time:      ts,
 	}
 	if leavingEstablished {
-		// DisconnectReason's zero value (DISCONNECT_REASON_UNSPECIFIED) means
-		// GoBGP didn't attach a reason — leave it unset rather than passing
-		// through the enum's zero-value name.
+		// A zero disconnect reason means GoBGP attached none. Leave it
+		// unset rather than pass through the enum's zero-value name.
 		if ev.Peer.State.DisconnectReason != 0 {
 			change.DisconnectReason = ev.Peer.State.DisconnectReason.String()
 		}
@@ -135,11 +122,10 @@ func (r *GoBGPRuntime) onPeerUpdate(ev *apiutil.WatchEventMessage_PeerEvent, ts 
 	r.observer.ObservePeerStateChange(change)
 }
 
-// bgpFSMStateToModel converts a GoBGP FSM state, as carried by the
-// WatchEvent/OnPeerUpdate peer-event stream, to a model.BGPPeerState. This
-// mirrors fsmStateToModel in runtime.go, which converts the analogous but
-// distinctly-typed state field GoBGP's ListPeer API returns
-// (api.PeerState_SessionState) for the same six FSM states.
+// bgpFSMStateToModel converts a GoBGP FSM state, as carried by the peer-event
+// stream, to the model's own. It mirrors the conversion in runtime.go for the
+// analogous but distinctly typed field the peer-listing API returns for the same
+// six states.
 func bgpFSMStateToModel(state bgp.FSMState) model.BGPPeerState {
 	switch state {
 	case bgp.BGP_FSM_IDLE:

--- a/internal/runtime/gobgp/peers.go
+++ b/internal/runtime/gobgp/peers.go
@@ -20,9 +20,8 @@ const (
 	safiEVPN    = "evpn"
 )
 
-// familyToGlobalInt maps a model.AddressFamily to the integer used in
-// api.Global.Families. These values correspond to OC AfiSafi type codes:
-// ipv4/unicast=0, ipv6/unicast=1, l2vpn/evpn=9.
+// familyToGlobalInt maps an address family to the integer GoBGP's global
+// configuration uses, which are the standard AFI/SAFI type codes.
 func familyToGlobalInt(af model.AddressFamily) uint32 {
 	switch {
 	case af.AFI == afiIPv4 && af.SAFI == safiUnicast:
@@ -56,10 +55,10 @@ func familyFromModel(af model.AddressFamily) *api.Family {
 	return f
 }
 
-// peerFromDesired converts a DesiredPeer to a GoBGP api.Peer.
-// localAddress, if non-empty, is the process-wide default TCP source address;
-// p.UpdateSource, if non-empty, overrides it for this peer specifically.
-// routeReflectorMode, when true, marks this peer as an iBGP route-reflector client.
+// peerFromDesired converts a desired peer into GoBGP's own peer type.
+// localAddress, when non-empty, is the process-wide default TCP source, which
+// the peer's own update source overrides. routeReflectorMode marks the peer as
+// an iBGP route-reflector client.
 func peerFromDesired(p model.DesiredPeer, localAddress string, routeReflectorMode bool) *api.Peer {
 	peer := &api.Peer{
 		Conf: &api.PeerConf{
@@ -87,13 +86,13 @@ func peerFromDesired(p model.DesiredPeer, localAddress string, routeReflectorMod
 		peer.Conf.AuthPassword = p.AuthPassword
 	}
 
-	// LocalAddress pins the TCP source to the node's SRv6 loopback by default,
-	// so the return path from the RR uses a routed prefix instead of the link
-	// address. p.UpdateSource overrides this per peer (BGPPeer.spec.updateSource)
-	// for a session that needs to source from somewhere else instead — e.g. a
-	// peer reached over the node's own eth0/bond0 link rather than the SRv6
-	// underlay. RemotePort defaults to 1790 (the overlay BGP port) since port
-	// 179 is occupied by the underlay FRR bgpd on every node.
+	// The local address pins the TCP source to the node's SRv6 loopback by
+	// default, so the return path uses a routed prefix rather than a link
+	// address. A per-peer update source overrides that for a session that must
+	// source elsewhere, such as one reached over the node's own link rather
+	// than the SRv6 underlay. The remote port defaults to the overlay BGP
+	// port, the standard one being taken by the underlay daemon on every
+	// node.
 	peerLocalAddress := localAddress
 	if p.UpdateSource != "" {
 		peerLocalAddress = p.UpdateSource

--- a/internal/runtime/gobgp/policies.go
+++ b/internal/runtime/gobgp/policies.go
@@ -100,9 +100,10 @@ func buildStatements(p model.DesiredPolicy) []*api.Statement {
 				}
 			}
 			if len(term.Set.CommunitiesRemove) > 0 {
-				// If we already have an add action, the remove must be a separate pass.
-				// GoBGP CommunityAction supports only one operation per statement.
-				// When both add and remove are present, prefer add here.
+				// An add action is already set, so the remove must be a
+				// separate pass: the community action supports only one
+				// operation per statement. With both present, add wins
+				// here.
 				if stmt.Actions.Community == nil {
 					stmt.Actions.Community = &api.CommunityAction{
 						Type:        api.CommunityAction_TYPE_REMOVE,
@@ -120,9 +121,8 @@ func buildStatements(p model.DesiredPolicy) []*api.Statement {
 	return stmts
 }
 
-// removeToRegexp converts community strings to GoBGP community regexp format.
-// GoBGP community matching uses exact string comparison, so we wrap each
-// community in ^...$ anchors to prevent partial matches.
+// removeToRegexp wraps each community in anchors, GoBGP's community matching
+// being a regexp match, so a community cannot match another partially.
 func removeToRegexp(communities []string) []string {
 	out := make([]string, len(communities))
 	for i, c := range communities {

--- a/internal/runtime/gobgp/runtime.go
+++ b/internal/runtime/gobgp/runtime.go
@@ -29,10 +29,9 @@ import (
 type GoBGPRuntime struct {
 	key    types.NamespacedName
 	server *Server
-	// listenPort is the process-wide default TCP port GoBGP binds for
-	// incoming BGP connections (from GALACTIC_ROUTER_BGP_LISTEN_PORT). A
-	// per-router BGPRouter.spec.listenPort, carried as DesiredRouter.ListenPort,
-	// overrides it when set — see applyGlobal.
+	// listenPort is the process-wide default TCP port GoBGP binds for incoming
+	// connections. A per-router listen port, carried on DesiredRouter,
+	// overrides it when set.
 	listenPort   int32
 	reflector    bool
 	localAddress string
@@ -40,107 +39,88 @@ type GoBGPRuntime struct {
 
 	lastASN      int64
 	lastRouterID string
-	// lastListenPort is the effective listen port (r.listenPort, overridden by
-	// DesiredRouter.ListenPort when set) applied on the last StartBgp — zero
-	// means "not yet applied," the same unset-sentinel convention lastASN and
-	// lastRouterID use, since a real listen port is never 0 (validated to
-	// -1 or 1-65535 upstream). A change forces a Reconfigure, same as
-	// asnChanged/idChanged, because GoBGP cannot rebind its listen socket on
-	// an already-started BgpServer.
+	// lastListenPort is the effective listen port applied on the last start, 0
+	// meaning not yet applied, since a real port is never 0. A change forces a
+	// reconfigure, like an ASN or router ID change, because GoBGP cannot
+	// rebind its listen socket on an already-started server.
 	lastListenPort int32
 	// establishedAt tracks when each peer last reached the Established state.
 	establishedAt map[string]time.Time
 	// appliedPolicies tracks the direction of each applied policy by name so
 	// stale policies can be removed when they disappear from desired state.
 	appliedPolicies map[string]model.BGPPolicyDirection
-	// appliedVRFs tracks the kernel VRF table ID of each VRF that has been
-	// applied to GoBGP, keyed by VRF name, so stale VRFs can be removed when
-	// they disappear from desired state and so the route-write privilege probe
-	// runs only once per VRF rather than on every reconcile.
+	// appliedVRFs tracks the kernel VRF table ID of each VRF applied to GoBGP,
+	// keyed by VRF name, so stale VRFs can be removed when they leave desired
+	// state and the route-write probe runs once per VRF rather than on every
+	// reconcile.
 	appliedVRFs map[string]uint32
-	// appliedVRFImportRTs tracks the last-applied import route-target set for
-	// each already-registered VRF, keyed by VRF name, so applyVRFs can detect
-	// when an existing VRF's import RTs change (not just when a VRF is first
-	// registered) and trigger a RIB backfill for it — see applyVRFs.
+	// appliedVRFImportRTs tracks the last-applied import route-target set per
+	// registered VRF, so applyVRFs can tell when an existing VRF's targets
+	// change, not only when a VRF is first registered, and trigger a RIB
+	// backfill for it.
 	appliedVRFImportRTs map[string][]string
 	// rtIndexMu guards rtIndex, which is read concurrently by the shared EVPN
 	// RIB watcher goroutine.
 	rtIndexMu sync.RWMutex
-	// rtIndex maps an import route-target string to the kernel VRF table ID
-	// that imports it, letting the single shared watcher dispatch a best-path
-	// event to the right table in O(1) instead of scanning every VRF — a node
-	// can host thousands of VPC attachments, each with its own VRF.
+	// rtIndex maps an import route target to the kernel VRF table ID importing
+	// it, so the shared watcher dispatches a best-path event in constant time
+	// rather than scanning every VRF. A node can host thousands.
 	rtIndex map[string]uint32
-	// appliedAdvertisements tracks the last-applied DesiredAdvertisement per
-	// name so a changed advertisement's previous EVPN paths can be withdrawn.
-	// This matters because the EVPN Type 5 route's Gateway IP Address (the
-	// SRv6 SID) is part of the NLRI itself, not a mutable path attribute:
-	// re-adding a path with a new SID creates a structurally different route
-	// rather than replacing the old one, so the stale route must be withdrawn
-	// explicitly or it stays advertised indefinitely.
+	// appliedAdvertisements tracks the last-applied advertisement per name, so a
+	// changed one's previous EVPN paths can be withdrawn. The route's gateway
+	// address, the SRv6 SID, is part of the NLRI rather than a mutable
+	// attribute, so re-adding a path with a new SID creates a structurally
+	// different route instead of replacing the old one, which then stays
+	// advertised until withdrawn explicitly.
 	appliedAdvertisements map[string]model.DesiredAdvertisement
 	// serverCtxCancel cancels the goroutine running server.Start.
 	serverCtxCancel context.CancelFunc
 	// srvCtx is the context passed to server.Start; monitor goroutines use it.
 	srvCtx context.Context
-	// monitorOnce ensures the single shared EVPN RIB watcher goroutine is
-	// started at most once per runtime lifetime; it dispatches to all VRFs via
-	// rtIndex rather than being scoped to one VRF.
+	// monitorOnce starts the shared EVPN RIB watcher at most once per runtime
+	// lifetime. It dispatches to every VRF through rtIndex rather than being
+	// scoped to one.
 	monitorOnce sync.Once
-	// peerMonitorOnce ensures the shared peer FSM transition watcher goroutine
-	// (see peer_monitor.go) is started at most once per runtime lifetime, the
-	// same one-shared-goroutine pattern monitorOnce uses for EVPN best-path.
+	// peerMonitorOnce starts the shared peer FSM watcher at most once per
+	// runtime lifetime, as monitorOnce does for best-path events.
 	peerMonitorOnce sync.Once
-	// peerStateMu guards lastPeerState. Kept separate from mu (rather than
-	// reusing it) so the peer-event watcher goroutine — which fires
-	// concurrently with Apply/Status — never contends with the lock those
-	// hold for potentially long VRF/policy convergence work.
+	// peerStateMu guards lastPeerState, kept separate from mu so the peer-event
+	// watcher never contends with the lock Apply and Status hold for
+	// potentially long VRF and policy convergence work.
 	peerStateMu sync.Mutex
 	// lastPeerState tracks each peer's last-observed FSM state, keyed by
-	// neighbor address, so onPeerUpdate can detect an actual transition
-	// instead of logging every re-signal of the same state. This is distinct
-	// from establishedAt below: that one records when a peer first reached
-	// Established for status reporting, this one records the current state
-	// of every peer regardless of what it is, for transition logging.
+	// neighbor address, so a transition can be told apart from a re-signal of
+	// the same state. Distinct from establishedAt, which records when a peer
+	// first reached Established for status reporting.
 	lastPeerState map[string]model.BGPPeerState
-	// appliedPeers tracks the last-applied DesiredPeer per address so
-	// applyPeers can skip re-adding/updating a peer whose config hasn't
-	// actually changed. Without this, applyPeers called AddPeer/UpdatePeer
-	// for every desired peer on every Apply() — including reconciles where
-	// nothing changed — and GoBGP's UpdatePeer resets the session
-	// unconditionally, so a peer could never stay Established: any
-	// watch-triggered reconcile (including one caused by this router's own
-	// BGPPeer status write) tore every session back down before it converged.
+	// appliedPeers tracks the last-applied peer config per address, so a peer
+	// whose config has not changed is not pushed again. GoBGP resets the
+	// session on every update, even an identical one, so without this any
+	// reconcile, including one caused by this router's own status write, tore
+	// every session down before it could converge.
 	appliedPeers map[string]model.DesiredPeer
-	// observer, when non-nil, is notified in real time of every peer FSM
-	// transition onPeerUpdate detects (see peer_monitor.go). May be nil in
-	// tests that construct a GoBGPRuntime directly without going through
-	// NewRuntimeFactory.
+	// observer, when non-nil, is notified of every peer FSM transition
+	// detected. It may be nil in tests that construct a runtime directly.
 	observer model.PeerStateObserver
-	// wg tracks the server.Start and watchEVPNRIB goroutines so Stop can block
-	// until both have actually exited instead of merely cancelling srvCtx and
-	// returning. GoBGP keeps some path-selection state (table.SelectionOptions,
-	// table.UseMultiplePaths) as package-level globals rather than per-server
-	// fields, so a BgpServer that outlives Stop() races the next runtime's
-	// StartBgp in any test (or other in-process caller) that creates more than
-	// one GoBGPRuntime -- this is what the CI race detector caught once this
-	// package's tests started creating more than one GoBGPRuntime per run.
+	// wg tracks the server and RIB watcher goroutines so Stop blocks until both
+	// have exited rather than merely being asked to. GoBGP keeps some
+	// path-selection state in package-level globals rather than per-server
+	// fields, so a server that outlives Stop races the next runtime's start in
+	// any process that creates more than one.
 	wg sync.WaitGroup
 }
 
-// NewRuntimeFactory returns a RuntimeFactory that creates a GoBGPRuntime per key.
-// listenPort controls the TCP port GoBGP binds for incoming BGP connections.
-// Pass -1 to disable inbound connections (outbound-only mode).
-// reflector, when true, marks every peer of this runtime instance as an iBGP
-// route-reflector client — this is a distinct, explicit signal from
+// NewRuntimeFactory returns a RuntimeFactory that creates one GoBGPRuntime per
+// key.
+//
+// listenPort is the TCP port GoBGP binds for incoming connections; -1 disables
+// inbound connections entirely. reflector marks every peer of the created
+// runtime as an iBGP route-reflector client. That is deliberately separate from
 // listenPort: whether a node accepts inbound BGP is not the same property as
-// whether it is the fabric-facing route-reflector, even though the two
-// happen to coincide in every overlay that exists today.
-// localAddress, if non-empty, is bound as the source address for outgoing BGP
-// TCP connections (sets Transport.LocalAddress on every peer).
-// observer, when non-nil, is notified in real time of every peer FSM
-// transition each created runtime detects (see peer_monitor.go); pass nil to
-// disable this (e.g. in tests that don't care about it).
+// whether it is the fabric's route reflector, even where the two coincide today.
+// localAddress, when non-empty, is bound as the source address for outgoing BGP
+// connections. observer, when non-nil, is notified of every peer FSM transition
+// each created runtime detects.
 func NewRuntimeFactory(
 	listenPort int32, reflector bool, localAddress string, observer model.PeerStateObserver,
 ) runtime.RuntimeFactory {
@@ -308,24 +288,20 @@ func (r *GoBGPRuntime) applyPeers(ctx context.Context, b *gobgpserver.BgpServer,
 	return nil
 }
 
-// peerNeedsApply reports whether p must be (re-)pushed to GoBGP via
-// AddPeer/UpdatePeer: either it was never applied, its desired config
-// changed since the last apply, or GoBGP no longer reports it as configured
-// (e.g. silently dropped by an unrelated churn elsewhere, such as a GC cycle
-// recreating the BGPVRFInstance/BGPAdvertisement CRs backing it). Any other
-// case is a true no-op — skipping it matters because AddPeer/UpdatePeer
-// reset the BGP session unconditionally, even when the pushed config is
-// identical to what's already running.
+// peerNeedsApply reports whether p must be pushed to GoBGP: it was never
+// applied, its config changed since the last apply, or GoBGP no longer reports
+// it as configured, which can happen when unrelated churn drops it. Any other
+// case is a true no-op, and skipping matters because adding or updating a peer
+// resets the session unconditionally, even when the config is identical.
 func peerNeedsApply(applied map[string]model.DesiredPeer, current map[string]bool, p model.DesiredPeer) bool {
 	last, ok := applied[p.Address]
 	return !ok || !current[p.Address] || !reflect.DeepEqual(last, p)
 }
 
-// applyVRFs configures every desired VRF instance and removes stale ones. A
-// node can host many VRFs (one per VPC that has at least one attachment on
-// this node, shared by every attachment on that VPC/node — not one per
-// attachment), so this — unlike the single-VRF code it replaces — must
-// handle the full set, not just one.
+// applyVRFs configures every desired VRF instance and removes stale ones. A node
+// can host many VRFs, one per VPC with at least one attachment here and shared
+// by every attachment on that VPC, so this handles the full set rather than a
+// single VRF.
 func (r *GoBGPRuntime) applyVRFs(
 	ctx context.Context, b *gobgpserver.BgpServer, vrfs []model.DesiredVRFInstance, routerID string,
 ) error {
@@ -353,12 +329,11 @@ func (r *GoBGPRuntime) applyVRFs(
 			var err error
 			tableID, err = vrfTableID(v.Name)
 			if err != nil {
-				// A VRF whose interface simply isn't in this process's own
-				// netns is the ordinary case for a VPC served only by #855's
-				// ingress sidecar on this node, not a fault -- and there is
-				// nothing for this process to install for it either way (see
-				// vrfTableID's own History note). Skip it quietly rather than
-				// reporting a failure on every reconcile, forever.
+				// A VRF whose interface is not in this process's namespace is
+				// the ordinary case for a VPC served only by the ingress
+				// sidecar on this node, and there is nothing for this process
+				// to install for it either way. Skip quietly rather than
+				// report a failure on every reconcile.
 				if errors.Is(err, errVRFNotInThisNetns) {
 					slog.Debug("applyVRFs: skipping VRF whose kernel interface is not in this netns",
 						"vrf", v.Name, "err", err)
@@ -378,13 +353,12 @@ func (r *GoBGPRuntime) applyVRFs(
 			r.appliedVRFs[v.Name] = tableID
 			needsBackfill = true
 		} else if !equalRTSets(r.appliedVRFImportRTs[v.Name], v.ImportRouteTargets) {
-			// This VRF was already registered, but its import route-target
-			// set has changed (e.g. an import policy widened to pick up
-			// another VPC/location's RT). A remote path matching a
-			// newly-added RT may already be best-path in GoBGP's RIB —
-			// added before this VRF's rtIndex entry existed for that RT —
-			// and watchEVPNRIB only notifies on *future* best-path events,
-			// so it would never be redelivered without a backfill.
+			// This VRF is registered but its import route targets have
+			// changed, for instance because a policy widened to pick up
+			// another location's target. A remote path matching a newly
+			// added target may already be best path, having arrived
+			// before the index held that target, and the watcher notifies
+			// only on future events, so it would never be redelivered.
 			needsBackfill = true
 		}
 		r.appliedVRFImportRTs[v.Name] = append([]string(nil), v.ImportRouteTargets...)
@@ -398,12 +372,11 @@ func (r *GoBGPRuntime) applyVRFs(
 	r.rtIndex = rtIndex
 	r.rtIndexMu.Unlock()
 
-	// A newly registered VRF's route targets, or a route-target set that
-	// changed on an already-registered VRF, may match paths that were
-	// already best-path in GoBGP's RIB before that RT existed in rtIndex —
-	// the shared watcher's WatchBestPath(true) only replays the RIB once, at
-	// its own startup, so it would never redeliver those. Backfill from the
-	// current RIB now that rtIndex reflects the change.
+	// A newly registered VRF's targets, or a changed set on an existing one, may
+	// match paths that were already best path before the index held that
+	// target. The shared watcher replays the RIB only once, at its own startup,
+	// so backfill from the current RIB now that the index reflects the
+	// change.
 	if needsBackfill {
 		r.backfillEVPNRoutes(b)
 	}
@@ -411,10 +384,9 @@ func (r *GoBGPRuntime) applyVRFs(
 	return nil
 }
 
-// equalRTSets reports whether a and b contain the same route targets,
-// ignoring order — the desired route-target list's order isn't guaranteed
-// stable across reconciles, since it round-trips through a Kubernetes CR
-// spec (BGPVRFInstance.Spec.ImportRouteTargets).
+// equalRTSets reports whether a and b hold the same route targets, ignoring
+// order, since the desired list round-trips through a CRD spec and its order is
+// not stable across reconciles.
 func equalRTSets(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -553,11 +525,10 @@ func (r *GoBGPRuntime) Status(ctx context.Context) (model.RuntimeStatus, error) 
 	return status, nil
 }
 
-// Stop shuts down the GoBGP server. It blocks until the embedded server and
-// the shared EVPN RIB watcher have both actually exited (not merely been
-// asked to), so a caller that creates another GoBGPRuntime immediately after
-// Stop returns -- as tests in this package do -- cannot race the outgoing
-// server's GoBGP package-level path-selection state (see the wg field doc).
+// Stop shuts down the GoBGP server, blocking until the embedded server and the
+// EVPN RIB watcher have both exited rather than merely been asked to. A caller
+// that creates another runtime immediately after would otherwise race the
+// outgoing server's package-level path-selection state; see the wg field.
 func (r *GoBGPRuntime) Stop(_ context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -590,11 +561,10 @@ func fsmStateToModel(state api.PeerState_SessionState) model.BGPPeerState {
 	}
 }
 
-// applyVRF configures a VRF in GoBGP via AddVrf. The route distinguisher is
-// derived as the RFC 4364 Type 1 (IP-address:local-admin) format
-// "routerID:vrfID", matching the convention buildEVPNPaths uses for the
-// per-VRF RD so that EVPN paths and VRF registration share the same distinguisher.
-// If the VRF already exists, the call is treated as idempotent (no-op).
+// applyVRF configures one VRF in GoBGP. The route distinguisher is the RFC 4364
+// Type 1 "routerID:vrfID" form, matching what EVPN path construction uses, so
+// paths and VRF registration share one distinguisher. A VRF that already exists
+// is a no-op.
 func applyVRF(ctx context.Context, b *gobgpserver.BgpServer, vrf *model.DesiredVRFInstance, routerID string) error {
 	// Derive and parse the route distinguisher.
 	rdStr := fmt.Sprintf("%s:%d", routerID, vrf.VRFID)

--- a/internal/runtime/gobgp/server.go
+++ b/internal/runtime/gobgp/server.go
@@ -59,10 +59,10 @@ func (s *Server) Start(ctx context.Context) error {
 	return nil
 }
 
-// Reconfigure replaces the running BgpServer with a fresh instance.
-// StopBgp in GoBGP v4 terminates the Serve loop, making the server permanently
-// dead. Call this instead of StopBgp+StartBgp when reconfiguration is needed.
-// The caller must call StartBgp on the returned server.
+// Reconfigure replaces the running server with a fresh instance and returns it.
+// Stopping the server terminates its serve loop permanently, so this is what to
+// call instead of a stop-then-start when reconfiguration is needed. The caller
+// must start the returned server.
 func (s *Server) Reconfigure() (*gobgpserver.BgpServer, error) {
 	if old := s.bgp.Load(); old != nil {
 		old.Stop()

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -74,9 +74,9 @@ func (m *runtimeManager) Status(ctx context.Context, key types.NamespacedName) (
 	m.mu.RUnlock()
 
 	if !ok {
-		// No runtime yet — this is normal before the first successful Apply.
-		// Return an empty status so the caller can distinguish "not yet applied"
-		// from "applied but unhealthy".
+		// No runtime yet, which is normal before the first successful apply.
+		// An empty status lets the caller tell "not yet applied" from "applied
+		// but unhealthy".
 		return model.RuntimeStatus{}, nil
 	}
 	return rt.Status(ctx)

--- a/internal/webhook/authorizer.go
+++ b/internal/webhook/authorizer.go
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package webhook implements galactic-router's admission webhooks. This is
-// the first webhook in this repository — required for NetworkRule
-// specifically: NetworkRule is tenant-writable and carries the target
-// vpc/vpcattachment identifier directly, so without validation a tenant
-// could write a rule targeting another tenant's vpc/vpcattachment,
-// redirecting or intercepting their ingress traffic.
+// Package webhook implements galactic-router's admission webhooks.
+//
+// It exists for NetworkRule specifically: that resource is tenant-writable and
+// names the target VPC and attachment directly, so without validation a tenant
+// could write a rule targeting another tenant's, redirecting or intercepting
+// their ingress traffic.
 package webhook
 
 import (
@@ -18,40 +18,33 @@ import (
 	networkv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// Authorizer decides whether requester is authorized to create or update a
-// NetworkRule targeting rule.Spec.VPCRef/VPCAttachmentRef.
+// Authorizer decides whether a requester may create or update a NetworkRule
+// targeting the VPC and attachment it names.
 //
-// This is a pluggable interface, not a concrete implementation, because VPC
-// and VPCAttachment ownership resolution lives in a separate companion
-// operator this repo does not own (per CLAUDE.md's "VPC and VPCAttachment
-// CRD management lives in a separate companion operator") — this repo has
-// no client, API, or even network path to that operator today.
+// It is a pluggable interface rather than a concrete implementation because VPC
+// ownership resolution lives in a separate companion operator this repo does
+// not own, and to which it has no client, API, or network path today.
 type Authorizer interface {
-	// Authorize reports whether requester is authorized for the
-	// vpc/vpcattachment named in rule. A false result (with a nil error)
-	// means "authoritatively denied"; a non-nil error means the check
-	// itself failed (e.g. the companion operator was unreachable) and the
-	// webhook should fail closed.
+	// Authorize reports whether requester may act on the VPC and attachment
+	// named in rule. False with a nil error is an authoritative denial; a
+	// non-nil error means the check itself failed and the webhook should fail
+	// closed.
 	Authorize(ctx context.Context, requester authenticationv1.UserInfo, rule *networkv1alpha1.NetworkRule) (bool, error)
 }
 
-// AllowAllAuthorizer is the TODO-marked placeholder Authorizer
-// implementation. It unconditionally allows every request.
+// AllowAllAuthorizer unconditionally allows every request.
 //
-// TODO(edge-gateway): this is NOT real authorization. Real authorization
-// requires calling out to the companion operator that owns VPC/
-// VPCAttachment ownership resolution (see CLAUDE.md's "VPC and
-// VPCAttachment CRD management lives in a separate companion operator")
-// to confirm requester is actually permitted to attach to
-// rule.Spec.VPCRef/VPCAttachmentRef — that integration does not exist yet
-// (no client, no API contract, no network path from this repo to that
-// operator). Until it lands, every NetworkRule create/update is admitted
-// regardless of who's asking or what vpc/vpcattachment they name, which
-// means a tenant CAN currently write a rule targeting another tenant's
-// vpc/vpcattachment (the exact vulnerability admission control exists to
-// close) — this must not be treated as production-ready and must not be
-// deployed with real tenant traffic before the Authorizer above is given a
-// real implementation.
+// TODO(edge-gateway): this is not real authorization. Real authorization means
+// calling out to the companion operator that owns VPC ownership resolution to
+// confirm the requester may attach to the VPC and attachment the rule names,
+// and that integration does not exist yet: no client, no API contract, no
+// network path.
+//
+// Until it lands, every create and update is admitted whoever is asking and
+// whatever they name, so a tenant can write a rule targeting another tenant's
+// VPC, the exact vulnerability admission control exists to close. This must not
+// be deployed with real tenant traffic before Authorizer has a real
+// implementation.
 type AllowAllAuthorizer struct{}
 
 // Authorize always returns true. See the type's doc comment for why this is

--- a/internal/webhook/networkrule_webhook.go
+++ b/internal/webhook/networkrule_webhook.go
@@ -14,14 +14,12 @@ import (
 	networkv1alpha1 "go.datum.net/network/api/v1alpha1"
 )
 
-// NetworkRuleValidator implements the typed admission.Validator generic
-// interface for NetworkRule, verifying (via the pluggable Authorizer) that
-// the requesting identity is authorized for the vpc/vpcattachment named in
-// the rule before a create or update is admitted.
+// NetworkRuleValidator is the admission validator for NetworkRule, verifying
+// through the pluggable Authorizer that the requesting identity may act on the
+// VPC and attachment the rule names before a create or update is admitted.
 type NetworkRuleValidator struct {
-	// Authorizer performs the actual authorization check. Production
-	// callers must not leave this as AllowAllAuthorizer{} — see that
-	// type's doc comment.
+	// Authorizer performs the actual check. Production callers must not leave
+	// this as AllowAllAuthorizer.
 	Authorizer Authorizer
 }
 
@@ -35,33 +33,32 @@ func (v *NetworkRuleValidator) ValidateCreate(
 	return nil, v.authorize(ctx, rule)
 }
 
-// ValidateUpdate re-verifies authorization on update — a rule's vpcRef/
-// vpcAttachmentRef could otherwise be changed post-creation to point at a
-// different tenant's resources without ever re-running the create-time
-// check.
+// ValidateUpdate re-verifies authorization on update: a rule's VPC and
+// attachment references could otherwise be changed after creation to point at
+// another tenant's resources without the create-time check running again.
 func (v *NetworkRuleValidator) ValidateUpdate(
 	ctx context.Context, _, newRule *networkv1alpha1.NetworkRule,
 ) (admission.Warnings, error) {
 	return nil, v.authorize(ctx, newRule)
 }
 
-// ValidateDelete performs no additional authorization check: deleting a
-// NetworkRule that already exists in the cluster is scoped by Kubernetes'
-// own RBAC on the delete verb, not by vpc/vpcattachment ownership.
+// ValidateDelete performs no additional check. Deleting a rule that already
+// exists is scoped by the cluster's own access control on the delete verb, not
+// by VPC ownership.
 func (v *NetworkRuleValidator) ValidateDelete(
 	context.Context, *networkv1alpha1.NetworkRule,
 ) (admission.Warnings, error) {
 	return nil, nil
 }
 
-// authorize resolves the requesting identity from the admission.Request
-// carried on ctx (controller-runtime's Validator interface does not pass
-// the request directly) and calls the configured Authorizer. A denial
-// surfaces to the requester as the admission rejection message; the
-// Accepted condition on the NetworkRule itself is set by the future
-// NetworkRule controller once the object has passed admission and been
-// persisted, since a validating webhook cannot itself write to the
-// object's status subresource on a create/update it hasn't yet admitted.
+// authorize resolves the requesting identity from the admission request carried
+// on ctx, the validator interface not passing it directly, and calls the
+// configured Authorizer. A denial surfaces to the requester as the rejection
+// message.
+//
+// The Accepted condition on the rule itself is set by the reconciler once the
+// object has passed admission and been persisted: a validating webhook cannot
+// write to the status of a request it has not yet admitted.
 func (v *NetworkRuleValidator) authorize(ctx context.Context, rule *networkv1alpha1.NetworkRule) error {
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
@@ -70,9 +67,9 @@ func (v *NetworkRuleValidator) authorize(ctx context.Context, rule *networkv1alp
 
 	ok, err := v.Authorizer.Authorize(ctx, req.UserInfo, rule)
 	if err != nil {
-		// Fail closed: an authorization check that itself failed (e.g. the
-		// companion operator was unreachable) must never be treated as an
-		// implicit allow.
+		// Fail closed: a check that itself failed, because the companion
+		// operator was unreachable, must never be treated as an implicit
+		// allow.
 		return fmt.Errorf("authorization check failed: %w", err)
 	}
 	if !ok {
@@ -85,18 +82,14 @@ func (v *NetworkRuleValidator) authorize(ctx context.Context, rule *networkv1alp
 }
 
 // SetupWebhookWithManager registers the NetworkRule validating webhook with
-// mgr, using controller-runtime's generic builder API — the shape
-// sigs.k8s.io/controller-runtime v0.24.1 (this repo's go.mod) actually
-// exposes: NewWebhookManagedBy[T] infers T from the object argument, and
-// WithValidator takes the typed admission.Validator[T] this type
-// implements above.
+// mgr, through controller-runtime's generic builder: the constructor infers the
+// object type from its argument, and the validator argument takes the typed
+// interface this type implements.
 func (v *NetworkRuleValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr, &networkv1alpha1.NetworkRule{}).
 		WithValidator(v).
 		Complete()
 }
 
-// Production webhook registration additionally requires a
-// ValidatingWebhookConfiguration/Service manifest, plus a cert-manager (or
-// equivalent) TLS provisioning step -- Phase D of the design plan, not
-// wired up yet.
+// Production registration additionally requires a webhook configuration and
+// service manifest, plus TLS provisioning, neither of which is wired up here.


### PR DESCRIPTION
## Summary

Comments had grown to about a third of the non-test source, carrying issue numbers, milestone references, reviewer names, and narration of designs that were rejected or already replaced.

That bulk buries the contract a reader actually needs, and six comments had drifted far enough to describe behavior the code no longer has.

Docstrings now state why a function exists, what its inputs and returns mean, and what it does, keeping non-obvious invariants and the reason for each. Comment volume drops by about a quarter and no code changed.

## Test plan

- [ ] Lint, unit tests, and eBPF compilation all pass
- [ ] The diff changes comments only, with no code touched

Related to #293