### PR TITLE
fix(ebpf): Keep web responses from general-purpose Instances from stalling

### DIFF
--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -175,6 +175,12 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 // mirror whatever budget the original sender chose.
 #define USID_EGRESS_HOP_LIMIT 64
 
+// BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 from the kernel's UAPI. It marks the room
+// usid_egress opens as an outer IPv6 tunnel header, so a GSO packet the tenant
+// handed over is still segmented after encapsulation; without it the kernel
+// cannot segment the packet on the uplink and drops it.
+#define USID_BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 (1ULL << 2)
+
 // USID_L3_OFFSET is the fixed byte offset of the IPv6 header from skb->data, a
 // compile-time constant.
 //
@@ -1512,7 +1518,17 @@ int usid_egress(struct __sk_buff *skb)
 	// room, the ingress strip being the same call with a negative one, and the
 	// MAC-anchored mode keeps the Ethernet header at the front and opens the
 	// space directly after it, where the outer header belongs.
-	if (bpf_skb_adjust_room(skb, (__s32) sizeof(struct usid_ip6hdr), BPF_ADJ_ROOM_MAC, 0)) {
+	//
+	// The room is declared an outer IPv6 tunnel header. A guest behind a tap
+	// with offloads hands over TCP super-segments many MSS long, and only a
+	// tunnel-marked GSO packet can be segmented once it reaches the uplink;
+	// an unmarked one is dropped there, leaving the connection to crawl along
+	// on single-segment retransmissions. The kernel refuses the flag for a
+	// packet already marked encapsulated, which keeps the unmarked push.
+	__s32 outer_len = (__s32) sizeof(struct usid_ip6hdr);
+
+	if (bpf_skb_adjust_room(skb, outer_len, BPF_ADJ_ROOM_MAC, USID_BPF_F_ADJ_ROOM_ENCAP_L3_IPV6) &&
+	    bpf_skb_adjust_room(skb, outer_len, BPF_ADJ_ROOM_MAC, 0)) {
 		count_claimed_drop(DROP_REASON_EGRESS_ROUTE_ENCAP_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}


### PR DESCRIPTION
Web responses from general-purpose Instances on a VPC network no longer crawl or stall. A page that took anywhere from 2 to 16 seconds to download, with roughly two retransmissions for every segment sent, now arrives at the speed the path allows.

## What was wrong

A general-purpose guest hands its tap large TCP super-segments, each many segments long, and lets the host split them. When the egress datapath wrapped such a packet in its SRv6 outer header, it did not mark the new header as a tunnel. The uplink then could not split the tunnelled packet and dropped it. Each connection survived only on single-segment retransmissions, which is why responses completed slowly or timed out, while small responses looked healthy.

## Evidence

Measured on a staging general-purpose Instance serving a 34 KB page, with 10 downloads per batch and the guest's TCP counters read before and after:

| Guest sending pattern | Retransmissions per segment | Time per download |
|---|---|---|
| Normal writes, segment size 536 to 1200 bytes | 1.8 to 2.1 | 0.8 to 16 seconds |
| Sub-segment writes that keep the guest from offloading, segment size 1200 to 1300 bytes | 0 | 0.2 to 0.3 seconds |

Only the way the guest hands packets to its tap changed between the two rows, so segment size is not the cause. The node's uplink counters show where the packets went: with normal writes it dropped 226 of 577 packets it tried to send in one batch, while with offloading avoided, and at idle, it dropped none. The kernel's IPv6-in-IPv6 segmentation rejects any offloaded packet that is not marked as tunnelled, which is the drop this change removes.

## Scope

This changes only how the outer header is declared to the kernel. The packet on the wire is unchanged. Companion MTU correction: datum-cloud/galactic#533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

