### PR TITLE
fix(usid): Deliver inbound traffic to tap and veth Instances that share a VPC on one node

### DIFF
--- a/internal/cni/ops_del.go
+++ b/internal/cni/ops_del.go
@@ -104,8 +104,8 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table entry
-// if one exists. The interface's ifindex is resolved by its deterministic name,
+// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table and
+// ifindex_egress_kind_table entries if they exist. The interface's ifindex is resolved by its deterministic name,
 // the same name the ADD path resolved it by, and before the interface is torn
 // down, since there is nothing to resolve from afterward.
 //
@@ -132,6 +132,20 @@ func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 
 	if err := table.Unregister(uint32(link.Attrs().Index)); err != nil {
 		slog.Warn("DEL: failed to unregister eBPF ifindex_vrf_table entry", "err", err,
+			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
+	}
+
+	// The egress kind entry shares this row's lifecycle. Left behind, it would
+	// steer delivery for whatever attachment next reuses this ifindex until
+	// that attachment's own ADD overwrites it.
+	kinds, kindsCloser, err := ifindexvrfmap.OpenPinnedEgressKind(attach.PinDir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = kindsCloser.Close() }()
+
+	if err := kinds.Unregister(uint32(link.Attrs().Index)); err != nil {
+		slog.Warn("DEL: failed to unregister eBPF ifindex_egress_kind_table entry", "err", err,
 			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
 	}
 }

--- a/internal/cnibgp/bgp.go
+++ b/internal/cnibgp/bgp.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -69,7 +70,7 @@ const (
 // publishing needs.
 type publishConfig struct {
 	vpc, vpcAttachment string
-	// ifaceType selects the vrf_table egress_kind, veth or tap. Inferred from
+	// ifaceType selects the attachment's egress kind, veth or tap. Inferred from
 	// prevResult, never a config field.
 	ifaceType string
 }
@@ -592,6 +593,9 @@ func registerEBPFDatapath(
 	if err := ifindexTable.Register(hostIfindex, block, argument); err != nil {
 		return false, fmt.Errorf("register eBPF ifindex_vrf_table entry: %w", err)
 	}
+	if err := registerEgressKind(pinDir, hostIfindex, egressKind); err != nil {
+		return false, err
+	}
 
 	// Attach usid_egress to this attachment's host-side interface. This is
 	// what translates a reply's source address on the way back out.
@@ -782,10 +786,37 @@ func hostInterfaceIndex(vpc, vpcAttachment string) (uint32, error) {
 	return uint32(link.Attrs().Index), nil
 }
 
+// registerEgressKind records which redirect helper usid_ingress uses to deliver
+// into this attachment's host-side interface. It is keyed by that interface
+// rather than by VPC because one VPC can hold tap and veth attachments on the
+// same node.
+//
+// A map that is not pinned yet is logged, not returned. The install-cni init
+// container replaces this binary before the run container reloads the datapath
+// that pins the map, so an ADD can land in between. Failing it would block
+// Instances from starting during every upgrade, while the datapath's fallback
+// for a missing entry, a plain redirect, still delivers to both kinds.
+func registerEgressKind(pinDir string, hostIfindex, egressKind uint32) error {
+	table, closer, err := ifindexvrfmap.OpenPinnedEgressKind(pinDir)
+	if errors.Is(err, os.ErrNotExist) {
+		slog.Warn("ADD: eBPF ifindex_egress_kind_table is not pinned yet; "+
+			"delivery to this attachment uses the plain-redirect fallback until its next ADD",
+			"hostIfindex", hostIfindex, "err", err)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open pinned eBPF ifindex_egress_kind_table: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+	if err := table.Register(hostIfindex, egressKind); err != nil {
+		return fmt.Errorf("register eBPF ifindex_egress_kind_table entry: %w", err)
+	}
+	return nil
+}
+
 // egressKindForInterfaceType maps a "veth" or "tap" interface type to the
-// vrf_table egress_kind value the datapath uses to choose between
-// bpf_redirect_peer, which crosses into the container's netns, and plain
-// bpf_redirect, which does not.
+// egress kind the datapath uses to choose between bpf_redirect_peer, which
+// crosses into the container's netns, and plain bpf_redirect, which does not.
 func egressKindForInterfaceType(ifaceType string) (uint32, error) {
 	switch ifaceType {
 	case ifaceTypeVeth:

--- a/internal/cnibgp/bgp_ebpf_test.go
+++ b/internal/cnibgp/bgp_ebpf_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
+	"go.datum.net/galactic/internal/cni/tap"
 	"go.datum.net/galactic/internal/cni/veth"
 	"go.datum.net/galactic/internal/plumbing/ebpf/attach"
 	"go.datum.net/galactic/internal/plumbing/ebpf/egressroutemap"
@@ -329,5 +330,103 @@ func TestRegisterEBPFDatapath_SecondAttachmentSharesEntry(t *testing.T) {
 		if !sid.Equal(net.IPv6zero) {
 			t.Errorf("egress_route_table entry for %s = sid %s, want the all-zero pass-through sentinel", prefixStr, sid)
 		}
+	}
+}
+
+// TestRegisterEBPFDatapath_MixedInterfaceTypesKeepOwnEgressKind reproduces a
+// VPC holding a tap and a veth attachment on one node. Their shared vrf_table
+// entry can only hold the last writer's kind, so each host-side interface must
+// carry its own, whichever registers last, and removing one must leave the
+// other intact.
+func TestRegisterEBPFDatapath_MixedInterfaceTypesKeepOwnEgressKind(t *testing.T) {
+	requireRoot(t)
+
+	const (
+		vpc            = testVPC
+		locator        = "2001:db8:1::/48"
+		nodeID         = int32(5)
+		vrfID          = int32(42)
+		tapAttachment  = testAttachment
+		vethAttachment = "def2"
+	)
+	type attachment struct{ name, ifaceType string }
+	tapAtt := attachment{name: tapAttachment, ifaceType: ifaceTypeTap}
+	vethAtt := attachment{name: vethAttachment, ifaceType: ifaceTypeVeth}
+
+	for _, tt := range []struct {
+		name  string
+		order []attachment
+	}{
+		{name: "tap then veth", order: []attachment{tapAtt, vethAtt}},
+		{name: "veth then tap", order: []attachment{vethAtt, tapAtt}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := vrf.Add(vpc); err != nil {
+				t.Fatalf("vrf.Add: %v", err)
+			}
+			t.Cleanup(func() { _ = vrf.Delete(vpc) })
+			if err := tap.Add(vpc, tapAttachment, 1500); err != nil {
+				t.Fatalf("tap.Add: %v", err)
+			}
+			t.Cleanup(func() { _ = tap.Delete(vpc, tapAttachment) })
+			if err := veth.Add(vpc, vethAttachment, 1500); err != nil {
+				t.Fatalf("veth.Add: %v", err)
+			}
+			t.Cleanup(func() { _ = veth.Delete(vpc, vethAttachment) })
+
+			pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-%d", os.Getpid())
+			t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+			loaderObjs, err := attach.Load(pinDir)
+			if err != nil {
+				t.Fatalf("attach.Load: %v", err)
+			}
+			t.Cleanup(func() { _ = loaderObjs.Close() })
+
+			cfg := bgpConfig{srv6Locator: locator, nodeID: nodeID}
+			for _, a := range tt.order {
+				if _, err := registerEBPFDatapath(cfg, vpc, a.name, a.ifaceType, uint16(vrfID), pinDir, nil); err != nil {
+					t.Fatalf("registerEBPFDatapath(%s): %v", a.name, err)
+				}
+			}
+
+			for _, a := range []attachment{tapAtt, vethAtt} {
+				if err := checkEgressKind(pinDir, vpc, a.name, a.ifaceType); err != nil {
+					t.Errorf("CHECK of %s attachment after both registered: %v", a.ifaceType, err)
+				}
+			}
+			if err := checkEgressKind(pinDir, vpc, tapAttachment, ifaceTypeVeth); err == nil {
+				t.Error("CHECK of the tap attachment against type veth = nil error, want a mismatch")
+			}
+
+			kinds, closer, err := ifindexvrfmap.OpenPinnedEgressKind(pinDir)
+			if err != nil {
+				t.Fatalf("OpenPinnedEgressKind: %v", err)
+			}
+			defer func() { _ = closer.Close() }()
+			tapIfindex, err := hostInterfaceIndex(vpc, tapAttachment)
+			if err != nil {
+				t.Fatalf("hostInterfaceIndex(tap): %v", err)
+			}
+			if err := kinds.Unregister(tapIfindex); err != nil {
+				t.Fatalf("Unregister(tap): %v", err)
+			}
+			if err := checkEgressKind(pinDir, vpc, vethAttachment, ifaceTypeVeth); err != nil {
+				t.Errorf("CHECK of the veth attachment after the tap's entry was removed: %v", err)
+			}
+			if err := checkEgressKind(pinDir, vpc, tapAttachment, ifaceTypeTap); err == nil {
+				t.Error("CHECK of the tap attachment after its entry was removed = nil error, want not found")
+			}
+		})
+	}
+}
+
+// TestRegisterEgressKind_UnpinnedMapIsNotFatal covers an ADD that runs after
+// install-cni replaced this binary but before the datapath reloaded and pinned
+// the map. Failing it would block Instances from starting during an upgrade.
+func TestRegisterEgressKind_UnpinnedMapIsNotFatal(t *testing.T) {
+	requireRoot(t)
+	pinDir := fmt.Sprintf("/sys/fs/bpf/galactic-bgp-test-unpinned-%d", os.Getpid())
+	if err := registerEgressKind(pinDir, 42, usidmap.EgressKindTap); err != nil {
+		t.Errorf("registerEgressKind with no pinned map = %v, want nil", err)
 	}
 }

--- a/internal/cnibgp/ops_check.go
+++ b/internal/cnibgp/ops_check.go
@@ -25,6 +25,7 @@ import (
 	"go.datum.net/galactic/internal/config"
 	"go.datum.net/galactic/internal/crdnames"
 	"go.datum.net/galactic/internal/nadpatch"
+	"go.datum.net/galactic/internal/plumbing/ebpf/ifindexvrfmap"
 	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
 	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
 	"go.datum.net/galactic/internal/plumbing/srv6"
@@ -82,7 +83,8 @@ func cmdCheck(args *skel.CmdArgs) error {
 	// No IPAM result, or one carrying no IPv6 address, means cmdAdd never
 	// published an EndpointSlice for this attachment, the same skip the ADD
 	// path takes.
-	if _, ipamResult, _, prevErr := inferFromPrevResult(pluginConf.RawPrevResult); prevErr != nil {
+	ifaceType, ipamResult, _, prevErr := inferFromPrevResult(pluginConf.RawPrevResult)
+	if prevErr != nil {
 		errs = append(errs, fmt.Errorf("infer from prevResult: %w", prevErr))
 	} else if ipamResult != nil && ipamResult.IPv6Subnet != nil {
 		podName := nadpatch.ParsePodName(args.Args)
@@ -102,7 +104,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	// it carrying the Argument they are keyed on, and this node's router
 	// actually has SRv6 configured.
 	if vrfErr == nil {
-		if err := checkEBPFEntry(pluginConf, uint16(vrfInst.Spec.VRFID), bgp); err != nil {
+		if err := checkEBPFEntry(pluginConf, uint16(vrfInst.Spec.VRFID), bgp, ifaceType); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -126,10 +128,16 @@ func cmdCheck(args *skel.CmdArgs) error {
 // entry, or a node ID that drifted out of range, while still reporting the
 // attachment healthy.
 //
+// ifaceType is the attachment's interface type inferred from prevResult. When
+// set, the host-side interface's egress kind entry is checked against it too,
+// since a missing or wrong entry changes how inbound traffic is delivered. It
+// is empty only when prevResult could not be parsed, which the caller already
+// reports.
+//
 // Returns nil, not an error, when this node's router has no locator or node ID
 // configured: SRv6 was intentionally never set up. bgp is this node's
 // BGPRouter, looked up once by the caller.
-func checkEBPFEntry(pluginConf *PluginConf, argument uint16, bgp bgpConfig) error {
+func checkEBPFEntry(pluginConf *PluginConf, argument uint16, bgp bgpConfig, ifaceType string) error {
 	if bgp.srv6Locator == "" || bgp.nodeID == 0 {
 		return nil
 	}
@@ -187,7 +195,45 @@ func checkEBPFEntry(pluginConf *PluginConf, argument uint16, bgp bgpConfig) erro
 		errs = append(errs, fmt.Errorf("eBPF vrf_table entry VRFTableID = %#x, want %#x", entry.VRFTableID, vrfTableID))
 	}
 
+	if ifaceType != "" {
+		if err := checkEgressKind(ebpfPinDir, pluginConf.VPC, pluginConf.VPCAttachment, ifaceType); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
 	return errors.Join(errs...)
+}
+
+// checkEgressKind verifies the host-side interface's ifindex_egress_kind_table
+// entry exists and matches ifaceType. Unlike ADD, a map that is not pinned is
+// an error here: once the datapath has reloaded, a still-missing entry means
+// this attachment has lost its fast delivery path.
+func checkEgressKind(pinDir, vpc, vpcAttachment, ifaceType string) error {
+	want, err := egressKindForInterfaceType(ifaceType)
+	if err != nil {
+		return fmt.Errorf("determine eBPF egress kind: %w", err)
+	}
+	hostIfindex, err := hostInterfaceIndex(vpc, vpcAttachment)
+	if err != nil {
+		return fmt.Errorf("resolve host interface ifindex for eBPF check: %w", err)
+	}
+	table, closer, err := ifindexvrfmap.OpenPinnedEgressKind(pinDir)
+	if err != nil {
+		return fmt.Errorf("open pinned eBPF ifindex_egress_kind_table: %w", err)
+	}
+	defer func() { _ = closer.Close() }()
+
+	got, ok, err := table.Get(hostIfindex)
+	switch {
+	case err != nil:
+		return fmt.Errorf("read eBPF ifindex_egress_kind_table entry: %w", err)
+	case !ok:
+		return fmt.Errorf("eBPF ifindex_egress_kind_table entry for host ifindex %d not found", hostIfindex)
+	case got != want:
+		return fmt.Errorf("eBPF ifindex_egress_kind_table entry for host ifindex %d = %d, want %d (%s)",
+			hostIfindex, got, want, ifaceType)
+	}
+	return nil
 }
 
 // checkEndpointSlice verifies the per-pod EndpointSlice the ADD path published

--- a/internal/cnitap/ops_del.go
+++ b/internal/cnitap/ops_del.go
@@ -92,8 +92,8 @@ func cmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table entry
-// if one exists, mirroring the veth plugin's identical helper but resolving a
+// unregisterIfindexVRFEntry removes this attachment's ifindex_vrf_table and
+// ifindex_egress_kind_table entries if they exist, mirroring the veth plugin's identical helper but resolving a
 // tap device's host-side interface rather than a veth pair's.
 func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 	hostName := intf.GenerateInterfaceNameHost(vpc, vpcAttachment)
@@ -110,6 +110,20 @@ func unregisterIfindexVRFEntry(vpc, vpcAttachment, containerID string) {
 
 	if err := table.Unregister(uint32(link.Attrs().Index)); err != nil {
 		slog.Warn("DEL: failed to unregister eBPF ifindex_vrf_table entry", "err", err,
+			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
+	}
+
+	// The egress kind entry shares this row's lifecycle. Left behind, it would
+	// steer delivery for whatever attachment next reuses this ifindex until
+	// that attachment's own ADD overwrites it.
+	kinds, kindsCloser, err := ifindexvrfmap.OpenPinnedEgressKind(attach.PinDir)
+	if err != nil {
+		return
+	}
+	defer func() { _ = kindsCloser.Close() }()
+
+	if err := kinds.Unregister(uint32(link.Attrs().Index)); err != nil {
+		slog.Warn("DEL: failed to unregister eBPF ifindex_egress_kind_table entry", "err", err,
 			"containerID", containerID, "vpc", vpc, "vpcAttachment", vpcAttachment, "hostInterface", hostName)
 	}
 }

--- a/internal/ingresssidecar/ebpfdatapath.go
+++ b/internal/ingresssidecar/ebpfdatapath.go
@@ -290,9 +290,9 @@ func ensureEgressDatapath(vpc string, tableID uint32) error {
 	defer func() { _ = closer.Close() }()
 
 	// EgressKindVeth is a don't-care here, not a claim about this device's link
-	// type. EgressKind steers only usid_ingress's redirect, and usid_ingress is
-	// never attached in this pod's namespace, since this sidecar has no decap
-	// side. usid_egress never reads it.
+	// type. The current datapath reads egress kind per interface rather than
+	// from vrf_table, and usid_ingress never delivers into this pod's namespace
+	// anyway, since this sidecar has no decap side. usid_egress never reads it.
 	if err := registry.VRF.Register(ingressSidecarBlock, argument, tableID, usidmap.EgressKindVeth); err != nil {
 		return fmt.Errorf("register eBPF vrf_table entry: %w", err)
 	}

--- a/internal/plumbing/ebpf/attach/attach_test.go
+++ b/internal/plumbing/ebpf/attach/attach_test.go
@@ -297,3 +297,45 @@ func TestResolveFilterPriority_EnvOverride(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_AddedMapKeepsExistingPinnedState covers rolling out a datapath build
+// that adds a map. The previous build's pins lack it, and that alone must not
+// count as incompatible, which would recreate every map empty and drop live
+// routing state until each attachment is re-added.
+func TestLoad_AddedMapKeepsExistingPinnedState(t *testing.T) {
+	requireRoot(t)
+
+	pinDir := filepath.Join("/sys/fs/bpf", fmt.Sprintf("galactic-test-added-map-%d", os.Getpid()))
+	t.Cleanup(func() { _ = os.RemoveAll(pinDir) })
+
+	objs, err := Load(pinDir)
+	if err != nil {
+		t.Fatalf("first Load(): %v", err)
+	}
+	const vrfKey = uint64(0x123)
+	if err := objs.VrfTable.Put(vrfKey, prog.UsidVrfValue{VrfTableId: 7}); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+	addedPin := filepath.Join(pinDir, prog.UsidMapIfindexEgressKindTable)
+	if err := os.Remove(addedPin); err != nil {
+		t.Fatalf("remove %s pin to stand in for the previous build's pin set: %v", prog.UsidMapIfindexEgressKindTable, err)
+	}
+	_ = objs.Close()
+
+	objs, err = Load(pinDir)
+	if err != nil {
+		t.Fatalf("second Load(): %v", err)
+	}
+	defer func() { _ = objs.Close() }()
+
+	var got prog.UsidVrfValue
+	if err := objs.VrfTable.Lookup(vrfKey, &got); err != nil {
+		t.Fatalf("vrf_table entry after loading with an added map: %v, want it preserved", err)
+	}
+	if got.VrfTableId != 7 {
+		t.Errorf("vrf_table entry VrfTableId = %d, want 7", got.VrfTableId)
+	}
+	if _, err := os.Stat(addedPin); err != nil {
+		t.Errorf("added map was not pinned: %v", err)
+	}
+}

--- a/internal/plumbing/ebpf/ifindexvrfmap/egresskind.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/egresskind.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cilium/ebpf"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/prog"
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+// EgressKindTable is the read/write API for ifindex_egress_kind_table: which
+// redirect helper usid_ingress uses to deliver into one attachment's host-side
+// interface, keyed by that interface's ifindex.
+//
+// It is per interface rather than a field of vrf_table's per-VPC entry because
+// one VPC can hold both tap and veth attachments on the same node. It shares
+// ifindex_vrf_table's lifecycle, written at CNI ADD and removed at DEL, so it
+// needs no generation bookkeeping of its own.
+type EgressKindTable struct {
+	table usidmap.Table
+}
+
+// NewEgressKindTable wraps table as an EgressKindTable. Production callers use
+// OpenPinnedEgressKind; tests pass a fake.
+func NewEgressKindTable(table usidmap.Table) *EgressKindTable {
+	return &EgressKindTable{table: table}
+}
+
+// OpenPinnedEgressKind opens ifindex_egress_kind_table from its pinned path
+// under pinDir. The returned map must be closed when the caller is done.
+//
+// The error wraps os.ErrNotExist when the running datapath predates this map.
+// The CNI binary is installed before the datapath that pins the map is
+// reloaded, so callers must be able to tell that window apart from a real
+// failure.
+func OpenPinnedEgressKind(pinDir string) (*EgressKindTable, *ebpf.Map, error) {
+	m, err := ebpf.LoadPinnedMap(filepath.Join(pinDir, prog.UsidMapIfindexEgressKindTable), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ifindexvrfmap: open pinned map %q: %w", prog.UsidMapIfindexEgressKindTable, err)
+	}
+	return NewEgressKindTable(usidmap.KernelTable{Map: m}), m, nil
+}
+
+// Register writes, or overwrites, the egress kind for ifindex. An unknown kind
+// is rejected rather than written, since the datapath treats every value other
+// than usidmap.EgressKindVeth as a plain redirect and would hide the mistake.
+func (t *EgressKindTable) Register(ifindex uint32, egressKind uint32) error {
+	if egressKind != usidmap.EgressKindVeth && egressKind != usidmap.EgressKindTap {
+		return fmt.Errorf("ifindexvrfmap: ifindex_egress_kind_table: register ifindex=%d: unknown egress kind %d",
+			ifindex, egressKind)
+	}
+	if err := t.table.Put(ifindex, egressKind); err != nil {
+		return fmt.Errorf("ifindexvrfmap: ifindex_egress_kind_table: register ifindex=%d: %w", ifindex, err)
+	}
+	return nil
+}
+
+// Unregister removes the entry for ifindex if present. An already-absent entry
+// is not an error: DEL is idempotent per the CNI spec.
+func (t *EgressKindTable) Unregister(ifindex uint32) error {
+	if err := t.table.Delete(ifindex); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		return fmt.Errorf("ifindexvrfmap: ifindex_egress_kind_table: unregister ifindex=%d: %w", ifindex, err)
+	}
+	return nil
+}
+
+// Get reads the egress kind for ifindex, reporting whether an entry exists.
+func (t *EgressKindTable) Get(ifindex uint32) (egressKind uint32, ok bool, err error) {
+	if err := t.table.Lookup(ifindex, &egressKind); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("ifindexvrfmap: ifindex_egress_kind_table: get ifindex=%d: %w", ifindex, err)
+	}
+	return egressKind, true, nil
+}

--- a/internal/plumbing/ebpf/ifindexvrfmap/egresskind_test.go
+++ b/internal/plumbing/ebpf/ifindexvrfmap/egresskind_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package ifindexvrfmap
+
+import (
+	"testing"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/usidmap"
+)
+
+const (
+	tapIfindex  uint32 = 42
+	vethIfindex uint32 = 43
+)
+
+func assertEgressKind(t *testing.T, table *EgressKindTable, ifindex, want uint32) {
+	t.Helper()
+	got, ok, err := table.Get(ifindex)
+	if err != nil {
+		t.Fatalf("Get(%d): unexpected error: %v", ifindex, err)
+	}
+	if !ok {
+		t.Fatalf("Get(%d): no entry, want egress kind %d", ifindex, want)
+	}
+	if got != want {
+		t.Errorf("Get(%d) = %d, want %d", ifindex, got, want)
+	}
+}
+
+// A VPC holding a tap and a veth attachment on one node must keep both kinds,
+// whichever registers last. vrf_table's shared per-VPC value could not.
+func TestEgressKindTable_MixedKindsSurviveEitherRegistrationOrder(t *testing.T) {
+	type registration struct {
+		ifindex uint32
+		kind    uint32
+	}
+	tap := registration{ifindex: tapIfindex, kind: usidmap.EgressKindTap}
+	veth := registration{ifindex: vethIfindex, kind: usidmap.EgressKindVeth}
+
+	for _, tt := range []struct {
+		name  string
+		order []registration
+	}{
+		{name: "tap then veth", order: []registration{tap, veth}},
+		{name: "veth then tap", order: []registration{veth, tap}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewEgressKindTable(newFakeTable())
+			for _, r := range tt.order {
+				if err := table.Register(r.ifindex, r.kind); err != nil {
+					t.Fatalf("Register(%d, %d): %v", r.ifindex, r.kind, err)
+				}
+			}
+			assertEgressKind(t, table, tapIfindex, usidmap.EgressKindTap)
+			assertEgressKind(t, table, vethIfindex, usidmap.EgressKindVeth)
+		})
+	}
+}
+
+func TestEgressKindTable_UnregisterLeavesSiblingIntact(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		removed, kept uint32
+		keptKind      uint32
+	}{
+		{name: "remove tap", removed: tapIfindex, kept: vethIfindex, keptKind: usidmap.EgressKindVeth},
+		{name: "remove veth", removed: vethIfindex, kept: tapIfindex, keptKind: usidmap.EgressKindTap},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			table := NewEgressKindTable(newFakeTable())
+			if err := table.Register(tapIfindex, usidmap.EgressKindTap); err != nil {
+				t.Fatalf("Register(tap): %v", err)
+			}
+			if err := table.Register(vethIfindex, usidmap.EgressKindVeth); err != nil {
+				t.Fatalf("Register(veth): %v", err)
+			}
+			if err := table.Unregister(tt.removed); err != nil {
+				t.Fatalf("Unregister(%d): %v", tt.removed, err)
+			}
+			if _, ok, err := table.Get(tt.removed); err != nil || ok {
+				t.Errorf("Get(%d) after Unregister: ok=%v err=%v, want no entry", tt.removed, ok, err)
+			}
+			assertEgressKind(t, table, tt.kept, tt.keptKind)
+		})
+	}
+}
+
+func TestEgressKindTable_UnregisterAbsentIsNotError(t *testing.T) {
+	table := NewEgressKindTable(newFakeTable())
+	if err := table.Unregister(tapIfindex); err != nil {
+		t.Errorf("Unregister(never registered) = %v, want nil", err)
+	}
+}
+
+func TestEgressKindTable_RegisterOverwrites(t *testing.T) {
+	table := NewEgressKindTable(newFakeTable())
+	if err := table.Register(tapIfindex, usidmap.EgressKindVeth); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	// An ifindex freed by a DEL that never ran can be reused by a different
+	// kind of attachment, whose own ADD must win.
+	if err := table.Register(tapIfindex, usidmap.EgressKindTap); err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+	assertEgressKind(t, table, tapIfindex, usidmap.EgressKindTap)
+}
+
+func TestEgressKindTable_RegisterRejectsUnknownKind(t *testing.T) {
+	ft := newFakeTable()
+	table := NewEgressKindTable(ft)
+	if err := table.Register(tapIfindex, 7); err == nil {
+		t.Error("Register(kind=7) = nil error, want rejection")
+	}
+	if ft.len() != 0 {
+		t.Errorf("Register(kind=7) wrote %d entries, want 0", ft.len())
+	}
+}

--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -36,9 +36,9 @@
 //  8. bpf_fib_lookup against the resolved Linux VRF table, scoped to that
 //     table exactly as the kernel's own End.DT46 does.
 //  9. Redirect to the resolved egress interface: bpf_redirect_peer for a veth
-//     attachment, whose container-side peer is in another namespace, or plain
-//     bpf_redirect for a tap, which already sits in this namespace. Which one
-//     comes from vrf_table's egress_kind, set at registration time.
+//     host-side end, which crosses straight into the peer's namespace, and
+//     plain bpf_redirect otherwise. Which one comes from
+//     ifindex_egress_kind_table, keyed by the egress interface itself.
 //
 // This file depends on no libbpf headers. It declares only the helpers it
 // calls, using the enum constants from the system's <linux/bpf.h>, and defines
@@ -108,9 +108,9 @@ static long (*bpf_skb_change_proto)(struct __sk_buff *skb, __be16 proto,
 static long (*bpf_fib_lookup)(void *ctx, struct bpf_fib_lookup *params, __s32 plen,
 			       __u32 flags) = (void *) BPF_FUNC_fib_lookup;
 
-// Step 9 calls one of these two, chosen per entry through vrf_table's
-// egress_kind: bpf_redirect_peer for a veth attachment, which crosses into the
-// peer's namespace, and bpf_redirect for a tap, which does not.
+// Step 9 calls one of these two, chosen per egress interface through
+// ifindex_egress_kind_table: bpf_redirect_peer for a veth attachment, which
+// crosses into the peer's namespace, and bpf_redirect for everything else.
 static long (*bpf_redirect_peer)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redirect_peer;
 static long (*bpf_redirect)(__u32 ifindex, __u64 flags) = (void *) BPF_FUNC_redirect;
 
@@ -261,17 +261,17 @@ struct function_value {
 	__u32 behavior;
 };
 
-// enum egress_kind selects which redirect helper step 9 uses for an entry's
-// resolved egress interface. EGRESS_KIND_VETH, the zero value, uses
-// bpf_redirect_peer; EGRESS_KIND_TAP uses plain bpf_redirect, since a tap
-// device never has a namespace-crossing peer.
+// enum egress_kind selects which redirect helper step 9 uses for a resolved
+// egress interface. EGRESS_KIND_VETH uses bpf_redirect_peer; EGRESS_KIND_TAP
+// uses plain bpf_redirect, since a tap device never has a namespace-crossing
+// peer.
 enum egress_kind {
 	EGRESS_KIND_VETH = 0,
 	EGRESS_KIND_TAP = 1,
 };
 
 // struct vrf_value is vrf_table's value: the Linux VRF table ID this Argument
-// resolves to, per-Argument counters, an egress_kind, and a generation.
+// resolves to, per-Argument counters, a legacy egress_kind, and a generation.
 //
 // generation is written only by userspace, at registration time, and never read
 // here. It lets the GC sweep tell "existed before this sweep's snapshot" from
@@ -286,6 +286,11 @@ enum egress_kind {
 // is a claimed count, and packets minus dropped_packets is what actually left.
 // Without it, a VRF dropping everything still shows healthy per-Argument
 // counters, since drop_reasons has no Block or Argument dimension.
+//
+// egress_kind is no longer read here. It is still written, because a datapath
+// rolled back to an older build reads it, but step 9 cannot use it: this entry
+// is shared by every attachment on one VPC and node, and one VPC can hold both
+// tap and veth attachments. See ifindex_egress_kind_table.
 //
 // egress_kind occupies what was an alignment pad, and generation and
 // dropped_packets are placed last, so every other field keeps its offset.
@@ -627,6 +632,28 @@ struct {
 	__type(key, __u32); // ifindex
 	__type(value, struct ifindex_vrf_value);
 } ifindex_vrf_table SEC(".maps");
+
+// ifindex_egress_kind_table: the enum egress_kind of each attachment's
+// host-side interface, keyed by that interface's ifindex and written and
+// removed alongside its ifindex_vrf_table row. Step 9 keys on the interface the
+// FIB lookup resolved rather than on vrf_table, whose single per-VPC value
+// cannot describe a VPC mixing tap and veth attachments on one node.
+//
+// A separate map rather than a field on ifindex_vrf_value: changing a pinned
+// map's layout makes the loader recreate every map empty, wiping live routing
+// state on every node until each attachment is re-added.
+//
+// A miss uses plain bpf_redirect, which delivers to either kind. Into a veth it
+// transmits on the host-side end, whose xmit forwards into the peer's
+// namespace, so it only forgoes bpf_redirect_peer's shortcut past the backlog
+// queue. That keeps attachments registered before this map existed, or after a
+// recreated pin, delivering until their next ADD.
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 16384);
+	__type(key, __u32); // host-side ifindex
+	__type(value, __u32); // enum egress_kind
+} ifindex_egress_kind_table SEC(".maps");
 
 // nptv6_table: one row per VRF with NPTv6 configured, keyed like vrf_table.
 // usid_ingress already holds that key locally, and usid_egress resolves it
@@ -1235,24 +1262,25 @@ int usid_ingress(struct __sk_buff *skb)
 	// Step 9: redirect to the resolved egress interface.
 	//
 	// A veth attachment's egress interface is the pod's host-side veth, whose
-	// container-side peer is in another namespace, so bpf_redirect_peer is
-	// required to cross into it. A tap has no peer at all, being created in this
-	// namespace and never moved, so plain bpf_redirect is required instead.
-	// bpf_redirect_peer against a tap always fails, which is the tap-mode
-	// blackhole this per-entry egress_kind fixes.
+	// container-side peer is in another namespace, so bpf_redirect_peer crosses
+	// straight into it. A tap has no peer at all, being created in this namespace
+	// and never moved, so bpf_redirect_peer against a tap is silently discarded
+	// after this program returns TC_ACT_REDIRECT, and plain bpf_redirect is
+	// required instead.
 	//
-	// Unit tests cover egress_kind's control-plane wiring only. A real
-	// lookup-then-redirect by egress kind needs a live route and net device
-	// that a synthetic program run cannot fabricate, so that part is a
-	// live-cluster concern like this file's other FIB-lookup tests.
+	// The choice is keyed by the resolved interface, not by vrf_table's entry: a
+	// VPC can mix both kinds on one node, and a per-VPC value black-holes
+	// whichever kind did not register last.
 	long redirect_rc;
+	__u32 egress_ifindex = fib_params.ifindex;
+	__u32 *egress_kind = bpf_map_lookup_elem(&ifindex_egress_kind_table, &egress_ifindex);
 
 	count_drop(DROP_REASON_TRACE_ING_REACHED_REDIRECT); // TEMPORARY
 
-	if (vrf->egress_kind == EGRESS_KIND_TAP)
-		redirect_rc = bpf_redirect(fib_params.ifindex, 0);
+	if (egress_kind && *egress_kind == EGRESS_KIND_VETH)
+		redirect_rc = bpf_redirect_peer(egress_ifindex, 0);
 	else
-		redirect_rc = bpf_redirect_peer(fib_params.ifindex, 0);
+		redirect_rc = bpf_redirect(egress_ifindex, 0);
 
 	if (redirect_rc != TC_ACT_REDIRECT) {
 		count_claimed_drop(DROP_REASON_REDIRECT_FAILED, vrf);

--- a/internal/plumbing/ebpf/prog/usid_redirect_test.go
+++ b/internal/plumbing/ebpf/prog/usid_redirect_test.go
@@ -1,0 +1,486 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package prog
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// These tests drive real frames through usid_ingress into real tap and veth
+// devices, because BPF_PROG_TEST_RUN reports TC_ACT_REDIRECT for either helper
+// and never performs the redirect, so it cannot show which one delivers.
+
+const (
+	egressKindVeth uint32 = 0
+	egressKindTap  uint32 = 1
+
+	redirectLabTableID = 100
+
+	// deliveryWait bounds how long a frame that should arrive may take.
+	// quietWait bounds the check that a frame did not appear somewhere; the
+	// redirect runs synchronously in softirq, so it is short.
+	deliveryWait = 2 * time.Second
+	quietWait    = 300 * time.Millisecond
+)
+
+var (
+	tapInnerDst  = net.IPv4(10, 0, 1, 10).To4()
+	vethInnerDst = net.IPv4(10, 0, 2, 10).To4()
+	tapGuestMAC  = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x01, 0x10}
+)
+
+// redirectLab is one private network namespace holding a tap standing in for
+// the fabric uplink, with usid_ingress attached, plus one tap attachment and
+// one veth attachment whose peer sits in a second namespace. Both attachments
+// belong to the same VPC, that is, the same vrf_table entry.
+type redirectLab struct {
+	objs *UsidObjects
+
+	uplinkFd  int
+	uplinkMAC net.HardwareAddr
+
+	tapIfindex uint32
+	tapFd      int
+
+	vethIfindex uint32
+	// vethHostCapture sees frames transmitted on the host-side end, which only
+	// plain bpf_redirect produces. vethPeerCapture sees frames arriving on the
+	// peer inside its own namespace, which both helpers produce.
+	vethHostCapture int
+	vethPeerCapture int
+}
+
+func newRedirectLab(t *testing.T) *redirectLab {
+	t.Helper()
+	requireRoot(t)
+	if _, err := os.Stat("/dev/net/tun"); err != nil {
+		t.Skipf("test requires /dev/net/tun: %v", err)
+	}
+
+	// Netlink calls, tap creation, and sysctl writes all act on the calling
+	// thread's namespace, so this goroutine stays pinned to one thread for the
+	// whole test. If the thread cannot be moved back it is left locked, which
+	// makes the runtime discard it rather than reuse it.
+	runtime.LockOSThread()
+	origNS := openThreadNetns(t)
+	t.Cleanup(func() {
+		if err := unix.Setns(origNS, unix.CLONE_NEWNET); err != nil {
+			t.Errorf("restore original network namespace: %v", err)
+			return
+		}
+		_ = unix.Close(origNS)
+		runtime.UnlockOSThread()
+	})
+
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		t.Fatalf("unshare lab network namespace: %v", err)
+	}
+	labNS := openThreadNetns(t)
+	t.Cleanup(func() { _ = unix.Close(labNS) })
+	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
+		t.Fatalf("unshare peer network namespace: %v", err)
+	}
+	peerNS := openThreadNetns(t)
+	t.Cleanup(func() { _ = unix.Close(peerNS) })
+	setNetns(t, labNS)
+
+	lab := &redirectLab{objs: loadObjects(t)}
+
+	var uplink netlink.Link
+	lab.uplinkFd, uplink = openTap(t, "up0")
+	lab.uplinkMAC = uplink.Attrs().HardwareAddr
+
+	var tapLink netlink.Link
+	lab.tapFd, tapLink = openTap(t, "dt0")
+	lab.tapIfindex = uint32(tapLink.Attrs().Index)
+
+	if err := netlink.LinkAdd(&netlink.Veth{LinkAttrs: netlink.LinkAttrs{Name: "dv0"}, PeerName: "dv1"}); err != nil {
+		t.Fatalf("add veth pair: %v", err)
+	}
+	peer, err := netlink.LinkByName("dv1")
+	if err != nil {
+		t.Fatalf("look up veth peer: %v", err)
+	}
+	if err := netlink.LinkSetNsFd(peer, peerNS); err != nil {
+		t.Fatalf("move veth peer into its namespace: %v", err)
+	}
+	setNetns(t, peerNS)
+	peer = setLinkUp(t, "dv1")
+	lab.vethPeerCapture = openCapture(t, peer.Attrs().Index)
+	setNetns(t, labNS)
+	vethHost := setLinkUp(t, "dv0")
+	lab.vethIfindex = uint32(vethHost.Attrs().Index)
+	lab.vethHostCapture = openCapture(t, vethHost.Attrs().Index)
+
+	// bpf_fib_lookup refuses to resolve a route for a packet whose ingress
+	// device does not forward.
+	for _, path := range []string{
+		"/proc/sys/net/ipv4/conf/all/forwarding",
+		"/proc/sys/net/ipv4/conf/up0/forwarding",
+	} {
+		if err := os.WriteFile(path, []byte("1"), 0o644); err != nil {
+			t.Fatalf("enable forwarding via %s: %v", path, err)
+		}
+	}
+
+	addHostRoute(t, tapLink, tapInnerDst, tapGuestMAC)
+	addHostRoute(t, vethHost, vethInnerDst, peer.Attrs().HardwareAddr)
+	attachIngress(t, uplink, lab.objs.UsidIngress)
+
+	if err := lab.objs.LocatorTable.Put(baseUSID.locatorKey(t), UsidLocatorValue{Generation: 1}); err != nil {
+		t.Fatalf("populate locator_table: %v", err)
+	}
+	if err := lab.objs.FunctionTable.Put(baseUSID.functionKey(t), UsidFunctionValue{Behavior: 1}); err != nil {
+		t.Fatalf("populate function_table: %v", err)
+	}
+	return lab
+}
+
+// registerAttachment writes what CNI ADD writes for one attachment. vrf_table's
+// entry is shared by the whole VPC, so it keeps only the last writer's kind.
+func (lab *redirectLab) registerAttachment(t *testing.T, ifindex, kind uint32) {
+	t.Helper()
+	value := UsidVrfValue{VrfTableId: redirectLabTableID, EgressKind: kind}
+	if err := lab.objs.VrfTable.Put(baseUSID.vrfKey(), value); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+	lab.putEgressKind(t, ifindex, kind)
+}
+
+func (lab *redirectLab) putEgressKind(t *testing.T, ifindex, kind uint32) {
+	t.Helper()
+	if err := lab.objs.IfindexEgressKindTable.Put(ifindex, kind); err != nil {
+		t.Fatalf("populate ifindex_egress_kind_table[%d]: %v", ifindex, err)
+	}
+}
+
+func (lab *redirectLab) deleteEgressKind(t *testing.T, ifindex uint32) {
+	t.Helper()
+	if err := lab.objs.IfindexEgressKindTable.Delete(ifindex); err != nil {
+		t.Fatalf("delete ifindex_egress_kind_table[%d]: %v", ifindex, err)
+	}
+}
+
+func (lab *redirectLab) registerTap(t *testing.T) {
+	lab.registerAttachment(t, lab.tapIfindex, egressKindTap)
+}
+func (lab *redirectLab) registerVeth(t *testing.T) {
+	lab.registerAttachment(t, lab.vethIfindex, egressKindVeth)
+}
+
+// assertTapDelivers sends one encapsulated frame toward the tap attachment and
+// requires it to come out of the tap.
+func (lab *redirectLab) assertTapDelivers(t *testing.T, label string) {
+	t.Helper()
+	marker := lab.send(t, tapInnerDst, label)
+	if !awaitMarker(t, lab.tapFd, marker, deliveryWait, readTap) {
+		t.Errorf("%s: frame for the tap attachment never reached the tap", label)
+	}
+}
+
+// assertVethDelivers sends one encapsulated frame toward the veth attachment,
+// requires it to arrive in the peer's namespace, and checks which helper
+// carried it there: bpf_redirect_peer never transmits on the host-side end.
+func (lab *redirectLab) assertVethDelivers(t *testing.T, label string, wantPeerRedirect bool) {
+	t.Helper()
+	marker := lab.send(t, vethInnerDst, label)
+	if !awaitMarker(t, lab.vethPeerCapture, marker, deliveryWait, readCapture(false)) {
+		t.Errorf("%s: frame for the veth attachment never reached the peer namespace", label)
+		return
+	}
+	sawHostTransmit := awaitMarker(t, lab.vethHostCapture, marker, quietWait, readCapture(true))
+	switch {
+	case wantPeerRedirect && sawHostTransmit:
+		t.Errorf("%s: frame was transmitted on the host-side veth, want bpf_redirect_peer", label)
+	case !wantPeerRedirect && !sawHostTransmit:
+		t.Errorf("%s: frame was not transmitted on the host-side veth, want plain bpf_redirect", label)
+	}
+}
+
+// A VPC with a tap and a veth attachment on one node delivers to both whichever
+// registers last. Before the per-interface map, the last veth registration
+// switched the whole VPC to bpf_redirect_peer and black-holed the tap.
+func TestUsidIngress_MixedEgressKindsInOneVPCDeliverInEitherOrder(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		tapFirst bool
+	}{
+		{name: "tap then veth", tapFirst: true},
+		{name: "veth then tap", tapFirst: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			lab := newRedirectLab(t)
+			if tt.tapFirst {
+				lab.registerTap(t)
+				lab.registerVeth(t)
+			} else {
+				lab.registerVeth(t)
+				lab.registerTap(t)
+			}
+			lab.assertTapDelivers(t, "tap")
+			lab.assertVethDelivers(t, "veth", true)
+		})
+	}
+}
+
+// An attachment registered before ifindex_egress_kind_table existed has no
+// entry. Its traffic takes plain bpf_redirect, which still reaches a veth's
+// peer namespace, whatever kind vrf_table holds.
+func TestUsidIngress_MissingEgressKindFallsBackToPlainRedirect(t *testing.T) {
+	lab := newRedirectLab(t)
+	// EGRESS_KIND_VETH is the vrf_table value that used to black-hole taps.
+	value := UsidVrfValue{VrfTableId: redirectLabTableID, EgressKind: egressKindVeth}
+	if err := lab.objs.VrfTable.Put(baseUSID.vrfKey(), value); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+	lab.assertTapDelivers(t, "tap without entry")
+	lab.assertVethDelivers(t, "veth without entry", false)
+}
+
+// Removing one attachment's entry, as its DEL does, leaves the other's
+// redirect choice untouched.
+func TestUsidIngress_RemovingOneEgressKindLeavesSiblingIntact(t *testing.T) {
+	t.Run("remove tap", func(t *testing.T) {
+		lab := newRedirectLab(t)
+		lab.registerTap(t)
+		lab.registerVeth(t)
+		lab.deleteEgressKind(t, lab.tapIfindex)
+		lab.assertVethDelivers(t, "veth after tap removal", true)
+	})
+	t.Run("remove veth", func(t *testing.T) {
+		lab := newRedirectLab(t)
+		lab.registerVeth(t)
+		lab.registerTap(t)
+		lab.deleteEgressKind(t, lab.vethIfindex)
+		var kind uint32
+		if err := lab.objs.IfindexEgressKindTable.Lookup(lab.tapIfindex, &kind); err != nil {
+			t.Fatalf("look up tap's ifindex_egress_kind_table entry after veth removal: %v", err)
+		}
+		if kind != egressKindTap {
+			t.Errorf("tap's egress kind after veth removal = %d, want %d", kind, egressKindTap)
+		}
+		lab.assertTapDelivers(t, "tap after veth removal")
+	})
+}
+
+// send writes one SRv6 frame addressed to baseUSID, carrying an inner IPv4
+// packet to innerDst, into the uplink tap, and returns the payload marker to
+// look for on the far side.
+func (lab *redirectLab) send(t *testing.T, innerDst net.IP, label string) []byte {
+	t.Helper()
+	marker := []byte(fmt.Sprintf("galactic-egress-kind:%s:%d", label, time.Now().UnixNano()))
+	payload := make([]byte, 64)
+	copy(payload, marker)
+
+	inner := make([]byte, 0, 20+len(payload))
+	totLen := uint16(20 + len(payload))
+	inner = append(inner, 0x45, 0x00, byte(totLen>>8), byte(totLen), 0x00, 0x00, 0x40, 0x00)
+	inner = append(inner, 64, 253, 0x00, 0x00) // ttl, experimental protocol, checksum unchecked here
+	inner = append(inner, 192, 0, 2, 1)
+	inner = append(inner, innerDst...)
+	inner = append(inner, payload...)
+
+	frame := make([]byte, 0, ethHeaderLen+ip6HeaderLen+len(inner))
+	frame = append(frame, lab.uplinkMAC...)
+	frame = append(frame, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x86, 0xDD)
+	frame = append(frame, 0x60, 0x00, 0x00, 0x00, byte(len(inner)>>8), byte(len(inner)), 4, 64)
+	src := [16]byte{0x20, 0x01, 0x0d, 0xb8, 15: 0x01}
+	frame = append(frame, src[:]...)
+	dst := baseUSID.addr(t).As16()
+	frame = append(frame, dst[:]...)
+	frame = append(frame, inner...)
+
+	if _, err := unix.Write(lab.uplinkFd, frame); err != nil {
+		t.Fatalf("write frame into uplink tap: %v", err)
+	}
+	return marker
+}
+
+type frameReader func(fd int, buf []byte) (n int, accept bool, err error)
+
+func readTap(fd int, buf []byte) (int, bool, error) {
+	n, err := unix.Read(fd, buf)
+	return n, true, err
+}
+
+// readCapture reads one frame from an AF_PACKET socket. outgoingOnly keeps just
+// the frames its interface transmitted.
+func readCapture(outgoingOnly bool) frameReader {
+	return func(fd int, buf []byte) (int, bool, error) {
+		n, from, err := unix.Recvfrom(fd, buf, unix.MSG_DONTWAIT)
+		if err != nil || !outgoingOnly {
+			return n, true, err
+		}
+		ll, ok := from.(*unix.SockaddrLinklayer)
+		return n, ok && ll.Pkttype == unix.PACKET_OUTGOING, nil
+	}
+}
+
+// awaitMarker reports whether a frame containing marker is read from fd within
+// wait. Unrelated frames, such as IPv6 neighbor discovery, are skipped.
+func awaitMarker(t *testing.T, fd int, marker []byte, wait time.Duration, read frameReader) bool {
+	t.Helper()
+	deadline := time.Now().Add(wait)
+	buf := make([]byte, 65536)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
+		ready, err := unix.Poll(fds, int(remaining.Milliseconds())+1)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("poll fd %d: %v", fd, err)
+		}
+		if ready == 0 {
+			return false
+		}
+		n, accept, err := read(fd, buf)
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("read fd %d: %v", fd, err)
+		}
+		if accept && bytes.Contains(buf[:n], marker) {
+			return true
+		}
+	}
+}
+
+func openThreadNetns(t *testing.T) int {
+	t.Helper()
+	fd, err := unix.Open("/proc/thread-self/ns/net", unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("open thread network namespace: %v", err)
+	}
+	return fd
+}
+
+func setNetns(t *testing.T, fd int) {
+	t.Helper()
+	if err := unix.Setns(fd, unix.CLONE_NEWNET); err != nil {
+		t.Fatalf("setns: %v", err)
+	}
+}
+
+// openTap creates a non-persistent tap owned by the returned descriptor and
+// brings it up. Holding the descriptor open is what gives the tap carrier.
+func openTap(t *testing.T, name string) (int, netlink.Link) {
+	t.Helper()
+	fd, err := unix.Open("/dev/net/tun", unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("open /dev/net/tun: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(fd) })
+	ifr, err := unix.NewIfreq(name)
+	if err != nil {
+		t.Fatalf("ifreq for %s: %v", name, err)
+	}
+	ifr.SetUint16(unix.IFF_TAP | unix.IFF_NO_PI)
+	if err := unix.IoctlIfreq(fd, unix.TUNSETIFF, ifr); err != nil {
+		t.Fatalf("create tap %s: %v", name, err)
+	}
+	return fd, setLinkUp(t, name)
+}
+
+func setLinkUp(t *testing.T, name string) netlink.Link {
+	t.Helper()
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("look up %s: %v", name, err)
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("set %s up: %v", name, err)
+	}
+	if link, err = netlink.LinkByName(name); err != nil {
+		t.Fatalf("re-read %s: %v", name, err)
+	}
+	return link
+}
+
+func openCapture(t *testing.T, ifindex int) int {
+	t.Helper()
+	proto := bswap16(unix.ETH_P_ALL)
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_CLOEXEC, int(proto))
+	if err != nil {
+		t.Fatalf("open packet socket: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(fd) })
+	if err := unix.Bind(fd, &unix.SockaddrLinklayer{Protocol: proto, Ifindex: ifindex}); err != nil {
+		t.Fatalf("bind packet socket to ifindex %d: %v", ifindex, err)
+	}
+	return fd
+}
+
+// addHostRoute installs a /32 route and a permanent neighbor for dst in the
+// lab's VRF table, so bpf_fib_lookup resolves both the egress interface and
+// the destination MAC without any address resolution traffic.
+func addHostRoute(t *testing.T, link netlink.Link, dst net.IP, mac net.HardwareAddr) {
+	t.Helper()
+	route := &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       &net.IPNet{IP: dst, Mask: net.CIDRMask(32, 32)},
+		Table:     redirectLabTableID,
+		Scope:     netlink.SCOPE_LINK,
+	}
+	if err := netlink.RouteAdd(route); err != nil {
+		t.Fatalf("add route to %s via %s: %v", dst, link.Attrs().Name, err)
+	}
+	neigh := &netlink.Neigh{
+		LinkIndex:    link.Attrs().Index,
+		Family:       netlink.FAMILY_V4,
+		State:        netlink.NUD_PERMANENT,
+		IP:           dst,
+		HardwareAddr: mac,
+	}
+	if err := netlink.NeighAdd(neigh); err != nil {
+		t.Fatalf("add neighbor %s on %s: %v", dst, link.Attrs().Name, err)
+	}
+}
+
+func attachIngress(t *testing.T, link netlink.Link, program *ebpf.Program) {
+	t.Helper()
+	qdisc := &netlink.GenericQdisc{
+		QdiscAttrs: netlink.QdiscAttrs{
+			LinkIndex: link.Attrs().Index,
+			Handle:    netlink.MakeHandle(0xffff, 0),
+			Parent:    netlink.HANDLE_CLSACT,
+		},
+		QdiscType: "clsact",
+	}
+	if err := netlink.QdiscAdd(qdisc); err != nil {
+		t.Fatalf("add clsact qdisc to %s: %v", link.Attrs().Name, err)
+	}
+	filter := &netlink.BpfFilter{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: link.Attrs().Index,
+			Parent:    netlink.HANDLE_MIN_INGRESS,
+			Handle:    netlink.MakeHandle(0, 1),
+			Protocol:  unix.ETH_P_ALL,
+			Priority:  1,
+		},
+		Fd:           program.FD(),
+		Name:         "usid_ingress_test",
+		DirectAction: true,
+	}
+	if err := netlink.FilterAdd(filter); err != nil {
+		t.Fatalf("attach usid_ingress to %s: %v", link.Attrs().Name, err)
+	}
+}

--- a/internal/plumbing/ebpf/usidmap/egresskind.go
+++ b/internal/plumbing/ebpf/usidmap/egresskind.go
@@ -4,15 +4,15 @@
 
 package usidmap
 
-// Egress kind values for vrf_table's value field, mirroring the datapath's own
-// enum. Hand-kept in sync with the C source, because the generator cannot
-// produce a Go type for an enum used only as a literal constant.
+// Egress kind values, mirroring the datapath's own enum. Hand-kept in sync with
+// the C source, because the generator cannot produce a Go type for an enum used
+// only as a literal constant.
 //
-// The value selects which redirect helper the datapath uses: a veth
-// attachment's egress interface has a peer in another namespace, while a tap
-// never leaves this one and so has no peer. EgressKindVeth is the zero value, so
-// a registration that never sets it explicitly defaults to the more common veth
-// behavior.
+// The value selects which redirect helper the datapath uses to deliver into an
+// attachment's host-side interface: a veth has a peer in another namespace,
+// while a tap never leaves this one and so has no peer. The datapath reads it
+// per interface, from ifindex_egress_kind_table. vrf_table still carries a copy
+// only so that a datapath rolled back to an older build keeps working.
 const (
 	EgressKindVeth uint32 = 0
 	EgressKindTap  uint32 = 1

--- a/internal/plumbing/ebpf/usidmap/vrf.go
+++ b/internal/plumbing/ebpf/usidmap/vrf.go
@@ -32,8 +32,9 @@ type VRFEntry struct {
 	// (internal/plumbing/vrf.TableID()) this Argument resolves to.
 	VRFTableID uint32
 
-	// EgressKind is EgressKindVeth or EgressKindTap: which redirect helper the
-	// datapath uses for this entry's resolved egress interface.
+	// EgressKind is EgressKindVeth or EgressKindTap. The current datapath does
+	// not read it, since one VPC can mix both kinds on a node; it is kept for a
+	// datapath rolled back to an older build, which does.
 	EgressKind uint32
 
 	// Generation is the table's monotonic-clock reading when this entry was


### PR DESCRIPTION
## Summary

A general-purpose Instance could become unreachable as soon as a unikernel Instance joined the same VPC on the same node. Inbound connections to it timed out, and no drop counter recorded the loss. With this change, both kinds of Instance receive inbound traffic, whatever order they attach in.

## Cause

The datapath picks one of two kernel redirect methods to deliver decapsulated traffic. Veth attachments (unikernel Instances) use a method that crosses into the Instance's network namespace. Tap attachments (general-purpose Instances) need the plain method. That choice was stored once per VPC per node, so the last attachment to register decided it for every attachment in the VPC. When a veth registered after a tap, the kernel silently discarded every packet sent to the tap. The staging outage on `eris-giune` in VPC `b` followed exactly that order.

## Fix

- The redirect choice now belongs to each attachment's host-side interface. It is recorded when the attachment is added, removed when it is deleted, and verified by the CNI CHECK operation.
- The choice lives in a new datapath map. No existing map changes layout, so rolling this out does not force the loader to recreate maps and wipe live routing state.
- An interface with no entry uses the plain redirect method. This covers attachments added before this change and any upgrade window before the new map is pinned. According to the kernel source, a plain redirect into a veth's host-side end is forwarded into the peer namespace, so it delivers to both kinds. The only cost is skipping the peer method's faster path. A test confirms this against a real kernel.
- During an upgrade, CNI ADD runs with the new CNI binary before the new datapath is loaded. In that window, ADD logs a missing map instead of failing, so Instances keep starting during the rollout.

## Testing

A new datapath test sends real SRv6 frames through the program into tap and veth devices. Against the current main datapath, it reproduces the outage: the tap attachment is black-holed when the veth registers last. With this change, both attachments receive traffic in both registration orders, each through the expected redirect method. Other tests cover the no-entry fallback, deletion of one attachment's entry, and loading a pin set from the previous build without losing routing state.

## Related

- Tap attachments for general-purpose Instances: datum-cloud/galactic#528, datum-cloud/galactic#531, datum-cloud/galactic#533
- Ingress sidecar route handling: datum-cloud/galactic#526, datum-cloud/galactic#518
- A separate fix for GRO-merged return packets on the decap path is in flight and edits the same datapath source file, outside the redirect step. The two changes don't overlap, but whichever merges second needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
