### PR TITLE
fix(cni): Report a rejected attach annotation instead of hiding it

### DIFF
--- a/internal/nadpatch/nadpatch.go
+++ b/internal/nadpatch/nadpatch.go
@@ -62,9 +62,10 @@ func ParsePodName(cniArgs string) string {
 // AnnotateNAD patches the attachment definition with the host interface name.
 //
 // The definition is expected to already exist, created by the external VPC
-// operator before the CNI runs, so not-found is a hard failure. A conflict is
-// the one non-fatal case: it means a previous invocation already applied the
-// annotation.
+// operator before the CNI runs, so not-found is a hard failure. So is every
+// other rejection: the patch states no resourceVersion precondition, so a
+// repeat attach just reapplies it, and any error that does come back means the
+// host interface name never reached the definition.
 //
 // The patch is a merge patch so it touches only this one annotation. The
 // definition belongs to the external operator and carries annotations from
@@ -93,11 +94,6 @@ func AnnotateNAD(ctx context.Context, k8s client.Client, nadName, nadNamespace, 
 
 	err = k8s.Patch(ctx, nad, client.RawPatch(types.MergePatchType, patch))
 	if err != nil {
-		if apierrors.IsConflict(err) {
-			slog.Debug("annotate NAD: already annotated by a previous invocation",
-				"name", nadName, "namespace", nadNamespace)
-			return nil
-		}
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("NetworkAttachmentDefinition %s/%s not found: %w", nadNamespace, nadName, err)
 		}

--- a/internal/nadpatch/nadpatch_test.go
+++ b/internal/nadpatch/nadpatch_test.go
@@ -6,14 +6,17 @@ package nadpatch
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func fakeClient(objs ...client.Object) client.Client {
@@ -201,6 +204,32 @@ func TestAnnotateNAD(t *testing.T) {
 		}
 		if v := got.GetAnnotations()[foreignKey]; v != "intel.com/sriov_netdevice" {
 			t.Errorf("annotation %s = %q, want it preserved", foreignKey, v)
+		}
+	})
+
+	t.Run("a conflict from the server is surfaced, not swallowed", func(t *testing.T) {
+		// A merge patch carries no resourceVersion, so the API server has no
+		// precondition to fail and cannot answer this call with a conflict of
+		// its own. One can still arrive from an admission webhook, and it
+		// means the host interface never reached the definition: report it so
+		// the attach fails loudly instead of handing back an interface with no
+		// path to its VPC.
+		base := fake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+		k8s := interceptor.NewClient(base, interceptor.Funcs{
+			Patch: func(context.Context, client.WithWatch, client.Object, client.Patch, ...client.PatchOption) error {
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: nadGVK.Group, Resource: "network-attachment-definitions"},
+					nadName, errors.New("rejected by webhook"),
+				)
+			},
+		})
+
+		err := AnnotateNAD(context.Background(), k8s, nadName, nadNamespace, hostIface)
+		if err == nil {
+			t.Fatal("expected error when the server reports a conflict, got nil")
+		}
+		if !apierrors.IsConflict(err) {
+			t.Errorf("expected error to wrap a conflict status, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Attaching an Instance to a VPC records the host interface name on the network's attachment definition. When the API server rejected that write with a conflict, the attach reported success anyway, on the assumption that the conflict meant an earlier attach had already recorded the name. That assumption never held: the write states no resource-version precondition, so the server has nothing to conflict on, and a repeat attach simply reapplies the annotation. The only way a conflict can actually arrive is admission rejecting the write, which leaves the interface name unrecorded — and the Instance came up with an interface that has no path to its VPC, with no error reported anywhere.

Every rejection is now reported, so a failed attach fails visibly instead of handing back a silently broken Instance.

Follows datum-cloud/galactic#529, which fixed the same annotation write erasing a network's other annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
