### PR TITLE
Attach general-purpose workloads to a customer's VPC network

### DIFF
--- a/docs/cni/conflist-reference.md
+++ b/docs/cni/conflist-reference.md
@@ -27,6 +27,7 @@ else is).
 | `vpcattachment` | **Yes**  | `string` | Base62-encoded VPC attachment identifier (16-bit value). Paired with `vpc` for deterministic VRF/BGP naming.                                                                                                         |
 | `mtu`           | No       | `int`    | MTU for the host-side interface. For `galactic-veth` this applies to both veth endpoints; for `galactic-tap` it applies to the tap interface.                                                                        |
 | `namespace`     | No       | `string` | Kubernetes namespace used for NAD lookup (and, for `galactic-bgp`'s own stanza, `BGPRouter`/BGP CRD lookup). Resolution order: this field → `GALACTIC_CNI_NAMESPACE` env → `HostConf.Namespace` → `galactic-system`. |
+| `dan`           | No       | `bool`   | `galactic-tap` only. Write a Directly Attachable Network file for the sandbox, so a Kata runtime-rs shim adopts this tap instead of discovering a network of its own. Off unless set. See [Directly attachable networking](#directly-attachable-networking) below.                                                     |
 | `ipam`          | No       | `IPAM`   | IPAM delegation block (see [IPAM Fields](#ipam-fields) below). Presence alone decides whether IPAM runs at all — no env var or sibling field can trigger or suppress it.                                             |
 
 Standard CNI fields (`cniVersion`, `name`, `dns`, `runtimeConfig`) are also
@@ -70,6 +71,32 @@ never delegates to host-device and never configures a guest netns. It still
 runs IPAM (if `"ipam"` is present) and configures the host gateway exactly as
 `galactic-veth` does; the CNI result carries a single interface (the host tap,
 empty sandbox) since there's no guest-side interface entry.
+
+#### Directly attachable networking
+
+A microVM guest cannot be handed an interface the way a container can, so a
+Kata shim has to be told which host device belongs to the sandbox and what the
+guest should see on it. Setting `"dan": true` makes `galactic-tap` write that
+description to `<DAN directory>/<sandbox ID>.json` at the end of ADD, from
+values it already holds: the tap name, the addresses IPAM allocated, their
+gateways, the MTU, and a guest MAC derived from the tap name so it is stable
+across instance replacement. The directory is node-level configuration (see
+[`GALACTIC_CNI_DAN_DIR`](environment-variables.md#galactic_cni_dan_dir)) and
+defaults to `/run/kata-containers/dans-rs`.
+
+Per attachment rather than per node, because the decision follows the
+workload: one cell runs guests of several runtimes over this same plugin, and
+only some of them read the file. It is carried in the CNI config because that
+is the one channel delivered identically to ADD, DEL, and CHECK, so no
+operation has to re-derive it.
+
+A failed write fails ADD. Kata treats a missing file as "discover the network
+yourself", which produces a healthy-looking sandbox on the wrong network — a
+far worse outcome than an attachment that does not come up.
+
+DEL removes the file unconditionally, whether or not the attachment asked for
+one. Nothing in Kata removes it, so the CNI plugin owns it for the sandbox's
+whole lifetime.
 
 The IPv4 gateway address on the host tap is a `/25`, not the `/32` used
 everywhere else (veth's host/guest gateways, and the pod's own address in both

--- a/docs/cni/environment-variables.md
+++ b/docs/cni/environment-variables.md
@@ -40,6 +40,7 @@ they resolve only `LogFile`/`LogLevel` from `HostConf` — never `NodeName` or
 | `LogFile`        | Path the plugin logs to (`/var/log/galactic/galactic-cni.log` by default, shared across every binary in the chain).                                                                                                                                                                                                                  |
 | `LogLevel`       | Verbosity of plugin logging: `debug`, `info`, `warn`, or `error` (`info` by default). See [Log verbosity](#log-verbosity) below.                                                                                                                                                                                                     |
 | `NAT66ShardSIDs` | Comma-separated list of every live `galactic-nat66` shard's `Status.ShardSID`, resolved once by `galactic-cni init` from `GALACTIC_CNI_NAT66_SHARD_SIDS` and written here so a per-pod CNI invocation can read it. See [`GALACTIC_CNI_NAT66_SHARD_SIDS`](#galactic_cni_nat66_shard_sids) below.                                      |
+| `DANDir`         | Directory the tap master plugin writes a sandbox's Directly Attachable Network file to (`/run/kata-containers/dans-rs` by default). Only the location is node-level; whether an attachment gets a file is the `dan` field in its own CNI config. See [`GALACTIC_CNI_DAN_DIR`](#galactic_cni_dan_dir) below.                        |
 | `EBPFInterfaces` | Comma-separated interface list the eBPF uSID datapath attaches its ingress hook to, resolved once by `galactic-cni init` (env override or auto-detection) and written here for the same reason as `NAT66ShardSIDs`. See [`GALACTIC_CNI_EBPF_INTERFACES`](#galactic_cni_ebpf_interfaces-and-galactic_cni_ebpf_filter_priority) below. |
 
 ## Resolution precedence
@@ -53,6 +54,7 @@ they resolve only `LogFile`/`LogLevel` from `HostConf` — never `NodeName` or
 | Log level            | `GALACTIC_CNI_LOG_LEVEL` env → `HostConf.LogLevel`                                                                                                                                                                               | `info`                               | every binary in the chain                       |
 | NAT66 shard SIDs     | `GALACTIC_CNI_NAT66_SHARD_SIDS` env (`galactic-cni init`/`run` only) → `HostConf.NAT66ShardSIDs`                                                                                                                                 | _(empty: no shard configured)_       | `galactic-cni init`, `galactic-bgp`             |
 | eBPF interfaces      | `GALACTIC_CNI_EBPF_INTERFACES` env → `HostConf.EBPFInterfaces` (bridged back into the env var for `galactic-bgp`'s own process, see below) → auto-detect (interface(s) carrying the default IPv6 route)                          | _(auto-detected)_                    | `galactic-cni init`/`run`, `galactic-bgp`       |
+| DAN directory        | `GALACTIC_CNI_DAN_DIR` env → `HostConf.DANDir`                                                                                                                                                                                  | `/run/kata-containers/dans-rs`       | `galactic-cni init`, `galactic-tap`             |
 | eBPF filter priority | `GALACTIC_CNI_EBPF_FILTER_PRIORITY` env (plain `os.Getenv`, no `HostConf`/conflist tier)                                                                                                                                         | `1`                                  | `galactic-cni init`/`run`                       |
 
 `GALACTIC_CNI_*` env var names are shared as-is across every binary that
@@ -152,6 +154,25 @@ the same behavior as before this mechanism existed, not an error.
 
 **Type:** comma-separated string · **Default:** _(empty — no shard
 configured)_
+
+## `GALACTIC_CNI_DAN_DIR`
+
+Directory the tap master plugin writes a sandbox's Directly Attachable
+Network (DAN) file to. A Kata runtime-rs shim reads that file and adopts
+the tap galactic already created for the attachment, instead of discovering
+a network of its own.
+
+Set it only for a node whose shim is configured to read somewhere other
+than the default. The Go shim's directory, `/run/kata-containers/dans`, is
+refused: that shim hard-errors on the host tap device this plugin writes,
+with no fallback, which would stop every sandbox on the node from starting.
+
+Node-level because it describes where that node's shim reads. Whether an
+attachment gets a file at all is the `dan` field in its own CNI config, no
+file being written for an attachment that does not ask for one.
+
+**Type:** string (filesystem path) · **Default:**
+`/run/kata-containers/dans-rs`
 
 ## `GALACTIC_CNI_KUBERNETES_CONFIG`
 

--- a/internal/cnimaster/config.go
+++ b/internal/cnimaster/config.go
@@ -261,6 +261,7 @@ func ParseConf(data []byte, cniConfig *config.CNIConfig, confFile string) (*Plug
 		Namespace:  hostConf.Namespace,
 		LogFile:    hostConf.LogFile,
 		LogLevel:   hostConf.LogLevel,
+		DANDir:     hostConf.DANDir,
 	})
 
 	// Fall back to auto-detecting the node name from the API by matching local

--- a/internal/cnitap/config.go
+++ b/internal/cnitap/config.go
@@ -5,6 +5,8 @@
 package cnitap
 
 import (
+	"encoding/json"
+
 	"go.datum.net/galactic/internal/cnimaster"
 	"go.datum.net/galactic/internal/config"
 )
@@ -27,4 +29,27 @@ func InitCNIConfig() {
 // resolver and conflist path.
 func parseConf(data []byte) (*PluginConf, error) {
 	return cnimaster.ParseConf(data, cniConfig, ConfFile)
+}
+
+// danRequested reports whether this attachment's guest adopts the tap through a
+// Directly Attachable Network file, rather than having its network discovered
+// by the runtime.
+//
+// The decision follows the workload rather than the node, because a cell runs
+// guests of several runtimes over the same tap master plugin. The CNI config
+// carries it, that being the one channel delivered identically to ADD, DEL, and
+// CHECK.
+//
+// It is read from the raw config rather than the shared master-plugin struct,
+// this being the one master plugin that acts on it.
+func danRequested(data []byte) bool {
+	var conf struct {
+		DAN bool `json:"dan"`
+	}
+	// A decode error needs no report. The caller unmarshals the same bytes into
+	// the full config first, so malformed JSON is already rejected.
+	if err := json.Unmarshal(data, &conf); err != nil {
+		return false
+	}
+	return conf.DAN
 }

--- a/internal/cnitap/dan.go
+++ b/internal/cnitap/dan.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cnitap
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+
+	"go.datum.net/galactic/internal/cniipam"
+	"go.datum.net/galactic/internal/plumbing/dan"
+)
+
+// ipv4TapMask is the prefix length a tap's IPv4 address carries in the guest.
+// It matches the mask the host side of the tap is given, so the guest and the
+// host agree on what is on-link.
+const ipv4TapMask = 25
+
+// writeDANFile hands this attachment to a Kata runtime-rs shim by describing
+// it in the sandbox's DAN file.
+//
+// Callers must treat an error as fatal to CNI ADD. See dan.Write.
+func writeDANFile(dir, sandboxID, tapName string, res *cniipam.IPAMResult, mtu int) error {
+	document, err := buildDANDocument(tapName, res, mtu)
+	if err != nil {
+		return fmt.Errorf("build DAN document: %w", err)
+	}
+	return dan.Write(dir, sandboxID, document)
+}
+
+// buildDANDocument describes this attachment to a Kata runtime-rs shim. It
+// names the tap to adopt and what the guest should configure on it.
+//
+// Every value comes from state this plugin already owns, so the shim discovers
+// nothing. The document carries exactly one device, because an attachment is
+// one interface.
+func buildDANDocument(tapName string, res *cniipam.IPAMResult, mtu int) (*dan.Document, error) {
+	if res == nil {
+		return nil, fmt.Errorf("no addresses were allocated for tap %q", tapName)
+	}
+
+	var addresses []string
+	routes := []dan.Route{}
+
+	if res.IPv6Subnet != nil {
+		addresses = append(addresses, res.IPv6Subnet.String())
+	}
+	if res.IPv6Gateway != nil {
+		routes = append(routes, defaultRoute(res.IPv6Gateway))
+	}
+	if res.IPv4Address != nil {
+		ipv4 := net.IPNet{IP: res.IPv4Address, Mask: net.CIDRMask(ipv4TapMask, 32)}
+		addresses = append(addresses, ipv4.String())
+	}
+	if res.IPv4Gateway != nil {
+		routes = append(routes, defaultRoute(res.IPv4Gateway))
+	}
+
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("no addresses were allocated for tap %q", tapName)
+	}
+
+	return &dan.Document{
+		Devices: []dan.Device{{
+			Name:     "eth0",
+			GuestMAC: guestMAC(tapName).String(),
+			Device: dan.DeviceSpec{
+				Type:    dan.DeviceTypeHostTap,
+				TapName: tapName,
+			},
+			NetworkInfo: dan.NetworkInfo{
+				Interface: dan.Interface{
+					IPAddresses: addresses,
+					MTU:         mtu,
+					Ntype:       dan.InterfaceTypeTap,
+				},
+				Routes:    routes,
+				Neighbors: []any{},
+			},
+		}},
+	}, nil
+}
+
+// defaultRoute returns the guest's default route through gateway. An empty
+// destination is the default route for the gateway's own family.
+func defaultRoute(gateway net.IP) dan.Route {
+	return dan.Route{Gateway: gateway.String()}
+}
+
+// guestMAC derives the guest interface's address from the tap's name, which
+// already encodes the VPC and the attachment.
+//
+// A derived address stays stable across instance replacement, so a guest or a
+// peer holding a neighbor entry sees the same interface come back. The address
+// is locally administered and unicast, and the attachment is unique per node,
+// so it cannot collide on the link.
+func guestMAC(tapName string) net.HardwareAddr {
+	sum := sha256.Sum256([]byte(tapName))
+	mac := make(net.HardwareAddr, 6)
+	copy(mac, sum[:6])
+	mac[0] = 0x02
+	return mac
+}

--- a/internal/cnitap/dan_test.go
+++ b/internal/cnitap/dan_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cnitap
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"go.datum.net/galactic/internal/cniipam"
+	"go.datum.net/galactic/internal/plumbing/dan"
+)
+
+// ipv6Result is a single-stack allocation, the shape a VPC attachment has
+// today.
+func ipv6Result() *cniipam.IPAMResult {
+	_, subnet, _ := net.ParseCIDR("fd20:0:f::4:0:0/96")
+	subnet.IP = net.ParseIP("fd20:0:f::4:0:0")
+	return &cniipam.IPAMResult{
+		IPv6Subnet:  subnet,
+		IPv6Gateway: net.ParseIP("fd20:0:f::1"),
+	}
+}
+
+// TestBuildDANDocumentDescribesTheAttachment checks the document against the
+// values the plugin already holds, including the guest address and default
+// route the guest is told to configure.
+func TestBuildDANDocumentDescribesTheAttachment(t *testing.T) {
+	document, err := buildDANDocument("G00000000bayhH", ipv6Result(), 1460)
+	if err != nil {
+		t.Fatalf("buildDANDocument: %v", err)
+	}
+
+	if len(document.Devices) != 1 {
+		t.Fatalf("document holds %d devices, want 1", len(document.Devices))
+	}
+	device := document.Devices[0]
+	if device.Device.Type != dan.DeviceTypeHostTap {
+		t.Errorf("device type = %q, want %q", device.Device.Type, dan.DeviceTypeHostTap)
+	}
+	if device.Device.TapName != "G00000000bayhH" {
+		t.Errorf("tap name = %q, want the host interface's", device.Device.TapName)
+	}
+	if device.NetworkInfo.Interface.MTU != 1460 {
+		t.Errorf("MTU = %d, want 1460", device.NetworkInfo.Interface.MTU)
+	}
+	wantAddresses := []string{"fd20:0:f::4:0:0/96"}
+	if !reflect.DeepEqual(device.NetworkInfo.Interface.IPAddresses, wantAddresses) {
+		t.Errorf("addresses = %v, want %v", device.NetworkInfo.Interface.IPAddresses, wantAddresses)
+	}
+	wantRoutes := []dan.Route{{Gateway: "fd20:0:f::1"}}
+	if !reflect.DeepEqual(device.NetworkInfo.Routes, wantRoutes) {
+		t.Errorf("routes = %v, want %v", device.NetworkInfo.Routes, wantRoutes)
+	}
+	if device.NetworkInfo.Neighbors == nil {
+		t.Error("neighbors is nil, want an empty list so the file carries []")
+	}
+}
+
+// TestBuildDANDocumentOrdersDualStackAddresses covers a dual-stack attachment.
+// Both families land on the one device, because the guest has one interface
+// either way.
+func TestBuildDANDocumentOrdersDualStackAddresses(t *testing.T) {
+	res := ipv6Result()
+	res.IPv4Address = net.ParseIP("10.244.1.5")
+	res.IPv4Gateway = net.ParseIP("10.244.1.1")
+
+	document, err := buildDANDocument("G00000000bayhH", res, 1460)
+	if err != nil {
+		t.Fatalf("buildDANDocument: %v", err)
+	}
+	if len(document.Devices) != 1 {
+		t.Fatalf("document holds %d devices, want 1", len(document.Devices))
+	}
+	want := []string{"fd20:0:f::4:0:0/96", "10.244.1.5/25"}
+	if !reflect.DeepEqual(document.Devices[0].NetworkInfo.Interface.IPAddresses, want) {
+		t.Errorf("addresses = %v, want %v", document.Devices[0].NetworkInfo.Interface.IPAddresses, want)
+	}
+	wantRoutes := []dan.Route{{Gateway: "fd20:0:f::1"}, {Gateway: "10.244.1.1"}}
+	if !reflect.DeepEqual(document.Devices[0].NetworkInfo.Routes, wantRoutes) {
+		t.Errorf("routes = %v, want %v", document.Devices[0].NetworkInfo.Routes, wantRoutes)
+	}
+}
+
+// TestGuestMACIsStableAndLocal covers the two properties the guest depends on:
+// the same attachment always gets the same address, and the address is
+// locally administered and unicast.
+func TestGuestMACIsStableAndLocal(t *testing.T) {
+	first := guestMAC("G00000000bayhH")
+	if !reflect.DeepEqual(first, guestMAC("G00000000bayhH")) {
+		t.Error("guest MAC differs between calls for the same tap")
+	}
+	if reflect.DeepEqual(first, guestMAC("G00000000otherH")) {
+		t.Error("two taps share a guest MAC")
+	}
+	if first[0]&0x02 == 0 {
+		t.Errorf("guest MAC %s is not locally administered", first)
+	}
+	if first[0]&0x01 != 0 {
+		t.Errorf("guest MAC %s is a multicast address", first)
+	}
+}
+
+// TestBuildDANDocumentRequiresAddresses covers the case where no address was
+// allocated. A guest with a tap and no address looks healthy until traffic is
+// tried, so the build must fail instead.
+func TestBuildDANDocumentRequiresAddresses(t *testing.T) {
+	for name, res := range map[string]*cniipam.IPAMResult{
+		"no IPAM result": nil,
+		"empty result":   {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := buildDANDocument("G00000000bayhH", res, 1460); err == nil {
+				t.Error("buildDANDocument succeeded, want an error")
+			}
+		})
+	}
+}
+
+// TestWriteDANFileProducesTheProvenShape checks the whole path from allocation
+// to bytes on disk against the document observed to work on a real node.
+func TestWriteDANFileProducesTheProvenShape(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeDANFile(dir, "sandbox-1", "G00000000bayhH", ipv6Result(), 1460); err != nil {
+		t.Fatalf("writeDANFile: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "sandbox-1.json"))
+	if err != nil {
+		t.Fatalf("read DAN file: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse DAN file: %v", err)
+	}
+
+	devices, ok := got["devices"].([]any)
+	if !ok || len(devices) != 1 {
+		t.Fatalf("devices = %v, want one entry", got["devices"])
+	}
+	device := devices[0].(map[string]any)
+	if device["guest_mac"] == "" {
+		t.Error("guest_mac is empty, want an explicit address")
+	}
+	deviceSpec := device["device"].(map[string]any)
+	if deviceSpec["type"] != "host-tap" || deviceSpec["tap_name"] != "G00000000bayhH" {
+		t.Errorf("device = %v, want the host tap", deviceSpec)
+	}
+	if _, present := got["netns"]; present {
+		t.Errorf("DAN JSON carries a netns field: %s", data)
+	}
+}
+
+// TestWriteDANFileFailsOnTheGoShimDirectory checks that ADD's write reaches the
+// guardrail rather than routing around it.
+func TestWriteDANFileFailsOnTheGoShimDirectory(t *testing.T) {
+	if err := writeDANFile(dan.GoShimDir, "sandbox-1", "G00000000bayhH", ipv6Result(), 1460); err == nil {
+		t.Error("writeDANFile succeeded on the Go shim's directory, want refusal")
+	}
+}
+
+// TestWriteDANFileReportsWriteFailures checks that a failed write surfaces to
+// ADD. A sandbox with no DAN file comes up on the wrong network and looks
+// healthy, so ADD must fail rather than continue.
+func TestWriteDANFileReportsWriteFailures(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+	if err := writeDANFile(blocked, "sandbox-1", "G00000000bayhH", ipv6Result(), 1460); err == nil {
+		t.Error("writeDANFile succeeded where the directory cannot exist, want an error")
+	}
+}
+
+// TestDANRequestedIsOptIn covers the gate that keeps DAN files off the path of
+// a workload whose runtime never reads one.
+func TestDANRequestedIsOptIn(t *testing.T) {
+	base := `{"cniVersion":"1.0.0","name":"net","type":"galactic-tap","vpc":"a","vpcattachment":"b"`
+	for name, tc := range map[string]struct {
+		config string
+		want   bool
+	}{
+		"field absent":     {base + "}", false},
+		"explicitly false": {base + `,"dan":false}`, false},
+		"explicitly true":  {base + `,"dan":true}`, true},
+		"malformed config": {`{"dan":`, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := danRequested([]byte(tc.config)); got != tc.want {
+				t.Errorf("danRequested = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cnitap/ops_add.go
+++ b/internal/cnitap/ops_add.go
@@ -160,6 +160,19 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		}
 	}
 
+	// Hand the sandbox to a Kata runtime-rs shim, when this attachment asked
+	// for it. This is the last thing ADD does, so the file exists only once the
+	// tap behind it is real and addressed. A failure is fatal to ADD, never
+	// best-effort. See dan.Write.
+	if danRequested(args.StdinData) {
+		tracker.danDir, tracker.danSandboxID = cniConfig.DANDir, args.ContainerID
+		if err := writeDANFile(cniConfig.DANDir, args.ContainerID, hostName, ipamResult, hostMTU); err != nil {
+			return fmt.Errorf("emit DAN file: %w", err)
+		}
+		slog.Debug("ADD: DAN file written", "containerID", args.ContainerID,
+			"dir", cniConfig.DANDir, "tap", hostName)
+	}
+
 	result := buildTapResult(pluginConf, ipamResult, hostName, hostMac, hostMTU)
 	return types.PrintResult(result, pluginConf.CNIVersion)
 }

--- a/internal/cnitap/ops_del.go
+++ b/internal/cnitap/ops_del.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"go.datum.net/galactic/internal/cni/tap"
+	"go.datum.net/galactic/internal/plumbing/dan"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/intf"
@@ -55,6 +56,17 @@ func cmdDel(args *skel.CmdArgs) error {
 	// never had an IPv6 gateway allocated, is not an error, and DEL must stay
 	// idempotent.
 	removeRadvState(vpc, vpcAtt, args.ContainerID)
+
+	// Remove the sandbox's DAN file. Nothing in Kata deletes it, so files would
+	// accumulate in a tmpfs directory for the node's uptime.
+	//
+	// Removal is unconditional because it is idempotent, so a misread opt-in
+	// cannot strand state. Failures are logged rather than returned, because
+	// DEL is required to succeed.
+	if err := dan.Remove(cniConfig.DANDir, args.ContainerID); err != nil {
+		slog.Warn("DEL: failed to remove DAN file", "err", err,
+			"containerID", args.ContainerID, "dir", cniConfig.DANDir)
+	}
 
 	// Delete this attachment's tap device. Unlike the VRF and CRDs below it is
 	// private to this attachment, so no sibling VM can still depend on it and

--- a/internal/cnitap/resource.go
+++ b/internal/cnitap/resource.go
@@ -11,6 +11,7 @@ import (
 
 	"go.datum.net/galactic/internal/cni/tap"
 	"go.datum.net/galactic/internal/cnimaster"
+	"go.datum.net/galactic/internal/plumbing/dan"
 )
 
 // resourceTracker tracks the resources cmdAdd created, for selective rollback.
@@ -27,6 +28,11 @@ type resourceTracker struct {
 	ipamDelegated bool
 	ipamType      string
 	ipamStdin     []byte
+
+	// danDir and danSandboxID locate the DAN file to unlink during rollback.
+	// They are empty for an attachment that did not ask for one, and cleanup
+	// tolerates a file that was never written.
+	danDir, danSandboxID string
 }
 
 // cleanup rolls back the tracked resources in reverse creation order.
@@ -46,6 +52,14 @@ func (rt *resourceTracker) cleanup() {
 			slog.Error("Rollback: failed to release IPAM allocation", "err", err, "ipamType", rt.ipamType)
 		} else {
 			slog.Debug("Rollback: released IPAM allocation", "ipamType", rt.ipamType)
+		}
+	}
+
+	// Unlink the DAN file before the tap it names goes away, so no window
+	// exists where a shim could adopt a device that is being deleted.
+	if rt.danDir != "" && rt.danSandboxID != "" {
+		if err := dan.Remove(rt.danDir, rt.danSandboxID); err != nil {
+			slog.Error("Rollback: failed to remove DAN file", "err", err, "dir", rt.danDir)
 		}
 	}
 

--- a/internal/config/cni.go
+++ b/internal/config/cni.go
@@ -6,6 +6,8 @@ package config
 
 import (
 	"os"
+
+	"go.datum.net/galactic/internal/plumbing/dan"
 )
 
 // --- CNI environment variable keys -----------------------------------------
@@ -45,6 +47,13 @@ const (
 	// Unset or empty means no shard is configured yet: a VRF gets no default
 	// route, which is no egress capability rather than an error.
 	EnvCNINAT66ShardSIDs = "GALACTIC_CNI_NAT66_SHARD_SIDS"
+
+	// EnvCNIDANDir overrides where Directly Attachable Network files are
+	// written, for a node whose shim reads somewhere other than the default.
+	//
+	// Only the location is node-level. Whether an attachment gets a file at all
+	// is stated in its own CNI config, that being a property of the workload.
+	EnvCNIDANDir = "GALACTIC_CNI_DAN_DIR"
 )
 
 // --- CNIConfig -------------------------------------------------------------
@@ -65,6 +74,9 @@ type CNIConfig struct {
 	// plugin splits and validates it.
 	NAT66ShardSIDs string
 
+	// DANDir is where Directly Attachable Network files are written.
+	DANDir string
+
 	// EBPFInterfaces is the raw comma-separated interface list. It needs the
 	// same environment-over-conflist-over-default resolution as NAT66ShardSIDs,
 	// not a plain environment read at the call site.
@@ -82,6 +94,7 @@ func NewCNIConfig() *CNIConfig {
 // the environment and the compiled-in defaults.
 func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 	var cnflistNode, cnflistKube, cnflistNS, cnflistLog, cnflistLevel, cnflistShardSIDs, cnflistEBPFIfaces string
+	var cnflistDANDir string
 	if conflist != nil {
 		cnflistNode = conflist.NodeName
 		cnflistKube = conflist.Kubeconfig
@@ -90,6 +103,7 @@ func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 		cnflistLevel = conflist.LogLevel
 		cnflistShardSIDs = conflist.NAT66ShardSIDs
 		cnflistEBPFIfaces = conflist.EBPFInterfaces
+		cnflistDANDir = conflist.DANDir
 	}
 
 	// NodeName: env > conflist > legacy fallback > (no default)
@@ -119,6 +133,8 @@ func (c *CNIConfig) Resolve(conflist *ConflistValues) {
 	// No default: empty means fall back to the datapath's own interface
 	// auto-detection, not an error.
 	c.EBPFInterfaces = resolveEnv(EnvCNIEBPFInterfaces, cnflistEBPFIfaces, "")
+
+	c.DANDir = resolveEnv(EnvCNIDANDir, cnflistDANDir, dan.DefaultDir)
 }
 
 // ConflistValues holds the raw values read from the CNI conflist file.
@@ -131,4 +147,5 @@ type ConflistValues struct {
 	LogLevel       string
 	NAT66ShardSIDs string
 	EBPFInterfaces string
+	DANDir         string
 }

--- a/internal/config/cni_test.go
+++ b/internal/config/cni_test.go
@@ -4,7 +4,11 @@
 
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/dan"
+)
 
 const (
 	testConflistNode = "conflist-node"
@@ -15,6 +19,7 @@ const (
 	testEnvKube      = "/env/kubeconfig"
 	testEnvNS        = "env-ns"
 	testEnvNode      = "env-node"
+	testConflistDAN  = "/run/other/dans"
 )
 
 func TestCNIConfigDefaults(t *testing.T) {
@@ -170,5 +175,30 @@ func TestCNIConfigNodeNameLegacyFallback(t *testing.T) {
 
 	if cfg.NodeName != "legacy-node" {
 		t.Errorf("NodeName = %q, want %q", cfg.NodeName, "legacy-node")
+	}
+}
+
+func TestCNIConfigDANDir(t *testing.T) {
+	// Default: the runtime-rs directory. Whether anything is written there is
+	// decided per attachment, not here.
+	cfg := NewCNIConfig()
+	cfg.Resolve(&ConflistValues{})
+	if cfg.DANDir != dan.DefaultDir {
+		t.Errorf("DANDir = %q, want %q", cfg.DANDir, dan.DefaultDir)
+	}
+
+	// Conflist value flows through.
+	cfg = NewCNIConfig()
+	cfg.Resolve(&ConflistValues{DANDir: testConflistDAN})
+	if cfg.DANDir != testConflistDAN {
+		t.Errorf("DANDir = %q, want the conflist value", cfg.DANDir)
+	}
+
+	// Env var overrides the conflist value.
+	t.Setenv(EnvCNIDANDir, "/run/env/dans")
+	cfg = NewCNIConfig()
+	cfg.Resolve(&ConflistValues{DANDir: testConflistDAN})
+	if cfg.DANDir != "/run/env/dans" {
+		t.Errorf("DANDir = %q, want the env value", cfg.DANDir)
 	}
 }

--- a/internal/hostconf/hostconf.go
+++ b/internal/hostconf/hostconf.go
@@ -74,6 +74,12 @@ type HostConf struct {
 	// route is not the fabric interface, and produces a plausible but wrong
 	// uplink entry for the DSR reply redirect.
 	EBPFInterfaces string `json:"ebpf_interfaces,omitempty"`
+
+	// DANDir is where the tap master plugin writes Directly Attachable Network
+	// files. The installer writes it from its own environment for the same
+	// reason as the fields above. A per-pod CNI invocation sees none of the
+	// daemonset's environment.
+	DANDir string `json:"dan_dir,omitempty"`
 }
 
 // conflistEnvelope matches standard CNI conflist JSON structure.

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -347,6 +347,7 @@ func Bootstrap(ctx context.Context, nodeName string) error {
 	logLevel := resolveLogLevel()
 	nat66ShardSIDs := resolveNAT66ShardSIDs()
 	ebpfInterfaces := resolveEBPFInterfaces()
+	danDir := os.Getenv(config.EnvCNIDANDir)
 	conflistContent := fmt.Sprintf(`{
   "cniVersion": "1.0.0",
   "name": "galactic",
@@ -359,12 +360,13 @@ func Bootstrap(ctx context.Context, nodeName string) error {
       "log_file": %q,
       "log_level": %q,
       "nat66_shard_sids": %q,
-      "ebpf_interfaces": %q
+      "ebpf_interfaces": %q,
+      "dan_dir": %q
     }
   ]
 }
 `, nodeName, config.DefaultKubeconfig, config.DefaultNamespace, config.DefaultLogFile, logLevel,
-		nat66ShardSIDs, ebpfInterfaces)
+		nat66ShardSIDs, ebpfInterfaces, danDir)
 
 	if err := atomicWriteFile(HostConflist, []byte(conflistContent), 0644); err != nil {
 		return fmt.Errorf("write conflist file: %w", err)

--- a/internal/plumbing/dan/dan.go
+++ b/internal/plumbing/dan/dan.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package dan writes Directly Attachable Network files, the handoff a Kata
+// runtime-rs shim reads instead of scanning a sandbox network namespace.
+//
+// A microVM guest cannot be handed an interface the way a container can. The
+// shim has to be told which host device belongs to the sandbox and what the
+// guest should see on it. A DAN file states that, so the guest adopts the tap
+// this node's CNI plugin already created, addressed and enslaved to its VPC's
+// VRF.
+//
+// The file is named for the sandbox ID and is the CNI plugin's property for the
+// sandbox's whole lifetime. Nothing in Kata removes it, so ADD writes it and
+// DEL unlinks it.
+package dan
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultDir is where a runtime-rs shim configured for directly attachable
+// networking looks for a sandbox's file.
+//
+// This is not the Go shim's directory. See GoShimDir.
+const DefaultDir = "/run/kata-containers/dans-rs"
+
+// GoShimDir is the directory the Go shim reads, which this package refuses to
+// write to.
+//
+// The Go shim understands a different set of device types and hard-errors on
+// the host tap this package emits. A file dropped there stops every sandbox on
+// the node from starting, not only the ones attached to a VPC.
+const GoShimDir = "/run/kata-containers/dans"
+
+// DeviceTypeHostTap names the device type that adopts an existing tap in the
+// host network namespace. The shim resolves the device by name before entering
+// any namespace guard, which is why the tap must already exist on the host.
+const DeviceTypeHostTap = "host-tap"
+
+// InterfaceTypeTap is the interface type a tap-backed guest interface reports.
+const InterfaceTypeTap = "tuntap"
+
+// Document is a sandbox's whole DAN file.
+//
+// The top-level netns field a DAN file may carry is absent. Naming a namespace
+// sends the shim back to scanning it.
+type Document struct {
+	Devices []Device `json:"devices"`
+}
+
+// Device is one interface handed to the guest.
+//
+// The shim derives the guest interface name from the position in
+// Document.Devices, not from Name. Name is set for whoever reads the file
+// next.
+type Device struct {
+	Name string `json:"name"`
+	// GuestMAC is set explicitly so the guest's address is stable across
+	// sandbox restarts. Left unset, the shim draws a random one.
+	GuestMAC    string      `json:"guest_mac"`
+	Device      DeviceSpec  `json:"device"`
+	NetworkInfo NetworkInfo `json:"network_info"`
+}
+
+// DeviceSpec names the host resource backing a guest interface.
+type DeviceSpec struct {
+	Type    string `json:"type"`
+	TapName string `json:"tap_name"`
+}
+
+// NetworkInfo is what the guest is told to configure on the interface.
+type NetworkInfo struct {
+	Interface Interface `json:"interface"`
+	Routes    []Route   `json:"routes"`
+	Neighbors []any     `json:"neighbors"`
+}
+
+// Interface carries the guest-side addressing for one device.
+type Interface struct {
+	IPAddresses []string `json:"ip_addresses"`
+	MTU         int      `json:"mtu"`
+	Ntype       string   `json:"ntype"`
+	Flags       uint32   `json:"flags"`
+}
+
+// Route is one route installed inside the guest. An empty Dest is the default
+// route for whichever family Gateway belongs to.
+type Route struct {
+	Dest    string `json:"dest"`
+	Gateway string `json:"gateway"`
+	Source  string `json:"source"`
+	Scope   uint32 `json:"scope"`
+	Flags   uint32 `json:"flags"`
+	MTU     uint32 `json:"mtu"`
+}
+
+// Path returns the DAN file path for a sandbox under dir. The sandbox ID is the
+// container ID the runtime passes the CNI plugin for the pod sandbox, which is
+// byte-identical to the ID the shim looks the file up by.
+func Path(dir, sandboxID string) (string, error) {
+	if dir == "" {
+		return "", errors.New("DAN directory is required")
+	}
+	if filepath.Clean(dir) == GoShimDir {
+		return "", fmt.Errorf("refusing to use the Go shim's DAN directory %q: "+
+			"a %s device there fails every sandbox on this node; use %q",
+			GoShimDir, DeviceTypeHostTap, DefaultDir)
+	}
+	if err := validateSandboxID(sandboxID); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, sandboxID+".json"), nil
+}
+
+// validateSandboxID rejects an ID that would escape dir or name something other
+// than one file. The ID reaches this package straight from the runtime's
+// environment, and it is used as a filename.
+func validateSandboxID(sandboxID string) error {
+	if sandboxID == "" {
+		return errors.New("sandbox ID is required")
+	}
+	if strings.ContainsAny(sandboxID, `/\`) || sandboxID == "." || sandboxID == ".." {
+		return fmt.Errorf("invalid sandbox ID %q: must name a single file", sandboxID)
+	}
+	return nil
+}
+
+// Write stores a sandbox's DAN file under dir, replacing any existing one.
+//
+// The write is atomic, so a shim reading concurrently sees the whole document
+// or none of it. Treat a failure as fatal to CNI ADD. Without the file the shim
+// falls back to scanning the sandbox namespace and produces a healthy-looking
+// sandbox on the wrong network.
+func Write(dir, sandboxID string, doc *Document) error {
+	path, err := Path(dir, sandboxID)
+	if err != nil {
+		return err
+	}
+	if doc == nil || len(doc.Devices) == 0 {
+		return fmt.Errorf("refusing to write a DAN file with no devices for sandbox %q", sandboxID)
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal DAN document for sandbox %q: %w", sandboxID, err)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create DAN directory %q: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "."+sandboxID+".*")
+	if err != nil {
+		return fmt.Errorf("create temporary DAN file in %q: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write DAN file %q: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close DAN file %q: %w", tmpPath, err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return fmt.Errorf("set DAN file mode on %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("install DAN file %q: %w", path, err)
+	}
+	return nil
+}
+
+// Remove deletes a sandbox's DAN file. Call it on DEL. Nothing in Kata removes
+// the file, and a stale one is adopted by a later sandbox that reuses the ID. A
+// missing file is not an error, because DEL is idempotent and is reached when
+// ADD never wrote one.
+func Remove(dir, sandboxID string) error {
+	path, err := Path(dir, sandboxID)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove DAN file %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/plumbing/dan/dan_test.go
+++ b/internal/plumbing/dan/dan_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package dan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// testSandboxID stands in for the runtime's container ID.
+const testSandboxID = "sandbox-1"
+
+// sampleDocument mirrors the document a tap attachment produces, so the shape
+// assertions below read against something realistic.
+func sampleDocument() *Document {
+	return &Document{
+		Devices: []Device{{
+			Name:     "eth0",
+			GuestMAC: "02:00:0f:00:04:00",
+			Device:   DeviceSpec{Type: DeviceTypeHostTap, TapName: "G00000000bayhH"},
+			NetworkInfo: NetworkInfo{
+				Interface: Interface{
+					IPAddresses: []string{"fd20:0:f::4:0:0/96"},
+					MTU:         1460,
+					Ntype:       InterfaceTypeTap,
+				},
+				Routes:    []Route{{Gateway: "fd20:0:f::1"}},
+				Neighbors: []any{},
+			},
+		}},
+	}
+}
+
+// TestWriteMatchesDocumentedShape pins the on-disk JSON against the shape a
+// runtime-rs shim was observed to accept. Key names and nesting are the
+// contract with a component outside this repository.
+func TestWriteMatchesDocumentedShape(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, testSandboxID, sampleDocument()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, testSandboxID+".json"))
+	if err != nil {
+		t.Fatalf("read DAN file: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse DAN file: %v", err)
+	}
+
+	want := map[string]any{
+		"devices": []any{map[string]any{
+			"name":      "eth0",
+			"guest_mac": "02:00:0f:00:04:00",
+			"device": map[string]any{
+				"type":     "host-tap",
+				"tap_name": "G00000000bayhH",
+			},
+			"network_info": map[string]any{
+				"interface": map[string]any{
+					"ip_addresses": []any{"fd20:0:f::4:0:0/96"},
+					"mtu":          float64(1460),
+					"ntype":        "tuntap",
+					"flags":        float64(0),
+				},
+				"routes": []any{map[string]any{
+					"dest":    "",
+					"gateway": "fd20:0:f::1",
+					"source":  "",
+					"scope":   float64(0),
+					"flags":   float64(0),
+					"mtu":     float64(0),
+				}},
+				"neighbors": []any{},
+			},
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DAN JSON = %#v, want %#v", got, want)
+	}
+}
+
+// TestWriteOmitsNetns guards the field whose presence sends the shim back to
+// scanning the sandbox namespace.
+func TestWriteOmitsNetns(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, testSandboxID, sampleDocument()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, testSandboxID+".json"))
+	if err != nil {
+		t.Fatalf("read DAN file: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse DAN file: %v", err)
+	}
+	if _, present := got["netns"]; present {
+		t.Errorf("DAN JSON carries a netns field: %s", data)
+	}
+}
+
+// TestWriteRoundTrips checks that the document survives the file, so a reader
+// of this package's own types sees what was written.
+func TestWriteRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	want := sampleDocument()
+	if err := Write(dir, testSandboxID, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, testSandboxID+".json"))
+	if err != nil {
+		t.Fatalf("read DAN file: %v", err)
+	}
+	var got Document
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse DAN file: %v", err)
+	}
+	if !reflect.DeepEqual(&got, want) {
+		t.Errorf("round-tripped document = %#v, want %#v", &got, want)
+	}
+}
+
+// TestWriteRefusesGoShimDir covers the guardrail against the directory whose
+// shim hard-errors on a host tap.
+func TestWriteRefusesGoShimDir(t *testing.T) {
+	for _, dir := range []string{GoShimDir, GoShimDir + "/", GoShimDir + "/../dans"} {
+		err := Write(dir, testSandboxID, sampleDocument())
+		if err == nil {
+			t.Fatalf("Write(%q) succeeded, want refusal", dir)
+		}
+		if !strings.Contains(err.Error(), "refusing") {
+			t.Errorf("Write(%q) error = %v, want a refusal", dir, err)
+		}
+		if _, statErr := os.Stat(filepath.Join(GoShimDir, testSandboxID+".json")); statErr == nil {
+			t.Fatalf("Write(%q) created a file in the Go shim's directory", dir)
+		}
+	}
+}
+
+// TestRemoveRefusesGoShimDir keeps the guardrail symmetric, so no path in this
+// package can be aimed at the Go shim's directory.
+func TestRemoveRefusesGoShimDir(t *testing.T) {
+	if err := Remove(GoShimDir, testSandboxID); err == nil {
+		t.Error("Remove succeeded on the Go shim's directory, want refusal")
+	}
+}
+
+// TestRemoveIsIdempotent covers DEL being called twice, and being called when
+// ADD never wrote a file.
+func TestRemoveIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := Remove(dir, "never-written"); err != nil {
+		t.Errorf("Remove of a missing file: %v", err)
+	}
+	if err := Write(dir, testSandboxID, sampleDocument()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	for attempt := range 2 {
+		if err := Remove(dir, testSandboxID); err != nil {
+			t.Errorf("Remove attempt %d: %v", attempt+1, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, testSandboxID+".json")); !os.IsNotExist(err) {
+		t.Errorf("DAN file still present after Remove: %v", err)
+	}
+}
+
+// TestRemoveIdempotentOnMissingDirectory covers a DEL on a node where emission
+// was never enabled, so the directory itself does not exist.
+func TestRemoveIdempotentOnMissingDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "never-created")
+	if err := Remove(dir, testSandboxID); err != nil {
+		t.Errorf("Remove under a missing directory: %v", err)
+	}
+}
+
+// TestWriteReplacesExistingFile covers an ADD retried after a partial failure,
+// which must leave the current document rather than the stale one.
+func TestWriteReplacesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := Write(dir, testSandboxID, sampleDocument()); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	replacement := sampleDocument()
+	replacement.Devices[0].Device.TapName = "G00000000otherH"
+	if err := Write(dir, testSandboxID, replacement); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, testSandboxID+".json"))
+	if err != nil {
+		t.Fatalf("read DAN file: %v", err)
+	}
+	var got Document
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse DAN file: %v", err)
+	}
+	if got.Devices[0].Device.TapName != "G00000000otherH" {
+		t.Errorf("tap name = %q, want the replacement's", got.Devices[0].Device.TapName)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read directory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("directory holds %d entries, want only the DAN file", len(entries))
+	}
+}
+
+// TestWriteRejectsUnusableInput covers the inputs that would put a file
+// somewhere other than one sandbox's own, or write one no shim can use.
+func TestWriteRejectsUnusableInput(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]struct {
+		dir       string
+		sandboxID string
+		doc       *Document
+	}{
+		"empty directory":          {"", testSandboxID, sampleDocument()},
+		"empty sandbox ID":         {dir, "", sampleDocument()},
+		"path in ID":               {dir, "../escape", sampleDocument()},
+		"nil document":             {dir, testSandboxID, nil},
+		"document with no devices": {dir, testSandboxID, &Document{}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := Write(tc.dir, tc.sandboxID, tc.doc); err == nil {
+				t.Error("Write succeeded, want an error")
+			}
+		})
+	}
+}
+
+// TestWriteFailsWhenDirectoryCannotBeCreated checks that a write failure
+// surfaces to the caller. A swallowed failure leaves the shim falling back to
+// namespace scanning.
+func TestWriteFailsWhenDirectoryCannotBeCreated(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+	if err := Write(blocked, testSandboxID, sampleDocument()); err == nil {
+		t.Error("Write succeeded where the directory cannot exist, want an error")
+	}
+}
+
+// TestDefaultDirIsNotTheGoShimDir pins the two directories apart.
+func TestDefaultDirIsNotTheGoShimDir(t *testing.T) {
+	if DefaultDir == GoShimDir {
+		t.Fatalf("DefaultDir is the Go shim's directory %q", GoShimDir)
+	}
+}


### PR DESCRIPTION
General-purpose workloads cannot be attached to a customer's VPC network. Their guests run under a Kata sandbox, which builds a network of its own and never sees the interface galactic already created for the attachment, so these workloads are limited to the cluster's own networking. This change closes that gap, so a customer can run a general-purpose workload on the same VPC as everything else they run.

The CNI plugin now writes a small file for each sandbox describing the interface the guest should adopt: the device, the addresses it holds, its gateway, and its MTU. The Kata runtime reads that description instead of discovering a network itself, and the guest comes up already on the VPC. The approach was validated end to end on a real node.

It is opt-in per attachment, so nothing is written for a workload whose runtime does not read it. Nothing opts in today, so merging this is inert on every existing cell. Enabling it for general-purpose workloads is separate work in the control plane.

## Testing

Unit tests cover the file's shape, the opt-in gate, cleanup on teardown, and the guardrails that make a bad write fail loudly. This repository does not build on macOS, so the build, vet, lint, and unit suite were run in a Linux container; CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
