### PR TITLE
fix(cni): Give general-purpose Instances their network's MTU

### DIFF
--- a/internal/cni/tap/tap.go
+++ b/internal/cni/tap/tap.go
@@ -48,7 +48,10 @@ func updateForwardRule(interfaceName string, action string) error {
 					return err
 				}
 			case "delete":
-				if err := ipt.Delete("filter", "FORWARD", ruleSpec...); err != nil {
+				// A rule already gone is the desired end state, and treating it
+				// as a failure would make a repeated or partial DEL impossible
+				// to complete.
+				if err := ipt.DeleteIfExists("filter", "FORWARD", ruleSpec...); err != nil {
 					return err
 				}
 			default:
@@ -76,15 +79,12 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 	existingTap, err := netlink.LinkByName(tapName)
 	if err == nil {
 		slog.Warn("tap: found existing tap from a previous ADD attempt, repairing state", "tap", tapName)
-		return repairTap(existingTap, vrfLink, tapName)
+		return repairTap(existingTap, vrfLink, tapName, mtu)
 	}
 
 	tap := &netlink.Tuntap{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: tapName,
-			MTU:  mtu,
-		},
-		Mode: netlink.TUNTAP_MODE_TAP,
+		LinkAttrs: netlink.LinkAttrs{Name: tapName},
+		Mode:      netlink.TUNTAP_MODE_TAP,
 	}
 
 	if err := netlink.LinkAdd(tap); err != nil {
@@ -94,6 +94,10 @@ func Add(vpc, vpcAttachment string, mtu int) error {
 
 	tapLink, err := netlink.LinkByName(tapName)
 	if err != nil {
+		return err
+	}
+
+	if err := ensureMTU(tapLink, tapName, mtu); err != nil {
 		return err
 	}
 
@@ -148,8 +152,33 @@ func Delete(vpc, vpcAttachment string) error {
 	return nil
 }
 
+// ensureMTU sets the tap's MTU to mtu, leaving the kernel default in place
+// when none is configured.
+//
+// Creating a tap never applies an MTU: the tap is made by an ioctl that has no
+// MTU field, and the netlink library silently drops the one it is given. An
+// unset MTU leaves the tap at 1500, too large for a VPC network whose packets
+// gain an SRv6 header on the wire, and the guest adopts whatever the tap
+// carries.
+func ensureMTU(tapLink netlink.Link, tapName string, mtu int) error {
+	if mtu <= 0 || tapLink.Attrs().MTU == mtu {
+		return nil
+	}
+	if err := netlink.LinkSetMTU(tapLink, mtu); err != nil {
+		return fmt.Errorf("set MTU %d on tap %q: %w", mtu, tapName, err)
+	}
+	return nil
+}
+
 // repairTap verifies and repairs a pre-existing tap interface's state.
-func repairTap(tapLink netlink.Link, vrfLink netlink.Link, tapName string) error {
+func repairTap(tapLink netlink.Link, vrfLink netlink.Link, tapName string, mtu int) error {
+	// A tap left behind by an earlier ADD keeps whatever MTU it had, and the
+	// caller reports this tap's MTU to the guest, so a wrong value would
+	// otherwise persist for the life of the instance.
+	if err := ensureMTU(tapLink, tapName, mtu); err != nil {
+		return err
+	}
+
 	// Verify VRF enslavement.
 	if tapLink.Attrs().MasterIndex != vrfLink.Attrs().Index {
 		slog.Warn("tap: re-enslaving tap to VRF during repair", "tap", tapName)

--- a/internal/cni/tap/tap_test.go
+++ b/internal/cni/tap/tap_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
+
+	"go.datum.net/galactic/internal/plumbing/intf"
 )
 
 func TestIsLinkNotFoundError(t *testing.T) {
@@ -66,8 +68,8 @@ func TestUpdateForwardRuleInvalidAction(t *testing.T) {
 	}
 }
 
-// requiresRoot skips the test when not running as root.
-func requiresRoot(t *testing.T) {
+// requireRoot skips the test when not running as root.
+func requireRoot(t *testing.T) {
 	t.Helper()
 	if os.Getuid() != 0 {
 		t.Skip("skipping: requires root")
@@ -75,20 +77,20 @@ func requiresRoot(t *testing.T) {
 }
 
 func TestDeleteNonExistent(t *testing.T) {
-	requiresRoot(t)
+	requireRoot(t)
 
 	// Delete with a name that definitely doesn't exist.
-	err := Delete("zzz_nonexistent_vpc", "zzz_nonexistent_att")
+	err := Delete("zz", "zz9")
 	if err != nil {
 		t.Errorf("Delete(nonexistent) = %v, want nil", err)
 	}
 }
 
 func TestAddCreatesTapLink(t *testing.T) {
-	requiresRoot(t)
+	requireRoot(t)
 
-	vpc := "taptest_a"
-	att := "taptest_b"
+	vpc, att := "at", "b1"
+	addVRFStandIn(t, vpc)
 	t.Cleanup(func() { _ = Delete(vpc, att) })
 
 	err := Add(vpc, att, 1500)
@@ -97,20 +99,92 @@ func TestAddCreatesTapLink(t *testing.T) {
 	}
 
 	// Verify the link exists and is a tap.
-	link, err := findLink(t, generateInterfaceNameHost(vpc, att))
+	link, err := findLink(t, intf.GenerateInterfaceNameHost(vpc, att))
 	if err != nil {
 		t.Fatalf("link not found: %v", err)
 	}
-	if link.Type() != "tap" {
-		t.Errorf("link type = %q, want %q", link.Type(), "tap")
+	if link.Type() != "tuntap" {
+		t.Errorf("link type = %q, want %q", link.Type(), "tuntap")
+	}
+}
+
+// testMTU differs from the kernel's 1500 default, so a tap that silently kept
+// the default fails the assertion.
+const testMTU = 1460
+
+// addVRFStandIn creates the master device Add enslaves the tap to. A bridge
+// stands in for the VRF because Add only needs a master-capable link under the
+// VRF's name, and not every kernel that runs these tests ships the VRF module.
+func addVRFStandIn(t *testing.T, vpc string) {
+	t.Helper()
+	name := intf.GenerateInterfaceNameVRF(vpc)
+	if err := netlink.LinkAdd(&netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: name}}); err != nil {
+		t.Fatalf("create VRF stand-in %q: %v", name, err)
+	}
+	t.Cleanup(func() {
+		if link, err := netlink.LinkByName(name); err == nil {
+			_ = netlink.LinkDel(link)
+		}
+	})
+}
+
+func TestAddAppliesConfiguredMTU(t *testing.T) {
+	requireRoot(t)
+
+	vpc, att := "mt", "a1"
+	addVRFStandIn(t, vpc)
+	t.Cleanup(func() { _ = Delete(vpc, att) })
+
+	if err := Add(vpc, att, testMTU); err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+
+	link, err := findLink(t, intf.GenerateInterfaceNameHost(vpc, att))
+	if err != nil {
+		t.Fatalf("link not found: %v", err)
+	}
+	if got := link.Attrs().MTU; got != testMTU {
+		t.Errorf("tap MTU = %d, want %d", got, testMTU)
+	}
+}
+
+func TestAddRepairRestoresConfiguredMTU(t *testing.T) {
+	requireRoot(t)
+
+	vpc, att := "mr", "b1"
+	addVRFStandIn(t, vpc)
+	t.Cleanup(func() { _ = Delete(vpc, att) })
+
+	if err := Add(vpc, att, testMTU); err != nil {
+		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
+	}
+	hostName := intf.GenerateInterfaceNameHost(vpc, att)
+	link, err := findLink(t, hostName)
+	if err != nil {
+		t.Fatalf("link not found: %v", err)
+	}
+	// Model a tap an earlier ADD left at the kernel default.
+	if err := netlink.LinkSetMTU(link, 1500); err != nil {
+		t.Fatalf("LinkSetMTU: %v", err)
+	}
+
+	if err := Add(vpc, att, testMTU); err != nil {
+		t.Fatalf("repeat Add(%q, %q) = %v", vpc, att, err)
+	}
+	link, err = findLink(t, hostName)
+	if err != nil {
+		t.Fatalf("link not found after repair: %v", err)
+	}
+	if got := link.Attrs().MTU; got != testMTU {
+		t.Errorf("tap MTU after repair = %d, want %d", got, testMTU)
 	}
 }
 
 func TestAddEnslavesToVRF(t *testing.T) {
-	requiresRoot(t)
+	requireRoot(t)
 
-	vpc := "taptest_c"
-	att := "taptest_d"
+	vpc, att := "ct", "d1"
+	addVRFStandIn(t, vpc)
 	t.Cleanup(func() { _ = Delete(vpc, att) })
 
 	err := Add(vpc, att, 1500)
@@ -118,8 +192,8 @@ func TestAddEnslavesToVRF(t *testing.T) {
 		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
 	}
 
-	hostName := generateInterfaceNameHost(vpc, att)
-	vrfName := generateInterfaceNameVRF(vpc, att)
+	hostName := intf.GenerateInterfaceNameHost(vpc, att)
+	vrfName := intf.GenerateInterfaceNameVRF(vpc)
 
 	link, err := findLink(t, hostName)
 	if err != nil {
@@ -137,10 +211,10 @@ func TestAddEnslavesToVRF(t *testing.T) {
 }
 
 func TestAddBidirectionalRules(t *testing.T) {
-	requiresRoot(t)
+	requireRoot(t)
 
-	vpc := "taptest_e"
-	att := "taptest_f"
+	vpc, att := "et", "f1"
+	addVRFStandIn(t, vpc)
 	t.Cleanup(func() { _ = Delete(vpc, att) })
 
 	err := Add(vpc, att, 1500)
@@ -148,7 +222,7 @@ func TestAddBidirectionalRules(t *testing.T) {
 		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
 	}
 
-	hostName := generateInterfaceNameHost(vpc, att)
+	hostName := intf.GenerateInterfaceNameHost(vpc, att)
 
 	// Check iptables rules exist for both -i and -o.
 	for _, proto := range []int{iptablesProtocolIPv4, iptablesProtocolIPv6} {
@@ -180,17 +254,17 @@ func TestAddBidirectionalRules(t *testing.T) {
 }
 
 func TestDeleteRemovesLink(t *testing.T) {
-	requiresRoot(t)
+	requireRoot(t)
 
-	vpc := "taptest_g"
-	att := "taptest_h"
+	vpc, att := "gt", "h1"
+	addVRFStandIn(t, vpc)
 
 	err := Add(vpc, att, 1500)
 	if err != nil {
 		t.Fatalf("Add(%q, %q) = %v", vpc, att, err)
 	}
 
-	hostName := generateInterfaceNameHost(vpc, att)
+	hostName := intf.GenerateInterfaceNameHost(vpc, att)
 	if _, err := findLink(t, hostName); err != nil {
 		t.Fatalf("link not found after Add: %v", err)
 	}
@@ -206,18 +280,6 @@ func TestDeleteRemovesLink(t *testing.T) {
 }
 
 // ---- helpers -------------------------------------------------------------
-
-func generateInterfaceNameHost(vpc, att string) string {
-	// Inline the intf name generation to avoid a test-time import cycle.
-	// This mirrors intf.GenerateInterfaceNameHost.
-	return "H" + vpc + att
-}
-
-func generateInterfaceNameVRF(vpc, att string) string {
-	// Inline the intf name generation to avoid a test-time import cycle.
-	// This mirrors intf.GenerateInterfaceNameVRF.
-	return "V" + vpc + att
-}
 
 const (
 	iptablesProtocolIPv4 = 0


### PR DESCRIPTION
General-purpose Instances on a VPC network now get the MTU their network is configured with, instead of silently running at 1500. A guest that believes its link is 1500 sends full-size packets that no longer fit once SRv6 encapsulation adds its 40-byte outer header, and the underlay drops them without a Packet Too Big reply, so large responses hang.

## What was wrong

- A tap device never received the configured MTU. The kernel creates a tap without one, and the netlink library quietly ignores the MTU it is handed at creation, so every tap stayed at the 1500 default. Veth attachments on the same node correctly run at the configured 1460. The guest adopts the tap's MTU, so it also ran at 1500.
- A tap that already existed when an attachment was added kept whatever MTU it had. That path is routine today, because the attachment is added twice per sandbox (datum-cloud/cloud), so nothing ever corrected a wrong value.
- The tap package's privileged tests never ran in CI, because the root-test job selects packages by a helper name this package spelled differently. Those tests had also stopped passing. They now run, and use a stand-in master device so they do not depend on the VRF kernel module. Removing a forwarding rule that is already gone no longer fails, so a repeated teardown can complete.

## Scope

This makes the tap, the interface description handed to the guest, and the CNI result all carry the configured MTU. Two related issues remain outside this change:

- The configured value itself is too large for today's staging path. Measured with single-segment traffic from a staging general-purpose Instance, encapsulated frames up to 1480 bytes arrive and frames of 1492 bytes or more are lost, so the largest safe inner MTU is 1440 rather than the network default of 1460. That value is set on the Network, not here.
- The retransmission-heavy slowness of general-purpose responses is a separate offload defect, fixed in datum-cloud/galactic#532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
