### PR TITLE
fix(cni): Stop the attach from erasing a VPC network's annotations

### DIFF
--- a/internal/nadpatch/nadpatch.go
+++ b/internal/nadpatch/nadpatch.go
@@ -10,6 +10,7 @@ package nadpatch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -64,6 +65,13 @@ func ParsePodName(cniArgs string) string {
 // operator before the CNI runs, so not-found is a hard failure. A conflict is
 // the one non-fatal case: it means a previous invocation already applied the
 // annotation.
+//
+// The patch is a merge patch so it touches only this one annotation. The
+// definition belongs to the external operator and carries annotations from
+// Multus, the CNI tooling, and whatever applied it; a patch that replaced the
+// whole annotation map would drop all of them. A key-scoped JSON Patch would
+// scope the write just as narrowly but fails outright on a definition that
+// carries no annotations yet, which is the common case.
 func AnnotateNAD(ctx context.Context, k8s client.Client, nadName, nadNamespace, hostInterface string) error {
 	if nadNamespace == "" {
 		return nil
@@ -74,10 +82,16 @@ func AnnotateNAD(ctx context.Context, k8s client.Client, nadName, nadNamespace, 
 	nad.SetName(nadName)
 	nad.SetNamespace(nadNamespace)
 
-	patch := fmt.Sprintf(`[{"op":"add","path":"/metadata/annotations","value":{"%s":"%s"}}]`,
-		AnnotationHostInterface, hostInterface)
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{AnnotationHostInterface: hostInterface},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("build annotation patch for %s/%s: %w", nadNamespace, nadName, err)
+	}
 
-	err := k8s.Patch(ctx, nad, client.RawPatch(types.JSONPatchType, []byte(patch)))
+	err = k8s.Patch(ctx, nad, client.RawPatch(types.MergePatchType, patch))
 	if err != nil {
 		if apierrors.IsConflict(err) {
 			slog.Debug("annotate NAD: already annotated by a previous invocation",

--- a/internal/nadpatch/nadpatch_test.go
+++ b/internal/nadpatch/nadpatch_test.go
@@ -122,6 +122,88 @@ func TestAnnotateNAD(t *testing.T) {
 		}
 	})
 
+	t.Run("pre-existing foreign annotations survive", func(t *testing.T) {
+		// A NetworkAttachmentDefinition is authored and owned by the external
+		// VPC operator, so it arrives carrying annotations from Multus, the
+		// CNI tooling, and whatever applied it. The patch has to leave every
+		// one of them in place.
+		const (
+			resourceNameKey = "k8s.v1.cni.cncf.io/resourceName"
+			resourceNameVal = "intel.com/sriov_netdevice"
+			lastAppliedKey  = "kubectl.kubernetes.io/last-applied-configuration"
+			lastAppliedVal  = `{"apiVersion":"k8s.cni.cncf.io/v1"}`
+			tildeKey        = "example.com/odd~key/with~slash"
+			tildeVal        = "preserved"
+		)
+
+		nad := &unstructured.Unstructured{}
+		nad.SetGroupVersionKind(nadGVK)
+		nad.SetName(nadName)
+		nad.SetNamespace(nadNamespace)
+		nad.SetAnnotations(map[string]string{
+			resourceNameKey: resourceNameVal,
+			lastAppliedKey:  lastAppliedVal,
+			tildeKey:        tildeVal,
+		})
+		k8s := fakeClient(nad)
+
+		if err := AnnotateNAD(context.Background(), k8s, nadName, nadNamespace, hostIface); err != nil {
+			t.Fatalf("AnnotateNAD() = %v, want nil", err)
+		}
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(nadGVK)
+		if err := k8s.Get(context.Background(), client.ObjectKey{Name: nadName, Namespace: nadNamespace}, got); err != nil {
+			t.Fatalf("get NAD after annotate: %v", err)
+		}
+
+		want := map[string]string{
+			resourceNameKey:         resourceNameVal,
+			lastAppliedKey:          lastAppliedVal,
+			tildeKey:                tildeVal,
+			AnnotationHostInterface: hostIface,
+		}
+		gotAnnotations := got.GetAnnotations()
+		for key, wantValue := range want {
+			if gotAnnotations[key] != wantValue {
+				t.Errorf("annotation %s = %q, want %q", key, gotAnnotations[key], wantValue)
+			}
+		}
+		if len(gotAnnotations) != len(want) {
+			t.Errorf("annotations = %v, want exactly %d entries", gotAnnotations, len(want))
+		}
+	})
+
+	t.Run("re-annotating an already annotated NAD overwrites only its own key", func(t *testing.T) {
+		const foreignKey = "k8s.v1.cni.cncf.io/resourceName"
+
+		nad := &unstructured.Unstructured{}
+		nad.SetGroupVersionKind(nadGVK)
+		nad.SetName(nadName)
+		nad.SetNamespace(nadNamespace)
+		nad.SetAnnotations(map[string]string{
+			foreignKey:              "intel.com/sriov_netdevice",
+			AnnotationHostInterface: "vpc-stale-iface",
+		})
+		k8s := fakeClient(nad)
+
+		if err := AnnotateNAD(context.Background(), k8s, nadName, nadNamespace, hostIface); err != nil {
+			t.Fatalf("AnnotateNAD() = %v, want nil", err)
+		}
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(nadGVK)
+		if err := k8s.Get(context.Background(), client.ObjectKey{Name: nadName, Namespace: nadNamespace}, got); err != nil {
+			t.Fatalf("get NAD after annotate: %v", err)
+		}
+		if v := got.GetAnnotations()[AnnotationHostInterface]; v != hostIface {
+			t.Errorf("annotation %s = %q, want %q", AnnotationHostInterface, v, hostIface)
+		}
+		if v := got.GetAnnotations()[foreignKey]; v != "intel.com/sriov_netdevice" {
+			t.Errorf("annotation %s = %q, want it preserved", foreignKey, v)
+		}
+	})
+
 	t.Run("empty pod namespace is a no-op", func(t *testing.T) {
 		k8s := fakeClient()
 


### PR DESCRIPTION
Attaching an Instance to a VPC quietly erased the annotations on that VPC network's attachment definition. Galactic records the host interface name it just created as an annotation, but wrote it by replacing the entire annotation map, so on the first attach every other annotation on the object disappeared.

The loss reaches past Datum's own bookkeeping. Multus reads its device-plugin resource binding from an annotation on the same object, and the tooling that applies the definition tracks ownership and last-applied state there too. A definition that had been attached to once came back materially different from the one its operator declared, and nothing surfaced the change.

Galactic now records only its own annotation and leaves the rest untouched.

Follows datum-cloud/galactic#528, datum-cloud/galactic#526, and datum-cloud/galactic#527. Found while bringing up general-purpose Instance networking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
