### PR TITLE
fix(ebpf): Keep downloads from general-purpose Instances through the edge from stalling

### DIFF
--- a/internal/plumbing/ebpf/prog/usid.c
+++ b/internal/plumbing/ebpf/prog/usid.c
@@ -181,6 +181,25 @@ static long (*bpf_skb_store_bytes)(struct __sk_buff *skb, __u32 offset, const vo
 // cannot segment the packet on the uplink and drops it.
 #define USID_BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 (1ULL << 2)
 
+// The kernel UAPI flags usid_ingress passes when it strips the outer header.
+// FIXED_GSO keeps a merged packet's segment size at what the sender chose;
+// without it the kernel grows the segment size by the stripped header length,
+// so the forwarded segments no longer match the ones that arrived. The DECAP
+// flags name the inner header the packet is left with.
+#define USID_BPF_F_ADJ_ROOM_FIXED_GSO (1ULL << 0)
+#define USID_BPF_F_ADJ_ROOM_DECAP_L3_IPV4 (1ULL << 7)
+#define USID_BPF_F_ADJ_ROOM_DECAP_L3_IPV6 (1ULL << 8)
+
+// Transport header facts the FIB length computation needs: where the TCP data
+// offset lives, and the UDP header's fixed size.
+#define USID_TCP_DOFF_OFFSET 12
+#define USID_TCP_MIN_HDR_LEN 20
+#define USID_UDP_HDR_LEN 8
+
+// GSO_BY_FRAGS, a segment size that means "each fragment is one segment". Such
+// a packet has no single segment length to check.
+#define USID_GSO_BY_FRAGS 0xFFFF
+
 // USID_L3_OFFSET is the fixed byte offset of the IPv6 header from skb->data, a
 // compile-time constant.
 //
@@ -854,6 +873,49 @@ static USID_ALWAYS_INLINE long apply_vip_xlat(struct __sk_buff *skb, __u32 addr_
 // Program
 // ---------------------------------------------------------------------
 
+// usid_fib_tot_len returns the L3 length step 8's FIB lookup checks against the
+// route MTU: the packet's own length for a single packet, and the length of one
+// segment for a packet the NIC merged with GRO.
+//
+// The lookup compares any nonzero length strictly against the MTU, so passing a
+// merged packet's total length drops return traffic whose every segment fits.
+// Passing zero is no better: the kernel then accepts any GSO packet without
+// checking its segments at all. One segment's length keeps path-MTU enforcement
+// for both cases, matching what the kernel's own IPv4 and IPv6 forwarding check.
+//
+// A GSO packet whose transport header can't be read falls back to the total
+// length, which can only over-reject.
+static USID_ALWAYS_INLINE __u16 usid_fib_tot_len(struct __sk_buff *skb, __u8 *l4, __u16 l3_len, __u32 l3_hdr_len,
+						__u8 l4proto)
+{
+	void *data_end = (void *) (long) skb->data_end;
+	__u32 gso_size = skb->gso_size;
+	__u32 l4_hdr_len;
+
+	if (gso_size == 0)
+		return l3_len;
+	if (gso_size == USID_GSO_BY_FRAGS || l3_hdr_len < sizeof(struct usid_iphdr))
+		return l3_len;
+
+	if (l4proto == USID_IPPROTO_TCP) {
+		__u8 *doff = l4 + USID_TCP_DOFF_OFFSET;
+
+		if ((void *) (doff + 1) > data_end)
+			return l3_len;
+		l4_hdr_len = (__u32) (*doff >> 4) * 4;
+		if (l4_hdr_len < USID_TCP_MIN_HDR_LEN)
+			return l3_len;
+	} else if (l4proto == USID_IPPROTO_UDP) {
+		l4_hdr_len = USID_UDP_HDR_LEN;
+	} else {
+		return l3_len;
+	}
+
+	__u32 seg_len = l3_hdr_len + l4_hdr_len + gso_size;
+
+	return seg_len < l3_len ? (__u16) seg_len : l3_len;
+}
+
 SEC("tc")
 int usid_ingress(struct __sk_buff *skb)
 {
@@ -1032,7 +1094,13 @@ int usid_ingress(struct __sk_buff *skb)
 	// in front of the real inner header, which the plain carve below removes,
 	// exposing it at offset 0 as in the IPv6 case. Net bytes removed is 40
 	// either way; only the protocol side effect differs.
+	//
+	// A packet the NIC merged with GRO keeps its sender's segment size, and
+	// the DECAP flag names the inner header it is left with. A kernel that
+	// predates the DECAP flags rejects them, so the strip retries without.
 	__s32 strip_len = (__s32) sizeof(struct usid_ip6hdr);
+	__u64 strip_flags = USID_BPF_F_ADJ_ROOM_FIXED_GSO;
+	__u64 decap_flag = USID_BPF_F_ADJ_ROOM_DECAP_L3_IPV6;
 
 	if (inner_version == 4) {
 		if (bpf_skb_change_proto(skb, __builtin_bswap16(USID_ETH_P_IP), 0)) {
@@ -1040,9 +1108,11 @@ int usid_ingress(struct __sk_buff *skb)
 			return TC_ACT_SHOT;
 		}
 		strip_len = (__s32) sizeof(struct usid_iphdr);
+		decap_flag = USID_BPF_F_ADJ_ROOM_DECAP_L3_IPV4;
 	}
 
-	if (bpf_skb_adjust_room(skb, -strip_len, BPF_ADJ_ROOM_MAC, 0)) {
+	if (bpf_skb_adjust_room(skb, -strip_len, BPF_ADJ_ROOM_MAC, strip_flags | decap_flag) &&
+	    bpf_skb_adjust_room(skb, -strip_len, BPF_ADJ_ROOM_MAC, strip_flags)) {
 		count_claimed_drop(DROP_REASON_STRIP_FAILED, vrf);
 		return TC_ACT_SHOT;
 	}
@@ -1168,13 +1238,12 @@ int usid_ingress(struct __sk_buff *skb)
 		__builtin_memcpy(fib_params.ipv6_dst, inner6->daddr, sizeof(fib_params.ipv6_dst));
 		new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IPV6);
 
-		// fib_params.tot_len is the L3 length the kernel's MTU check compares
-		// against the route's MTU, but only when nonzero: left at zero that
-		// check is skipped and a fragmentation-needed result can never fire.
-		// IPv6 has no total-length field, so this is the fixed 40-byte header
-		// plus payload_len, in host order.
-		fib_params.tot_len = (__u16) sizeof(struct usid_ip6hdr) +
-				     __builtin_bswap16(inner6->payload_len);
+		// IPv6 has no total-length field, so the packet's L3 length is the
+		// fixed 40-byte header plus payload_len, in host order.
+		__u16 l3_len = (__u16) sizeof(struct usid_ip6hdr) + __builtin_bswap16(inner6->payload_len);
+
+		fib_params.tot_len = usid_fib_tot_len(skb, (__u8 *) (inner6 + 1), l3_len, sizeof(struct usid_ip6hdr),
+						      inner6->nexthdr);
 	} else {
 		struct usid_iphdr *inner4 = (void *) inner;
 
@@ -1188,10 +1257,12 @@ int usid_ingress(struct __sk_buff *skb)
 		__builtin_memcpy(&fib_params.ipv4_dst, inner4->daddr, sizeof(fib_params.ipv4_dst));
 		new_eth->h_proto = __builtin_bswap16(USID_ETH_P_IP);
 
-		// The same tot_len requirement as the IPv6 branch, except IPv4 carries
-		// its own total-length field, in host order, so no arithmetic is
-		// needed.
-		fib_params.tot_len = __builtin_bswap16(inner4->tot_len);
+		// IPv4 carries its own total-length field. The header length comes from
+		// IHL, since options move the transport header.
+		__u32 ihl_len = (__u32) (inner4->ver_ihl & 0x0F) * 4;
+
+		fib_params.tot_len = usid_fib_tot_len(skb, (__u8 *) inner4 + ihl_len, __builtin_bswap16(inner4->tot_len),
+						      ihl_len, inner4->protocol);
 	}
 
 	fib_params.ifindex = skb->ingress_ifindex;

--- a/internal/plumbing/ebpf/prog/usid_gso_test.go
+++ b/internal/plumbing/ebpf/prog/usid_gso_test.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Datum Cloud, Inc.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package prog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+
+	"go.datum.net/galactic/internal/plumbing/ebpf/uformat"
+)
+
+const (
+	gsoTestTableID  = 100
+	gsoTestRouteMTU = 1450
+	tcpHeaderLen    = 20
+	ip4HeaderLen    = 20
+
+	// virtio_net_hdr values from the kernel UAPI.
+	virtioNetHdrLen       = 10
+	virtioNetHdrNeedsCsum = 1
+	virtioNetHdrGSONone   = 0
+	virtioNetHdrGSOTCPv4  = 1
+	virtioNetHdrGSOTCPv6  = 4
+)
+
+var (
+	gsoTestInner6Src = netip.MustParseAddr("2001:db8:100::1")
+	gsoTestInner6Dst = netip.MustParseAddr("2001:db8:200::2")
+	gsoTestInner4Src = netip.MustParseAddr("192.0.2.1")
+	gsoTestInner4Dst = netip.MustParseAddr("198.51.100.2")
+)
+
+// TestUsidIngress_FIBLookupJudgesMergedPacketsPerSegment checks that a packet
+// the NIC merged with GRO is held to the route MTU one segment at a time, while
+// a single packet is still held to it whole.
+//
+// BPF_PROG_TEST_RUN can set a context's gso_size but not its gso_type, and the
+// kernel refuses to strip a header from a GSO packet that isn't marked TCP. A
+// tap with a virtio-net header is the closest stand-in for a merged packet the
+// kernel builds: it delivers a TCP GSO packet through the attached program the
+// same way the uplink does.
+func TestUsidIngress_FIBLookupJudgesMergedPacketsPerSegment(t *testing.T) {
+	requireRoot(t)
+
+	tests := []struct {
+		name         string
+		innerV4      bool
+		gso          bool
+		segL3Len     int
+		wantFragDrop uint64
+		wantForward  bool
+	}{
+		{"IPv6SinglePacketFits", false, false, gsoTestRouteMTU, 0, true},
+		{"IPv6SinglePacketTooBig", false, false, gsoTestRouteMTU + 1, 1, false},
+		{"IPv6MergedSegmentsFit", false, true, gsoTestRouteMTU, 0, true},
+		{"IPv6MergedSegmentsTooBig", false, true, gsoTestRouteMTU + 1, 1, false},
+		{"IPv4SinglePacketFits", true, false, gsoTestRouteMTU, 0, true},
+		{"IPv4SinglePacketTooBig", true, false, gsoTestRouteMTU + 1, 1, false},
+		{"IPv4MergedSegmentsFit", true, true, gsoTestRouteMTU, 0, true},
+		{"IPv4MergedSegmentsTooBig", true, true, gsoTestRouteMTU + 1, 1, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := loadObjects(t)
+			usid := testUSID{block: baseUSID.block, nodeID: baseUSID.nodeID, function: uformat.FunctionEndDT46, argument: 0x321}
+			populateGSOTestTables(t, objs, usid)
+
+			netNS, err := ns.TempNetNS()
+			if err != nil {
+				t.Fatalf("create test netns: %v", err)
+			}
+			t.Cleanup(func() { _ = netNS.Close() })
+
+			err = netNS.Do(func(_ ns.NetNS) error {
+				return runGSOTestCase(t, objs, usid, tt.innerV4, tt.gso, tt.segL3Len, tt.wantForward)
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := sumPerCPU(t, objs.DropReasons, DropReasonFibFragNeeded); got != tt.wantFragDrop {
+				t.Errorf("drop_reasons[fib_frag_needed] = %d, want %d", got, tt.wantFragDrop)
+			}
+			var vrfVal UsidVrfValue
+			if err := objs.VrfTable.Lookup(usid.vrfKey(), &vrfVal); err != nil {
+				t.Fatalf("lookup vrf_table entry: %v", err)
+			}
+			if vrfVal.Packets != 1 {
+				t.Errorf("vrf_table packets = %d, want 1 (the packet must reach the program's VRF match)", vrfVal.Packets)
+			}
+		})
+	}
+}
+
+func populateGSOTestTables(t *testing.T, objs *UsidObjects, usid testUSID) {
+	t.Helper()
+	if err := objs.LocatorTable.Put(usid.locatorKey(t), UsidLocatorValue{Generation: 1}); err != nil {
+		t.Fatalf("populate locator_table: %v", err)
+	}
+	if err := objs.FunctionTable.Put(usid.functionKey(t), UsidFunctionValue{Behavior: 1}); err != nil {
+		t.Fatalf("populate function_table: %v", err)
+	}
+	// A dummy device has no namespace-crossing peer, so it needs the plain
+	// redirect a tap attachment gets.
+	vrfVal := UsidVrfValue{VrfTableId: gsoTestTableID, EgressKind: 1}
+	if err := objs.VrfTable.Put(usid.vrfKey(), vrfVal); err != nil {
+		t.Fatalf("populate vrf_table: %v", err)
+	}
+}
+
+// runGSOTestCase runs inside a fresh netns: it builds a tap for the program to
+// receive on and a dummy route target whose MTU is the route MTU, writes one
+// tunneled frame, and checks whether the target transmitted the decapsulated
+// packet.
+func runGSOTestCase(t *testing.T, objs *UsidObjects, usid testUSID, innerV4, gso bool, segL3Len int,
+	wantForward bool) error {
+	tap := &netlink.Tuntap{
+		LinkAttrs:  netlink.LinkAttrs{Name: "usidgso0"},
+		Mode:       netlink.TUNTAP_MODE_TAP,
+		Flags:      netlink.TUNTAP_NO_PI | netlink.TUNTAP_VNET_HDR,
+		Queues:     1,
+		NonPersist: true,
+	}
+	if err := netlink.LinkAdd(tap); err != nil {
+		return fmt.Errorf("add tap: %w", err)
+	}
+	tapFile := tap.Fds[0]
+	defer tapFile.Close() //nolint:errcheck // best-effort cleanup
+
+	dst := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "usidgsodst0", MTU: gsoTestRouteMTU}}
+	if err := netlink.LinkAdd(dst); err != nil {
+		return fmt.Errorf("add dummy: %w", err)
+	}
+	// Without a link-local address the target sends no neighbor discovery or
+	// MLD traffic of its own, which would otherwise land in its transmit count.
+	if err := netlink.LinkSetIP6AddrGenMode(dst, nl.IN6_ADDR_GEN_MODE_NONE); err != nil {
+		return fmt.Errorf("disable address generation on dummy: %w", err)
+	}
+	for _, l := range []netlink.Link{tap, dst} {
+		if err := netlink.LinkSetUp(l); err != nil {
+			return fmt.Errorf("set %s up: %w", l.Attrs().Name, err)
+		}
+	}
+	tapLink, err := netlink.LinkByName(tap.Name)
+	if err != nil {
+		return fmt.Errorf("look up tap: %w", err)
+	}
+	dstLink, err := netlink.LinkByName(dst.Name)
+	if err != nil {
+		return fmt.Errorf("look up dummy: %w", err)
+	}
+
+	if err := installGSOTestRoutes(dstLink); err != nil {
+		return err
+	}
+	// The FIB lookup refuses to forward for an ingress device with forwarding
+	// off, which is every device in a fresh netns.
+	for _, path := range []string{"/proc/sys/net/ipv6/conf/all/forwarding", "/proc/sys/net/ipv4/ip_forward"} {
+		if err := os.WriteFile(path, []byte("1"), 0o644); err != nil {
+			return fmt.Errorf("enable forwarding via %s: %w", path, err)
+		}
+	}
+
+	tcx, err := link.AttachTCX(link.TCXOptions{
+		Interface: tapLink.Attrs().Index,
+		Program:   objs.UsidIngress,
+		Attach:    ebpf.AttachTCXIngress,
+	})
+	if err != nil {
+		return fmt.Errorf("attach usid_ingress to tap: %w", err)
+	}
+	defer tcx.Close() //nolint:errcheck // best-effort cleanup
+
+	before, err := dummyTxStats(dst.Name)
+	if err != nil {
+		return err
+	}
+	frame := buildGSOTestFrame(t, tapLink.Attrs().HardwareAddr, usid.addr(t), innerV4, gso, segL3Len)
+	if _, err := tapFile.Write(frame); err != nil {
+		return fmt.Errorf("write frame to tap: %w", err)
+	}
+
+	// The dummy does not segment, so a forwarded merged packet counts as one
+	// transmit of the whole decapsulated frame.
+	var wantPkts, wantBytes uint64
+	if wantForward {
+		wantPkts, wantBytes = 1, uint64(len(frame)-virtioNetHdrLen-ip6HeaderLen)
+	}
+	// Transmit happens in the write's own context, so a short poll only absorbs
+	// stats propagation.
+	var gotPkts, gotBytes uint64
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); time.Sleep(20 * time.Millisecond) {
+		after, err := dummyTxStats(dst.Name)
+		if err != nil {
+			return err
+		}
+		gotPkts, gotBytes = after.TxPackets-before.TxPackets, after.TxBytes-before.TxBytes
+		if wantForward && gotPkts >= wantPkts {
+			break
+		}
+	}
+	if gotPkts != wantPkts || gotBytes != wantBytes {
+		t.Errorf("route target transmitted %d packets, %d bytes; want %d packets, %d bytes",
+			gotPkts, gotBytes, wantPkts, wantBytes)
+	}
+	return nil
+}
+
+func dummyTxStats(name string) (*netlink.LinkStatistics, error) {
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("read %s stats: %w", name, err)
+	}
+	return l.Attrs().Statistics, nil
+}
+
+func installGSOTestRoutes(dstLink netlink.Link) error {
+	for _, inner := range []netip.Addr{gsoTestInner6Dst, gsoTestInner4Dst} {
+		bits := 64
+		if inner.Is4() {
+			bits = 24
+		}
+		prefix := netip.PrefixFrom(inner, bits).Masked()
+		route := &netlink.Route{
+			LinkIndex: dstLink.Attrs().Index,
+			Dst:       &net.IPNet{IP: prefix.Addr().AsSlice(), Mask: net.CIDRMask(bits, inner.BitLen())},
+			Table:     gsoTestTableID,
+			Scope:     netlink.SCOPE_LINK,
+		}
+		if err := netlink.RouteAdd(route); err != nil {
+			return fmt.Errorf("add route %s: %w", prefix, err)
+		}
+		neigh := &netlink.Neigh{
+			LinkIndex:    dstLink.Attrs().Index,
+			State:        netlink.NUD_PERMANENT,
+			IP:           inner.AsSlice(),
+			HardwareAddr: net.HardwareAddr{0x02, 0, 0, 0, 0, 0x02},
+		}
+		if err := netlink.NeighAdd(neigh); err != nil {
+			return fmt.Errorf("add neighbor %s: %w", inner, err)
+		}
+	}
+	return nil
+}
+
+// buildGSOTestFrame returns a virtio-net header followed by an Ethernet frame
+// carrying an inner TCP packet in an outer IPv6 header addressed to outerDst.
+// Each inner segment's L3 length is segL3Len. A GSO frame carries three such
+// segments merged into one packet; otherwise the frame is a single segment.
+func buildGSOTestFrame(t *testing.T, dstMAC net.HardwareAddr, outerDst netip.Addr, innerV4, gso bool,
+	segL3Len int) []byte {
+	t.Helper()
+
+	innerHdrLen, nextHdr, gsoType := ip6HeaderLen, byte(41), byte(virtioNetHdrGSOTCPv6)
+	if innerV4 {
+		innerHdrLen, nextHdr, gsoType = ip4HeaderLen, 4, virtioNetHdrGSOTCPv4
+	}
+	segPayload := segL3Len - innerHdrLen - tcpHeaderLen
+	payload := segPayload
+	if gso {
+		payload = 3 * segPayload
+	}
+	innerLen := innerHdrLen + tcpHeaderLen + payload
+
+	frame := make([]byte, virtioNetHdrLen+ethHeaderLen+ip6HeaderLen+innerLen)
+	vnet := frame[:virtioNetHdrLen]
+	if gso {
+		csumStart := ethHeaderLen + ip6HeaderLen + innerHdrLen
+		vnet[0] = virtioNetHdrNeedsCsum
+		vnet[1] = gsoType
+		binary.NativeEndian.PutUint16(vnet[2:], uint16(csumStart+tcpHeaderLen))
+		binary.NativeEndian.PutUint16(vnet[4:], uint16(segPayload))
+		binary.NativeEndian.PutUint16(vnet[6:], uint16(csumStart))
+		binary.NativeEndian.PutUint16(vnet[8:], 16)
+	} else {
+		vnet[1] = virtioNetHdrGSONone
+	}
+
+	eth := frame[virtioNetHdrLen:]
+	copy(eth[0:6], dstMAC)
+	copy(eth[6:12], []byte{0x02, 0, 0, 0, 0, 0x01})
+	binary.BigEndian.PutUint16(eth[12:], 0x86DD)
+
+	outer := eth[ethHeaderLen:]
+	outer[0] = 0x60
+	binary.BigEndian.PutUint16(outer[4:], uint16(innerLen))
+	outer[6] = nextHdr
+	outer[7] = 64
+	src := netip.MustParseAddr("2001:db8::1").As16()
+	dst := outerDst.As16()
+	copy(outer[8:24], src[:])
+	copy(outer[24:40], dst[:])
+
+	inner := outer[ip6HeaderLen:]
+	if innerV4 {
+		inner[0] = 0x45
+		binary.BigEndian.PutUint16(inner[2:], uint16(innerLen))
+		binary.BigEndian.PutUint16(inner[6:], 0x4000) // DF
+		inner[8] = 64
+		inner[9] = 6
+		s4, d4 := gsoTestInner4Src.As4(), gsoTestInner4Dst.As4()
+		copy(inner[12:16], s4[:])
+		copy(inner[16:20], d4[:])
+		binary.BigEndian.PutUint16(inner[10:], ipv4HeaderChecksum(inner[:ip4HeaderLen]))
+	} else {
+		inner[0] = 0x60
+		binary.BigEndian.PutUint16(inner[4:], uint16(tcpHeaderLen+payload))
+		inner[6] = 6
+		inner[7] = 64
+		s6, d6 := gsoTestInner6Src.As16(), gsoTestInner6Dst.As16()
+		copy(inner[8:24], s6[:])
+		copy(inner[24:40], d6[:])
+	}
+
+	tcp := inner[innerHdrLen:]
+	binary.BigEndian.PutUint16(tcp[0:], 443)
+	binary.BigEndian.PutUint16(tcp[2:], 40000)
+	binary.BigEndian.PutUint32(tcp[4:], 1)
+	binary.BigEndian.PutUint32(tcp[8:], 1)
+	tcp[12] = tcpHeaderLen / 4 << 4
+	tcp[13] = 0x10 // ACK
+	binary.BigEndian.PutUint16(tcp[14:], 65535)
+	return frame
+}
+
+func ipv4HeaderChecksum(hdr []byte) uint16 {
+	var sum uint32
+	for i := 0; i+1 < len(hdr); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(hdr[i:]))
+	}
+	for sum > 0xFFFF {
+		sum = sum>>16 + sum&0xFFFF
+	}
+	return ^uint16(sum)
+}


### PR DESCRIPTION
Downloads from a general-purpose Instance through the edge gateway no longer stall. Return traffic that the gateway node's network card had merged into larger packets is now forwarded, not dropped, so responses arrive at the speed the path allows.

## What was wrong

Receiving network cards merge consecutive TCP segments of the same flow into one large packet before the node's datapath sees it. When the ingress datapath removed the SRv6 outer header from such a packet, it checked the merged packet's total size against the destination's MTU, not the size of each segment. A merged packet made of segments that each fit was judged too large and dropped. The sender recovered only by retransmitting one segment at a time.

This is the receive-side counterpart of datum-cloud/galactic#532, which fixed the same class of problem on encapsulation.

## Evidence

Measured on a staging gateway node during six downloads of a 34 KB response from a general-purpose Instance:

| Signal on the gateway node | Change |
|---|---|
| Ingress drops for "fragmentation needed" | +154 |
| Every other drop reason, uplink drops, and errors | 0 |
| Guest retransmissions against new segments sent | 358 against 200 |
| Time per download | 1.4 to 3.3 seconds |

A capture of tunneled return traffic on the uplink showed 57 of 124 packets already merged beyond 1500 bytes, at exact multiples of the guest's segment size. The destination device's MTU is 1450, and each individual segment fits within it.

## What changed

- Each segment of a merged packet is now checked against the route MTU at its own size. A single packet is still checked whole, exactly as before, so a packet that is genuinely too large is still dropped. A merged packet whose segments are each too large is dropped too.
- Removing the outer header keeps the sender's segment size and declares the inner header the packet is left with. Without that, the kernel enlarges each segment by the removed header's length, and segments that arrived within the MTU could leave the node exceeding it.
- Both inner IPv6 and inner IPv4 traffic are covered.

A new test delivers real merged TCP packets through the datapath, for both address families. On the current main branch it fails exactly for merged packets whose segments fit, and it passes with this change. Cases for oversized single packets and oversized segments pass both before and after.

No pinned map changes, so upgrading preserves routing state on every node.

## Sequencing

A concurrent change to the same datapath source file reworks how the ingress path picks its redirect helper for each destination interface, and adds a map for that. This change touches only header removal and the MTU length check, a separate region, so the two should merge cleanly in either order. Whichever lands second should rebase and re-run the eBPF tests.

Related: datum-cloud/galactic#532, datum-cloud/galactic#533, datum-cloud/galactic#528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
