### PR TITLE
fix(radv): release a failed advertisement attempt's context

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -594,7 +594,16 @@ func reconcileRadvActors(ctx context.Context, actors *radvActorSet) {
 // it, reconcileRadvActors would stay convinced the actor is running. Deleting a
 // key that is already gone, because the attachment itself disappeared, is a
 // safe no-op.
+//
+// Each attempt derives its context from one that lives as long as the process.
+// Only cancelling detaches the derived context. Deleting the entry alone leaves
+// it attached, so a retry loop grows this daemon's memory without bound.
 func radvActorFailed(actors *radvActorSet, iface string) {
+	cancel, ok := actors.cancel[iface]
+	if !ok {
+		return
+	}
+	cancel()
 	delete(actors.cancel, iface)
 }
 

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -687,7 +687,24 @@ func TestReconcileRadvActors_FailedStartupIsRetried(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("actors.failed never received a report for the interface that can't exist")
 	}
+	// Cancelling releases the attempt's context from the daemon's own, so a
+	// retry loop cannot grow memory without bound.
+	recorded, ok := actors.cancel[iface]
+	if !ok {
+		t.Fatalf("actors.cancel[%q] missing before radvActorFailed", iface)
+	}
+	cancelled := false
+	actors.cancel[iface] = func() {
+		cancelled = true
+		recorded()
+	}
+
 	radvActorFailed(actors, iface)
+
+	if !cancelled {
+		t.Fatalf("radvActorFailed did not cancel %q's context, leaving it attached to "+
+			"the daemon's context for the life of the process", iface)
+	}
 
 	if _, ok := actors.cancel[iface]; ok {
 		t.Fatalf("actors.cancel[%q] still present after radvActorFailed, want it cleared so the next reconcile retries",


### PR DESCRIPTION
The CNI installer runs on every compute node and sets up guest networking there. It leaks memory every time it fails to start an address advertisement for a tap attachment, and it runs under a memory limit tight enough that the leak eventually gets it killed. When it dies it takes node networking setup down with it, including the neighbor resolution that decapsulated traffic needs to reach a guest.

The leak is unbounded in practice rather than theoretical. An attachment whose host interface no longer exists can never start, so it fails and retries every couple of seconds for as long as the attachment record survives. A node in that state today is retrying six of them continuously. A failed attempt now releases what it held.

Two related problems on the same component are real but need a design decision, so they are tracked in datum-cloud/infra#5175 rather than fixed here. Nothing reconciles stale attachment records against the interfaces that exist, and the memory limit is small enough that a single shell command inside the container can breach it.

## Testing

The existing retry test now also asserts that a failed attempt is released. This repository does not build on macOS, because the eBPF bindings are generated at build time and the network namespace dependency excludes darwin, so CI is authoritative.

Related: datum-cloud/infra#5175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
